### PR TITLE
Fix display cutout padding causing gap between top bar and content

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -114,6 +115,7 @@ fun DiscoverScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .horizontalCutoutPadding()
         ) {
             when {
                 state.isLoading -> {

--- a/app/src/main/java/eu/darken/bluemusic/common/compose/WindowInsetsExtensions.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/compose/WindowInsetsExtensions.kt
@@ -1,0 +1,14 @@
+package eu.darken.bluemusic.common.compose
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.only
+import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Modifier.horizontalCutoutPadding(): Modifier = windowInsetsPadding(
+    WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)
+)

--- a/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/ui/RecorderScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/ui/RecorderScreen.kt
@@ -13,15 +13,13 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -120,7 +118,7 @@ private fun RecorderScreen(
                 Surface(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .windowInsetsPadding(WindowInsets.navigationBars),
+                        .safeDrawingPadding(),
                     color = MaterialTheme.colorScheme.surface,
                     shadowElevation = 8.dp
                 ) {

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/appselection/AppSelectionScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/appselection/AppSelectionScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -144,6 +145,7 @@ fun AppSelectionScreen(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
+                .horizontalCutoutPadding()
         ) {
             // Search bar
             OutlinedTextField(

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -329,7 +330,8 @@ fun DeviceConfigScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
+                .padding(paddingValues)
+                .horizontalCutoutPadding(),
             contentPadding = PaddingValues(vertical = 8.dp)
         ) {
             // Device Header Card

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -127,7 +128,8 @@ fun DevicesScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
+                .padding(paddingValues)
+                .horizontalCutoutPadding(),
             contentPadding = PaddingValues(vertical = 8.dp)
         ) {
             // Critical permission/state cards - these block normal functionality

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsScreen.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.devices.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -79,7 +80,8 @@ fun DevicesSettingsScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
+                .padding(paddingValues)
+                .horizontalCutoutPadding(),
             verticalArrangement = Arrangement.Top
         ) {
             item {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/onboarding/OnboardingScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/onboarding/OnboardingScreen.kt
@@ -3,9 +3,8 @@ package eu.darken.bluemusic.main.ui.onboarding
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
@@ -63,8 +62,7 @@ private fun OnboardingScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .statusBarsPadding()
-            .navigationBarsPadding()
+            .safeDrawingPadding()
             .padding(16.dp)
     ) {
         HorizontalPager(

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreen.kt
@@ -2,6 +2,7 @@ package eu.darken.bluemusic.main.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -120,7 +121,8 @@ fun SettingsIndexScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
+                .padding(paddingValues)
+                .horizontalCutoutPadding(),
             verticalArrangement = Arrangement.Top
         ) {
             item {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/acknowledgements/AcknowledgementsScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/acknowledgements/AcknowledgementsScreen.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.main.ui.settings.acknowledgements
 
 import androidx.compose.foundation.layout.Arrangement
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -51,7 +52,8 @@ fun AcknowledgementsScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
+                .padding(paddingValues)
+                .horizontalCutoutPadding(),
             verticalArrangement = Arrangement.Top
         ) {
             item {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/general/GeneralSettingsScreen.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.main.ui.settings.general
 
 import androidx.compose.foundation.layout.Arrangement
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -92,7 +93,8 @@ fun GeneralSettingsScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
+                .padding(paddingValues)
+                .horizontalCutoutPadding(),
             verticalArrangement = Arrangement.Top
         ) {
             item {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/support/SupportScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/support/SupportScreen.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.main.ui.settings.support
 
 import androidx.compose.foundation.layout.Arrangement
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -93,7 +94,8 @@ fun SupportScreen(
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(paddingValues),
+                .padding(paddingValues)
+                .horizontalCutoutPadding(),
             verticalArrangement = Arrangement.Top
         ) {
             item {


### PR DESCRIPTION
## Summary
- Fix gap between top bar and content caused by `displayCutoutPadding()` applying padding to all sides
- Add `horizontalCutoutPadding()` extension that only applies to left/right sides

## Changes
- New: `WindowInsetsExtensions.kt` with `horizontalCutoutPadding()` function
- Updated 11 screen files to use the new extension

## Root Cause
`displayCutoutPadding()` applies padding to ALL sides (including top for notches), which stacks with Scaffold's `paddingValues` that already handles the top bar area.

## Solution
Use `WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)` to only protect against side cutouts in landscape while avoiding the portrait gap.

## Test plan
- [x] Portrait mode: Verify NO gap between top bar and content
- [x] Landscape mode: Verify content isn't obscured by side cutouts