### PR TITLE
Fix crash/hanging on Pixel devices after March 2025 security update

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/core/LiveBluetoothSource.java
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/core/LiveBluetoothSource.java
@@ -283,12 +283,17 @@ class LiveBluetoothSource implements BluetoothSource {
                         }
                     };
 
+                    Timber.v("getDevicesForProfile(profile=%d)...", desiredProfile);
                     final boolean success = adapter != null && adapter.getProfileProxy(context, listener, desiredProfile);
                     Timber.v("getDevicesForProfile(profile=%d, success=%b)", desiredProfile, success);
                     if (!success) emitter.onSuccess(new ArrayList<>());
                 })
                 .subscribeOn(Schedulers.io())
                 .observeOn(Schedulers.io())
+                .onErrorReturn(throwable -> {
+                    Timber.e(throwable, "getDevicesForProfile failed for %d", desiredProfile);
+                    return Collections.emptyList();
+                })
                 .timeout(8, TimeUnit.SECONDS, Single.just(new ArrayList<>()));
     }
 


### PR DESCRIPTION
Security update related refactoring by Google misplaced a null check. The NPE now hits us and either prevents the device list from being loaded or crashes the app (depending on timing).

See https://issuetracker.google.com/issues/404058947