### PR TITLE
Fix crashing when navigating quickly

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -286,15 +286,15 @@ dependencies {
     implementation("androidx.compose.material3.adaptive:adaptive")
 
     implementation("androidx.activity:activity-compose:1.10.1")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.2")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.9.3")
 
-    implementation("androidx.hilt:hilt-navigation-compose:1.3.0-alpha02")
+    implementation("androidx.hilt:hilt-navigation-compose:1.3.0-rc01")
 
     implementation("com.google.accompanist:accompanist-drawablepainter:0.37.3")
 
 
-    implementation("androidx.navigation3:navigation3-runtime:1.0.0-alpha06")
-    implementation("androidx.navigation3:navigation3-ui:1.0.0-alpha06")
+    implementation("androidx.navigation3:navigation3-runtime:1.0.0-alpha08")
+    implementation("androidx.navigation3:navigation3-ui:1.0.0-alpha08")
 
     implementation("androidx.compose.material3.adaptive:adaptive-navigation3:1.0.0-SNAPSHOT")
     implementation("androidx.lifecycle:lifecycle-viewmodel-navigation3:1.0.0-alpha04")


### PR DESCRIPTION
Possible fix for:

```java
Exception java.lang.IllegalArgumentException: NavDisplay backstack cannot be empty
  at androidx.navigation3.ui.NavDisplay.NavDisplay (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:409)
  at eu.darken.bluemusic.main.ui.MainActivity.Navigation (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:448)
  at androidx.compose.foundation.CanvasKt$$ExternalSyntheticLambda0.invoke (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:305)
  at androidx.compose.runtime.internal.ComposableLambdaImpl.invoke (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:10)
  at androidx.compose.runtime.internal.ComposableLambdaImpl$invoke$1.invoke (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:65)
  at androidx.compose.runtime.ComposerImpl.recomposeToGroupEnd (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:549)
  at androidx.compose.runtime.ComposerImpl.skipCurrentGroup (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:168)
  at androidx.compose.runtime.ComposerImpl.doCompose-aFTiNEg (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:121)
  at androidx.compose.runtime.CompositionImpl.recompose (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:82)
  at androidx.compose.runtime.Recomposer.performRecompose (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:100)
  at androidx.compose.runtime.Recomposer$runRecomposeAndApplyChanges$2$$ExternalSyntheticLambda0.invoke (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:540)
  at androidx.compose.ui.platform.AndroidUiFrameClock$withFrameNanos$2$callback$1.doFrame (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:7)
  at androidx.compose.ui.platform.AndroidUiDispatcher$dispatchCallback$1.doFrame (r8-map-id-6bfe9880fbea13de34e9c258ad328b42e86f845e87835db3b53f0ca046a77f01:48)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1819)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1830)
  at android.view.Choreographer.doCallbacks (Choreographer.java:1318)
  at android.view.Choreographer.doFrame (Choreographer.java:1184)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:1789)
  at android.os.Handler.handleCallback (Handler.java:959)
  at android.os.Handler.dispatchMessage (Handler.java:100)
  at android.os.Looper.loopOnce (Looper.java:249)
  at android.os.Looper.loop (Looper.java:337)
  at android.app.ActivityThread.main (ActivityThread.java:9511)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:636)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1005)
  ```