### PR TITLE
Add Bluetooth settings shortcut to dashboard toolbar

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BluetoothDisabled
 import androidx.compose.material.icons.twotone.Add
+import androidx.compose.material.icons.twotone.Bluetooth
 import androidx.compose.material.icons.twotone.Lock
 import androidx.compose.material.icons.twotone.Settings
 import androidx.compose.material.icons.twotone.Stars
@@ -201,6 +202,8 @@ private fun ManagedDevicesTopBar(
     onNavigateToSettings: () -> Unit,
     onNavigateToUpgrade: () -> Unit
 ) {
+    val context = LocalContext.current
+    
     TopAppBar(
         title = {
             if (isProVersion) {
@@ -213,6 +216,15 @@ private fun ManagedDevicesTopBar(
             }
         },
         actions = {
+            IconButton(onClick = {
+                val intent = Intent(android.provider.Settings.ACTION_BLUETOOTH_SETTINGS)
+                context.startActivity(intent)
+            }) {
+                Icon(
+                    imageVector = Icons.TwoTone.Bluetooth,
+                    contentDescription = stringResource(R.string.label_bluetooth_settings)
+                )
+            }
             if (!isProVersion) {
                 IconButton(onClick = onNavigateToUpgrade) {
                     Icon(


### PR DESCRIPTION
Adds a two-tone Bluetooth icon to the dashboard toolbar that opens system Bluetooth settings when tapped. The icon is positioned before existing settings/upgrade icons and uses localized content description.

<img width="436" height="478" alt="Screenshot 2025-09-06 at 13 17 49" src="https://github.com/user-attachments/assets/b1397de8-969c-44fa-b47e-a5d711a5dcb8" />
