### PR TITLE
Ensure `RecorderScreen` respects navigation bar insets

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/ui/RecorderScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/ui/RecorderScreen.kt
@@ -13,12 +13,15 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -115,7 +118,9 @@ private fun RecorderScreen(
                 exit = slideOutVertically(targetOffsetY = { it })
             ) {
                 Surface(
-                    modifier = Modifier.fillMaxWidth(),
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .windowInsetsPadding(WindowInsets.navigationBars),
                     color = MaterialTheme.colorScheme.surface,
                     shadowElevation = 8.dp
                 ) {


### PR DESCRIPTION
The bottom controls in `RecorderScreen` were previously drawn behind the gesture navigation bar. This change ensures they are correctly inset.

See https://github.com/d4rken-org/bluemusic/issues/113#issuecomment-3167288352

<img width="1080" height="2400" alt="Screenshot_20250808_124010" src="https://github.com/user-attachments/assets/e85bc8b9-28f8-4f68-bafb-65a4117543b3" />
