### PR TITLE
Fix volume settings applied to speaker when Bluetooth is turned off

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverViewModel.kt
@@ -35,7 +35,7 @@ class DiscoverViewModel @Inject constructor(
         upgradeRepo.upgradeInfo,
     ) { bluetoothState, managed, upgradeInfo ->
         State(
-            devices = bluetoothState.devices!!
+            devices = bluetoothState.devices
                 .filterNot { p -> managed.any { p.address == it.address } }
                 .sortedWith(
                     compareBy(

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/DeviceRepo.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/DeviceRepo.kt
@@ -29,10 +29,10 @@ class DeviceRepo @Inject constructor(
         bluetoothRepo.state,
         deviceDatabase.devices.getAllDevices()
     ) { btState, managed ->
-        val pairedMap = btState.devices?.associateBy { it.address }
+        val pairedMap = btState.devices.associateBy { it.address }
         val mappings = managed
             .mapNotNull { config ->
-                val paired = pairedMap?.get(config.address) ?: return@mapNotNull null
+                val paired = pairedMap[config.address] ?: return@mapNotNull null
                 config to paired
             }
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/NewDeviceCreator.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/NewDeviceCreator.kt
@@ -26,7 +26,7 @@ class NewDeviceCreator @Inject constructor(
         val device = bluetoothRepo.state
             .filter { it.isReady }
             .first()
-            .devices!!
+            .devices
             .find { it.address == address } ?: throw IllegalStateException("Device not found: $address")
 
         var config = DeviceConfigEntity(


### PR DESCRIPTION
When Bluetooth is disabled (via settings, airplane mode, or device reboot), Android doesn't fire ACTION_ACL_DISCONNECTED events for connected devices. This caused the app to continue applying Bluetooth device volume settings to the built-in speaker, potentially resulting in unexpected audio levels.

The fix monitors Bluetooth adapter state changes using flatMapLatest on the isEnabled flow. When Bluetooth is turned OFF, pairedDevices now correctly emits only the speaker device, ensuring proper volume settings are applied.

Also refactored BluetoothRepo for better readability:
- Extracted bluetoothDeviceEvents() function from inline callbackFlow
- Moved retryWhen outside flatMapLatest for better state re-evaluation
- Simplified speaker device addition to single location
- Made State.devices non-nullable for type safety

Fixes issue reported via email regarding volume management during BT state changes.