### PR TITLE
Enable generation of `localeConfig`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -159,7 +159,7 @@ android {
 
     androidResources {
         @Suppress("UnstableApiUsage")
-        generateLocaleConfig = false // TODO: Fix resources.properties file
+        generateLocaleConfig = true
     }
 
     packaging {

--- a/app/src/main/res/resources.properties
+++ b/app/src/main/res/resources.properties
@@ -1,0 +1,1 @@
+unqualifiedResLocale=en-US


### PR DESCRIPTION
The `generateLocaleConfig` build feature was disabled. This commit enables it and provides the `resource.properties` file with `en-US` as the default locale.

Fixes https://github.com/d4rken-org/bluemusic/issues/113#issuecomment-3168016594