### PR TITLE
Faster device loading

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/core/LiveBluetoothSource.java
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/core/LiveBluetoothSource.java
@@ -207,13 +207,6 @@ class LiveBluetoothSource implements BluetoothSource {
                 .defer(() -> {
                     final List<SingleSource<List<BluetoothDevice>>> profiles = new ArrayList<>();
 
-                    if (!settings.isGATTExcluded()) {
-                        profiles.add(LiveBluetoothSource.this.getDevicesForProfile(BluetoothProfile.GATT));
-                    }
-                    if (!settings.isGATTServerExcluded()) {
-                        profiles.add(LiveBluetoothSource.this.getDevicesForProfile(BluetoothProfile.GATT_SERVER));
-                    }
-
                     profiles.add(LiveBluetoothSource.this.getDevicesForProfile(BluetoothProfile.HEADSET));
                     profiles.add(LiveBluetoothSource.this.getDevicesForProfile(BluetoothProfile.A2DP));
 

--- a/app/src/main/java/eu/darken/bluemusic/settings/core/Settings.java
+++ b/app/src/main/java/eu/darken/bluemusic/settings/core/Settings.java
@@ -23,8 +23,6 @@ public class Settings {
     private static final String PREFKEY_ONBOARDING_INTRODONE = "core.onboarding.introdone";
 
     private static final String PREFKEY_ADVANCED_EXCLUDE_HEALTHDEVICES = "core.advanced.exclude.healthdevices";
-    private static final String PREFKEY_ADVANCED_EXCLUDE_GATT = "core.advanced.exclude.gatt";
-    private static final String PREFKEY_ADVANCED_EXCLUDE_GATTSERVER = "core.advanced.exclude.gattserver";
 
     public static final String PREFKEY_BUGREPORTING = "core.bugreporting.enabled";
 
@@ -94,14 +92,6 @@ public class Settings {
 
     public boolean isHealthDeviceExcluded() {
         return preferences.getBoolean(PREFKEY_ADVANCED_EXCLUDE_HEALTHDEVICES, true);
-    }
-
-    public boolean isGATTExcluded() {
-        return preferences.getBoolean(PREFKEY_ADVANCED_EXCLUDE_GATT, false);
-    }
-
-    public boolean isGATTServerExcluded() {
-        return preferences.getBoolean(PREFKEY_ADVANCED_EXCLUDE_GATTSERVER, false);
     }
 
 //    public boolean isBatterySavingHintDismissed() {

--- a/app/src/main/res/xml/settings_advanced.xml
+++ b/app/src/main/res/xml/settings_advanced.xml
@@ -4,15 +4,5 @@
         android:defaultValue="true"
         android:key="core.advanced.exclude.healthdevices"
         android:summary="@string/description_exclude_health"
-        android:title="@string/label_exclude_health"/>
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="core.advanced.exclude.gatt"
-        android:summary="@string/description_exclude_gatt"
-        android:title="@string/label_exclude_gatt"/>
-    <CheckBoxPreference
-        android:defaultValue="false"
-        android:key="core.advanced.exclude.gattserver"
-        android:summary="@string/description_exclude_gattserver"
-        android:title="@string/label_exclude_gattserver"/>
+        android:title="@string/label_exclude_health" />
 </PreferenceScreen>


### PR DESCRIPTION
Don't attempt retrieval of `BluetoothProfile.GATT/GATT_SERVER`. This was never supported and just wastes resources. I likely added this some time ago before the function documentation mentioned `BluetoothProfile.GATT` as example, despite not actually supporting it. Wasn't an issue before but now accessing an unsupported profile causes #92