### PR TITLE
Move autoplay key type setting to be "per device"

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/core/DevicesSettings.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/DevicesSettings.kt
@@ -1,7 +1,6 @@
 package eu.darken.bluemusic.devices.core
 
 import android.content.Context
-import android.view.KeyEvent
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
@@ -9,14 +8,12 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.bluemusic.common.datastore.PreferenceData
 import eu.darken.bluemusic.common.datastore.createValue
 import eu.darken.bluemusic.common.debug.logging.logTag
-import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class DevicesSettings @Inject constructor(
     @param:ApplicationContext private val context: Context,
-    json: Json,
 ) : PreferenceData {
 
     private val Context.dataStore by preferencesDataStore(name = "settings_devices")
@@ -27,7 +24,6 @@ class DevicesSettings @Inject constructor(
     val isEnabled = dataStore.createValue("devices.enabled", true)
     val visibleAdjustments = dataStore.createValue("devices.volume.adjustments.visible", true)
     val restoreOnBoot = dataStore.createValue("devices.volume.restore.boot.enabled", true)
-    val autoplayKeycodes = dataStore.createValue("devices.autoplay.keycodes", listOf(KeyEvent.KEYCODE_MEDIA_PLAY), json)
 
     companion object {
         internal val TAG = logTag("Devices", "Settings")

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsScreen.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.filled.Adjust
-import androidx.compose.material.icons.filled.PlayCircleOutline
 import androidx.compose.material.icons.filled.Start
 import androidx.compose.material.icons.twotone.Approval
 import androidx.compose.material3.Icon
@@ -19,9 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -30,10 +27,8 @@ import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
 import eu.darken.bluemusic.common.error.ErrorEventHandler
 import eu.darken.bluemusic.common.settings.SettingsDivider
-import eu.darken.bluemusic.common.settings.SettingsPreferenceItem
 import eu.darken.bluemusic.common.settings.SettingsSwitchItem
 import eu.darken.bluemusic.common.ui.waitForState
-import eu.darken.bluemusic.devices.ui.settings.dialogs.AutoplayKeycodesDialog
 import eu.darken.bluemusic.main.ui.settings.general.GeneralSettingsScreen
 import eu.darken.bluemusic.main.ui.settings.general.GeneralSettingsViewModel
 
@@ -51,8 +46,6 @@ fun DevicesSettingsScreenHost(vm: DevicesSettingsViewModel = hiltViewModel()) {
             onToggleEnabled = { vm.onToggleEnabled(it) },
             onToggleVisibleVolumeAdjustments = { vm.onToggleVisibleVolumeAdjustments(it) },
             onToggleRestoreOnBoot = { vm.onToggleRestoreOnBoot(it) },
-            onAutoplayKeycodesClicked = { vm.onAutoplayKeycodesClicked() },
-            onAutoplayKeycodesChanged = { vm.onAutoplayKeycodesChanged(it) },
         )
     }
 }
@@ -65,12 +58,9 @@ fun DevicesSettingsScreen(
     onToggleEnabled: (Boolean) -> Unit,
     onToggleVisibleVolumeAdjustments: (Boolean) -> Unit,
     onToggleRestoreOnBoot: (Boolean) -> Unit,
-    onAutoplayKeycodesClicked: () -> Unit,
-    onAutoplayKeycodesChanged: (List<Int>) -> Unit,
 ) {
 
     val snackbarHostState = remember { SnackbarHostState() }
-    var showAutoplayKeycodesDialog by remember { mutableStateOf(false) }
 
     Scaffold(
         snackbarHost = { SnackbarHost(snackbarHostState) },
@@ -125,49 +115,9 @@ fun DevicesSettingsScreen(
                 )
                 SettingsDivider()
             }
-            item {
-                SettingsPreferenceItem(
-                    icon = Icons.Default.PlayCircleOutline,
-                    title = stringResource(R.string.label_autoplay_keytype),
-                    subtitle = if (state.autoplayKeycodes.isEmpty()) {
-                        stringResource(R.string.desc_autoplay_keytype)
-                    } else {
-                        val keycodeNames = state.autoplayKeycodes.mapNotNull { keycode ->
-                            when (keycode) {
-                                android.view.KeyEvent.KEYCODE_MEDIA_PLAY -> "Play"
-                                android.view.KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> "Play/Pause"
-                                android.view.KeyEvent.KEYCODE_MEDIA_NEXT -> "Next"
-                                android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS -> "Previous"
-                                android.view.KeyEvent.KEYCODE_MEDIA_STOP -> "Stop"
-                                android.view.KeyEvent.KEYCODE_MEDIA_REWIND -> "Rewind"
-                                android.view.KeyEvent.KEYCODE_MEDIA_FAST_FORWARD -> "Fast Forward"
-                                else -> null
-                            }
-                        }.joinToString(", ")
-                        keycodeNames.ifEmpty { stringResource(R.string.desc_autoplay_keytype) }
-                    },
-                    onClick = {
-                        showAutoplayKeycodesDialog = true
-                        onAutoplayKeycodesClicked()
-                    }
-                )
-                SettingsDivider()
-            }
         }
     }
 
