### PR TITLE
Refactor: Migrate legacy settings and improve Realm migration

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/legacy/LegacyMigration.kt
+++ b/app/src/main/java/eu/darken/bluemusic/legacy/LegacyMigration.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.legacy
 
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.common.datastore.value
 import eu.darken.bluemusic.common.datastore.valueBlocking
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.DEBUG
@@ -8,6 +9,9 @@ import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.DevicesSettings
+import eu.darken.bluemusic.devices.core.currentDevices
 import eu.darken.bluemusic.main.core.CurriculumVitae
 import eu.darken.bluemusic.main.core.GeneralSettings
 import eu.darken.bluemusic.main.core.LegacySettings
@@ -19,13 +23,31 @@ import javax.inject.Singleton
 @Singleton
 class LegacyMigration @Inject constructor(
     private val generalSettings: GeneralSettings,
+    private val devicesSettings: DevicesSettings,
     private val legacySettings: LegacySettings,
     private val curriculumVitae: CurriculumVitae,
     private val realmToRoomMigrator: RealmToRoomMigrator,
+    private val deviceRepo: DeviceRepo,
 ) {
 
     fun migration() = runBlocking {
         log(TAG) { "migration()" }
+        if (!generalSettings.legacyDatabaseMigrationDone.valueBlocking) {
+            log(TAG, INFO) { "migration():  Realm/Room migration required" }
+            try {
+                val migrationSuccess = realmToRoomMigrator.migrate()
+                if (migrationSuccess) {
+                    log(TAG, DEBUG) { "migration(): Data migration completed successfully" }
+                    realmToRoomMigrator.cleanUp()
+                    generalSettings.legacyDatabaseMigrationDone.value(true)
+                }
+            } catch (e: Exception) {
+                log(TAG, ERROR) { "migration(): Data migration failed: ${e.asLog()}" }
+            }
+        } else {
+            log(TAG, INFO) { "migration(): Realm/Room migration already done" }
+        }
+
         if (!generalSettings.legacySettingsMigrationDone.valueBlocking) {
             log(TAG, INFO) { "migration(): Legacy settings migration required" }
 
@@ -33,23 +55,36 @@ class LegacyMigration @Inject constructor(
                 installedAt = Instant.ofEpochMilli(legacySettings.getInstallTime()),
                 launchCount = legacySettings.getLaunchCount(),
             )
-            // TODO Migrate LegacySettings
 
+            devicesSettings.isEnabled.value(legacySettings.isEnabled())
+            devicesSettings.restoreOnBoot.value(legacySettings.isBootRestoreEnabled())
             generalSettings.legacySettingsMigrationDone.value(true)
-        }
 
-        if (!generalSettings.legacyDatabaseMigrationDone.valueBlocking) {
-            log(TAG, INFO) { "migration():  Realm/Room migration required" }
-            try {
-                val migrationSuccess = realmToRoomMigrator.migrate()
-                if (migrationSuccess) {
-                    log(TAG, DEBUG) { "migration(): Data migration completed successfully" }
-                    realmToRoomMigrator.cleanupRealmFiles()
-                    generalSettings.legacySettingsMigrationDone.value(true)
+            val devices = deviceRepo.currentDevices()
+
+            val visibleAdjustment = legacySettings.isVolumeAdjustedVisibly()
+            log(TAG) { "migration(): Visible adjustment: $visibleAdjustment" }
+            val volumeObserving = legacySettings.isVolumeChangeListenerEnabled()
+            log(TAG) { "migration(): Volume observing: $volumeObserving" }
+            devices.map { it.address }.forEach { addr ->
+                log(TAG) { "migration(): Updating $addr" }
+                deviceRepo.updateDevice(addr) {
+                    it.copy(
+                        visibleAdjustments = visibleAdjustment,
+                        volumeObserving = volumeObserving,
+                    )
                 }
-            } catch (e: Exception) {
-                log(TAG, ERROR) { "migration(): Data migration failed: ${e.asLog()}" }
             }
+
+            devices.singleOrNull { it.type == SourceDevice.Type.PHONE_SPEAKER }?.let { speakerDev ->
+                deviceRepo.updateDevice(speakerDev.address) {
+                    val speakerAutoSave = legacySettings.isSpeakerAutoSaveEnabled()
+                    log(TAG) { "migration(): Saving  isSpeakerAutoSaveEnabled=$speakerAutoSave" }
+                    it.copy(volumeSaveOnDisconnect = speakerAutoSave)
+                }
+            }
+        } else {
+            log(TAG, INFO) { "migration(): Legacy settings migration already done" }
         }
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/legacy/RealmToRoomMigrator.kt
+++ b/app/src/main/java/eu/darken/bluemusic/legacy/RealmToRoomMigrator.kt
@@ -11,9 +11,11 @@ import eu.darken.bluemusic.devices.core.database.DeviceDatabase
 import eu.darken.bluemusic.devices.core.database.legacy.DeviceConfig
 import io.realm.Realm
 import io.realm.RealmConfiguration
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.withContext
+import java.io.File
+import java.util.concurrent.Executors
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,29 +24,49 @@ class RealmToRoomMigrator @Inject constructor(
     @ApplicationContext private val context: Context,
     private val deviceDatabase: DeviceDatabase,
 ) {
+    private val realmExecutor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "Realm-Migration-Thread")
+    }
+    private val realmDispatcher = realmExecutor.asCoroutineDispatcher()
 
-    suspend fun migrate(): Boolean = withContext(Dispatchers.IO + NonCancellable) {
+    private fun getRealmFiles(): List<File> {
+        val filesDir = context.filesDir
+        return listOf(
+            "default.realm",
+            "default.realm.lock",
+            "default.realm.note",
+            ".realm.temp",
+            "default.realm.management"
+        ).map { File(filesDir, it) }
+    }
+
+    suspend fun migrate(): Boolean = withContext(NonCancellable + realmDispatcher) {
         try {
             log(TAG) { "Starting Realm to Room migration" }
-            // TODO check if realm files exist?
 
-            // Initialize Realm
+            val anyRealmFileExists = getRealmFiles().any { it.exists() }
+
+            if (!anyRealmFileExists) {
+                log(TAG) { "No Realm files found, skipping migration" }
+                return@withContext true
+            }
+
             Realm.init(context)
-            val realmConfig = RealmConfiguration.Builder()
-                .schemaVersion(9) // Current Realm schema version
-                .build()
+
+            val realmConfig = RealmConfiguration.Builder().apply {
+                schemaVersion(9)
+            }.build()
 
             val realm = Realm.getInstance(realmConfig)
 
-            try {
-                // Read all device configs from Realm
+            val migrationResult = try {
                 val realmDevices = realm.where(DeviceConfig::class.java).findAll()
 
                 log(TAG) { "Found ${realmDevices.size} devices to migrate" }
 
-                // Convert and insert into Room
-                realmDevices.forEach { realmDevice ->
-                    val roomDevice = DeviceConfigEntity(
+                // Copy data to avoid accessing Realm objects after closing
+                realmDevices.map { realmDevice ->
+                    DeviceConfigEntity(
                         address = realmDevice.address ?: "",
                         lastConnected = realmDevice.lastConnected,
                         actionDelay = realmDevice.actionDelay,
@@ -61,36 +83,52 @@ class RealmToRoomMigrator @Inject constructor(
                         autoplay = realmDevice.autoplay,
                         launchPkgs = realmDevice.launchPkg?.let { listOf(it) } ?: emptyList()
                     )
-
-                    deviceDatabase.devices.updateDevice(roomDevice)
-                    log(TAG) { "Migrated device: ${roomDevice.address}" }
                 }
-
-                log(TAG) { "Migration completed successfully" }
-                true
             } finally {
                 realm.close()
             }
+
+            migrationResult.forEach { roomDevice ->
+                deviceDatabase.devices.updateDevice(roomDevice)
+                log(TAG) { "Migrated device: ${roomDevice.address}" }
+            }
+
+            log(TAG) { "Migration completed successfully" }
+            true
         } catch (e: Exception) {
             log(TAG, ERROR) { "Migration failed: ${e.asLog()}" }
             false
         }
     }
 
-    suspend fun cleanupRealmFiles() = withContext(Dispatchers.IO + NonCancellable) {
+    suspend fun cleanUp() = withContext(realmDispatcher + NonCancellable) {
         try {
-            context.deleteDatabase("default.realm")
-            context.deleteDatabase("default.realm.lock")
-            context.deleteDatabase("default.realm.note")
-            context.deleteDatabase("default.realm.management")
+            val realmFiles = getRealmFiles()
 
-            log(TAG) { "Realm files cleaned up" }
+            realmFiles.forEach { file ->
+                if (file.exists()) {
+                    val deleted = if (file.isDirectory) {
+                        file.deleteRecursively()
+                    } else {
+                        file.delete()
+                    }
+
+                    if (deleted) {
+                        log(TAG) { "Deleted: ${file.name}" }
+                    } else {
+                        log(TAG) { "Failed to delete: ${file.name}" }
+                    }
+                }
+            }
+
+            log(TAG) { "Realm cleanup completed" }
         } catch (e: Exception) {
             log(TAG, ERROR) { "Failed to cleanup Realm files: ${e.asLog()}" }
         }
     }
 
     companion object {
+
         private val TAG = logTag("Legacy", "Migration", "RealmToRoom")
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/main/core/LegacySettings.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/core/LegacySettings.kt
@@ -1,7 +1,6 @@
 package eu.darken.bluemusic.main.core
 
 import android.content.Context
-import android.view.KeyEvent
 import androidx.core.content.edit
 import androidx.preference.PreferenceManager
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -25,10 +24,6 @@ class LegacySettings @Inject constructor(
         preferences.edit { putInt(PREFKEY_LAUNCHCOUNT, ++currentLaunchCount) }
     }
 
-    fun isBugReportingEnabled(): Boolean {
-        return preferences!!.getBoolean(PREFKEY_BUGREPORTING, true)
-    }
-
     fun isVolumeAdjustedVisibly(): Boolean {
         return preferences!!.getBoolean(PREFKEY_VISIBLE_ADJUSTMENTS, true)
     }
@@ -39,14 +34,6 @@ class LegacySettings @Inject constructor(
 
     fun isEnabled(): Boolean {
         return preferences!!.getBoolean(PREFKEY_CORE_ENABLED, true)
-    }
-
-    fun getAutoplayKeycode(): Int {
-        return preferences!!.getInt(PREFKEY_AUTOPLAY_KEYCODE, KeyEvent.KEYCODE_MEDIA_PLAY)
-    }
-
-    fun setAutoplayKeycode(keycode: Int) {
-        preferences!!.edit { putInt(PREFKEY_AUTOPLAY_KEYCODE, keycode) }
     }
 
     fun isSpeakerAutoSaveEnabled(): Boolean {
@@ -65,30 +52,14 @@ class LegacySettings @Inject constructor(
         return preferences!!.getBoolean(PREFKEY_BOOT_RESTORE, true)
     }
 
-    fun isShowOnboarding(): Boolean {
-        return preferences!!.getBoolean(PREFKEY_ONBOARDING_INTRODONE, true)
-    }
-
-    fun setShowOnboarding(show: Boolean) {
-        preferences!!.edit { putBoolean(PREFKEY_ONBOARDING_INTRODONE, show) }
-    }
-
-    fun isHealthDeviceExcluded(): Boolean {
-        return preferences!!.getBoolean(PREFKEY_ADVANCED_EXCLUDE_HEALTHDEVICES, true)
-    }
-
     companion object {
         const val PREFKEY_VOLUMELISTENER: String = "core.volume.changelistener"
         const val PREFKEY_VISIBLE_ADJUSTMENTS: String = "core.volume.visibleadjustments"
-        const val PREFKEY_AUTOPLAY_KEYCODE: String = "core.autoplay.keycode"
         const val PREFKEY_SPEAKER_AUTOSAVE: String = "core.speaker.autosave"
 
         const val PREFKEY_INSTALLTIME: String = "core.metrics.installtime"
         const val PREFKEY_LAUNCHCOUNT: String = "core.metrics.launchcount"
         const val PREFKEY_BOOT_RESTORE: String = "core.onboot.restore"
-        const val PREFKEY_ONBOARDING_INTRODONE: String = "core.onboarding.introdone"
-        const val PREFKEY_ADVANCED_EXCLUDE_HEALTHDEVICES: String = "core.advanced.exclude.healthdevices"
-        const val PREFKEY_BUGREPORTING: String = "core.bugreporting.enabled"
         const val PREFKEY_CORE_ENABLED: String = "core.enabled"
     }
 }


### PR DESCRIPTION
- Migrate remaining settings from `LegacySettings` to new DataStore preferences.
- Enhance `RealmToRoomMigrator`:
    - Run migration on a dedicated thread.
    - Check for Realm file existence before migration.
    - Improve Realm file cleanup logic.
- Remove unused code from `LegacySettings`.