### PR TITLE
Fix Fastlane short description length for pcm-NG, ro, and sc-IT locales

### DIFF
--- a/fastlane/metadata/android/pcm-NG/short_description.txt
+++ b/fastlane/metadata/android/pcm-NG/short_description.txt
@@ -1,1 +1,1 @@
-Different voice and music volume setting for each Bluetooth device wey you dey use.
+Different voice and music volume setting for each Bluetooth device wey you use.

--- a/fastlane/metadata/android/ro/short_description.txt
+++ b/fastlane/metadata/android/ro/short_description.txt
@@ -1,1 +1,1 @@
-Configurare individuală a volumului pentru voce și muzică pentru dispozitivele Bluetooth.
+Configurare volum voce și muzică individuală pentru dispozitive Bluetooth.

--- a/fastlane/metadata/android/sc-IT/short_description.txt
+++ b/fastlane/metadata/android/sc-IT/short_description.txt
@@ -1,1 +1,1 @@
-Cunfiguratzione individuali de volùmine boghe & mùsica pro dispositivos Bluetooth.
+Cunfiguratzione volùmine boghe & mùsica individuali pro dispositivos Bluetooth.


### PR DESCRIPTION
Shortened descriptions to comply with 80-character limit:
- pcm-NG: 83→79 chars (removed redundant "dey")
- ro: 89→74 chars (simplified structure)
- sc-IT: 82→79 chars (reordered words)

Fixes #128