-    if (showAutoplayKeycodesDialog) {
-        AutoplayKeycodesDialog(
-            currentKeycodes = state.autoplayKeycodes,
-            onConfirm = { keycodes ->
-                onAutoplayKeycodesChanged(keycodes)
-                showAutoplayKeycodesDialog = false
-            },
-            onDismiss = {
-                showAutoplayKeycodesDialog = false
-            }
-        )
-    }
 }
 
 @Preview2

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
@@ -28,14 +28,12 @@ constructor(
         devicesSettings.isEnabled.flow,
         devicesSettings.visibleAdjustments.flow,
         devicesSettings.restoreOnBoot.flow,
-        devicesSettings.autoplayKeycodes.flow,
-    ) { upgradeInfo, isEnabled, visibleAdjustments, restoreOnBoot, autoplayKeycodes ->
+    ) { upgradeInfo, isEnabled, visibleAdjustments, restoreOnBoot ->
         State(
             isUpgraded = upgradeInfo.isUpgraded,
             isEnabled = isEnabled,
             visibleAdjustments = visibleAdjustments,
             restoreOnBoot = restoreOnBoot,
-            autoplayKeycodes = autoplayKeycodes,
         )
     }.asStateFlow()
 
@@ -59,21 +57,11 @@ constructor(
         devicesSettings.restoreOnBoot.value(enabled)
     }
 
-    fun onAutoplayKeycodesClicked() {
-        log(tag) { "onAutoplayKeycodesClicked()" }
-        // The dialog is shown directly in the UI, this is just for logging
-    }
-
-    fun onAutoplayKeycodesChanged(keycodes: List<Int>) = launch {
-        log(tag) { "onAutoplayKeycodesChanged($keycodes)" }
-        devicesSettings.autoplayKeycodes.update { keycodes }
-    }
 
     data class State(
         val isUpgraded: Boolean,
         val isEnabled: Boolean,
         val visibleAdjustments: Boolean,
         val restoreOnBoot: Boolean,
-        val autoplayKeycodes: List<Int>,
     )
 }

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Wys die stelsel se volume venster terwyl hierdie aanpassings gemaak word.</string>
     <string name="label_volume_listener">Neem verandering waar</string>
     <string name="description_volume_listener">Bly aktief terwyl \'n toestel verbind is, en berg volume veranderinge wat nie deur die program gedoen is nie.</string>
-    <string name="label_autoplay_keytype">Outo-speel sleutel tipe</string>
-    <string name="desc_autoplay_keytype">Die sleutel tipe wat gestuur word indien \'n outo-speel toestel inskakel.</string>
     <string name="label_boot_restore">Herstel met \&quot;boot\&quot;</string>
     <string name="description_boot_restore">Herstel volume na \&quot;booting/rebooting\&quot; as \'n Bluetooth-toestel gekoppel is.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">إظهار نافذة حجم الصوت للنظام بينما يقوم التطبيق بإجراء تعديلات.</string>
     <string name="label_volume_listener">ملاحظة التغييرات</string>
     <string name="description_volume_listener">تبقى فعالة عند إتصال جهاز وتحفظ التغييرات في حجم الصوت التي لم يكن سببها هذا التطبيق.</string>
-    <string name="label_autoplay_keytype">نوع مفتاح التشغيل التلقائي</string>
-    <string name="desc_autoplay_keytype">نوع المفتاح الذي يتم إرساله عند توصيل جهاز تم تمكين التشغيل التلقائي له.</string>
     <string name="label_boot_restore">الإستعادة عند تشغيل الجهاز</string>
     <string name="description_boot_restore">استعادة حجم الصوت بعد التشغيل/إعادة التشغيل إذا كان جهاز بلوتوث متصلا.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Bu tətbiq, nizamlamalar edərkən sistemin səs pəncərəsini göstər.</string>
     <string name="label_volume_listener">Dəyişiklikləri müşahidə et</string>
     <string name="description_volume_listener">Bir cihazla bağlantı qurduqda aktiv qal və bu tətbiqdən qaynaqlanmayan səs dəyişikliklərini saxla.</string>
-    <string name="label_autoplay_keytype">Avtomatik oynatma açar növü</string>
-    <string name="desc_autoplay_keytype">Avtomatik oynatma özəlliyi fəal cihaz ilə bağlantı qurduqda göndəriləcək açar növü.</string>
     <string name="label_boot_restore">Başlanğıcda geri qaytar</string>
     <string name="description_boot_restore">Bluetooth cihazı ilə bağlantı qurulsa, açılışdan/yenidən başlatmadan sonra səs səviyyəsini geri qaytarın.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-ban-rID/strings.xml
+++ b/app/src/main/res/values-ban-rID/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Show the system\'s volume window while this app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
     <string name="description_volume_listener">Stay active while a device is connected and save volume changes that have not been caused by this app.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">The key type that is sent when an autoplay enabled device connects.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Показва системния прозорец за звука, докато приложението прави корекции.</string>
     <string name="label_volume_listener">Следи промените</string>
     <string name="description_volume_listener">Записва промените на звука, които не са причинени от приложението докато устройството е свързано.</string>
