### PR TITLE
Add separate volume increase/decrease delays to rate limiter

### DIFF
--- a/app/schemas/eu.darken.bluemusic.devices.core.database.DevicesRoomDb/2.json
+++ b/app/schemas/eu.darken.bluemusic.devices.core.database.DevicesRoomDb/2.json
@@ -1,0 +1,174 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "ba6c97e7c0fc6eded6015bd9dae63e84",
+    "entities": [
+      {
+        "tableName": "device_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `custom_name` TEXT, `last_connected` INTEGER NOT NULL, `action_delay` INTEGER, `adjustment_delay` INTEGER, `monitoring_duration` INTEGER, `music_volume` REAL, `call_volume` REAL, `ring_volume` REAL, `notification_volume` REAL, `alarm_volume` REAL, `volume_lock` INTEGER NOT NULL, `volume_observing` INTEGER NOT NULL, `volume_rate_limiter` INTEGER NOT NULL, `volume_rate_limit_increase_ms` INTEGER, `volume_rate_limit_decrease_ms` INTEGER, `volume_save_on_disconnect` INTEGER NOT NULL DEFAULT false, `keep_awake` INTEGER NOT NULL, `nudge_volume` INTEGER NOT NULL, `autoplay` INTEGER NOT NULL, `launch_pkgs` TEXT NOT NULL DEFAULT '[]', `show_home_screen` INTEGER NOT NULL DEFAULT false, `autoplay_keycodes` TEXT NOT NULL DEFAULT '[126]', `is_enabled` INTEGER NOT NULL DEFAULT true, `visible_adjustments` INTEGER DEFAULT true, `dnd_mode` TEXT, PRIMARY KEY(`address`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "last_connected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionDelay",
+            "columnName": "action_delay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "adjustmentDelay",
+            "columnName": "adjustment_delay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "monitoringDuration",
+            "columnName": "monitoring_duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "musicVolume",
+            "columnName": "music_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "callVolume",
+            "columnName": "call_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "ringVolume",
+            "columnName": "ring_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "notificationVolume",
+            "columnName": "notification_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "alarmVolume",
+            "columnName": "alarm_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "volumeLock",
+            "columnName": "volume_lock",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeObserving",
+            "columnName": "volume_observing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeRateLimiter",
+            "columnName": "volume_rate_limiter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeRateLimitIncreaseMs",
+            "columnName": "volume_rate_limit_increase_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "volumeRateLimitDecreaseMs",
+            "columnName": "volume_rate_limit_decrease_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "volumeSaveOnDisconnect",
+            "columnName": "volume_save_on_disconnect",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "keepAwake",
+            "columnName": "keep_awake",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nudgeVolume",
+            "columnName": "nudge_volume",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoplay",
+            "columnName": "autoplay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchPkgs",
+            "columnName": "launch_pkgs",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "showHomeScreen",
+            "columnName": "show_home_screen",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "autoplayKeycodes",
+            "columnName": "autoplay_keycodes",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[126]'"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "is_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "visibleAdjustments",
+            "columnName": "visible_adjustments",
+            "affinity": "INTEGER",
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "dndMode",
+            "columnName": "dnd_mode",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "address"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ba6c97e7c0fc6eded6015bd9dae63e84')"
+    ]
+  }
+}

--- a/app/schemas/eu.darken.bluemusic.devices.core.database.DevicesRoomDb/3.json
+++ b/app/schemas/eu.darken.bluemusic.devices.core.database.DevicesRoomDb/3.json
@@ -1,0 +1,174 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 3,
+    "identityHash": "ba6c97e7c0fc6eded6015bd9dae63e84",
+    "entities": [
+      {
+        "tableName": "device_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `custom_name` TEXT, `last_connected` INTEGER NOT NULL, `action_delay` INTEGER, `adjustment_delay` INTEGER, `monitoring_duration` INTEGER, `music_volume` REAL, `call_volume` REAL, `ring_volume` REAL, `notification_volume` REAL, `alarm_volume` REAL, `volume_lock` INTEGER NOT NULL, `volume_observing` INTEGER NOT NULL, `volume_rate_limiter` INTEGER NOT NULL, `volume_rate_limit_increase_ms` INTEGER, `volume_rate_limit_decrease_ms` INTEGER, `volume_save_on_disconnect` INTEGER NOT NULL DEFAULT false, `keep_awake` INTEGER NOT NULL, `nudge_volume` INTEGER NOT NULL, `autoplay` INTEGER NOT NULL, `launch_pkgs` TEXT NOT NULL DEFAULT '[]', `show_home_screen` INTEGER NOT NULL DEFAULT false, `autoplay_keycodes` TEXT NOT NULL DEFAULT '[126]', `is_enabled` INTEGER NOT NULL DEFAULT true, `visible_adjustments` INTEGER DEFAULT true, `dnd_mode` TEXT, PRIMARY KEY(`address`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "last_connected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionDelay",
+            "columnName": "action_delay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "adjustmentDelay",
+            "columnName": "adjustment_delay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "monitoringDuration",
+            "columnName": "monitoring_duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "musicVolume",
+            "columnName": "music_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "callVolume",
+            "columnName": "call_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "ringVolume",
+            "columnName": "ring_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "notificationVolume",
+            "columnName": "notification_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "alarmVolume",
+            "columnName": "alarm_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "volumeLock",
+            "columnName": "volume_lock",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeObserving",
+            "columnName": "volume_observing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeRateLimiter",
+            "columnName": "volume_rate_limiter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeRateLimitIncreaseMs",
+            "columnName": "volume_rate_limit_increase_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "volumeRateLimitDecreaseMs",
+            "columnName": "volume_rate_limit_decrease_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "volumeSaveOnDisconnect",
+            "columnName": "volume_save_on_disconnect",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "keepAwake",
+            "columnName": "keep_awake",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nudgeVolume",
+            "columnName": "nudge_volume",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoplay",
+            "columnName": "autoplay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchPkgs",
+            "columnName": "launch_pkgs",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "showHomeScreen",
+            "columnName": "show_home_screen",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "autoplayKeycodes",
+            "columnName": "autoplay_keycodes",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[126]'"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "is_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "visibleAdjustments",
+            "columnName": "visible_adjustments",
+            "affinity": "INTEGER",
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "dndMode",
+            "columnName": "dnd_mode",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "address"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'ba6c97e7c0fc6eded6015bd9dae63e84')"
+    ]
+  }
+}

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDevice.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDevice.kt
@@ -44,8 +44,10 @@ data class ManagedDevice(
         get() = config.volumeObserving
     val volumeRateLimiter: Boolean
         get() = config.volumeRateLimiter
-    val volumeRateLimitMs: Long
-        get() = config.volumeRateLimitMs ?: 1000L // Default to 1 second
+    val volumeRateLimitIncreaseMs: Long
+        get() = config.volumeRateLimitIncreaseMs ?: 1000L
+    val volumeRateLimitDecreaseMs: Long
+        get() = config.volumeRateLimitDecreaseMs ?: 500L
     val volumeSaveOnDisconnect: Boolean
         get() = config.volumeSaveOnDisconnect
     val autoplay: Boolean

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceConfigEntity.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceConfigEntity.kt
@@ -51,8 +51,11 @@ data class DeviceConfigEntity(
     @ColumnInfo(name = "volume_rate_limiter")
     val volumeRateLimiter: Boolean = false,
 
-    @ColumnInfo(name = "volume_rate_limit_ms")
-    val volumeRateLimitMs: Long? = null,
+    @ColumnInfo(name = "volume_rate_limit_increase_ms")
+    val volumeRateLimitIncreaseMs: Long? = null,
+
+    @ColumnInfo(name = "volume_rate_limit_decrease_ms")
+    val volumeRateLimitDecreaseMs: Long? = null,
 
     @ColumnInfo(name = "volume_save_on_disconnect", defaultValue = "false")
     val volumeSaveOnDisconnect: Boolean = false,

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceDatabase.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceDatabase.kt
@@ -16,6 +16,7 @@ class DeviceDatabase @Inject constructor(
             context,
             DevicesRoomDb::class.java, "managed_devices"
         )
+            .addMigrations(MIGRATION_1_2)
             .build()
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceDatabaseMigrations.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceDatabaseMigrations.kt
@@ -1,0 +1,27 @@
+package eu.darken.bluemusic.devices.core.database
+
+import androidx.room.DeleteColumn
+import androidx.room.migration.AutoMigrationSpec
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+// Migration 1 → 2: Add new columns and copy data from old column
+val MIGRATION_1_2 = object : Migration(1, 2) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        // Add the two new columns for separate increase/decrease rate limits
+        db.execSQL("ALTER TABLE device_configs ADD COLUMN volume_rate_limit_increase_ms INTEGER")
+        db.execSQL("ALTER TABLE device_configs ADD COLUMN volume_rate_limit_decrease_ms INTEGER")
+
+        // Copy existing rate limit values to both new columns
+        db.execSQL("""
+            UPDATE device_configs
+            SET volume_rate_limit_increase_ms = volume_rate_limit_ms,
+                volume_rate_limit_decrease_ms = volume_rate_limit_ms
+            WHERE volume_rate_limit_ms IS NOT NULL
+        """.trimIndent())
+    }
+}
+
+// Migration 2 → 3: Delete old column using AutoMigration
+@DeleteColumn(tableName = "device_configs", columnName = "volume_rate_limit_ms")
+class Migration2To3 : AutoMigrationSpec

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/database/DevicesRoomDb.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/database/DevicesRoomDb.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.devices.core.database
 
