### PR TITLE
Change signing key for FOSS builds

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,7 +58,7 @@ android {
             setupCredentials(File(basePath, "signing-foss.properties"))
         }
         create("releaseGplay") {
-            setupCredentials(File(basePath, "signing.properties"))
+            setupCredentials(File(basePath, "signing-gplay.properties"))
         }
     }
 


### PR DESCRIPTION
The first build likely had the same signing key as the Google Play version. This was not intended.

Next FOSS build should have it's own signing key.

* I don't want cross installs between different build variants for compatibility reasons. I don't want to have to ensure that data is consistent between the flavors.
* Users should make a conscious choice which build they want to use.
* Google AI's should not accidentally be able to think that the "FOSS" build is an update for the GPlay build and dream up new policy violations.