-    <string name="label_autoplay_keytype">Autoplay опции</string>
-    <string name="desc_autoplay_keytype">Командата, която се изпраща при свързване към устройство.</string>
     <string name="label_boot_restore">Възстанови при стартиране</string>
     <string name="description_boot_restore">Възстановява силата на звука след старт/рестарт ако Bluetooth устройство е свързано.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Mostra la finestra de volum del sistema mentre aquesta aplicació realitza configuracions.</string>
     <string name="label_volume_listener">Observa els canvis</string>
     <string name="description_volume_listener">Roman actiu mentre un dispositiu estigui connectat i desa els canvis de volum que no hagin estat causats per aquesta aplicació.</string>
-    <string name="label_autoplay_keytype">Tipus de tecla de reproducció automàtica</string>
-    <string name="desc_autoplay_keytype">El tipus de tecla que s\'envia quan es connecta un dispositiu activat per a reproducció automàtica.</string>
     <string name="label_boot_restore">Restableix a l\'inici</string>
     <string name="description_boot_restore">Restableix el volum després d\'iniciar/reiniciar si un dispositiu Bluetooth està connectat.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Zobrazí systémové okno hlasitosti, zatímco aplikace provádí změny.</string>
     <string name="label_volume_listener">Sledování změn</string>
     <string name="description_volume_listener">Zůstaňte na pozoru, když je zařízení připojeno a uložte změny hlasitosti, které nepocházejí z této aplikace.</string>
-    <string name="label_autoplay_keytype">Typ tlačítka automatického přehrávání</string>
-    <string name="desc_autoplay_keytype">Typ tlačítka, který se odesílá při připojení zařízení s povoleným automatickým přehráváním.</string>
     <string name="label_boot_restore">Obnovit při spuštění</string>
     <string name="description_boot_restore">Obnoví hlasitosti po spuštění/restartování, když je zařízení připojeno.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Vis systemets lydstyrkevindue når denne app laver ændringer.</string>
     <string name="label_volume_listener">Observer ændringer</string>
     <string name="description_volume_listener">Forbliv aktiv når en enhed tilkobler, og gem lydstyrke-ændringer som ikke er ændret af denne app.</string>
-    <string name="label_autoplay_keytype">Autoplay knappetype</string>
-    <string name="desc_autoplay_keytype">Knappetypen som er sendt når en autoplay-aktiveret enhed tilsluttes.</string>
     <string name="label_boot_restore">Gendan på opstart</string>
     <string name="description_boot_restore">Gendan lydstyrken efter opstart/genstart, hvis en Bluetooth-enhed er tilsluttet.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -113,8 +113,6 @@
     <string name="description_visible_volume_adjustments">Zeigt das Lautstärken-Fenster des System an, während diese App Änderungen vornimmt.</string>
     <string name="label_volume_listener">Änderungen beobachten</string>
     <string name="description_volume_listener">Aktiv bleiben, während ein Gerät verbunden ist und Lautstärke-Änderungen speichern, die nicht von dieser App ausgelöst wurden.</string>
-    <string name="label_autoplay_keytype">Typ der Autoplay-Taste</string>
-    <string name="desc_autoplay_keytype">Der Tastendruck, der simuliert wird sobald ein Gerät mit Autoplay verbunden wird.</string>
     <string name="label_boot_restore">Wiederherstellen bei Neustart</string>
     <string name="description_boot_restore">Stellt die Lautstärke nach einem Neustart wieder her, falls ein Bluetooth-Gerät verbunden ist.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Εμφάνιση του παραθύρου ήχου του συστήματος, ενώ αυτή η εφαρμογή κάνει τις προσαρμογές.</string>
     <string name="label_volume_listener">Παρατήρηση αλλαγών</string>
     <string name="description_volume_listener">Η εφαρμογή παραμένει ενεργή όσο η συσκευή είναι συνδεδεμένη και αποθηκεύει τις αλλαγές εντάσεων του ήχου που δεν έχουν γίνει από αυτή την εφαρμογή.</string>
-    <string name="label_autoplay_keytype">Τύπος κλειδιού αυτόματης αναπαραγωγής</string>
-    <string name="desc_autoplay_keytype">Ο τύπος κλειδιού που στέλνεται όταν μια συσκευή αυτόματης αναπαραγωγής συνδέεται.</string>
     <string name="label_boot_restore">Επαναφορά κατά την εκκίνηση</string>
     <string name="description_boot_restore">Αποκατάσταση της έντασης μετά την εκκίνηση/επανεκκίνηση αν είναι συνδεδεμένη μια συσκευή Bluetooth.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-eo-rUY/strings.xml
+++ b/app/src/main/res/values-eo-rUY/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Show the system\'s volume window while this app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
     <string name="description_volume_listener">Stay active while a device is connected and save volume changes that have not been caused by this app.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">The key type that is sent when an autoplay enabled device connects.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -111,8 +111,6 @@
     <string name="description_visible_volume_adjustments">Muestra la ventana de volumen del sistema mientras esta aplicación realiza los ajustes.</string>
     <string name="label_volume_listener">Observar los cambios</string>
     <string name="description_volume_listener">Mantente activo mientras tu dispositivo está conectado y guarda los cambios de volumen no realizadas por la aplicación.</string>