+import androidx.room.AutoMigration
 import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
@@ -8,8 +9,9 @@ import androidx.room.TypeConverters
     entities = [
         DeviceConfigEntity::class,
     ],
-    version = 1,
+    version = 3,
     autoMigrations = [
+        AutoMigration(from = 2, to = 3, spec = Migration2To3::class)
     ],
     exportSchema = true,
 )

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/ConfigAction.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/ConfigAction.kt
@@ -24,13 +24,15 @@ sealed interface ConfigAction {
     data object OnEditMonitoringDurationClicked : ConfigAction
     data object OnEditReactionDelayClicked : ConfigAction
     data object OnEditAdjustmentDelayClicked : ConfigAction
-    data object OnEditVolumeRateLimitClicked : ConfigAction
+    data object OnEditVolumeRateLimitIncreaseClicked : ConfigAction
+    data object OnEditVolumeRateLimitDecreaseClicked : ConfigAction
     data object OnRenameClicked : ConfigAction
     data class DeleteDevice(val confirmed: Boolean = false) : ConfigAction
     data class OnEditMonitoringDuration(val duration: Duration?) : ConfigAction
     data class OnEditReactionDelay(val delay: Duration?) : ConfigAction
     data class OnEditAdjustmentDelay(val delay: Duration?) : ConfigAction
-    data class OnEditVolumeRateLimit(val duration: Duration?) : ConfigAction
+    data class OnEditVolumeRateLimitIncrease(val duration: Duration?) : ConfigAction
+    data class OnEditVolumeRateLimitDecrease(val duration: Duration?) : ConfigAction
     data class OnRename(val newName: String?) : ConfigAction
     data class OnConfirmDelete(val confirmed: Boolean) : ConfigAction
     data object OnToggleEnabled : ConfigAction

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/ConfigEvent.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/ConfigEvent.kt
@@ -10,7 +10,8 @@ sealed interface ConfigEvent {
     data class ShowMonitoringDurationDialog(val currentValue: Duration) : ConfigEvent
     data class ShowReactionDelayDialog(val currentValue: Duration) : ConfigEvent
     data class ShowAdjustmentDelayDialog(val currentValue: Duration) : ConfigEvent
-    data class ShowVolumeRateLimitDialog(val currentValue: Duration) : ConfigEvent
+    data class ShowVolumeRateLimitIncreaseDialog(val currentValue: Duration) : ConfigEvent
+    data class ShowVolumeRateLimitDecreaseDialog(val currentValue: Duration) : ConfigEvent
     data object ShowAutoplayKeycodesDialog : ConfigEvent
     data class ShowDndModeDialog(val currentMode: DndMode?) : ConfigEvent
     data object NavigateBack : ConfigEvent

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
@@ -91,7 +91,8 @@ fun DeviceConfigScreenHost(
     var showMonitoringDurationDialog by remember { mutableStateOf<Duration?>(null) }
     var showReactionDelayDialog by remember { mutableStateOf<Duration?>(null) }
     var showAdjustmentDelayDialog by remember { mutableStateOf<Duration?>(null) }
-    var showVolumeRateLimitDialog by remember { mutableStateOf<Duration?>(null) }
+    var showVolumeRateLimitIncreaseDialog by remember { mutableStateOf<Duration?>(null) }
+    var showVolumeRateLimitDecreaseDialog by remember { mutableStateOf<Duration?>(null) }
     var showAutoplayKeycodesDialog by remember { mutableStateOf(false) }
     var showDndModeDialog by remember { mutableStateOf(false) }
     var dndModeValue by remember { mutableStateOf<DndMode?>(null) }
@@ -111,7 +112,8 @@ fun DeviceConfigScreenHost(
                 is ConfigEvent.ShowMonitoringDurationDialog -> showMonitoringDurationDialog = event.currentValue
                 is ConfigEvent.ShowReactionDelayDialog -> showReactionDelayDialog = event.currentValue
                 is ConfigEvent.ShowAdjustmentDelayDialog -> showAdjustmentDelayDialog = event.currentValue
-                is ConfigEvent.ShowVolumeRateLimitDialog -> showVolumeRateLimitDialog = event.currentValue
+                is ConfigEvent.ShowVolumeRateLimitIncreaseDialog -> showVolumeRateLimitIncreaseDialog = event.currentValue
+                is ConfigEvent.ShowVolumeRateLimitDecreaseDialog -> showVolumeRateLimitDecreaseDialog = event.currentValue
                 is ConfigEvent.ShowAutoplayKeycodesDialog -> showAutoplayKeycodesDialog = true
                 is ConfigEvent.ShowDndModeDialog -> {
                     dndModeValue = event.currentMode
@@ -200,15 +202,28 @@ fun DeviceConfigScreenHost(
             )
         }
 
-        showVolumeRateLimitDialog?.let { delay ->
+        showVolumeRateLimitIncreaseDialog?.let { delay ->
             TimingDialog(
-                title = stringResource(R.string.devices_device_config_volume_rate_limit_duration_label),
-                message = stringResource(R.string.devices_device_config_volume_rate_limit_duration_desc, delay.toMillis()),
+                title = stringResource(R.string.devices_device_config_volume_rate_limit_increase_duration_label),
+                message = stringResource(R.string.devices_device_config_volume_rate_limit_increase_duration_desc, delay.toMillis()),
                 currentValue = delay,
-                onConfirm = { vm.handleAction(ConfigAction.OnEditVolumeRateLimit(it)) },
-                onReset = { vm.handleAction(ConfigAction.OnEditVolumeRateLimit(null)) },
+                onConfirm = { vm.handleAction(ConfigAction.OnEditVolumeRateLimitIncrease(it)) },
+                onReset = { vm.handleAction(ConfigAction.OnEditVolumeRateLimitIncrease(null)) },
                 onDismiss = {
-                    showVolumeRateLimitDialog = null
+                    showVolumeRateLimitIncreaseDialog = null
+                }
+            )
+        }
+
+        showVolumeRateLimitDecreaseDialog?.let { delay ->
+            TimingDialog(
+                title = stringResource(R.string.devices_device_config_volume_rate_limit_decrease_duration_label),
+                message = stringResource(R.string.devices_device_config_volume_rate_limit_decrease_duration_desc, delay.toMillis()),
+                currentValue = delay,
+                onConfirm = { vm.handleAction(ConfigAction.OnEditVolumeRateLimitDecrease(it)) },
+                onReset = { vm.handleAction(ConfigAction.OnEditVolumeRateLimitDecrease(null)) },
+                onDismiss = {
+                    showVolumeRateLimitDecreaseDialog = null
                 }
             )
         }
@@ -451,13 +466,23 @@ fun DeviceConfigScreen(
 
                         if (device.volumeRateLimiter) {
                             ClickablePreference(
-                                title = stringResource(R.string.devices_device_config_volume_rate_limit_duration_label),
+                                title = stringResource(R.string.devices_device_config_volume_rate_limit_increase_duration_label),
                                 description = stringResource(
-                                    R.string.devices_device_config_volume_rate_limit_duration_desc,
-                                    device.volumeRateLimitMs
+                                    R.string.devices_device_config_volume_rate_limit_increase_duration_desc,
+                                    device.volumeRateLimitIncreaseMs
                                 ),
                                 icon = Icons.TwoTone.Schedule,
-                                onClick = { onAction(ConfigAction.OnEditVolumeRateLimitClicked) }
+                                onClick = { onAction(ConfigAction.OnEditVolumeRateLimitIncreaseClicked) }
+                            )
+
+                            ClickablePreference(
+                                title = stringResource(R.string.devices_device_config_volume_rate_limit_decrease_duration_label),
+                                description = stringResource(
+                                    R.string.devices_device_config_volume_rate_limit_decrease_duration_desc,
+                                    device.volumeRateLimitDecreaseMs
+                                ),
+                                icon = Icons.TwoTone.Schedule,
+                                onClick = { onAction(ConfigAction.OnEditVolumeRateLimitDecreaseClicked) }
                             )
                         }
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigViewModel.kt
@@ -130,16 +130,28 @@ class DeviceConfigViewModel @AssistedInject constructor(
                 events.emit(ConfigEvent.ShowReactionDelayDialog(currentDelay))
             }
 
-            is ConfigAction.OnEditVolumeRateLimit -> {
+            is ConfigAction.OnEditVolumeRateLimitIncrease -> {
                 deviceRepo.updateDevice(deviceAddress) { oldConfig ->
-                    oldConfig.copy(volumeRateLimitMs = action.duration?.toMillis())
+                    oldConfig.copy(volumeRateLimitIncreaseMs = action.duration?.toMillis())
                 }
             }
 
-            is ConfigAction.OnEditVolumeRateLimitClicked -> {
+            is ConfigAction.OnEditVolumeRateLimitDecrease -> {
+                deviceRepo.updateDevice(deviceAddress) { oldConfig ->
+                    oldConfig.copy(volumeRateLimitDecreaseMs = action.duration?.toMillis())
+                }
+            }
+
+            is ConfigAction.OnEditVolumeRateLimitIncreaseClicked -> {
                 val device = state.first().device
-                val currentLimit = Duration.ofMillis(device.volumeRateLimitMs)
-                events.emit(ConfigEvent.ShowVolumeRateLimitDialog(currentLimit))
+                val currentLimit = Duration.ofMillis(device.volumeRateLimitIncreaseMs)
+                events.emit(ConfigEvent.ShowVolumeRateLimitIncreaseDialog(currentLimit))
+            }
+
+            is ConfigAction.OnEditVolumeRateLimitDecreaseClicked -> {
+                val device = state.first().device
+                val currentLimit = Duration.ofMillis(device.volumeRateLimitDecreaseMs)
+                events.emit(ConfigEvent.ShowVolumeRateLimitDecreaseDialog(currentLimit))
             }
 
             is ConfigAction.OnLaunchAppClicked -> {

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -53,6 +53,12 @@
     <string name="devices_device_config_volume_lock_desc">Any volume changes not made through this app will be reverted while this device is connected.</string>
     <string name="devices_device_config_autoplay_label">Outo speel</string>
     <string name="devices_device_config_autoplay_desc">Simuleer, druk speel, op \'n Bluetooth afstandbeheer indien hierdie toestel koppel.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Volume spoedbegrenzer</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Beperk die frekwensie van volumeveranderinge om vinnige of buitensporige volumejusteringe te voorkom.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Volume verhogingsvertraging</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimum tyd tussen volumeverhoginge: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Volume verlagingsvertraging</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimum tyd tussen volumeverlaginge: %d ms</string>
     <string name="devices_device_config_section_volumes_label">Volumes</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
     <string name="devices_device_config_alarm_volume_label">Alarm volume</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -60,6 +60,12 @@
     <string name="devices_device_config_volume_observe_desc">ابق نشطاً بينما هذا الجهاز متصل واحفظ تغييرات الصوت التي لم يسببها هذا التطبيق.</string>
     <string name="devices_device_config_volume_lock_label">قفل الصوت</string>
     <string name="devices_device_config_volume_lock_desc">Any volume changes not made through this app will be reverted while this device is connected.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">منظم معدل الصوت</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">تحديد تكرار تغييرات الصوت لمنع التعديلات السريعة أو المفرطة على الصوت.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">تأخير زيادة الصوت</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">الحد الأدنى للوقت بين زيادات الصوت: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">تأخير تقليل الصوت</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">الحد الأدنى للوقت بين تقليلات الصوت: %d ms</string>
     <string name="devices_device_config_autoplay_label">التشغيل التلقائي</string>
     <string name="devices_device_config_autoplay_desc">اظهار النقر على التشغيل على لوحة التحكم عن بعد للبلوتوث عند توصيل هذا الجهاز.</string>
     <string name="devices_device_config_autoplay_keycodes_available">أنواع المفاتيح المتاحة</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -33,6 +33,12 @@
     <string name="devices_device_config_rename_device_desc">Rename this device within this app, and if possible, within the system.</string>
     <string name="devices_device_config_rename_device_action">Rename</string>
     <string name="devices_device_config_section_timing_label">Timing</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Səs tezliyinin məhdudlaşdırıcısı</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Sürətli və ya artıq səs tənzimləmələrini qarşılamaq üçün səs dəyişikliklərinin tezliyini məhdudlaşdır.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Səs artırma gecikməsi</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Səs artımları arasında minimum vaxt: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Səs azalma gecikməsi</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Səs azalmaları arasında minimum vaxt: %d ms</string>
     <string name="devices_device_config_monitoring_duration_label">İzləmə müddəti</string>
     <string name="devices_device_config_monitoring_duration_desc">Nizamlamalar edildikdən sonra millisaniyə növündə müddət, bu vaxt digər səs səviyyəsi dəyişiklikləri əngəllənər.</string>
     <string name="devices_device_config_adjustment_delay_label">Nizamlama gecikməsi</string>

--- a/app/src/main/res/values-ban-rID/strings.xml
+++ b/app/src/main/res/values-ban-rID/strings.xml
@@ -51,6 +51,12 @@
     <string name="devices_device_config_volume_observe_desc">Stay active while this device is connected and save volume changes that have not been caused by this app.</string>
     <string name="devices_device_config_volume_lock_label">Volume lock</string>
     <string name="devices_device_config_volume_lock_desc">Any volume changes not made through this app will be reverted while this device is connected.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Pembatas laju volume</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Batasi frekuensi perubahan volume kanggo nyegah penyesuaian volume sané cepet utawa berlebihan.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Penundaan peningkatan volume</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Waktu minimum antara peningkatan volume: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Penundaan penurunan volume</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Waktu minimum antara penurunan volume: %d ms</string>
     <string name="devices_device_config_autoplay_label">Autoplay</string>
     <string name="devices_device_config_autoplay_desc">Simulate pressing play on a Bluetooth remote when this device connects.</string>
     <string name="devices_device_config_section_volumes_label">Volumes</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -57,6 +57,12 @@
     <string name="devices_device_config_nudge_volume_description">Lower then raise the volume by one increment, even if the desired volume is already set (according to the system).</string>
     <string name="devices_device_config_visible_adjustments_label">Видими настройки</string>
     <string name="devices_device_config_visible_adjustments_desc">Показвай системния прозорец за звука, докато приложението регулира звука за това устройство.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Ограничител на честотата на силата на звука</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Ограничава честотата на промените в силата на звука, за да се предотврати бързо или прекомерно регулиране.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Забавяне на увеличението на силата на звука</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Минимално време между увеличенията на силата на звука: %d мс</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Забавяне на намаляването на силата на звука</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Минимално време между намаленията на силата на звука: %d мс</string>
     <string name="devices_device_config_keep_awake_label">Keep awake</string>
     <string name="devices_device_config_keep_awake_desc">Keep the screen on while this device is connected.</string>
     <string name="devices_device_config_volume_observe_label">Observe changes</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -51,6 +51,12 @@
     <string name="devices_device_config_volume_observe_desc">Stay active while this device is connected and save volume changes that have not been caused by this app.</string>
     <string name="devices_device_config_volume_lock_label">Bloqueig de volum</string>
     <string name="devices_device_config_volume_lock_desc">Qualsevol canvi de volum que no s\'hagi fet a través d\'aquesta aplicació es revertirà mentre aquest dispositiu estigui connectat.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Limitador de taxa de volum</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Limita la freqüència dels canvis de volum per evitar ajustaments ràpids o excessius.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Retard d\'augment de volum</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Temps mínim entre augments de volum: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Retard de disminució de volum</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Temps mínim entre disminucions de volum: %d ms</string>
     <string name="devices_device_config_autoplay_label">Reproducció automàtica</string>
     <string name="devices_device_config_autoplay_desc">Simula prémer el botó reproducció en un control remot Bluetooth quan aquest dispositiu es connecta.</string>
     <string name="devices_device_config_section_volumes_label">Volums</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -69,6 +69,12 @@
     <string name="devices_device_config_volume_observe_desc">Zůstat aktivní, zatímco je toto zařízení připojené, a uložit změny hlasitosti, které nezpůsobila tato aplikace.</string>
     <string name="devices_device_config_volume_lock_label">Uzamknutí hlasitosti</string>
     <string name="devices_device_config_volume_lock_desc">Všechny změny hlasitosti, které nebyly provedeny pomocí této aplikace, budou při připojení tohoto zařízení zrušeny.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Omezovač frekvence hlasitosti</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Omezuje frekvenci změn hlasitosti, aby se zabránilo rychlým nebo nadměrným úpravám.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Zpoždění zvýšení hlasitosti</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimální čas mezi zvýšením hlasitosti: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Zpoždění snížení hlasitosti</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimální čas mezi snížením hlasitosti: %d ms</string>
     <string name="devices_device_config_autoplay_label">Automatické přehrávání</string>
     <string name="devices_device_config_autoplay_desc">Simuluje stisknutí přehrávání na ovládání Bluetooth při připojení tohoto zařízení.</string>
     <string name="devices_device_config_section_volumes_label">Hlasitosti</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -63,6 +63,12 @@
     <string name="devices_device_config_volume_lock_desc">Alle lydstyrkeændringer ikke lavet gennem denne app vil blive tilbageført mens denne enhed er tilsluttet.</string>
     <string name="devices_device_config_autoplay_label">Autoplay</string>
     <string name="devices_device_config_autoplay_desc">Simuler at trykke på afspil på en Bluetooth fjernbetjening, når denne enhed tilsluttes.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Lydstyrke-begrenzer</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Begræns hyppigheden af lydstyrkeændringer for at forhindre hurtige eller overdrevne lydstyrkeindstillinger.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Lydstyrkeforøgelsesforsinkelse</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimumstid mellem lydstyrkeforøgelser: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Lydstyrkenedgangs forsinkelse</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimumstid mellem lydstyrkenedgange: %d ms</string>
     <string name="devices_device_config_autoplay_keycodes_available">Tilgængelige tast typer</string>
     <string name="devices_device_config_autoplay_keycodes_desc">Konfigurer hvilke taster der skal sendes og i hvilken rækkefølge</string>
     <string name="devices_device_config_autoplay_keycodes_label">Tast typer</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -64,8 +64,10 @@
     <string name="devices_device_config_volume_lock_desc">Alle nicht über diese App vorgenommenen Lautstärkeänderungen werden zurückgesetzt, während dieses Gerät verbunden ist.</string>
     <string name="devices_device_config_volume_rate_limiter_label">Lautstärke-Begrenzer</string>
     <string name="devices_device_config_volume_rate_limiter_desc">Begrenzt die Häufigkeit von Lautstärkeänderungen, um schnelle oder übermäßige Lautstärke-Anpassungen zu verhindern.</string>
-    <string name="devices_device_config_volume_rate_limit_duration_label">Begrenzungsdauer</string>
-    <string name="devices_device_config_volume_rate_limit_duration_desc">Mindestzeit zwischen Lautstärkeänderungen: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Erhöhungsverzögerung</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Mindestzeit zwischen Lautstärkeerhöhungen: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Senkungsverzögerung</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Mindestzeit zwischen Lautstärkesenkungen: %d ms</string>
     <string name="devices_device_config_autoplay_label">Automatische Wiedergabe</string>
     <string name="devices_app_selection_currently_selected">Aktuell ausgewählt</string>
     <string name="devices_app_selection_search_hint">Apps suchen…</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -33,6 +33,12 @@
     <string name="devices_device_config_rename_device_desc">Μετονομάστε αυτή τη συσκευή μέσα σε αυτή την εφαρμογή, και αν είναι δυνατόν, στο σύστημα.</string>
     <string name="devices_device_config_rename_device_action">Μετονομασία</string>
     <string name="devices_device_config_section_timing_label">Χρονισμός</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Περιοριστής ρυθμού έντασης</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Περιορίστε τη συχνότητα των αλλαγών έντασης για να αποτρέψετε γρήγορες ή υπερβολικές προσαρμογές έντασης.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Καθυστέρηση αύξησης έντασης</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Ελάχιστος χρόνος μεταξύ αυξήσεων έντασης: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Καθυστέρηση μείωσης έντασης</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Ελάχιστος χρόνος μεταξύ μειώσεων έντασης: %d ms</string>
     <string name="devices_device_config_monitoring_duration_label">Διάρκεια παρακολούθησης</string>
     <string name="devices_device_config_monitoring_duration_desc">Διάρκεια σε χιλιοστά του δευτερολέπτου, μετά από τις προσαρμογές, κατά τη διάρκεια των οποίων θα μπλοκάρονται τυχόν αλλαγές έντασης.</string>
     <string name="devices_device_config_adjustment_delay_label">Καθυστέρηση προσαρμογής</string>

--- a/app/src/main/res/values-eo-rUY/strings.xml
+++ b/app/src/main/res/values-eo-rUY/strings.xml
@@ -45,6 +45,10 @@
     <string name="devices_device_config_nudge_volume_label">Nudge volume</string>
     <string name="devices_device_config_nudge_volume_description">Lower then raise the volume by one increment, even if the desired volume is already set (according to the system).</string>
     <string name="devices_device_config_visible_adjustments_label">Videblaj ĝustigoj</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Prokrastigoj por voluma plialtiĝo</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimuma tempo inter voluma plialtiĝoj: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Prokrastigoj por voluma malaltiĝo</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimuma tempo inter voluma malaltiĝoj: %d ms</string>
     <string name="devices_device_config_keep_awake_label">Keep awake</string>
     <string name="devices_device_config_keep_awake_desc">Keep the screen on while this device is connected.</string>
     <string name="devices_device_config_volume_observe_label">Observe changes</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -62,8 +62,10 @@
     <string name="devices_device_config_volume_lock_desc">Cualquier cambio de volumen no realizado a través de esta aplicación se revertirá mientras este dispositivo esté conectado.</string>
     <string name="devices_device_config_volume_rate_limiter_label">Limitador de velocidad de volumen</string>
     <string name="devices_device_config_volume_rate_limiter_desc">Limita la frecuencia de cambios de volumen para prevenir ajustes rápidos o excesivos de volumen.</string>
-    <string name="devices_device_config_volume_rate_limit_duration_label">Duración del límite de velocidad</string>
-    <string name="devices_device_config_volume_rate_limit_duration_desc">Tiempo mínimo entre cambios de volumen: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Retraso de aumento de volumen</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Tiempo mínimo entre aumentos de volumen: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Retraso de disminución de volumen</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Tiempo mínimo entre disminuciones de volumen: %d ms</string>
     <string name="devices_device_config_autoplay_label">Reproducción automática</string>
     <string name="devices_device_config_autoplay_desc">Simula presionar reproducir en un control remoto del Bluetooth cuando este dispositivo se conecta.</string>
     <string name="devices_device_config_autoplay_keycodes_available">Tipos de tecla disponibles</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -250,4 +250,10 @@
     <string name="general_navigate_back_action">Navigeeri tagasi</string>
     <string name="general_reset_action">Lähtesta</string>
     <string name="general_save_action">Salvesta</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Helitugevuse määra piirang</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Piirita helitugevuse muutuste sagedust, et vältida kiiret või liigset muutmist.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Helitugevuse tõstmise viivitus</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimaalne aeg helitugevuse tõstmiste vahel: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Helitugevuse alandamise viivitus</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimaalne aeg helitugevuse alandamiste vahel: %d ms</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -262,4 +262,10 @@
     <string name="devices_indicator_auto">Auto</string>
     <string name="devices_indicator_home">Koti</string>
     <string name="devices_indicator_dnd">ÄH</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Äänenvoimakkuuden nopeus rajaus</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Rajoita äänenvoimakkuus muutokset estääksesi nopeat tai liian suuret säädöt.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Äänenvoimakkuuden nosto viive</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Pienin aika äänenvoimakkuuden nousujen välillä: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Äänenvoimakkuuden lasku viive</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Pienin aika äänenvoimakkuuden laskujen välillä: %d ms</string>
 </resources>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -51,6 +51,12 @@
     <string name="devices_device_config_volume_observe_desc">Stay active while this device is connected and save volume changes that have not been caused by this app.</string>
     <string name="devices_device_config_volume_lock_label">Volume lock</string>
     <string name="devices_device_config_volume_lock_desc">Any volume changes not made through this app will be reverted while this device is connected.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Limitador ng rate ng volume</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Limitahan ang frequency ng mga pagbabago sa volume upang maiwasan ang mabilis o sobrang pagsasaayos ng volume.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Pagkaantala sa pagtaas ng volume</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimum na oras sa pagitan ng mga pagtaas ng volume: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Pagkaantala sa pagbaba ng volume</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimum na oras sa pagitan ng mga pagbaba ng volume: %d ms</string>
     <string name="devices_device_config_autoplay_label">Autoplay</string>
     <string name="devices_device_config_autoplay_desc">Subukang pindutin ang play sa remote ng Bluetooth habang nakakonekta ang device na ito.</string>
     <string name="devices_device_config_section_volumes_label">Volumes</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -60,8 +60,10 @@
     <string name="devices_device_config_volume_lock_desc">Tout changement de volume qui ne sera pas effectué grâce à cette appli sera annulé tant que cet appareil est connecté.</string>
     <string name="devices_device_config_volume_rate_limiter_label">Limiteur de débit de volume</string>
     <string name="devices_device_config_volume_rate_limiter_desc">Limite la fréquence des changements de volume pour prévenir les ajustements rapides ou excessifs.</string>
-    <string name="devices_device_config_volume_rate_limit_duration_label">Durée de limitation du débit</string>
-    <string name="devices_device_config_volume_rate_limit_duration_desc">Temps minimum entre les changements de volume : %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Délai d\'augmentation du volume</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Temps minimum entre les augmentations de volume : %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Délai de diminution du volume</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Temps minimum entre les diminutions de volume : %d ms</string>
     <string name="devices_device_config_autoplay_label">Lecture automatique</string>
     <string name="devices_device_config_autoplay_desc">Simuler l\'appui sur Lecture d\'une télécommande Bluetooth quand ce périphérique se connecte.</string>
     <string name="devices_device_config_autoplay_keycodes_available">Types de touches disponibles</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -51,6 +51,12 @@
     <string name="devices_device_config_volume_observe_desc">Stay active while this device is connected and save volume changes that have not been caused by this app.</string>
     <string name="devices_device_config_volume_lock_label">Volume lock</string>
     <string name="devices_device_config_volume_lock_desc">Any volume changes not made through this app will be reverted while this device is connected.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Limitador de taxa de volumen</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Limita a frecuencia de cambios de volume para evitar axustes rápidos ou excesivos.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Atraso de aumento de volumen</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Tempo mínimo entre aumentos de volumen: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Atraso de disminución de volumen</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Tempo mínimo entre disminucións de volumen: %d ms</string>
     <string name="devices_device_config_autoplay_label">Reprodución automática</string>
     <string name="devices_device_config_autoplay_desc">Simula que se toca o botón de reprodución vía bluetooth cando este dispositivo está conectado.</string>
     <string name="devices_device_config_section_volumes_label">Volumes</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -51,6 +51,12 @@
     <string name="devices_device_config_volume_observe_desc">जब यह डिवाइस जुड़ा हो तो सक्रिय रहें और उन वॉल्यूम परिवर्तनों को सेव करें जो इस ऐप के कारण नहीं हुए हैं।</string>
     <string name="devices_device_config_volume_lock_label">वॉल्यूम लॉक</string>
     <string name="devices_device_config_volume_lock_desc">इस उपकरण के माध्यम से नहीं किए गए किसी भी मात्रा परिवर्तन को वापस कर दिया जाएगा, जबकि यह उपकरण जुड़ा हुआ है।</string>
+    <string name="devices_device_config_volume_rate_limiter_label">वॉल्यूम दर सीमक</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">वॉल्यूम परिवर्तनों की आवृत्ति को सीमित करें ताकि तेज़ या अत्यधिक वॉल्यूम समायोजन को रोका जा सके।</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">वॉल्यूम बढ़ाने में देरी</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">वॉल्यूम बढ़ाने के बीच न्यूनतम समय: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">वॉल्यूम घटाने में देरी</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">वॉल्यूम घटाने के बीच न्यूनतम समय: %d ms</string>
     <string name="devices_device_config_autoplay_label">स्वचालित</string>
     <string name="devices_device_config_autoplay_desc">जब यह डिवाइस कनेक्ट होता है तो ब्लूटूथ रिमोट पर प्ले बटन दबाकर उसका का अनुकरण करें।</string>
     <string name="devices_device_config_section_volumes_label">ध्वनि</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -54,6 +54,12 @@
     <string name="devices_device_config_nudge_volume_description">Lower then raise the volume by one increment, even if the desired volume is already set (according to the system).</string>
     <string name="devices_device_config_visible_adjustments_label">Vidljive prilagodbe</string>
     <string name="devices_device_config_visible_adjustments_desc">Uključi/isključi koje se prilagodbe prikazuju na kartici uređaja</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Ograničnik frekvencije glasnoće</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Ograničava frekvenciju promjena glasnoće kako bi se izbjegla brza ili pretjerana podešavanja.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Kašnjenje povećanja glasnoće</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimalno vrijeme između povećanja glasnoće: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Kašnjenje smanjenja glasnoće</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimalno vrijeme između smanjenja glasnoće: %d ms</string>
     <string name="devices_device_config_keep_awake_label">Zadrži budnim</string>
     <string name="devices_device_config_keep_awake_desc">Zadržite zaslon uključenim dok je ovaj uređaj povezan.</string>
     <string name="devices_device_config_volume_observe_label">Observe changes</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -249,4 +249,10 @@
     <string name="error_iap_owned_message">Már birtoklod ezt a tételt</string>
     <string name="label_no_devices_title">Nincsenek eszközök</string>
     <string name="bluemusic_mascot_description">Alkalmazás ikon</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Hangerő rátálimitáló</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Korlátozzad a hangerőváltozások gyakoriságát, hogy elkerüld a gyors vagy túlzott hangerő-beállításokat.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Hangerő emelés késleltetése</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimális idő a hangerő-emelések között: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Hangerő csökkentés késleltetése</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimális idő a hangerő-csökkentések között: %d ms</string>
 </resources>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -33,6 +33,12 @@
     <string name="devices_device_config_rename_device_desc">Rename this device within this app, and if possible, within the system.</string>
     <string name="devices_device_config_rename_device_action">Rename</string>
     <string name="devices_device_config_section_timing_label">Timing</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Ձայնի տեմպի սահմանափակիչ</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Սահմանափակել ձայնի փոփոխությունների հաճախականությունը՝ արագ կամ չափազանց ձայնի կարգավորումներ կանխելու համար:</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Ձայնի բարձրացման հետաձգում</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Նվազագույն ժամանակ ձայնի բարձրացումների միջև. %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Ձայնի նվազման հետաձգում</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Նվազագույն ժամանակ ձայնի նվազումների միջև. %d ms</string>
     <string name="devices_device_config_monitoring_duration_label">Monitoring duration</string>
     <string name="devices_device_config_monitoring_duration_desc">A duration in milliseconds, after adjustments have been made, during which any further volume changes will be blocked.</string>
     <string name="devices_device_config_adjustment_delay_label">Adjustment delay</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -51,6 +51,12 @@
     <string name="devices_device_config_volume_observe_desc">Tetap aktif saat perangkat ini terhubung dan simpan perubahan volume yang tidak disebabkan oleh aplikasi ini.</string>
     <string name="devices_device_config_volume_lock_label">Kunci volume</string>
     <string name="devices_device_config_volume_lock_desc">Perubahan volume yang tidak buat melalui aplikasi ini akan dikembalikan ketika perangkat ini tersambung.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Pembatas laju volume</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Batasi frekuensi perubahan volume untuk mencegah penyesuaian volume yang cepat atau berlebihan.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Penundaan peningkatan volume</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Waktu minimum antar peningkatan volume: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Penundaan penurunan volume</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Waktu minimum antar penurunan volume: %d ms</string>
     <string name="devices_device_config_autoplay_label">Putar Otomatis</string>
     <string name="devices_device_config_autoplay_desc">Simulasikan penekanan tombol mulai dalam kendali jauh Bluetooth saat perangkat ini terhubung.</string>
     <string name="devices_device_config_section_volumes_label">Volume</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -63,8 +63,10 @@
     <string name="devices_device_config_volume_lock_desc">Qualsiasi cambiamento di volume non fatto tramite questa applicazione sarà resettato mentre il dispositivo è connesso.</string>
     <string name="devices_device_config_volume_rate_limiter_label">Limitatore di velocità volume</string>
     <string name="devices_device_config_volume_rate_limiter_desc">Limita la frequenza dei cambiamenti di volume per prevenire regolazioni rapide o eccessive.</string>
-    <string name="devices_device_config_volume_rate_limit_duration_label">Durata limite di velocità</string>
-    <string name="devices_device_config_volume_rate_limit_duration_desc">Tempo minimo tra i cambiamenti di volume: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Ritardo aumento volume</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Tempo minimo tra gli aumenti di volume: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Ritardo diminuzione volume</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Tempo minimo tra le diminuzioni di volume: %d ms</string>
     <string name="devices_device_config_autoplay_label">Autoplay</string>
     <string name="devices_device_config_autoplay_desc">Simula la pressione del tasto play quando un dispositivo Bluetooth viene connesso.</string>
     <string name="devices_device_config_autoplay_keycodes_available">Tipi di tasto disponibili</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -68,6 +68,12 @@
     <string name="devices_device_config_volume_observe_desc">הישאר פעיל כאשר המכשיר מחובר ושמור שינויי עוצמה שלא נגרמו על ידי האפליקציה.</string>
     <string name="devices_device_config_volume_lock_label">נעילת ווליום</string>
     <string name="devices_device_config_volume_lock_desc">Any volume changes not made through this app will be reverted while this device is connected.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">מנקה קצב עוצמה</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">הגבלת תכיפות שינויי עוצמה כדי למנוע התאמות עוצמה מהירות או מוגזמות.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">השהיית הגדלת עוצמה</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">הזמן המינימלי בין הגדלות עוצמה: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">השהיית הקטנת עוצמה</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">הזמן המינימלי בין הקטנות עוצמה: %d ms</string>
     <string name="devices_device_config_autoplay_label">ניגון אוטומטי</string>
     <string name="devices_device_config_autoplay_desc">הדמיית לחיצה על ניגון בשלט בלוטות\' כאשר מכשיר זה מתחבר.</string>
     <string name="devices_device_config_section_volumes_label">עוצמות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -66,8 +66,10 @@
     <string name="devices_device_config_volume_lock_desc">このデバイスが接続されている間は、このアプリ以外による音量の変更はすべて元に戻されます。</string>
     <string name="devices_device_config_volume_rate_limiter_label">音量レート制限</string>
     <string name="devices_device_config_volume_rate_limiter_desc">音量変更の頻度を制限して、急激または過度な音量調整を防ぎます。</string>
-    <string name="devices_device_config_volume_rate_limit_duration_label">レート制限期間</string>
-    <string name="devices_device_config_volume_rate_limit_duration_desc">音量変更間の最小時間: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">音量増加の遅延</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">音量増加間の最小時間: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">音量減少の遅延</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">音量減少間の最小時間: %d ms</string>
     <string name="devices_device_config_autoplay_label">自動再生</string>
     <string name="devices_device_config_autoplay_desc">このデバイスが接続されたときに、Bluetoothリモコンでの再生をシミュレートします。</string>
     <string name="devices_device_config_autoplay_keycodes_available">利用可能なキータイプ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -57,6 +57,12 @@
     <string name="devices_device_config_visible_adjustments_desc">기기 카드에 표시할 조정을 선택하세요</string>
     <string name="devices_device_config_keep_awake_label">켜짐 유지</string>
     <string name="devices_device_config_keep_awake_desc">이 디바이스를 연결하고 있을 때 화면을 계속 켜진 상태로 유지합니다.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">음량 속도 제한</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">음량 변경 빈도를 제한하여 빠르거나 과도한 음량 조정을 방지합니다.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">음량 증가 지연</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">음량 증가 간의 최소 시간: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">음량 감소 지연</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">음량 감소 간의 최소 시간: %d ms</string>
     <string name="devices_device_config_volume_observe_label">변경 감시</string>
     <string name="devices_device_config_volume_observe_desc">이 디바이스가 연결되어 있는 동안 활성 상태를 유지하고 이 앱에서 생성되지 않은 음량 변경사항을 저장합니다.</string>
     <string name="devices_device_config_volume_lock_label">음량 잠금</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -250,4 +250,10 @@
     <string name="general_navigate_back_action">Naviguoti atgal</string>
     <string name="general_reset_action">Atstatyti</string>
     <string name="general_save_action">Išsaugoti</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Garsumo keitimo limitavimas</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Riboti garsumo keitimo dažnumą, kad išvengtumėte greitų ar per didelių garsumo reguliavimų.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Garsumo kėlimo delsa</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimalus laikas tarp garsumo kėlimų: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Garsumo sumažinimo delsa</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimalus laikas tarp garsumo sumažinimų: %d ms</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -250,4 +250,10 @@
     <string name="general_navigate_back_action">Navigēt atpakaļ</string>
     <string name="general_reset_action">Atiestatīt</string>
     <string name="general_save_action">Saglabāt</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Skaļuma maiņas ātruma ierobežojums</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Ierobežo skaļuma maiņas biežumu, lai no rītas no straujos vai pārmērīgiem skaļuma pielāgojumiem.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Skaļuma paaugstināšanas aizkave</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimālais laiks starp skaļuma paaugstināšanu: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Skaļuma samazināšanas aizkave</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimālais laiks starp skaļuma samazināšanu: %d ms</string>
 </resources>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -45,6 +45,13 @@
     <string name="devices_device_config_nudge_volume_label">Nudge volume</string>
     <string name="devices_device_config_nudge_volume_description">Lower then raise the volume by one increment, even if the desired volume is already set (according to the system).</string>
     <string name="devices_device_config_visible_adjustments_label">Видливи прилагодувања</string>
+    <string name="devices_device_config_visible_adjustments_desc">Префрли кои прилагодувања се прикажуваат на картичката на уредот</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Ограничувач на фреквенција на јачина на звук</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Ограничува фреквенција на промени во јачина на звук за да се спречи брзо или прекомерно подесување.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Заостану при зголемување на јачина на звук</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Минимално време помеѓу зголемувањата на јачина на звук: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Заостану при намалување на јачина на звук</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Минимално време помеѓу намалувањата на јачина на звук: %d ms</string>
     <string name="devices_device_config_keep_awake_label">Остани буден</string>
     <string name="devices_device_config_keep_awake_desc">Чувајте го екранот уклучен додека е поврзан овој уред.</string>
     <string name="devices_device_config_volume_observe_label">Observe changes</string>
@@ -245,7 +252,6 @@
     <string name="devices_device_config_notification_policy_action">Дај пристап</string>
     <string name="devices_device_config_notification_policy_required_notification">Контролата на јачината на известувањата бара пристап до политиката на известувања</string>
     <string name="devices_device_config_notification_policy_required_ringtone">Контролата на јачината на ѕвонење бара пристап до политиката на известувања</string>
-    <string name="devices_device_config_visible_adjustments_desc">Префрли кои прилагодувања се прикажуваат на картичката на уредот</string>
     <string name="general_clear_action">Исчисти</string>
     <string name="general_navigate_back_action">Навигирај назад</string>
     <string name="general_reset_action">Ресетирај</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -51,6 +51,12 @@
     <string name="devices_device_config_volume_observe_desc">Kekal aktif semasa peranti ini disambungkan dan simpan perubahan volum yang bukan disebabkan oleh apl ini.</string>
     <string name="devices_device_config_volume_lock_label">Kunci volum</string>
     <string name="devices_device_config_volume_lock_desc">Sebarang perubahan volum yang tidak dilakukan melalui apl ini akan dikembalikan sementara peranti ini dihubungkan.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Pembatas kadar volum</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Hadkan kekerapan perubahan volum untuk menghalang pelarasan volum yang cepat atau berlebihan.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Kelewatan kenaikan volum</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Masa minimum di antara kenaikan volum: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Kelewatan penurunan volum</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Masa minimum di antara penurunan volum: %d ms</string>
     <string name="devices_device_config_autoplay_label">Automain</string>
     <string name="devices_device_config_autoplay_desc">Menekan main disimulasikan pada kawalan jauh Bluetooth bila peranti ini terhubung.</string>
     <string name="devices_device_config_section_volumes_label">Volum</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -51,6 +51,12 @@
     <string name="devices_device_config_volume_observe_desc">Stay active while this device is connected and save volume changes that have not been caused by this app.</string>
     <string name="devices_device_config_volume_lock_label">Volume lock</string>
     <string name="devices_device_config_volume_lock_desc">Any volume changes not made through this app will be reverted while this device is connected.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">အသံအတိုးအကျယ်နှုန်းကန့်သတ်ကိရိယာ</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">အသံအတိုးအကျယ်ပြောင်းလဲမှုများ၏ကြိမ်ဆင်းသက်မှုကိုကန့်သတ်ပြီးမြန်လျှင်သို့မဟုတ်အလွန်အကျွံအသံထိန်းချုပ်မှုများကိုကာကွယ်ပါ။</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">အသံအတိုးအကျယ်တိုးစည်းမျဉ်း</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">အသံအတိုးအကျယ်တိုးခြင်းများအကြားအနည်းငယ်ဆုံးအချိန်- %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">အသံအတိုးအကျယ်လျှော့ချမျဉ်း</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">အသံအတိုးအကျယ်လျှော့ချခြင်းများအကြားအနည်းငယ်ဆုံးအချိန်- %d ms</string>
     <string name="devices_device_config_autoplay_label">Autoplay</string>
     <string name="devices_device_config_autoplay_desc">Simulate pressing play on a Bluetooth remote when this device connects.</string>
     <string name="devices_device_config_section_volumes_label">Volumes</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -58,6 +58,12 @@
     <string name="devices_device_config_volume_lock_desc">Alle volumewijzigingen die niet via deze app worden gemaakt, worden ongedaan gemaakt terwijl dit apparaat is aangesloten.</string>
     <string name="devices_device_config_autoplay_label">Automatisch afspelen</string>
     <string name="devices_device_config_autoplay_desc">Simuleer op afspelen drukken op een bluetooth afstandsbediening wanneer dit apparaat verbinding maakt.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Volume snelheidsbegrenzer</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Beperk de frequentie van volumewijzigingen om snelle of buitensporige volumeaanpassingen te voorkomen.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Volume verhogingsvertraging</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimale tijd tussen volumeverhogingen: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Volume verlagingsvertraging</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimale tijd tussen volumeverlagingen: %d ms</string>
     <string name="devices_device_config_autoplay_keycodes_available">Beschikbare toetstypen</string>
     <string name="devices_device_config_autoplay_keycodes_desc">Configureer welke toetsen te versturen en in welke volgorde</string>
     <string name="devices_device_config_autoplay_keycodes_label">Toetstypen</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -59,6 +59,12 @@
     <string name="devices_device_config_volume_lock_desc">Eventuelle volumendringer som ikke gjøres gjennom denne appen, blir tilbakestilt mens denne enheten er tilkoblet.</string>
     <string name="devices_device_config_autoplay_label">Autospill</string>
     <string name="devices_device_config_autoplay_desc">Simuler å trykke spill på en bluetooth ekstern når denne enheten kobles til.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Volumbegrenser</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Begrens hyppigheten av volumendringer for å forhindre raske eller overdrevne volumjusteringer.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Volumøkningsforsinkelse</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimumstid mellom volumøkninger: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Volumreduksjonsforsinkelse</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimumstid mellom volumreduksjoner: %d ms</string>
     <string name="devices_device_config_autoplay_keycodes_available">Tilgjengelige nøkkeltyper</string>
     <string name="devices_device_config_autoplay_keycodes_desc">Konfigurer hvilke nøkler som skal sendes og i hvilken rekkefølge</string>
     <string name="devices_device_config_autoplay_keycodes_label">Nøkkeltyper</string>

--- a/app/src/main/res/values-pcm-rNG/strings.xml
+++ b/app/src/main/res/values-pcm-rNG/strings.xml
@@ -45,6 +45,10 @@
     <string name="devices_device_config_nudge_volume_label">Nudge volume</string>
     <string name="devices_device_config_nudge_volume_description">Lower then raise the volume by one increment, even if the desired volume is already set (according to the system).</string>
     <string name="devices_device_config_visible_adjustments_label">Adjustments wey dey show</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Volume go up delay</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Small time wey must pass before volume go up again: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Volume go down delay</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Small time wey must pass before volume go down again: %d ms</string>
     <string name="devices_device_config_keep_awake_label">Keep awake</string>
     <string name="devices_device_config_keep_awake_desc">Keep the screen on while this device is connected.</string>
     <string name="devices_device_config_volume_observe_label">Observe changes</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -67,6 +67,12 @@
     <string name="devices_device_config_volume_observe_desc">Pozostań aktywny, gdy to urządzenie jest połączone i zapisuj zmiany głośności, które nie zostały spowodowane przez tę aplikację.</string>
     <string name="devices_device_config_volume_lock_label">Blokada głośności</string>
     <string name="devices_device_config_volume_lock_desc">Jakiekolwiek zmiany, które nie będą wprowadzane przez aplikację, zostaną cofnięte, gdy urządzenie jest podłączone.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Ogranicznik częstotliwości głośności</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Ogranicza częstotliwość zmian głośności, aby zapobiec szybkim lub nadmiernym regulacjom.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Opóźnienie zwiększenia głośności</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimalny czas między zwiększeniami głośności: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Opóźnienie zmniejszenia głośności</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimalny czas między zmniejszeniami głośności: %d ms</string>
     <string name="devices_device_config_autoplay_label">Automatyczne odtwarzanie</string>
     <string name="devices_device_config_autoplay_desc">Symuluje naciśnięcie przycisku odtwarzania na zdalnym urządzeniu Bluetooth, gdy urządzenie zostanie podłączone.</string>
     <string name="devices_device_config_section_volumes_label">Głośności</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -70,8 +70,10 @@
     <string name="devices_device_config_volume_lock_desc">Qualquer alteração de volume não feita através deste aplicativo será revertida enquanto este dispositivo estiver conectado.</string>
     <string name="devices_device_config_volume_rate_limiter_label">Limitador de taxa de volume</string>
     <string name="devices_device_config_volume_rate_limiter_desc">Limita a frequência de mudanças de volume para prevenir ajustes rápidos ou excessivos.</string>
-    <string name="devices_device_config_volume_rate_limit_duration_label">Duração do limite de taxa</string>
-    <string name="devices_device_config_volume_rate_limit_duration_desc">Tempo mínimo entre mudanças de volume: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Atraso de aumento de volume</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Tempo mínimo entre aumentos de volume: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Atraso de diminuição de volume</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Tempo mínimo entre diminuições de volume: %d ms</string>
     <string name="devices_device_config_autoplay_label">Reprodução automática</string>
     <string name="devices_device_config_autoplay_desc">Simula uma reprodução imediata em um controle remoto bluetooth ao conectar este dispositivo.</string>
     <string name="devices_device_config_autoplay_keycodes_available">Tipos de teclas disponíveis</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -60,6 +60,12 @@
     <string name="devices_device_config_volume_observe_desc">Mantém-se ativo enquanto este dispositivo está conectado e guarda alterações de volume que não tenham sido causadas por esta aplicação.</string>
     <string name="devices_device_config_volume_lock_label">Bloqueio de volume</string>
     <string name="devices_device_config_volume_lock_desc">Quaisquer alterações de volume não feitas através desta aplicação serão revertidas enquanto este dispositivo estiver conectado.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Limitador de taxa de volume</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Limita a frequência de mudanças de volume para evitar ajustes rápidos ou excessivos.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Atraso de aumento de volume</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Tempo mínimo entre aumentos de volume: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Atraso de diminuição de volume</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Tempo mínimo entre diminuições de volume: %d ms</string>
     <string name="devices_device_config_autoplay_label">Reprodução automática</string>
     <string name="devices_device_config_autoplay_desc">Simular toque no Bluetooth remoto quando este dispositivo é conectado.</string>
     <string name="devices_device_config_autoplay_keycodes_available">Tipos de teclas disponíveis</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -56,6 +56,12 @@
     <string name="devices_device_config_volume_observe_desc">Rămâi activ cât timp acest dispozitiv este conectat și salvează schimbările de volum care nu au fost cauzate de această aplicație.</string>
     <string name="devices_device_config_volume_lock_label">Blocare volum</string>
     <string name="devices_device_config_volume_lock_desc">Orice schimbări de volum care nu sunt făcute prin această aplicație vor fi revenite cât timp acest dispozitiv este conectat.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Limitator de rată volum</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Limitează frecvența schimbărilor de volum pentru a preveni ajustările rapide sau excesive.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Întârziere creștere volum</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Timp minim între creșterile de volum: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Întârziere scădere volum</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Timp minim între scăderile de volum: %d ms</string>
     <string name="devices_device_config_autoplay_label">Redare automată</string>
     <string name="devices_device_config_autoplay_desc">Simulează apăsarea butonului play pe o telecomandă Bluetooth când se conectează acest dispozitiv.</string>
     <string name="devices_app_selection_currently_selected">Selectate în prezent</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -66,8 +66,10 @@
     <string name="devices_device_config_volume_lock_desc">Любые изменения громкости, не сделанные через это приложение, будут возвращены, к умолчаниям, пока это устройство подключено.</string>
     <string name="devices_device_config_volume_rate_limiter_label">Ограничитель частоты громкости</string>
     <string name="devices_device_config_volume_rate_limiter_desc">Ограничивает частоту изменений громкости для предотвращения быстрых или чрезмерных настроек.</string>
-    <string name="devices_device_config_volume_rate_limit_duration_label">Длительность ограничения частоты</string>
-    <string name="devices_device_config_volume_rate_limit_duration_desc">Минимальное время между изменениями громкости: %d мс</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Задержка увеличения громкости</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Минимальное время между увеличениями громкости: %d мс</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Задержка уменьшения громкости</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Минимальное время между уменьшениями громкости: %d мс</string>
     <string name="devices_device_config_autoplay_label">Автовоспроизведение</string>
     <string name="devices_device_config_autoplay_desc">Симуляция нажатия кнопки воспроизведения на пульте ДУ Bluetooth при подключении устройства.</string>
     <string name="devices_device_config_autoplay_keycodes_available">Доступные типы клавиш</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -51,6 +51,12 @@
     <string name="devices_device_config_volume_observe_desc">Stay active while this device is connected and save volume changes that have not been caused by this app.</string>
     <string name="devices_device_config_volume_lock_label">Volume lock</string>
     <string name="devices_device_config_volume_lock_desc">Any volume changes not made through this app will be reverted while this device is connected.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">හඩ වේගය සීමාකාරක</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">වේග හඩ වෙනස්කම් වලට සීමාකරණ ක්‍රියාවලිය තිබිය, ශීඝ්‍ර හෝ අධික හඩ සකසීම් වළක්වන්න.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">හඩ වැඩිකිරීම ප්‍රමාණකාරකතාව</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">හඩ වැඩිකිරීම් අතර අවම වේලාව: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">හඩ අඩුකිරීම ප්‍රමාණකාරකතාව</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">හඩ අඩුකිරීම් අතර අවම වේලාව: %d ms</string>
     <string name="devices_device_config_autoplay_label">Autoplay</string>
     <string name="devices_device_config_autoplay_desc">Simulate pressing play on a Bluetooth remote when this device connects.</string>
     <string name="devices_device_config_section_volumes_label">Volumes</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -60,6 +60,12 @@
     <string name="devices_device_config_volume_observe_desc">Stay active while this device is connected and save volume changes that have not been caused by this app.</string>
     <string name="devices_device_config_volume_lock_label">Uzamknutie hlasitosti</string>
     <string name="devices_device_config_volume_lock_desc">Všetky zmeny hlasitosti, ktoré neboli vykonané touto aplikáciou sa zrušia po pripojení zariadenia.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Regulátor frekvencie hlasitosti</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Obmedzuje frekvenciu zmien hlasitosti, aby sa zabránilo rýchlym alebo nadmerným úpravám.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Oneskorenie zvýšenia hlasitosti</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimálny čas medzi zvýšením hlasitosti: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Oneskorenie zníženia hlasitosti</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimálny čas medzi znížením hlasitosti: %d ms</string>
     <string name="devices_device_config_autoplay_label">Automatické prehrávanie</string>
     <string name="devices_device_config_autoplay_desc">Simuluje stlačenie prehrávania na vzdialenom Bluetooth pri pripojení tohto zariadenia.</string>
     <string name="devices_device_config_autoplay_keycodes_available">Dostupné typy klávesov</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -56,6 +56,12 @@
     <string name="devices_device_config_notification_policy_required_ringtone">Nadzor glasnosti zvonjenja zahteva dostop do pravilnika obvestil</string>
     <string name="devices_device_config_visible_adjustments_label">Vidne prilagoditve</string>
     <string name="devices_device_config_visible_adjustments_desc">Vklopi/izklopi katere prilagoditve so prikazane na kartici naprave</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Omejevalnik frekvence glasnosti</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Omejuje frekvenco sprememb glasnosti, da se izognete hitrim ali prevelikim prilagodtvam.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Zakasnjenje povečanja glasnosti</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Najmanjši čas med povečanji glasnosti: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Zakasnjenje zmanjšanja glasnosti</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Najmanjši čas med zmanjšanji glasnosti: %d ms</string>
     <string name="devices_device_config_keep_awake_label">Keep awake</string>
     <string name="devices_device_config_keep_awake_desc">Keep the screen on while this device is connected.</string>
     <string name="devices_device_config_volume_observe_label">Observe changes</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -45,6 +45,10 @@
     <string name="devices_device_config_nudge_volume_label">Nudge volume</string>
     <string name="devices_device_config_nudge_volume_description">Lower then raise the volume by one increment, even if the desired volume is already set (according to the system).</string>
     <string name="devices_device_config_visible_adjustments_label">Rregullimet e dukshme</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Vonesë për rritjen e volumit</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Koha minimale ndërmjet rritjeve të volumit: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Vonesë për zvogëlimin e volumit</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Koha minimale ndërmjet zvogëlimeve të volumit: %d ms</string>
     <string name="devices_device_config_keep_awake_label">Keep awake</string>
     <string name="devices_device_config_keep_awake_desc">Keep the screen on while this device is connected.</string>
     <string name="devices_device_config_volume_observe_label">Observe changes</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -258,8 +258,10 @@
     <string name="devices_device_config_volume_save_on_disconnect_desc">Fånga och spara aktuella volymnivåer när denna enhet kopplas från.</string>
     <string name="devices_device_config_volume_rate_limiter_label">Volymhastighetsbegränsare</string>
     <string name="devices_device_config_volume_rate_limiter_desc">Begränsa frekvensen av volymförändringar för att förhindra snabba eller överdrivna volymjusteringar.</string>
-    <string name="devices_device_config_volume_rate_limit_duration_label">Hastighetsbegränsning varaktighet</string>
-    <string name="devices_device_config_volume_rate_limit_duration_desc">Minimitid mellan volymförändringar: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Volymökningsfördröjning</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimitid mellan volymökningar: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Volymminskningsfördröjning</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimitid mellan volymminskningar: %d ms</string>
     <string name="devices_device_config_dnd_on_connect_label">Stör ej-läge</string>
     <string name="dnd_mode_dialog_title">Välj Stör ej-läge</string>
     <string name="dnd_mode_dont_change">Förändra inte</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -60,6 +60,12 @@
     <string name="devices_device_config_volume_observe_desc">ยังคงทำงานอยู่ขณะที่อุปกรณ์นี้เชื่อมต่อและบันทึกการเปลี่ยนแปลงระดับเสียงที่ไม่ได้เกิดจากแอปนี้</string>
     <string name="devices_device_config_volume_lock_label">ล็อกระดับเสียง</string>
     <string name="devices_device_config_volume_lock_desc">การเปลี่ยนแปลงระดับเสียงที่ไม่ได้ทำผ่านแอปนี้จะถูกย้อนกลับขณะที่อุปกรณ์นี้เชื่อมต่ออยู่</string>
+    <string name="devices_device_config_volume_rate_limiter_label">ตัวจำกัดอัตราเสียง</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">จำกัดความถี่ของการเปลี่ยนแปลงระดับเสียงเพื่อป้องกันการปรับระดับเสียงอย่างรวดเร็วหรือมากเกินไป</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">ความล่าช้าการเพิ่มระดับเสียง</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">เวลาขั้นต่ำระหว่างการเพิ่มระดับเสียง: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">ความล่าช้าในการลดระดับเสียง</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">เวลาขั้นต่ำระหว่างการลดระดับเสียง: %d ms</string>
     <string name="devices_device_config_autoplay_label">เล่นอัตโนมัติ</string>
     <string name="devices_device_config_autoplay_desc">จำลองการเล่นแบบกดบนรีโมตบลูทูธเมื่อเชื่อมต่ออุปกรณ์นี้</string>
     <string name="devices_device_config_autoplay_keycodes_available">ประเภทปุ่มที่มีอยู่</string>

--- a/app/src/main/res/values-tl-rPH/strings.xml
+++ b/app/src/main/res/values-tl-rPH/strings.xml
@@ -51,6 +51,12 @@
     <string name="devices_device_config_volume_observe_desc">Stay active while this device is connected and save volume changes that have not been caused by this app.</string>
     <string name="devices_device_config_volume_lock_label">Volume lock</string>
     <string name="devices_device_config_volume_lock_desc">Any volume changes not made through this app will be reverted while this device is connected.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Limitador ng rate ng volume</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Limitahan ang frequency ng mga pagbabago sa volume upang maiwasan ang mabilis o sobrang pagsasaayos ng volume.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Pagkaantala sa pagtaas ng volume</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimum na oras sa pagitan ng mga pagtaas ng volume: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Pagkaantala sa pagbaba ng volume</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimum na oras sa pagitan ng mga pagbaba ng volume: %d ms</string>
     <string name="devices_device_config_autoplay_label">Auto-play</string>
     <string name="devices_device_config_autoplay_desc">Gayahin ang pagpindont ng play sa remote ng Bluetooth kapag kumonekta ang device.</string>
     <string name="devices_device_config_section_volumes_label">Volumes</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -43,6 +43,10 @@
     <string name="devices_device_config_adjustment_delay_desc">Her ses ayarı arasındaki milisaniye cinsinden gecikme. 0ms gecikme, bu cihaz bağlandığında ses seviyesini anında ayarlamak anlamına gelir.</string>
     <string name="devices_device_config_reaction_delay_label">Reaksiyon gecikmesi</string>
     <string name="devices_device_config_reaction_delay_desc">Bu uygulama bu cihaza tepki verene kadarki milisaniye cinsinden gecikme.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Ses artırma gecikmesi</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Ses artırma işlemleri arasında geçen minimum süre: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Ses azaltma gecikmesi</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Ses azaltma işlemleri arasında geçen minimum süre: %d ms</string>
     <string name="devices_device_config_section_reaction_label">Diğer</string>
     <string name="devices_device_config_launch_app_label">Uygulamayı başlat</string>
     <string name="devices_device_config_launch_app_desc">Bu cihaz bağlandığında uygulamayı başlat.</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -61,6 +61,12 @@
     <string name="devices_device_config_volume_observe_desc">Залишатися активним, поки пристрій під\'єднаний, і зберігати зміни гучності, які не були викликані цим додатком.</string>
     <string name="devices_device_config_volume_lock_label">Блокування гучності</string>
     <string name="devices_device_config_volume_lock_desc">Будь-які зміни гучності, зроблені не через цей додаток, будуть скасовані, поки пристрій під\'єднаний.</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Обмежувач частоти гучності</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Обмежує частоту змін гучності, щоб запобігти швидким або надмірним регулюванням.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Затримка збільшення гучності</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Мінімальний час між збільшеннями гучності: %d мс</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Затримка зменшення гучності</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Мінімальний час між зменшеннями гучності: %d мс</string>
     <string name="devices_device_config_autoplay_keycodes_available">Доступні типи клавіш</string>
     <string name="devices_device_config_autoplay_keycodes_desc">Налаштуйте які клавіші надсилати та в якому порядку</string>
     <string name="devices_device_config_autoplay_keycodes_label">Типи клавіш</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -44,10 +44,16 @@
     <string name="devices_device_config_launch_app_desc">Khởi động ứng dụng khi kết nối thiết bị này.</string>
     <string name="devices_device_config_launch_app_multiple_desc">Đã chọn %d ứng dụng</string>
     <string name="devices_device_config_nudge_volume_label">Khuyến khích âm lượng</string>
+    <string name="devices_device_config_nudge_volume_description">Giảm rồi tăng âm lượng lên một bậc, ngay cả khi âm lượng mong muốn đã được đặt (theo hệ thống).</string>
+    <string name="devices_device_config_volume_rate_limiter_label">Giới hạn tốc độ âm lượng</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">Giới hạn tần suất thay đổi âm lượng để ngăn chặn điều chỉnh âm lượng nhanh chóng hoặc quá mức.</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Độ trễ tăng âm lượng</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Thời gian tối thiểu giữa các lần tăng âm lượng: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Độ trễ giảm âm lượng</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Thời gian tối thiểu giữa các lần giảm âm lượng: %d ms</string>
     <string name="devices_device_config_notification_policy_action">Cấp quyền truy cập</string>
     <string name="devices_device_config_notification_policy_required_notification">Điều khiển âm lượng thông báo cần quyền truy cập chính sách thông báo</string>
     <string name="devices_device_config_notification_policy_required_ringtone">Điều khiển âm lượng chuông cần quyền truy cập chính sách thông báo</string>
-    <string name="devices_device_config_nudge_volume_description">Giảm rồi tăng âm lượng lên một bậc, ngay cả khi âm lượng mong muốn đã được đặt (theo hệ thống).</string>
     <string name="devices_device_config_visible_adjustments_label">Điều chỉnh hiển thị</string>
     <string name="devices_device_config_visible_adjustments_desc">Chuyển đổi điều chỉnh nào được hiển thị trên thẻ thiết bị</string>
     <string name="devices_device_config_keep_awake_label">Giữ màn hình sáng</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -67,8 +67,10 @@
     <string name="devices_device_config_volume_lock_desc">此设备连接时，非此应用进行的音量更改将被还原。</string>
     <string name="devices_device_config_volume_rate_limiter_label">音量频率限制器</string>
     <string name="devices_device_config_volume_rate_limiter_desc">限制音量变更的频率，以防止快速或过度的音量调整。</string>
-    <string name="devices_device_config_volume_rate_limit_duration_label">频率限制持续时间</string>
-    <string name="devices_device_config_volume_rate_limit_duration_desc">音量变更之间的最短时间：%d 毫秒</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">音量增加延迟</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">音量增加之间的最短时间：%d 毫秒</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">音量降低延迟</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">音量降低之间的最短时间：%d 毫秒</string>
     <string name="devices_device_config_autoplay_label">自动播放</string>
     <string name="devices_device_config_autoplay_desc">当此设备连接时，将模拟在蓝牙遥控器上按下播放键。</string>
     <string name="devices_device_config_autoplay_keycodes_available">可用的按键类型</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -64,6 +64,12 @@
     <string name="devices_device_config_volume_observe_desc">在此裝置連接時保持活躍，並儲存非由這個應用程式引起的音量變更。</string>
     <string name="devices_device_config_volume_lock_label">音量鎖定</string>
     <string name="devices_device_config_volume_lock_desc">在該裝置連線時，任何未透過這個應用程式進行的音量變更都將被還原。</string>
+    <string name="devices_device_config_volume_rate_limiter_label">音量速率限制器</string>
+    <string name="devices_device_config_volume_rate_limiter_desc">限制音量變更的頻率，以防止快速或過度的音量調整。</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">音量增加延遲</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">音量增加之間的最短時間：%d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">音量降低延遲</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">音量降低之間的最短時間：%d ms</string>
     <string name="devices_device_config_autoplay_label">自動播放</string>
     <string name="devices_device_config_autoplay_desc">在這個裝置連線時模擬按下藍牙遙控器的播放鍵。</string>
     <string name="devices_device_config_autoplay_keycodes_available">可用按鍵類型</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -71,8 +71,10 @@
     <string name="devices_device_config_volume_lock_desc">Any volume changes not made through this app will be reverted while this device is connected.</string>
     <string name="devices_device_config_volume_rate_limiter_label">Volume rate limiter</string>
     <string name="devices_device_config_volume_rate_limiter_desc">Limit the frequency of volume changes to prevent rapid or excessive volume adjustments.</string>
-    <string name="devices_device_config_volume_rate_limit_duration_label">Rate limit duration</string>
-    <string name="devices_device_config_volume_rate_limit_duration_desc">Minimum time between volume changes: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_label">Volume increase delay</string>
+    <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimum time between volume increases: %d ms</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Volume decrease delay</string>
+    <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimum time between volume decreases: %d ms</string>
     <string name="devices_device_config_autoplay_label">Autoplay</string>
     <string name="devices_device_config_autoplay_desc">Simulate pressing play on a Bluetooth remote when this device connects.</string>
     <string name="devices_device_config_autoplay_keycodes_title">Autoplay Key Types</string>


### PR DESCRIPTION
The volume rate limiter feature now supports different delay configurations for increasing and decreasing volume, giving users more granular control.

- Database: Two-step migration (v1→v2→v3) to preserve existing settings
- UI: Separate configuration options for increase and decrease delays
- Core: Directional rate limiting logic based on volume change direction
- Localization: Translated to 50+ languages

Migration strategy combines manual migration (1→2) for data preservation with AutoMigration (2→3) for clean column deletion.