-    <string name="label_autoplay_keytype">Tipo de la clave de la reproducción automática</string>
-    <string name="desc_autoplay_keytype">El tipo de la clave que se envía cuando se conecta un dispositivo habilitado para la reproducción automática.</string>
     <string name="label_boot_restore">Restaurar al arrancar</string>
     <string name="description_boot_restore">Restaurar el volumen después de iniciar/reiniciar, si un dispositivo Bluetooth está conectado.</string>
     <string name="settings_support_label">Soporte</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Kuva süsteemi heli aken hetkel, mil rakendus teeb muudatusi.</string>
     <string name="label_volume_listener">Jälgi muudatusi</string>
     <string name="description_volume_listener">Olge tähelepanelik, kui seadet ühendatakse ja salvestatakse heli muudatusi, mis ei pärine praegusest rakendusest.</string>
-    <string name="label_autoplay_keytype">Automaatse esituse klahvi tüüp</string>
-    <string name="desc_autoplay_keytype">Klahvi tüüp, mida saadetakse automaatset esitust kasutava seadme ühendumisel.</string>
     <string name="label_boot_restore">Taasta käivitumisel</string>
     <string name="description_boot_restore">Taasta heli pärast käivitumist/taaskäivitumist, kui sinihammast toetavad seadet ühendatakse.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Näytä järjestelmän äänenvoimakkuus säätimet, kun tämä ohjelma tekee muutoksia.</string>
     <string name="label_volume_listener">Tarkkaile muutoksia</string>
     <string name="description_volume_listener">Pysy aktiivisena kun laite on yhteydessä ja tallenna äänenvoimakkuus muutokset, mitkä ei ole tämän sovelluksen tekemiä.</string>
-    <string name="label_autoplay_keytype">Automaattisentoiston näppäin painallus</string>
-    <string name="desc_autoplay_keytype">Näppäin painallus mikä lähetetään, kun laite minkä automaattinentoisto on päällä yhdistää.</string>
     <string name="label_boot_restore">Palauta uudelleenkäynnistyksen yhteydessä</string>
     <string name="description_boot_restore">Palauta äänenvoimakkuus käynnistyksen yhteydessä jos Bluetooth laite on yhdistettynä.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Ipakita ang volume window ng sistema habang gumagawa ng pagbabo ang app na ito.</string>
     <string name="label_volume_listener">Obserbahan ang mga pagbabago</string>
     <string name="description_volume_listener">Manatiling aktibo habang konektado ang isang device at i-seyb ang mga pagbabago sa volume na hindi kagagawan ng app na ito.</string>
-    <string name="label_autoplay_keytype">Autoplay na uri ng key</string>
-    <string name="desc_autoplay_keytype">Ang uri ng key na ipinapadala kung may naka-autoplay na device na kumokonek.</string>
     <string name="label_boot_restore">Ibalik pagkatapos magboot</string>
     <string name="description_boot_restore">Ibalik ang volume pagkatagpos magboot/magreboot kung ang isang Bluetooth device ay nakakonekta.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -111,8 +111,6 @@
     <string name="description_visible_volume_adjustments">Affiche la fenêtre de volume du système quand l\'appli effectue des réglages.</string>
     <string name="label_volume_listener">Observer les changements</string>
     <string name="description_volume_listener">Rester active tant qu\'un périphérique est connecté et enregistrer les changements de volume qui ne proviennent pas de cette appli.</string>
-    <string name="label_autoplay_keytype">Type d\'action de lecture automatique</string>
-    <string name="desc_autoplay_keytype">Le type d\'action qui est envoyée quand un périphérique dont la lecture est automatique se connecte.</string>
     <string name="label_boot_restore">Restaurer au démarrage</string>
     <string name="description_boot_restore">Restaurer le volume après démarrage ou redémarrage si un périphérique Bluetooth est connecté.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Mostra o volume do sistema mentres esta aplicación realiza axustes.</string>
     <string name="label_volume_listener">Observar os cambios</string>
     <string name="description_volume_listener">Mantense activo mentres un dispositivo está conectado e garda os cambios de volume non causados por esta aplicación.</string>
-    <string name="label_autoplay_keytype">Tipo de tecla de reprodución automática</string>
-    <string name="desc_autoplay_keytype">O tipo de tecla que se envía cando se conecta un dispositivo habilitado para a reprodución automática.</string>
     <string name="label_boot_restore">Restaurar ao inicio</string>
     <string name="description_boot_restore">Restaura o volume logo de iniciar ou reiniciar en caso de que estea conectado un dispositivo bluetooth.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">इस ऐप्प को समायोजन करने के दौरान सिस्टम की वॉल्यूम विंडो दिखाएं।</string>
     <string name="label_volume_listener">परिवर्तनों को देखें</string>
     <string name="description_volume_listener">डिवाइस जुड़े होने दौरान सक्रिय रहें और ध्वनि परिवर्तन सहेजे, जो इस ऐप के कारण नहीं हुए हैं।</string>
-    <string name="label_autoplay_keytype">ऑटोप्ले कुंजी प्रकार</string>
-    <string name="desc_autoplay_keytype">यह कुंजी प्रकार तब भेजी जाती है जब कोई एक ऑटोप्ले सक्षम डिवाइस जुड़ता है</string>
     <string name="label_boot_restore">बूट पर पुनर्स्थापित करें</string>
     <string name="description_boot_restore">यदि कोई ब्लूटूथ डिवाइस कनेक्टेड है, तो बूटिंग/रीबूट करने के बाद वॉल्यूम पुनर्स्थापित करें ।</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Prikažite prozor glasnoće sustava dok ova aplikacija izvršava izmjene.</string>
     <string name="label_volume_listener">Promatraj promjene</string>
     <string name="description_volume_listener">Ostaje aktivan dok je uređaj povezan i sprema promjene glasnoće koje nisu uzrokovane ovom aplikacijom.</string>
-    <string name="label_autoplay_keytype">Tip ključa automatske reprodukcije</string>
-    <string name="desc_autoplay_keytype">Ključ koji je poslan kada se poveže uređaj sa omogućenom automatskom reprodukcijom.</string>
     <string name="label_boot_restore">Vrati na ponovnom pokretanju</string>
     <string name="description_boot_restore">Vrati glasnoću nakon ponovnog pokretanja ako je Bluetooth uređaj povezan.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">A rendszer hangerő ablakának megjelenítése, miközben ez az alkalmazás elvégzi a módosításokat.</string>
     <string name="label_volume_listener">Változások megfigyelése</string>
     <string name="description_volume_listener">Maradjon aktív amíg az eszköz csatlakoztatva van, és mentse a hangerő módosításait, amelyeket nem az alkalmazás szabályoz.</string>
-    <string name="label_autoplay_keytype">Automatikus lejátszás gomb típusa</string>
-    <string name="desc_autoplay_keytype">A gomb típusának küldése amikor egy automatikus lejátszás engedélyezett eszköz csatlakozik.</string>
     <string name="label_boot_restore">Rendszer indulásakor elindul</string>
     <string name="description_boot_restore">A hangerő vissza állítása újra indulás után ha egy Bluetooth eszköz csatlakozik.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Show the system\'s volume window while this app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
     <string name="description_volume_listener">Stay active while a device is connected and save volume changes that have not been caused by this app.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">The key type that is sent when an autoplay enabled device connects.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Menampilkan jendela volume sistem saat aplikasi membuat penyesuaian.</string>
     <string name="label_volume_listener">Mengamati perubahan</string>
     <string name="description_volume_listener">Tetap aktif saat perangkat terhubung dan menyimpan perubahan volume yang tidak disebabkan oleh aplikasi.</string>
-    <string name="label_autoplay_keytype">Jenis kunci main otomatis</string>
-    <string name="desc_autoplay_keytype">Jenis kunci yang dikirim ketika perangkat putar otomatis terhubung.</string>
     <string name="label_boot_restore">Kembalikan saat dinyalakan</string>
     <string name="description_boot_restore">Kembalikan volume saat dinyalakan bila terdapat perangkat Bluetooth terhubung.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -109,8 +109,6 @@
     <string name="description_visible_volume_adjustments">Mostra la finestra di sistema dei volumi mentre quest\'app apporta delle regolazioni.</string>
     <string name="label_volume_listener">Rilevamento modifiche</string>
     <string name="description_volume_listener">Resta attivo mentre un dispositivo è connesso e salva le modifiche ai volumi non applicate da quest\'app.</string>
-    <string name="label_autoplay_keytype">Autoplay</string>
-    <string name="desc_autoplay_keytype">Il tipo di comportamento da avere quando un dispositivo autoplay compatibile viene connesso.</string>
     <string name="label_boot_restore">Ripristino all\'avvio</string>
     <string name="description_boot_restore">Ripristina i volumi dopo un avvio o un riavvio se un dispositivo Bluetooth è connesso.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">הצגת חלון ווליום של המערכת כאשר ההתאמות נעשות על ידי אפליקציה זו.</string>
     <string name="label_volume_listener">צפייה בשינויים</string>
     <string name="description_volume_listener">להשאיר פעיל כאשר התקן מחובר ושמירת שינויי ווליום שלא נגרמו על ידי אפליקציה זו.</string>
-    <string name="label_autoplay_keytype">סוג פעולת ניגון אוטומטי</string>
-    <string name="desc_autoplay_keytype">סוג הפעולה שנשלחת כאשר מכשיר עם ניגון אוטומטי מתחבר.</string>
     <string name="label_boot_restore">שחזור באתחול</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -109,8 +109,6 @@
     <string name="description_visible_volume_adjustments">このアプリが音量を調節する際に、システムの音量ウィンドウを表示します。</string>
     <string name="label_volume_listener">変更の監視</string>
     <string name="description_volume_listener">デバイスが接続されている間はアプリを常駐させて、このアプリ以外による音量の変更を保存します。</string>
-    <string name="label_autoplay_keytype">自動再生のキー種類</string>
-    <string name="desc_autoplay_keytype">自動再生対応デバイスが接続されたときに送信されるキーの種類です。</string>
     <string name="label_boot_restore">起動時に復元</string>
     <string name="description_boot_restore">Bluetoothデバイスが接続されている場合、起動/再起動後に音量を復元します。</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">이 앱이 설정을 변경할 때 시스템 음량 창을 표시합니다.</string>
     <string name="label_volume_listener">변경 관측</string>
     <string name="description_volume_listener">이 앱이 행하지 않은 음량 변경 사항을 저장합니다. 디바이스가 연결되어 있을 때 이 앱이 계속 켜져 있게 됩니다.</string>
-    <string name="label_autoplay_keytype">자동 재생 키 유형</string>
-    <string name="desc_autoplay_keytype">자동 재생이 가능한 디바이스가 연결되었을 때 전송되는 키 유형입니다.</string>
     <string name="label_boot_restore">부트 후 복구</string>
     <string name="description_boot_restore">안드로이드가 시작 또는 재시작된 뒤 블루투스 디바이스가 연결되어 있을 경우 음량을 복구합니다.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Rodo sistemos garsumo panelės langą programai keičiant garsumą.</string>
     <string name="label_volume_listener">Stebėti pokyčius</string>
     <string name="description_volume_listener">Laikyti aktyviu kai įrenginys prijungtas ir valdomas garsumas.</string>
-    <string name="label_autoplay_keytype">Automatinio paleidimo komanda</string>
-    <string name="desc_autoplay_keytype">Komanda, kuri automatiškai siunčiama prisijungiančiam įrenginiui.</string>
     <string name="label_boot_restore">Atstatyti įjungiant</string>
     <string name="description_boot_restore">Atstato garsumą po įjungimo/perkrovimo jei Bluetooth įrenginys prijungtas.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Show the system\'s volume window while this app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
     <string name="description_volume_listener">Stay active while a device is connected and save volume changes that have not been caused by this app.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">The key type that is sent when an autoplay enabled device connects.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Прикажи го системскиот прозорец за јачина на звукот додека оваа апликација прави прилагодувања.</string>
     <string name="label_volume_listener">Надгледува на промени</string>
     <string name="description_volume_listener">Останува активна додека е поврзан уредот и зачувај ги промените на звукот кои не се предизвикани од оваа апликација.</string>
-    <string name="label_autoplay_keytype">Тип на клуч од автоматско прикажување</string>
-    <string name="desc_autoplay_keytype">Тип на клуч што е испратен кога е поврзан уред со овозможен автостарт.</string>
     <string name="label_boot_restore">Врати на подигање</string>
     <string name="description_boot_restore">Враќање волумен по подигнување/рестартирање ако е поврзан уред со Блутут.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Tampilkan tetingkap volum sistem sementara apl ini melakukan pelarasan.</string>
     <string name="label_volume_listener">Perhatikan perubahan</string>
     <string name="description_volume_listener">Kekal aktif sementara peranti dihubungkan dan simpan perubahan volum yang tiada terkesan dari apl ini.</string>
-    <string name="label_autoplay_keytype">Jenis kekunci automain</string>
-    <string name="desc_autoplay_keytype">Jenis kekunci yang dihantar apabila automain peranti didayakan terhubung.</string>
     <string name="label_boot_restore">Simpan semula semasa boot</string>
     <string name="description_boot_restore">Simpan semula volum selepas booting/rebooting jika peranti Bluetooth disambungkan.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Show the system\'s volume window while this app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
     <string name="description_volume_listener">Stay active while a device is connected and save volume changes that have not been caused by this app.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">The key type that is sent when an autoplay enabled device connects.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Het systeem volume venster weergegeven terwijl deze app aanpassingen maakt.</string>
     <string name="label_volume_listener">Observeer wijzigingen</string>
     <string name="description_volume_listener">Actief blijven terwijl een apparaat is aangesloten en sla de volume veranderingen die niet zijn veroorzaakt door deze app op.</string>
-    <string name="label_autoplay_keytype">AutoPlay sleuteltype</string>
-    <string name="desc_autoplay_keytype">Het sleuteltype dat wordt verzonden wanneer een autoplay ingeschakeld apparaat verbinding maakt.</string>
     <string name="label_boot_restore">Herstel bij opstarten</string>
     <string name="description_boot_restore">Volume terugzet na het opstarten/rebooten als een Bluetooth-apparaat is aangesloten.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Vis systemets volumvindu når denne appen gjør endringer.</string>
     <string name="label_volume_listener">Observer endringer</string>
     <string name="description_volume_listener">Forbli aktiv mens en enhet er koblet til og lagre volumendringer som ikke har blitt forårsaket av denne appen.</string>
-    <string name="label_autoplay_keytype">Autospill knapptype</string>
-    <string name="desc_autoplay_keytype">Knapptypen som er sendt når en autospillaktivert enhet kobles til.</string>
     <string name="label_boot_restore">Gjenopprett på oppstart</string>
     <string name="description_boot_restore">Gjenopprett volum etter oppstart/omstart hvis en Bluetooth-enhet er tilkoblet.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-pcm-rNG/strings.xml
+++ b/app/src/main/res/values-pcm-rNG/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Show de system\'s volume window while dis dey app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
     <string name="description_volume_listener">Stay active while de device dey connected and save volume changes wey not fit caused by dis app.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">De key type wey dey sent wen an autoplay enabled device connects.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Wyświetla systemowe okno głośności, podczas zmiany wartości przez aplikację.</string>
     <string name="label_volume_listener">Obserwacja zmian</string>
     <string name="description_volume_listener">Pozostaje aktywna, gdy urządzenie jest podłączone i rejestruje zmiany głośności, które nie zostały wprowadzone przez aplikację.</string>
-    <string name="label_autoplay_keytype">Typ przycisku auto-odtwarzania</string>
-    <string name="desc_autoplay_keytype">Funkcja przycisku, która jest uaktywniana, gdy podłączone zostaje urządzenia z automatycznym odtwarzaniem.</string>
     <string name="label_boot_restore">Przywróć przy uruchomieniu</string>
     <string name="description_boot_restore">Przywraca głośność po ponownym uruchomieniu, jeśli urządzenie Bluetooth zostanie podłączone.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -109,8 +109,6 @@
     <string name="description_visible_volume_adjustments">Mostra a janela de volume do sistema enquanto este aplicativo faz ajustes.</string>
     <string name="label_volume_listener">Acompanhar as mudanças</string>
     <string name="description_volume_listener">Mantenha-se ativo enquanto um dispositivo estiver conectado e salve as alterações de volume que não forem decorrente deste aplicativo.</string>
-    <string name="label_autoplay_keytype">Tipo de tecla de reprodução automática</string>
-    <string name="desc_autoplay_keytype">O tipo de tecla que é transmitida quando se conecta um dispositivo habilitado para reprodução automática.</string>
     <string name="label_boot_restore">Restaurar ao ligar</string>
     <string name="description_boot_restore">Restaura o volume após a inicialização/reinicialização caso um dispositivo Bluetooth esteja conectado.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Mostra a janela de volume do sistema enquanto a aplicação estiver a fazer as alterações.</string>
     <string name="label_volume_listener">Observar alterações</string>
     <string name="description_volume_listener">Manter atividade enquanto um dispositivo é conectado e guardar alterações de volume não criadas por esta aplicação.</string>
-    <string name="label_autoplay_keytype">Tipo de toque para reprodução automática</string>
-    <string name="desc_autoplay_keytype">O tipo de toque enviado quando um dispositivo de reprodução automática é conectado.</string>
     <string name="label_boot_restore">Restaurar ao iniciar</string>
     <string name="description_boot_restore">Restaura o volume depois de iniciar/reiniciar o dispositivo se o dispositivo Bluetooth estiver conectado.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Show the system\'s volume window while this app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
     <string name="description_volume_listener">Stay active while a device is connected and save volume changes that have not been caused by this app.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">The key type that is sent when an autoplay enabled device connects.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -109,8 +109,6 @@
     <string name="description_visible_volume_adjustments">Отображение окна системной громкости при выполнении приложением настроек.</string>
     <string name="label_volume_listener">Отслеживание изменений</string>
     <string name="description_volume_listener">Поддержание активного режима при наличии подключенного устройства и сохранение изменений громкости, выполненных вне данного приложения.</string>
-    <string name="label_autoplay_keytype">Кнопка автовоспроизведения</string>
-    <string name="desc_autoplay_keytype">Кнопка, симуляция которой запускает автовоспроизведение на подключаемом устройстве.</string>
     <string name="label_boot_restore">Восстановить при загрузке</string>
     <string name="description_boot_restore">Восстановление громкости после загрузки/перезагрузки при подключенном устройстве Bluetooth.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Show the system\'s volume window while this app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
     <string name="description_volume_listener">Stay active while a device is connected and save volume changes that have not been caused by this app.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">The key type that is sent when an autoplay enabled device connects.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Zobraziť systémový panel hlasitosti počas vykonávania zmien aplikáciou.</string>
     <string name="label_volume_listener">Sledovanie zmien</string>
     <string name="description_volume_listener">Majte sa na pozore počas pripojenia zariadenia a uložte zmeny hlasitosti, ktoré vykonala aplikácia.</string>
-    <string name="label_autoplay_keytype">Typ tlačidla automatického prehrávania</string>
-    <string name="desc_autoplay_keytype">Typ tlačidla, ktorý je odoslaný po pripojení zariadenia so zapnutým automatickým prehrávaním.</string>
     <string name="label_boot_restore">Obnovenie po štarte</string>
     <string name="description_boot_restore">Obnoví hlasitosť pri štarte/reštarte ak je Bluetooth zariadenie pripojené.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Show the system\'s volume window while this app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
     <string name="description_volume_listener">Stay active while a device is connected and save volume changes that have not been caused by this app.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">The key type that is sent when an autoplay enabled device connects.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Show the system\'s volume window while this app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
     <string name="description_volume_listener">Stay active while a device is connected and save volume changes that have not been caused by this app.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">The key type that is sent when an autoplay enabled device connects.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Visa systemets volymfönster medan den här appen gör justeringar.</string>
     <string name="label_volume_listener">Observera förändringar</string>
     <string name="description_volume_listener">Fortsätt vara aktiv medan en enhet är ansluten och spara volymförändringar som inte har orsakats av den här appen.</string>
-    <string name="label_autoplay_keytype">Autoplay-nyckeltyp</string>
-    <string name="desc_autoplay_keytype">Nyckeltypen som skickas när en autoplay-aktiverad enhet ansluter.</string>
     <string name="label_boot_restore">Återställ vid omstart av enheten</string>
     <string name="description_boot_restore">Återställ volymen efter uppstart / omstart om en Bluetooth-enhet är ansluten.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">ปรับการแสดงหน้าต่างข้อมูลของระบบในขณะนี้</string>
     <string name="label_volume_listener">สังเกตการเปลี่ยนแปลง</string>
     <string name="description_volume_listener">ยังคงใช้งานในขณะที่อุปกรณ์เชื่อมต่อ และบันทึกการเปลี่ยนแปลงระดับเสียงที่ไม่ได้เกิดจากการตรวจสอบนี้</string>
-    <string name="label_autoplay_keytype">ชนิดคีย์\'เล่นอัตโนมัติ\'</string>
-    <string name="desc_autoplay_keytype">ชนิดคีย์ที่ส่งเชื่อมต่อเมื่ออุปกรณ์เปิดใช้งาน\'เล่นอัตโนมัติ\'</string>
     <string name="label_boot_restore">เรียกคืนเมื่อบูต</string>
     <string name="description_boot_restore">คืนค่าระดับเสียงหลังจากบูต/รีบูตเครื่องถ้าเชื่อมต่ออุปกรณ์บลูทูธแล้ว</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-tl-rPH/strings.xml
+++ b/app/src/main/res/values-tl-rPH/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Pagpapakita sa sistema ng volume window habang ang app na ito at nagaadjust.</string>
     <string name="label_volume_listener">Tingnan ang pagbabago</string>
     <string name="description_volume_listener">Manatiling active habang ang device ay konektado at isave ang pagbabago sa lakas ng tunog na hindi ginawa ng app na ito.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">Ang key type na naipadala kapag kumonekta ang naka-autoplay na devive.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Bu uygulama ayarlamalar yaparken sistemin ses düzeyi penceresini göster.</string>
     <string name="label_volume_listener">Değişiklikleri gözlemle</string>
     <string name="description_volume_listener">Bir cihaz bağlıyken aktif kalın ve bu uygulamanın neden olmadığı ses seviyesi değişikliklerini kaydedin.</string>
-    <string name="label_autoplay_keytype">Otomatik oynatma anahtar türü</string>
-    <string name="desc_autoplay_keytype">Otomatik oynatma özellikli bir cihaz bağlandığında gönderilen anahtar türü.</string>
     <string name="label_boot_restore">Cihaz açılırken başlat</string>
     <string name="description_boot_restore">Bluetooth cihazı bağlıysa, önyükleme / yeniden başlatma sonrasında sesi geri yükleyin.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Виводити вікно системної гучності при налаштуваннях цим додатком.</string>
     <string name="label_volume_listener">Відстеження змін</string>
     <string name="description_volume_listener">Залишатись активним доки пристрій приєднаний та зберігати зміни гучності, внесені іншими додатками.</string>
-    <string name="label_autoplay_keytype">Тип кнопки Автовідтворення</string>
-    <string name="desc_autoplay_keytype">Тип команди, яка надходить на під\'єднаний пристрій з увімкненим Автовідтворенням.</string>
     <string name="label_boot_restore">Відновити при завантаженні</string>
     <string name="description_boot_restore">Відновлення гучності після завантаження/перезавантаження, якщо пристрій Bluetooth під\'єднано.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">Hiển thị cửa sổ âm lượng của hệ thống trong khi ứng dụng này thực hiện các điều chỉnh.</string>
     <string name="label_volume_listener">Theo dõi các thay đổi</string>
     <string name="description_volume_listener">Luôn hoạt động trong khi thiết bị được kết nối và lưu các thay đổi âm lượng không do ứng dụng này.</string>
-    <string name="label_autoplay_keytype">Kiểu nút tự động phát</string>
-    <string name="desc_autoplay_keytype">Loại nút được gửi khi kết nối thiết bị tự động phát.</string>
     <string name="label_boot_restore">Khôi phục khi khởi động</string>
     <string name="description_boot_restore">Khôi phục âm lượng sau khi khởi động/khởi động lại nếu một thiết bị Bluetooth được kết nối.</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -109,8 +109,6 @@
     <string name="description_visible_volume_adjustments">此应用调整音量时，显示系统的音量调节窗口。</string>
     <string name="label_volume_listener">检查音量变化</string>
     <string name="description_volume_listener">设备连接时保持活动状态，并保存非此应用引起的音量更改。</string>
-    <string name="label_autoplay_keytype">自动播放设置</string>
-    <string name="desc_autoplay_keytype">当启用自动播放功能的设备连接时发送的密钥类型。</string>
     <string name="label_boot_restore">开机恢复配置</string>
     <string name="description_boot_restore">在开机/重启后，如果连接到蓝牙设备，则恢复其音量。</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -105,8 +105,6 @@
     <string name="description_visible_volume_adjustments">在此應用調整時顯示系統音量視窗。</string>
     <string name="label_volume_listener">檢查音量變更</string>
     <string name="description_volume_listener">在裝置連線時保持活動狀態，並保存不是由這個應用程式引起的音量變更。</string>
-    <string name="label_autoplay_keytype">自動播放鍵型式</string>
-    <string name="desc_autoplay_keytype">啟用自動播放功能的裝置連線時傳送的按鍵類型。</string>
     <string name="label_boot_restore">開機後復原</string>
     <string name="description_boot_restore">在開機/重新開機後，如果連上藍牙裝置就復原音量。</string>
     <string name="settings_support_label">Support</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -146,8 +146,6 @@
     <string name="description_visible_volume_adjustments">Show the system\'s volume window while this app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
     <string name="description_volume_listener">Stay active while a device is connected and save volume changes that have not been caused by this app.</string>
-    <string name="label_autoplay_keytype">Autoplay key type</string>
-    <string name="desc_autoplay_keytype">The key type that is sent when an autoplay enabled device connects.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
 


### PR DESCRIPTION
This commit removes the autoplay key type setting from the app. This includes removing the setting from the UI, ViewModel, and DataStore. It also removes the associated string resources for all languages.