### PR TITLE
Add connection alert feature for Bluetooth devices

### DIFF
--- a/app/schemas/eu.darken.bluemusic.devices.core.database.DevicesRoomDb/4.json
+++ b/app/schemas/eu.darken.bluemusic.devices.core.database.DevicesRoomDb/4.json
@@ -1,0 +1,186 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 4,
+    "identityHash": "232b45255b86081eb6c8fb3018897962",
+    "entities": [
+      {
+        "tableName": "device_configs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`address` TEXT NOT NULL, `custom_name` TEXT, `last_connected` INTEGER NOT NULL, `action_delay` INTEGER, `adjustment_delay` INTEGER, `monitoring_duration` INTEGER, `music_volume` REAL, `call_volume` REAL, `ring_volume` REAL, `notification_volume` REAL, `alarm_volume` REAL, `volume_lock` INTEGER NOT NULL, `volume_observing` INTEGER NOT NULL, `volume_rate_limiter` INTEGER NOT NULL, `volume_rate_limit_increase_ms` INTEGER, `volume_rate_limit_decrease_ms` INTEGER, `volume_save_on_disconnect` INTEGER NOT NULL DEFAULT false, `keep_awake` INTEGER NOT NULL, `nudge_volume` INTEGER NOT NULL, `autoplay` INTEGER NOT NULL, `launch_pkgs` TEXT NOT NULL DEFAULT '[]', `show_home_screen` INTEGER NOT NULL DEFAULT false, `autoplay_keycodes` TEXT NOT NULL DEFAULT '[126]', `is_enabled` INTEGER NOT NULL DEFAULT true, `visible_adjustments` INTEGER DEFAULT true, `dnd_mode` TEXT, `connection_alert_type` TEXT NOT NULL DEFAULT 'none', `connection_alert_sound_uri` TEXT, PRIMARY KEY(`address`))",
+        "fields": [
+          {
+            "fieldPath": "address",
+            "columnName": "address",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customName",
+            "columnName": "custom_name",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastConnected",
+            "columnName": "last_connected",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "actionDelay",
+            "columnName": "action_delay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "adjustmentDelay",
+            "columnName": "adjustment_delay",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "monitoringDuration",
+            "columnName": "monitoring_duration",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "musicVolume",
+            "columnName": "music_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "callVolume",
+            "columnName": "call_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "ringVolume",
+            "columnName": "ring_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "notificationVolume",
+            "columnName": "notification_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "alarmVolume",
+            "columnName": "alarm_volume",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "volumeLock",
+            "columnName": "volume_lock",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeObserving",
+            "columnName": "volume_observing",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeRateLimiter",
+            "columnName": "volume_rate_limiter",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "volumeRateLimitIncreaseMs",
+            "columnName": "volume_rate_limit_increase_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "volumeRateLimitDecreaseMs",
+            "columnName": "volume_rate_limit_decrease_ms",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "volumeSaveOnDisconnect",
+            "columnName": "volume_save_on_disconnect",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "keepAwake",
+            "columnName": "keep_awake",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nudgeVolume",
+            "columnName": "nudge_volume",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoplay",
+            "columnName": "autoplay",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "launchPkgs",
+            "columnName": "launch_pkgs",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[]'"
+          },
+          {
+            "fieldPath": "showHomeScreen",
+            "columnName": "show_home_screen",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "autoplayKeycodes",
+            "columnName": "autoplay_keycodes",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'[126]'"
+          },
+          {
+            "fieldPath": "isEnabled",
+            "columnName": "is_enabled",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "visibleAdjustments",
+            "columnName": "visible_adjustments",
+            "affinity": "INTEGER",
+            "defaultValue": "true"
+          },
+          {
+            "fieldPath": "dndMode",
+            "columnName": "dnd_mode",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "connectionAlertType",
+            "columnName": "connection_alert_type",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'none'"
+          },
+          {
+            "fieldPath": "connectionAlertSoundUri",
+            "columnName": "connection_alert_sound_uri",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "address"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '232b45255b86081eb6c8fb3018897962')"
+    ]
+  }
+}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
+    <uses-permission android:name="android.permission.VIBRATE" />
 
     <queries>
         <intent>

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDevice.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDevice.kt
@@ -2,6 +2,7 @@ package eu.darken.bluemusic.devices.core
 
 import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.monitor.core.alert.AlertType
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.DndMode
 import java.time.Duration
@@ -60,6 +61,10 @@ data class ManagedDevice(
         get() = config.visibleAdjustments ?: true
     val dndMode: DndMode?
         get() = config.dndMode
+    val connectionAlertType: AlertType
+        get() = config.connectionAlertType
+    val connectionAlertSoundUri: String?
+        get() = config.connectionAlertSoundUri
     val requiresMonitor: Boolean
         get() = volumeLock || volumeObserving || volumeRateLimiter
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/database/AlertTypeConverter.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/database/AlertTypeConverter.kt
@@ -1,0 +1,12 @@
+package eu.darken.bluemusic.devices.core.database
+
+import androidx.room.TypeConverter
+import eu.darken.bluemusic.monitor.core.alert.AlertType
+
+class AlertTypeConverter {
+    @TypeConverter
+    fun fromAlertType(type: AlertType?): String? = type?.key
+
+    @TypeConverter
+    fun toAlertType(key: String?): AlertType = AlertType.fromKey(key)
+}

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceConfigEntity.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceConfigEntity.kt
@@ -4,6 +4,7 @@ import android.view.KeyEvent
 import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import eu.darken.bluemusic.monitor.core.alert.AlertType
 import eu.darken.bluemusic.monitor.core.audio.DndMode
 
 @Entity(tableName = "device_configs")
@@ -86,4 +87,10 @@ data class DeviceConfigEntity(
 
     @ColumnInfo(name = "dnd_mode")
     val dndMode: DndMode? = null,
+
+    @ColumnInfo(name = "connection_alert_type", defaultValue = "none")
+    val connectionAlertType: AlertType = AlertType.NONE,
+
+    @ColumnInfo(name = "connection_alert_sound_uri")
+    val connectionAlertSoundUri: String? = null,
 )

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/database/DevicesRoomDb.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/database/DevicesRoomDb.kt
@@ -9,13 +9,14 @@ import androidx.room.TypeConverters
     entities = [
         DeviceConfigEntity::class,
     ],
-    version = 3,
+    version = 4,
     autoMigrations = [
-        AutoMigration(from = 2, to = 3, spec = Migration2To3::class)
+        AutoMigration(from = 2, to = 3, spec = Migration2To3::class),
+        AutoMigration(from = 3, to = 4)
     ],
     exportSchema = true,
 )
-@TypeConverters(StringListTypeConverter::class, IntListTypeConverter::class, DndModeTypeConverter::class)
+@TypeConverters(StringListTypeConverter::class, IntListTypeConverter::class, DndModeTypeConverter::class, AlertTypeConverter::class)
 abstract class DevicesRoomDb : RoomDatabase() {
     abstract fun devices(): DeviceConfigDao
 }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/ConfigAction.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/ConfigAction.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.devices.ui.config
 
+import eu.darken.bluemusic.monitor.core.alert.AlertType
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.DndMode
 import java.time.Duration
@@ -38,4 +39,7 @@ sealed interface ConfigAction {
     data object OnToggleEnabled : ConfigAction
     data object OnEditDndModeClicked : ConfigAction
     data class OnEditDndMode(val mode: DndMode?) : ConfigAction
+    data object OnEditConnectionAlertClicked : ConfigAction
+    data class OnEditConnectionAlertType(val type: AlertType) : ConfigAction
+    data class OnEditConnectionAlertSoundUri(val uri: String?) : ConfigAction
 }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/ConfigEvent.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/ConfigEvent.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.devices.ui.config
 
 import android.content.Intent
+import eu.darken.bluemusic.monitor.core.alert.AlertType
 import eu.darken.bluemusic.monitor.core.audio.DndMode
 import java.time.Duration
 
@@ -14,6 +15,7 @@ sealed interface ConfigEvent {
     data class ShowVolumeRateLimitDecreaseDialog(val currentValue: Duration) : ConfigEvent
     data object ShowAutoplayKeycodesDialog : ConfigEvent
     data class ShowDndModeDialog(val currentMode: DndMode?) : ConfigEvent
+    data class ShowConnectionAlertDialog(val currentType: AlertType, val currentSoundUri: String?) : ConfigEvent
     data object NavigateBack : ConfigEvent
     data object RequiresPro : ConfigEvent
     data class RequiresNotificationPolicyAccess(

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigViewModel.kt
@@ -333,6 +333,32 @@ class DeviceConfigViewModel @AssistedInject constructor(
                     oldConfig.copy(dndMode = action.mode)
                 }
             }
+
+            is ConfigAction.OnEditConnectionAlertClicked -> {
+                if (!upgradeRepo.isPro()) {
+                    events.emit(ConfigEvent.RequiresPro)
+                } else {
+                    val device = state.first().device
+                    events.emit(
+                        ConfigEvent.ShowConnectionAlertDialog(
+                            device.connectionAlertType,
+                            device.connectionAlertSoundUri
+                        )
+                    )
+                }
+            }
+
+            is ConfigAction.OnEditConnectionAlertType -> {
+                deviceRepo.updateDevice(deviceAddress) { oldConfig ->
+                    oldConfig.copy(connectionAlertType = action.type)
+                }
+            }
+
+            is ConfigAction.OnEditConnectionAlertSoundUri -> {
+                deviceRepo.updateDevice(deviceAddress) { oldConfig ->
+                    oldConfig.copy(connectionAlertSoundUri = action.uri)
+                }
+            }
         }
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/dialogs/ConnectionAlertDialog.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/dialogs/ConnectionAlertDialog.kt
@@ -1,0 +1,90 @@
+package eu.darken.bluemusic.devices.ui.config.dialogs
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.RadioButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import eu.darken.bluemusic.common.compose.Preview2
+import androidx.compose.ui.unit.dp
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.monitor.core.alert.AlertType
+
+@Composable
+fun ConnectionAlertDialog(
+    currentType: AlertType,
+    onConfirm: (AlertType) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val alertTypes = listOf(
+        AlertType.NONE to stringResource(R.string.connection_alert_type_none),
+        AlertType.SOUND to stringResource(R.string.connection_alert_type_sound),
+        AlertType.VIBRATION to stringResource(R.string.connection_alert_type_vibration),
+        AlertType.BOTH to stringResource(R.string.connection_alert_type_both)
+    )
+
+    var selectedType by remember { mutableStateOf(currentType) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.connection_alert_dialog_title)) },
+        text = {
+            LazyColumn {
+                items(alertTypes) { (type, label) ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { selectedType = type }
+                            .padding(vertical = 12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        RadioButton(
+                            selected = selectedType == type,
+                            onClick = { selectedType = type }
+                        )
+                        Text(
+                            text = label,
+                            modifier = Modifier.padding(start = 16.dp)
+                        )
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = { onConfirm(selectedType) }) {
+                Text(stringResource(R.string.general_ok_action))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.general_cancel_action))
+            }
+        }
+    )
+}
+
+@Preview2
+@Composable
+private fun ConnectionAlertDialogPreview() {
+    PreviewWrapper {
+        ConnectionAlertDialog(
+            currentType = AlertType.SOUND,
+            onConfirm = {},
+            onDismiss = {}
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/device/OptionIndicators.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/device/OptionIndicators.kt
@@ -19,6 +19,7 @@ import androidx.compose.material.icons.twotone.Lock
 import androidx.compose.material.icons.twotone.PlayArrow
 import androidx.compose.material.icons.twotone.PowerOff
 import androidx.compose.material.icons.twotone.Speed
+import androidx.compose.material.icons.twotone.NotificationsActive
 import androidx.compose.material.icons.twotone.Visibility
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -34,6 +35,7 @@ import eu.darken.bluemusic.common.apps.AppInfo
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
 import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.monitor.core.alert.AlertType
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -52,6 +54,7 @@ fun OptionIndicators(
         if (device.autoplay) add(Icons.TwoTone.PlayArrow to stringResource(R.string.devices_device_config_autoplay_label))
         if (device.showHomeScreen) add(Icons.TwoTone.Home to stringResource(R.string.devices_device_config_show_home_screen_label))
         if (device.dndMode != null) add(Icons.TwoTone.DoNotDisturb to stringResource(R.string.devices_device_config_dnd_on_connect_label))
+        if (device.connectionAlertType != AlertType.NONE) add(Icons.TwoTone.NotificationsActive to stringResource(R.string.devices_device_config_connection_alert_label))
     }
 
     val hasLaunchApps = launchApps.isNotEmpty()
@@ -115,6 +118,7 @@ fun OptionIndicators(
                             Icons.TwoTone.PlayArrow -> stringResource(R.string.devices_indicator_auto)
                             Icons.TwoTone.Home -> stringResource(R.string.devices_indicator_home)
                             Icons.TwoTone.DoNotDisturb -> stringResource(R.string.devices_indicator_dnd)
+                            Icons.TwoTone.NotificationsActive -> stringResource(R.string.devices_indicator_alert)
                             else -> ""
                         },
                         style = MaterialTheme.typography.labelSmall,

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/alert/AlertTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/alert/AlertTool.kt
@@ -1,0 +1,99 @@
+package eu.darken.bluemusic.monitor.core.alert
+
+import android.content.Context
+import android.media.Ringtone
+import android.media.RingtoneManager
+import android.net.Uri
+import android.os.Build
+import android.os.VibrationEffect
+import android.os.Vibrator
+import android.os.VibratorManager
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import javax.inject.Inject
+import javax.inject.Singleton
+import androidx.core.net.toUri
+
+@Singleton
+class AlertTool @Inject constructor(
+    @ApplicationContext private val context: Context
+) {
+    private var currentRingtone: Ringtone? = null
+
+    private val vibrator: Vibrator by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            val vibratorManager = context.getSystemService(Context.VIBRATOR_MANAGER_SERVICE) as VibratorManager
+            vibratorManager.defaultVibrator
+        } else {
+            @Suppress("DEPRECATION")
+            context.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        }
+    }
+
+    fun playAlert(type: AlertType, soundUri: String? = null) {
+        log(TAG) { "playAlert(type=$type, soundUri=$soundUri)" }
+
+        when (type) {
+            AlertType.NONE -> {}
+            AlertType.SOUND -> playSound(soundUri)
+            AlertType.VIBRATION -> vibrate()
+            AlertType.BOTH -> {
+                playSound(soundUri)
+                vibrate()
+            }
+        }
+    }
+
+    private fun playSound(soundUri: String?) {
+        try {
+            currentRingtone?.stop()
+
+            val uri = if (soundUri.isNullOrEmpty()) {
+                RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+            } else {
+                soundUri.toUri()
+            }
+
+            var ringtone = RingtoneManager.getRingtone(context, uri)
+            if (ringtone == null && !soundUri.isNullOrEmpty()) {
+                log(TAG) { "Failed to get ringtone for uri: $uri, falling back to default" }
+                val defaultUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION)
+                ringtone = RingtoneManager.getRingtone(context, defaultUri)
+            }
+            if (ringtone == null) {
+                log(TAG) { "Failed to get any ringtone" }
+                return
+            }
+            currentRingtone = ringtone
+            ringtone.play()
+            log(TAG) { "Playing sound: $uri" }
+        } catch (e: Exception) {
+            log(TAG) { "Failed to play sound: ${e.message}" }
+        }
+    }
+
+    private fun vibrate() {
+        try {
+            if (!vibrator.hasVibrator()) {
+                log(TAG) { "Device does not have vibrator hardware" }
+                return
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val effect = VibrationEffect.createOneShot(VIBRATION_DURATION_MS, VibrationEffect.DEFAULT_AMPLITUDE)
+                vibrator.vibrate(effect)
+            } else {
+                @Suppress("DEPRECATION")
+                vibrator.vibrate(VIBRATION_DURATION_MS)
+            }
+            log(TAG) { "Vibrating for $VIBRATION_DURATION_MS ms" }
+        } catch (e: Exception) {
+            log(TAG) { "Failed to vibrate: ${e.message}" }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Monitor", "Alert", "Tool")
+        private const val VIBRATION_DURATION_MS = 500L
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/alert/AlertType.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/alert/AlertType.kt
@@ -1,0 +1,18 @@
+package eu.darken.bluemusic.monitor.core.alert
+
+enum class AlertType(val key: String) {
+    NONE("none"),
+    SOUND("sound"),
+    VIBRATION("vibration"),
+    BOTH("both");
+
+    companion object {
+        fun fromKey(key: String?): AlertType = when (key) {
+            null, "none" -> NONE
+            "sound" -> SOUND
+            "vibration" -> VIBRATION
+            "both" -> BOTH
+            else -> NONE
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/ConnectionAlertModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/ConnectionAlertModule.kt
@@ -1,0 +1,69 @@
+package eu.darken.bluemusic.monitor.core.modules.connection
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.common.upgrade.UpgradeRepo
+import eu.darken.bluemusic.common.upgrade.isPro
+import eu.darken.bluemusic.monitor.core.alert.AlertTool
+import eu.darken.bluemusic.monitor.core.alert.AlertType
+import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
+import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
+import eu.darken.bluemusic.monitor.core.modules.delayForReactionDelay
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ConnectionAlertModule @Inject constructor(
+    private val alertTool: AlertTool,
+    private val upgradeRepo: UpgradeRepo,
+) : ConnectionModule {
+
+    private val activeAlertJobs = mutableMapOf<String, Job>()
+
+    override val tag: String
+        get() = TAG
+
+    override val priority: Int = 25
+
+    override suspend fun handle(event: DeviceEvent) {
+        if (event !is DeviceEvent.Connected) return
+
+        val device = event.device
+        if (device.connectionAlertType == AlertType.NONE) return
+
+        if (!upgradeRepo.isPro()) {
+            log(TAG) { "Skipping connection alert - requires Pro version" }
+            return
+        }
+
+        log(TAG) { "Connection alert enabled for device ${device.label}" }
+
+        activeAlertJobs[device.address]?.cancel()
+
+        coroutineScope {
+            activeAlertJobs[device.address] = launch {
+                delayForReactionDelay(event)
+
+                alertTool.playAlert(device.connectionAlertType, device.connectionAlertSoundUri)
+                log(TAG) { "Played connection alert (type=${device.connectionAlertType}) for device ${device.label}" }
+            }
+        }
+    }
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class Mod {
+        @Binds @IntoSet abstract fun bind(entry: ConnectionAlertModule): ConnectionModule
+    }
+
+    companion object {
+        private val TAG = logTag("Monitor", "ConnectionAlert", "Module")
+    }
+}

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">Navigeer terug</string>
     <string name="general_reset_action">Herstel</string>
     <string name="general_save_action">Bewaar</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Verbindingswaarskuwing</string>
+    <string name="connection_alert_dialog_title">Verbindingswaarskuwing</string>
+    <string name="connection_alert_type_none">Geen</string>
+    <string name="connection_alert_type_sound">Slegs klank</string>
+    <string name="connection_alert_type_vibration">Slegs vibrasie</string>
+    <string name="connection_alert_type_both">Klank en vibrasie</string>
+    <string name="devices_indicator_alert">Waarskuwing</string>
 </resources>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -241,6 +241,7 @@
     <string name="general_delete_action">Delete</string>
     <string name="general_navigate_back_action">العودة</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">مسح</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
@@ -256,4 +257,12 @@
     <string name="error_iap_owned_message">You already own this item</string>
     <string name="label_no_devices_title">No Devices</string>
     <string name="bluemusic_mascot_description">App Icon</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">تنبيه الاتصال</string>
+    <string name="connection_alert_dialog_title">تنبيه الاتصال</string>
+    <string name="connection_alert_type_none">بدون</string>
+    <string name="connection_alert_type_sound">صوت فقط</string>
+    <string name="connection_alert_type_vibration">اهتزاز فقط</string>
+    <string name="connection_alert_type_both">صوت واهتزاز</string>
+    <string name="devices_indicator_alert">تنبيه</string>
 </resources>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">Geriyə naviqasiya et</string>
     <string name="general_reset_action">Sıfırla</string>
     <string name="general_save_action">Saxla</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Bağlantı xəbərdarlığı</string>
+    <string name="connection_alert_dialog_title">Bağlantı xəbərdarlığı</string>
+    <string name="connection_alert_type_none">Heç biri</string>
+    <string name="connection_alert_type_sound">Yalnız səs</string>
+    <string name="connection_alert_type_vibration">Yalnız vibrasiya</string>
+    <string name="connection_alert_type_both">Səs və vibrasiya</string>
+    <string name="devices_indicator_alert">Xəbərdarlıq</string>
 </resources>

--- a/app/src/main/res/values-ban-rID/strings.xml
+++ b/app/src/main/res/values-ban-rID/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">Mulih</string>
     <string name="general_reset_action">Reset</string>
     <string name="general_save_action">Simpen</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Peringatan koneksi</string>
+    <string name="connection_alert_dialog_title">Peringatan koneksi</string>
+    <string name="connection_alert_type_none">Nénten wénten</string>
+    <string name="connection_alert_type_sound">Suara doang</string>
+    <string name="connection_alert_type_vibration">Getar doang</string>
+    <string name="connection_alert_type_both">Suara miwah getar</string>
+    <string name="devices_indicator_alert">Peringatan</string>
 </resources>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -242,6 +242,7 @@
     <string name="general_delete_action">Delete</string>
     <string name="general_navigate_back_action">Навигирай назад</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="error_iap_owned_message">You already own this item</string>
     <string name="label_no_devices_title">No Devices</string>
     <string name="bluemusic_mascot_description">App Icon</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Известие за връзка</string>
+    <string name="connection_alert_dialog_title">Известие за връзка</string>
+    <string name="connection_alert_type_none">Няма</string>
+    <string name="connection_alert_type_sound">Само звук</string>
+    <string name="connection_alert_type_vibration">Само вибрация</string>
+    <string name="connection_alert_type_both">Звук и вибрация</string>
+    <string name="devices_indicator_alert">Известие</string>
 </resources>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">Navega enrere</string>
     <string name="general_reset_action">Reinicia</string>
     <string name="general_save_action">Desa</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Alerta de connexió</string>
+    <string name="connection_alert_dialog_title">Alerta de connexió</string>
+    <string name="connection_alert_type_none">Cap</string>
+    <string name="connection_alert_type_sound">Només so</string>
+    <string name="connection_alert_type_vibration">Només vibració</string>
+    <string name="connection_alert_type_both">So i vibració</string>
+    <string name="devices_indicator_alert">Alerta</string>
 </resources>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -242,6 +242,7 @@
     <string name="general_delete_action">Smazat</string>
     <string name="general_navigate_back_action">Navigovat zpět</string>
     <string name="general_cancel_action">Zrušit</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Konfigurovat</string>
     <string name="battery_optimization_hint_title">Optimalizace baterie</string>
     <string name="battery_optimization_hint_message">Optimalizace baterie je zapnutá a může bránit správnému fungování. Zvaž její vypnutí.</string>
@@ -256,4 +257,13 @@
     <string name="error_iap_owned_message">Tuto položku již vlastníš</string>
     <string name="label_no_devices_title">Žádná zařízení</string>
     <string name="bluemusic_mascot_description">Ikona aplikace</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Upozorneni na pripojeni</string>
+    <string name="connection_alert_dialog_title">Upozorneni na pripojeni</string>
+    <string name="connection_alert_type_none">Zadne</string>
+    <string name="connection_alert_type_sound">Pouze zvuk</string>
+    <string name="connection_alert_type_vibration">Pouze vibrace</string>
+    <string name="connection_alert_type_both">Zvuk a vibrace</string>
+    <string name="devices_indicator_alert">Upozorneni</string>
 </resources>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -242,6 +242,7 @@
     <string name="managed_devices_empty_message">Ingen Bluetooth-enheder konfigureret.\nTryk på + knappen for at tilføje din første enhed.</string>
     <string name="general_delete_action">Slet</string>
     <string name="general_cancel_action">Annuller</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Konfigurer</string>
     <string name="battery_optimization_hint_title">Batteri-optimering</string>
     <string name="battery_optimization_hint_message">Batteri-optimering er aktiveret og kan forhindre korrekt drift. Overvej at deaktivere dem.</string>
@@ -256,4 +257,12 @@
     <string name="error_iap_owned_message">Du ejer allerede denne vare</string>
     <string name="label_no_devices_title">Ingen enheder</string>
     <string name="bluemusic_mascot_description">App-ikon</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Forbindelsesadvarsel</string>
+    <string name="connection_alert_dialog_title">Forbindelsesadvarsel</string>
+    <string name="connection_alert_type_none">Ingen</string>
+    <string name="connection_alert_type_sound">Kun lyd</string>
+    <string name="connection_alert_type_vibration">Kun vibration</string>
+    <string name="connection_alert_type_both">Lyd og vibration</string>
+    <string name="devices_indicator_alert">Advarsel</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -246,6 +246,7 @@
     <string name="general_reset_action">Zurücksetzen</string>
     <string name="general_save_action">Speichern</string>
     <string name="general_cancel_action">Abbrechen</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Löschen</string>
     <string name="general_configure_action">Konfigurieren</string>
     <string name="battery_optimization_hint_title">Batterieoptimierung</string>
@@ -282,4 +283,13 @@
     <string name="devices_indicator_auto">Auto</string>
     <string name="devices_indicator_home">Start</string>
     <string name="devices_indicator_dnd">BNS</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Verbindungsalarm</string>
+    <string name="connection_alert_dialog_title">Verbindungsalarm</string>
+    <string name="connection_alert_type_none">Keiner</string>
+    <string name="connection_alert_type_sound">Nur Ton</string>
+    <string name="connection_alert_type_vibration">Nur Vibration</string>
+    <string name="connection_alert_type_both">Ton und Vibration</string>
+    <string name="devices_indicator_alert">Alarm</string>
 </resources>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -242,6 +242,7 @@
     <string name="general_reset_action">Επαναφορά</string>
     <string name="general_save_action">Αποθήκευση</string>
     <string name="general_cancel_action">Ακύρωση</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Εκκαθάριση</string>
     <string name="general_configure_action">Διαμόρφωση</string>
     <string name="battery_optimization_hint_title">Βελτιστοποίηση μπαταρίας</string>
@@ -257,4 +258,12 @@
     <string name="error_iap_owned_message">Προμηθευτείτε ήδη αυτό το αντικείμενο</string>
     <string name="label_no_devices_title">Καμία Συσκευή</string>
     <string name="bluemusic_mascot_description">Εικονίδιο Εφαρμογής</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Ειδοποίηση σύνδεσης</string>
+    <string name="connection_alert_dialog_title">Ειδοποίηση σύνδεσης</string>
+    <string name="connection_alert_type_none">Καμία</string>
+    <string name="connection_alert_type_sound">Μόνο ήχος</string>
+    <string name="connection_alert_type_vibration">Μόνο δόνηση</string>
+    <string name="connection_alert_type_both">Ήχος και δόνηση</string>
+    <string name="devices_indicator_alert">Ειδοποίηση</string>
 </resources>

--- a/app/src/main/res/values-eo-rUY/strings.xml
+++ b/app/src/main/res/values-eo-rUY/strings.xml
@@ -221,6 +221,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -254,4 +255,12 @@
     <string name="general_navigate_back_action">Navigi reen</string>
     <string name="general_reset_action">Remetigi</string>
     <string name="general_save_action">Konservi</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Konekta averto</string>
+    <string name="connection_alert_dialog_title">Konekta averto</string>
+    <string name="connection_alert_type_none">Neniu</string>
+    <string name="connection_alert_type_sound">Nur sono</string>
+    <string name="connection_alert_type_vibration">Nur vibrado</string>
+    <string name="connection_alert_type_both">Sono kaj vibrado</string>
+    <string name="devices_indicator_alert">Averto</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -241,6 +241,7 @@
     <string name="privacy_policy_label">Política de privacidad</string>
     <string name="managed_devices_empty_message">No hay dispositivos Bluetooth configurados.\nToca el botón + para agregar tu primer dispositivo.</string>
     <string name="general_cancel_action">Cancelar</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Limpiar</string>
     <string name="general_delete_action">Eliminar</string>
     <string name="general_navigate_back_action">Navegar hacia atrás</string>
@@ -282,4 +283,13 @@
     <string name="devices_indicator_auto">Auto</string>
     <string name="devices_indicator_home">Inicio</string>
     <string name="devices_indicator_dnd">No molestar</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Alerta de conexion</string>
+    <string name="connection_alert_dialog_title">Alerta de conexion</string>
+    <string name="connection_alert_type_none">Ninguna</string>
+    <string name="connection_alert_type_sound">Solo sonido</string>
+    <string name="connection_alert_type_vibration">Solo vibracion</string>
+    <string name="connection_alert_type_both">Sonido y vibracion</string>
+    <string name="devices_indicator_alert">Alerta</string>
 </resources>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -217,6 +217,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimaalne aeg helitugevuse tõstmiste vahel: %d ms</string>
     <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Helitugevuse alandamise viivitus</string>
     <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimaalne aeg helitugevuse alandamiste vahel: %d ms</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Ühenduse teavitus</string>
+    <string name="connection_alert_dialog_title">Ühenduse teavitus</string>
+    <string name="connection_alert_type_none">Puudub</string>
+    <string name="connection_alert_type_sound">Ainult heli</string>
+    <string name="connection_alert_type_vibration">Ainult vibratsioon</string>
+    <string name="connection_alert_type_both">Heli ja vibratsioon</string>
+    <string name="devices_indicator_alert">Teavitus</string>
 </resources>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -235,6 +235,7 @@
     <string name="general_reset_action">Nollaa</string>
     <string name="general_save_action">Tallenna</string>
     <string name="general_cancel_action">Peruuta</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Tyhjennä</string>
     <string name="general_configure_action">Määritä</string>
     <string name="battery_optimization_hint_title">Akun optimointi</string>
@@ -268,4 +269,12 @@
     <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Pienin aika äänenvoimakkuuden nousujen välillä: %d ms</string>
     <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Äänenvoimakkuuden lasku viive</string>
     <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Pienin aika äänenvoimakkuuden laskujen välillä: %d ms</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Yhteyshälytys</string>
+    <string name="connection_alert_dialog_title">Yhteyshälytys</string>
+    <string name="connection_alert_type_none">Ei mitään</string>
+    <string name="connection_alert_type_sound">Vain ääni</string>
+    <string name="connection_alert_type_vibration">Vain värinä</string>
+    <string name="connection_alert_type_both">Ääni ja värinä</string>
+    <string name="devices_indicator_alert">Hälytys</string>
 </resources>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">Bumalik</string>
     <string name="general_reset_action">I-reset</string>
     <string name="general_save_action">I-save</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Alerto sa koneksyon</string>
+    <string name="connection_alert_dialog_title">Alerto sa koneksyon</string>
+    <string name="connection_alert_type_none">Wala</string>
+    <string name="connection_alert_type_sound">Tunog lang</string>
+    <string name="connection_alert_type_vibration">Vibrate lang</string>
+    <string name="connection_alert_type_both">Tunog at vibrate</string>
+    <string name="devices_indicator_alert">Alerto</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -246,6 +246,7 @@
     <string name="managed_devices_empty_message">Aucun périphérique Bluetooth configuré.\nAppuyez sur le bouton + pour ajouter votre premier périphérique.</string>
     <string name="general_delete_action">Supprimer</string>
     <string name="general_cancel_action">Annuler</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Effacer</string>
     <string name="general_configure_action">Configurer</string>
     <string name="battery_optimization_hint_title">Optimisation de la batterie</string>
@@ -282,4 +283,13 @@
     <string name="devices_indicator_auto">Auto</string>
     <string name="devices_indicator_home">Accueil</string>
     <string name="devices_indicator_dnd">NPD</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Alerte de connexion</string>
+    <string name="connection_alert_dialog_title">Alerte de connexion</string>
+    <string name="connection_alert_type_none">Aucune</string>
+    <string name="connection_alert_type_sound">Son uniquement</string>
+    <string name="connection_alert_type_vibration">Vibration uniquement</string>
+    <string name="connection_alert_type_both">Son et vibration</string>
+    <string name="devices_indicator_alert">Alerte</string>
 </resources>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">Navegar atrás</string>
     <string name="general_reset_action">Restablecer</string>
     <string name="general_save_action">Gardar</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Alerta de conexión</string>
+    <string name="connection_alert_dialog_title">Alerta de conexión</string>
+    <string name="connection_alert_type_none">Ningunha</string>
+    <string name="connection_alert_type_sound">Só son</string>
+    <string name="connection_alert_type_vibration">Só vibración</string>
+    <string name="connection_alert_type_both">Son e vibración</string>
+    <string name="devices_indicator_alert">Alerta</string>
 </resources>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">कोई ब्लूटूथ डिवाइस कॉन्फिगर नहीं किया गया।\nअपना पहला डिवाइस जोड़ने के लिए + बटन पर टैप करें।</string>
     <string name="general_delete_action">डिलीट</string>
     <string name="general_cancel_action">रद्द</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">कॉन्फिगर</string>
     <string name="battery_optimization_hint_title">बैटरी ओप्टिमाइजेशन</string>
     <string name="battery_optimization_hint_message">बैटरी ओप्टिमाइजेशन सक्षम हैं और सही ऑपरेशन को रोक सकते हैं। इन्हें अक्षम करने पर विचार करें।</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">वापस नेविगेट करें</string>
     <string name="general_reset_action">रीसेट करें</string>
     <string name="general_save_action">सेव करें</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">कनेक्शन अलर्ट</string>
+    <string name="connection_alert_dialog_title">कनेक्शन अलर्ट</string>
+    <string name="connection_alert_type_none">कुछ नहीं</string>
+    <string name="connection_alert_type_sound">केवल ध्वनि</string>
+    <string name="connection_alert_type_vibration">केवल कंपन</string>
+    <string name="connection_alert_type_both">ध्वनि और कंपन</string>
+    <string name="devices_indicator_alert">अलर्ट</string>
 </resources>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -242,6 +242,7 @@
     <string name="general_delete_action">Delete</string>
     <string name="general_navigate_back_action">Vrati se natrag</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="error_iap_owned_message">You already own this item</string>
     <string name="label_no_devices_title">No Devices</string>
     <string name="bluemusic_mascot_description">App Icon</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Upozorenje pri povezivanju</string>
+    <string name="connection_alert_dialog_title">Upozorenje pri povezivanju</string>
+    <string name="connection_alert_type_none">Ništa</string>
+    <string name="connection_alert_type_sound">Samo zvuk</string>
+    <string name="connection_alert_type_vibration">Samo vibracija</string>
+    <string name="connection_alert_type_both">Zvuk i vibracija</string>
+    <string name="devices_indicator_alert">Upozorenje</string>
 </resources>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -234,6 +234,7 @@
     <string name="managed_devices_empty_message">Nincsenek Bluetooth eszközök konfigurálva.\nKoppints a + gombra az első eszköz hozzáadásához.</string>
     <string name="general_delete_action">Törlés</string>
     <string name="general_cancel_action">Mégse</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Törlés</string>
     <string name="general_configure_action">Konfigurálás</string>
     <string name="battery_optimization_hint_title">Akkumulátor optimalizálás</string>
@@ -255,4 +256,13 @@
     <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimális idő a hangerő-emelések között: %d ms</string>
     <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Hangerő csökkentés késleltetése</string>
     <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimális idő a hangerő-csökkentések között: %d ms</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Csatlakozasi ertesites</string>
+    <string name="connection_alert_dialog_title">Csatlakozasi ertesites</string>
+    <string name="connection_alert_type_none">Nincs</string>
+    <string name="connection_alert_type_sound">Csak hang</string>
+    <string name="connection_alert_type_vibration">Csak rezges</string>
+    <string name="connection_alert_type_both">Hang es rezges</string>
+    <string name="devices_indicator_alert">Ertesites</string>
 </resources>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">Նավարկել հետ</string>
     <string name="general_reset_action">Վերակայել</string>
     <string name="general_save_action">Պահել</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Կdelays delays</string>
+    <string name="connection_alert_dialog_title">Delays delays</string>
+    <string name="connection_alert_type_none">Delays</string>
+    <string name="connection_alert_type_sound">Delays delays</string>
+    <string name="connection_alert_type_vibration">Delays delays</string>
+    <string name="connection_alert_type_both">Delays delays</string>
+    <string name="devices_indicator_alert">Delays</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">Tidak ada perangkat Bluetooth yang dikonfigurasi.\nKetuk tombol + untuk menambahkan perangkat pertamamu.</string>
     <string name="general_delete_action">Hapus</string>
     <string name="general_cancel_action">Batal</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Konfigurasi</string>
     <string name="battery_optimization_hint_title">Optimasi baterai</string>
     <string name="battery_optimization_hint_message">Optimasi baterai diaktifkan dan dapat mencegah operasi yang tepat. Pertimbangkan untuk menonaktifkannya.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">Navigasi kembali</string>
     <string name="general_reset_action">Reset</string>
     <string name="general_save_action">Simpan</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Peringatan koneksi</string>
+    <string name="connection_alert_dialog_title">Peringatan koneksi</string>
+    <string name="connection_alert_type_none">Tidak ada</string>
+    <string name="connection_alert_type_sound">Suara saja</string>
+    <string name="connection_alert_type_vibration">Getar saja</string>
+    <string name="connection_alert_type_both">Suara dan getar</string>
+    <string name="devices_indicator_alert">Peringatan</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -246,6 +246,7 @@
     <string name="general_reset_action">Ripristina</string>
     <string name="general_save_action">Salva</string>
     <string name="general_cancel_action">Annulla</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Cancella</string>
     <string name="general_configure_action">Configura</string>
     <string name="battery_optimization_hint_title">Ottimizzazione batteria</string>
@@ -282,4 +283,13 @@
     <string name="devices_indicator_auto">Auto</string>
     <string name="devices_indicator_home">Home</string>
     <string name="devices_indicator_dnd">DND</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Avviso di connessione</string>
+    <string name="connection_alert_dialog_title">Avviso di connessione</string>
+    <string name="connection_alert_type_none">Nessuno</string>
+    <string name="connection_alert_type_sound">Solo suono</string>
+    <string name="connection_alert_type_vibration">Solo vibrazione</string>
+    <string name="connection_alert_type_both">Suono e vibrazione</string>
+    <string name="devices_indicator_alert">Avviso</string>
 </resources>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -240,6 +240,7 @@
     <string name="managed_devices_empty_message">לא הוגדרו מכשירי בלוטוס.\nלחץ על כפתור + כדי להוסיף את המכשיר הראשון.</string>
     <string name="general_delete_action">מחק</string>
     <string name="general_cancel_action">בטל</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">הגדר</string>
     <string name="general_reset_action">איפוס</string>
     <string name="general_save_action">שמור</string>
@@ -256,4 +257,12 @@
     <string name="error_iap_owned_message">אתם כבר בעלים של פריט זה</string>
     <string name="label_no_devices_title">אין מכשירים</string>
     <string name="bluemusic_mascot_description">איקון אפליקציה</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">התראת חיבור</string>
+    <string name="connection_alert_dialog_title">התראת חיבור</string>
+    <string name="connection_alert_type_none">ללא</string>
+    <string name="connection_alert_type_sound">צליל בלבד</string>
+    <string name="connection_alert_type_vibration">רטט בלבד</string>
+    <string name="connection_alert_type_both">צליל ורטט</string>
+    <string name="devices_indicator_alert">התראה</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -242,6 +242,7 @@
     <string name="managed_devices_empty_message">Bluetoothデバイスが設定されていません。\n+ボタンをタップして最初のデバイスを追加してください。</string>
     <string name="general_delete_action">削除</string>
     <string name="general_cancel_action">キャンセル</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">設定</string>
     <string name="battery_optimization_hint_title">バッテリー最適化</string>
     <string name="battery_optimization_hint_message">バッテリー最適化が有効になっており、正常な動作を妨げる可能性があります。無効にすることを検討してください。</string>
@@ -277,4 +278,12 @@
     <string name="devices_indicator_auto">自動</string>
     <string name="devices_indicator_home">ホーム</string>
     <string name="devices_indicator_dnd">おやすみ</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">接続アラート</string>
+    <string name="connection_alert_dialog_title">接続アラート</string>
+    <string name="connection_alert_type_none">なし</string>
+    <string name="connection_alert_type_sound">サウンドのみ</string>
+    <string name="connection_alert_type_vibration">バイブのみ</string>
+    <string name="connection_alert_type_both">サウンドとバイブ</string>
+    <string name="devices_indicator_alert">アラート</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -242,6 +242,7 @@
     <string name="managed_devices_empty_message">설정된 블루투스 디바이스가 없습니다.\n+ 버튼을 눌러 첫 번째 디바이스를 추가하세요.</string>
     <string name="general_delete_action">삭제</string>
     <string name="general_cancel_action">취소</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">구성</string>
     <string name="battery_optimization_hint_title">배터리 최적화</string>
     <string name="battery_optimization_hint_message">배터리 최적화가 켜져 있어 정상 동작을 방해할 수 있습니다. 끄기를 고려해보세요.</string>
@@ -256,4 +257,12 @@
     <string name="error_iap_owned_message">이미 이 항목을 소유하고 있습니다</string>
     <string name="label_no_devices_title">디바이스 없음</string>
     <string name="bluemusic_mascot_description">앱 아이콘</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">연결 알림</string>
+    <string name="connection_alert_dialog_title">연결 알림</string>
+    <string name="connection_alert_type_none">없음</string>
+    <string name="connection_alert_type_sound">소리만</string>
+    <string name="connection_alert_type_vibration">진동만</string>
+    <string name="connection_alert_type_both">소리와 진동</string>
+    <string name="devices_indicator_alert">알림</string>
 </resources>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -217,6 +217,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimalus laikas tarp garsumo kėlimų: %d ms</string>
     <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Garsumo sumažinimo delsa</string>
     <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimalus laikas tarp garsumo sumažinimų: %d ms</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Prisijungimo įspėjimas</string>
+    <string name="connection_alert_dialog_title">Prisijungimo įspėjimas</string>
+    <string name="connection_alert_type_none">Joks</string>
+    <string name="connection_alert_type_sound">Tik garsas</string>
+    <string name="connection_alert_type_vibration">Tik vibracija</string>
+    <string name="connection_alert_type_both">Garsas ir vibracija</string>
+    <string name="devices_indicator_alert">Įspėjimas</string>
 </resources>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -217,6 +217,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="devices_device_config_volume_rate_limit_increase_duration_desc">Minimālais laiks starp skaļuma paaugstināšanu: %d ms</string>
     <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Skaļuma samazināšanas aizkave</string>
     <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimālais laiks starp skaļuma samazināšanu: %d ms</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Savienojuma brīdinājums</string>
+    <string name="connection_alert_dialog_title">Savienojuma brīdinājums</string>
+    <string name="connection_alert_type_none">Nav</string>
+    <string name="connection_alert_type_sound">Tikai skaņa</string>
+    <string name="connection_alert_type_vibration">Tikai vibrācija</string>
+    <string name="connection_alert_type_both">Skaņa un vibrācija</string>
+    <string name="devices_indicator_alert">Brīdinājums</string>
 </resources>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -224,6 +224,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">Навигирај назад</string>
     <string name="general_reset_action">Ресетирај</string>
     <string name="general_save_action">Зачувај</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Известување за поврзување</string>
+    <string name="connection_alert_dialog_title">Известување за поврзување</string>
+    <string name="connection_alert_type_none">Без</string>
+    <string name="connection_alert_type_sound">Само звук</string>
+    <string name="connection_alert_type_vibration">Само вибрација</string>
+    <string name="connection_alert_type_both">Звук и вибрација</string>
+    <string name="devices_indicator_alert">Известување</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">Tiada peranti Bluetooth dikonfigurasi.\nKetik butang + untuk tambah peranti pertama anda.</string>
     <string name="general_delete_action">Padam</string>
     <string name="general_cancel_action">Batal</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Konfigurasikan</string>
     <string name="battery_optimization_hint_title">Pengoptimuman bateri</string>
     <string name="battery_optimization_hint_message">Pengoptimuman bateri didayakan dan mungkin menghalang operasi yang betul. Pertimbang untuk nyahdayakannya.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">Navigasi kembali</string>
     <string name="general_reset_action">Set semula</string>
     <string name="general_save_action">Simpan</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Amaran sambungan</string>
+    <string name="connection_alert_dialog_title">Amaran sambungan</string>
+    <string name="connection_alert_type_none">Tiada</string>
+    <string name="connection_alert_type_sound">Bunyi sahaja</string>
+    <string name="connection_alert_type_vibration">Getaran sahaja</string>
+    <string name="connection_alert_type_both">Bunyi dan getaran</string>
+    <string name="devices_indicator_alert">Amaran</string>
 </resources>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">ေကြာင်း အခြက်သွားပါ</string>
     <string name="general_reset_action">အပဓင်း ဖခ္ပြတ်ပါ</string>
     <string name="general_save_action">ဂရှုံးတ်မှားပါ</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">ချိတ်ဆက်မှု သတိပေးချက်</string>
+    <string name="connection_alert_dialog_title">ချိတ်ဆက်မှု သတိပေးချက်</string>
+    <string name="connection_alert_type_none">မရှိပါ</string>
+    <string name="connection_alert_type_sound">အသံသာ</string>
+    <string name="connection_alert_type_vibration">တုန်ခါမှုသာ</string>
+    <string name="connection_alert_type_both">အသံနှင့် တုန်ခါမှု</string>
+    <string name="devices_indicator_alert">သတိပေးချက်</string>
 </resources>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -241,6 +241,7 @@
     <string name="managed_devices_empty_message">Geen Bluetooth-apparaten geconfigureerd.\nTik op de + knop om je eerste apparaat toe te voegen.</string>
     <string name="general_delete_action">Verwijderen</string>
     <string name="general_cancel_action">Annuleren</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Wissen</string>
     <string name="general_configure_action">Configureren</string>
     <string name="battery_optimization_hint_title">Batterijoptimalisatie</string>
@@ -277,4 +278,13 @@
     <string name="devices_indicator_auto">Auto</string>
     <string name="devices_indicator_home">Home</string>
     <string name="devices_indicator_dnd">NS</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Verbindingsmelding</string>
+    <string name="connection_alert_dialog_title">Verbindingsmelding</string>
+    <string name="connection_alert_type_none">Geen</string>
+    <string name="connection_alert_type_sound">Alleen geluid</string>
+    <string name="connection_alert_type_vibration">Alleen trillen</string>
+    <string name="connection_alert_type_both">Geluid en trillen</string>
+    <string name="devices_indicator_alert">Melding</string>
 </resources>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -241,6 +241,7 @@
     <string name="general_reset_action">Tilbakestill</string>
     <string name="general_save_action">Lagre</string>
     <string name="general_cancel_action">Avbryt</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Tøm</string>
     <string name="general_configure_action">Konfigurer</string>
     <string name="battery_optimization_hint_title">Batterioptimalisering</string>
@@ -256,4 +257,12 @@
     <string name="error_iap_owned_message">Du eier allerede denne varen</string>
     <string name="label_no_devices_title">Ingen enheter</string>
     <string name="bluemusic_mascot_description">App-ikon</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Tilkoblingsvarsel</string>
+    <string name="connection_alert_dialog_title">Tilkoblingsvarsel</string>
+    <string name="connection_alert_type_none">Ingen</string>
+    <string name="connection_alert_type_sound">Kun lyd</string>
+    <string name="connection_alert_type_vibration">Kun vibrasjon</string>
+    <string name="connection_alert_type_both">Lyd og vibrasjon</string>
+    <string name="devices_indicator_alert">Varsel</string>
 </resources>

--- a/app/src/main/res/values-pcm-rNG/strings.xml
+++ b/app/src/main/res/values-pcm-rNG/strings.xml
@@ -221,6 +221,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -254,4 +255,12 @@
     <string name="general_navigate_back_action">Go back</string>
     <string name="general_reset_action">Reset</string>
     <string name="general_save_action">Save</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Connection alert</string>
+    <string name="connection_alert_dialog_title">Connection alert</string>
+    <string name="connection_alert_type_none">Nothing</string>
+    <string name="connection_alert_type_sound">Sound only</string>
+    <string name="connection_alert_type_vibration">Vibration only</string>
+    <string name="connection_alert_type_both">Sound and vibration</string>
+    <string name="devices_indicator_alert">Alert</string>
 </resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -242,6 +242,7 @@
     <string name="general_reset_action">Resetuj</string>
     <string name="general_save_action">Zapisz</string>
     <string name="general_cancel_action">Anuluj</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Konfiguruj</string>
     <string name="battery_optimization_hint_title">Optymalizacja baterii</string>
     <string name="battery_optimization_hint_message">Optymalizacje baterii są włączone i mogą przeszkódzić w prawidłowym działaniu. Rozważ ich wyłączenie.</string>
@@ -277,4 +278,13 @@
     <string name="devices_indicator_auto">Auto</string>
     <string name="devices_indicator_home">Dom</string>
     <string name="devices_indicator_dnd">DND</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Alert polaczenia</string>
+    <string name="connection_alert_dialog_title">Alert polaczenia</string>
+    <string name="connection_alert_type_none">Brak</string>
+    <string name="connection_alert_type_sound">Tylko dzwiek</string>
+    <string name="connection_alert_type_vibration">Tylko wibracja</string>
+    <string name="connection_alert_type_both">Dzwiek i wibracja</string>
+    <string name="devices_indicator_alert">Alert</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -253,6 +253,7 @@
     <string name="general_reset_action">Redefinir</string>
     <string name="general_save_action">Salvar</string>
     <string name="general_cancel_action">Cancelar</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Limpar</string>
     <string name="general_configure_action">Configurar</string>
     <string name="battery_optimization_hint_title">Otimização de bateria</string>
@@ -268,4 +269,13 @@
     <string name="error_iap_owned_message">Você já possui este item</string>
     <string name="label_no_devices_title">Nenhum Dispositivo</string>
     <string name="bluemusic_mascot_description">Ícone do App</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Alerta de conexao</string>
+    <string name="connection_alert_dialog_title">Alerta de conexao</string>
+    <string name="connection_alert_type_none">Nenhum</string>
+    <string name="connection_alert_type_sound">Apenas som</string>
+    <string name="connection_alert_type_vibration">Apenas vibracao</string>
+    <string name="connection_alert_type_both">Som e vibracao</string>
+    <string name="devices_indicator_alert">Alerta</string>
 </resources>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -238,6 +238,7 @@
     <string name="managed_devices_empty_message">Nenhum dispositivo Bluetooth configurado.\nToca no botão + para adicionar o teu primeiro dispositivo.</string>
     <string name="general_delete_action">Eliminar</string>
     <string name="general_cancel_action">Cancelar</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Limpar</string>
     <string name="general_configure_action">Configurar</string>
     <string name="general_navigate_back_action">Navegar para trás</string>
@@ -277,4 +278,13 @@
     <string name="devices_indicator_auto">Auto</string>
     <string name="devices_indicator_home">Início</string>
     <string name="devices_indicator_dnd">DND</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Alerta de ligacao</string>
+    <string name="connection_alert_dialog_title">Alerta de ligacao</string>
+    <string name="connection_alert_type_none">Nenhum</string>
+    <string name="connection_alert_type_sound">Apenas som</string>
+    <string name="connection_alert_type_vibration">Apenas vibracao</string>
+    <string name="connection_alert_type_both">Som e vibracao</string>
+    <string name="devices_indicator_alert">Alerta</string>
 </resources>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -241,6 +241,7 @@
     <string name="general_reset_action">Resetează</string>
     <string name="general_save_action">Salvează</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Șterge</string>
     <string name="general_configure_action">Configurează</string>
     <string name="battery_optimization_hint_title">Optimizarea bateriei</string>
@@ -256,4 +257,12 @@
     <string name="error_iap_owned_message">Deții deja acest element</string>
     <string name="label_no_devices_title">Niciun Dispozitiv</string>
     <string name="bluemusic_mascot_description">Icona Aplicației</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Alertă de conexiune</string>
+    <string name="connection_alert_dialog_title">Alertă de conexiune</string>
+    <string name="connection_alert_type_none">Nimic</string>
+    <string name="connection_alert_type_sound">Doar sunet</string>
+    <string name="connection_alert_type_vibration">Doar vibrație</string>
+    <string name="connection_alert_type_both">Sunet și vibrație</string>
+    <string name="devices_indicator_alert">Alertă</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -247,6 +247,7 @@
     <string name="general_delete_action">Удалить</string>
     <string name="general_navigate_back_action">Вернуться назад</string>
     <string name="general_cancel_action">Отмена</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Настроить</string>
     <string name="battery_optimization_hint_title">Оптимизация батареи</string>
     <string name="battery_optimization_hint_message">Оптимизация батареи включена и может мешать нормальной работе. Рассмотри возможность отключения.</string>
@@ -282,4 +283,13 @@
     <string name="devices_indicator_auto">Авто</string>
     <string name="devices_indicator_home">Дом</string>
     <string name="devices_indicator_dnd">НБ</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Оповещение о подключении</string>
+    <string name="connection_alert_dialog_title">Оповещение о подключении</string>
+    <string name="connection_alert_type_none">Нет</string>
+    <string name="connection_alert_type_sound">Только звук</string>
+    <string name="connection_alert_type_vibration">Только вибрация</string>
+    <string name="connection_alert_type_both">Звук и вибрация</string>
+    <string name="devices_indicator_alert">Оповещение</string>
 </resources>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<resources>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Avisu de connessione</string>
+    <string name="connection_alert_dialog_title">Avisu de connessione</string>
+    <string name="connection_alert_type_none">Nisciunu</string>
+    <string name="connection_alert_type_sound">Solu sonu</string>
+    <string name="connection_alert_type_vibration">Solu vibrazione</string>
+    <string name="connection_alert_type_both">Sonu e vibrazione</string>
+    <string name="devices_indicator_alert">Avisu</string>
+</resources>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">භවපස් ගමන්</string>
     <string name="general_reset_action">ගෘමින් සකසන්න</string>
     <string name="general_save_action">සේක්ෂය කරන්න</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">සම්බන්ධතා අනතුරු ඇඟවීම</string>
+    <string name="connection_alert_dialog_title">සම්බන්ධතා අනතුරු ඇඟවීම</string>
+    <string name="connection_alert_type_none">නැත</string>
+    <string name="connection_alert_type_sound">ශබ්දය පමණි</string>
+    <string name="connection_alert_type_vibration">කම්පනය පමණි</string>
+    <string name="connection_alert_type_both">ශබ්දය සහ කම්පනය</string>
+    <string name="devices_indicator_alert">අනතුරු ඇඟවීම</string>
 </resources>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -242,6 +242,7 @@
     <string name="general_delete_action">Delete</string>
     <string name="general_navigate_back_action">Navigovať späť</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,13 @@
     <string name="error_iap_owned_message">You already own this item</string>
     <string name="label_no_devices_title">No Devices</string>
     <string name="bluemusic_mascot_description">App Icon</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Upozornenie na pripojenie</string>
+    <string name="connection_alert_dialog_title">Upozornenie na pripojenie</string>
+    <string name="connection_alert_type_none">Ziadne</string>
+    <string name="connection_alert_type_sound">Iba zvuk</string>
+    <string name="connection_alert_type_vibration">Iba vibracie</string>
+    <string name="connection_alert_type_both">Zvuk a vibracie</string>
+    <string name="devices_indicator_alert">Upozornenie</string>
 </resources>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -241,6 +241,7 @@
     <string name="general_delete_action">Delete</string>
     <string name="general_navigate_back_action">Navigiraj nazaj</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Počisti</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
@@ -256,4 +257,12 @@
     <string name="error_iap_owned_message">You already own this item</string>
     <string name="label_no_devices_title">No Devices</string>
     <string name="bluemusic_mascot_description">App Icon</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Opozorilo ob povezavi</string>
+    <string name="connection_alert_dialog_title">Opozorilo ob povezavi</string>
+    <string name="connection_alert_type_none">Brez</string>
+    <string name="connection_alert_type_sound">Samo zvok</string>
+    <string name="connection_alert_type_vibration">Samo vibracija</string>
+    <string name="connection_alert_type_both">Zvok in vibracija</string>
+    <string name="devices_indicator_alert">Opozorilo</string>
 </resources>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -221,6 +221,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -254,4 +255,12 @@
     <string name="general_navigate_back_action">Navigo mbrapa</string>
     <string name="general_reset_action">Rivendos</string>
     <string name="general_save_action">Ruaj</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Sinjalizim lidhje</string>
+    <string name="connection_alert_dialog_title">Sinjalizim lidhje</string>
+    <string name="connection_alert_type_none">Asnjë</string>
+    <string name="connection_alert_type_sound">Vetëm tingull</string>
+    <string name="connection_alert_type_vibration">Vetëm dridhje</string>
+    <string name="connection_alert_type_both">Tingull dhe dridhje</string>
+    <string name="devices_indicator_alert">Sinjalizim</string>
 </resources>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -230,6 +230,7 @@
     <string name="general_reset_action">Återställ</string>
     <string name="general_save_action">Spara</string>
     <string name="general_cancel_action">Avbryt</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Rensa</string>
     <string name="general_configure_action">Konfigurera</string>
     <string name="battery_optimization_hint_title">Batterioptimering</string>
@@ -282,4 +283,12 @@
     <string name="devices_indicator_auto">Auto</string>
     <string name="devices_indicator_home">Hem</string>
     <string name="devices_indicator_dnd">Stör ej</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Anslutningsvarning</string>
+    <string name="connection_alert_dialog_title">Anslutningsvarning</string>
+    <string name="connection_alert_type_none">Ingen</string>
+    <string name="connection_alert_type_sound">Endast ljud</string>
+    <string name="connection_alert_type_vibration">Endast vibration</string>
+    <string name="connection_alert_type_both">Ljud och vibration</string>
+    <string name="devices_indicator_alert">Varning</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -240,6 +240,7 @@
     <string name="general_navigate_back_action">นำทางย้อนกลับ</string>
     <string name="general_reset_action">รีเซ็ต</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">ล้าง</string>
     <string name="general_configure_action">Configure</string>
     <string name="general_save_action">บันทึก</string>
@@ -256,4 +257,12 @@
     <string name="error_iap_owned_message">คุณมีสินค้านี้อยู่แล้ว</string>
     <string name="label_no_devices_title">ไม่มีอุปกรณ์</string>
     <string name="bluemusic_mascot_description">ไอคอนแอป</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">การแจ้งเตือนการเชื่อมต่อ</string>
+    <string name="connection_alert_dialog_title">การแจ้งเตือนการเชื่อมต่อ</string>
+    <string name="connection_alert_type_none">ไม่มี</string>
+    <string name="connection_alert_type_sound">เสียงเท่านั้น</string>
+    <string name="connection_alert_type_vibration">สั่นเท่านั้น</string>
+    <string name="connection_alert_type_both">เสียงและสั่น</string>
+    <string name="devices_indicator_alert">แจ้งเตือน</string>
 </resources>

--- a/app/src/main/res/values-tl-rPH/strings.xml
+++ b/app/src/main/res/values-tl-rPH/strings.xml
@@ -223,6 +223,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations are enabled and may prevent proper operation. Consider disabling them.</string>
@@ -256,4 +257,12 @@
     <string name="general_navigate_back_action">Bumalik</string>
     <string name="general_reset_action">I-reset</string>
     <string name="general_save_action">I-save</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Alerto sa koneksyon</string>
+    <string name="connection_alert_dialog_title">Alerto sa koneksyon</string>
+    <string name="connection_alert_type_none">Wala</string>
+    <string name="connection_alert_type_sound">Tunog lang</string>
+    <string name="connection_alert_type_vibration">Vibrate lang</string>
+    <string name="connection_alert_type_both">Tunog at vibrate</string>
+    <string name="devices_indicator_alert">Alerto</string>
 </resources>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -239,6 +239,7 @@
     <string name="general_reset_action">Sıfırla</string>
     <string name="general_save_action">Kaydet</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Temizle</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Pil optimizasyonu</string>
@@ -275,4 +276,12 @@
     <string name="devices_indicator_auto">Otomatik</string>
     <string name="devices_indicator_home">Ana sayfa</string>
     <string name="devices_indicator_dnd">DND</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Bağlantı uyarısı</string>
+    <string name="connection_alert_dialog_title">Bağlantı uyarısı</string>
+    <string name="connection_alert_type_none">Yok</string>
+    <string name="connection_alert_type_sound">Sadece ses</string>
+    <string name="connection_alert_type_vibration">Sadece titreşim</string>
+    <string name="connection_alert_type_both">Ses ve titreşim</string>
+    <string name="devices_indicator_alert">Uyarı</string>
 </resources>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -239,6 +239,7 @@
     <string name="managed_devices_empty_message">Немає налаштованих Bluetooth-пристроїв.\nНатисні кнопку +, щоб додати перший пристрій.</string>
     <string name="general_delete_action">Видалити</string>
     <string name="general_cancel_action">Скасувати</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_navigate_back_action">Повернутися назад</string>
     <string name="general_reset_action">Скинути</string>
     <string name="general_save_action">Зберегти</string>
@@ -256,4 +257,13 @@
     <string name="error_iap_owned_message">Цей товар уже в тебе є</string>
     <string name="label_no_devices_title">Немає пристроїв</string>
     <string name="bluemusic_mascot_description">Іконка додатку</string>
+
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Сповіщення про підключення</string>
+    <string name="connection_alert_dialog_title">Сповіщення про підключення</string>
+    <string name="connection_alert_type_none">Немає</string>
+    <string name="connection_alert_type_sound">Лише звук</string>
+    <string name="connection_alert_type_vibration">Лише вібрація</string>
+    <string name="connection_alert_type_both">Звук і вібрація</string>
+    <string name="devices_indicator_alert">Сповіщення</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -242,6 +242,7 @@
     <string name="general_reset_action">Đặt lại</string>
     <string name="general_save_action">Lưu</string>
     <string name="general_cancel_action">Hủy</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">Xóa</string>
     <string name="general_configure_action">Cấu hình</string>
     <string name="battery_optimization_hint_title">Tối ưu hóa pin</string>
@@ -257,4 +258,12 @@
     <string name="error_iap_owned_message">Bạn đã sở hữu mục này</string>
     <string name="label_no_devices_title">Không có thiết bị</string>
     <string name="bluemusic_mascot_description">Biểu tượng ứng dụng</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">Cảnh báo kết nối</string>
+    <string name="connection_alert_dialog_title">Cảnh báo kết nối</string>
+    <string name="connection_alert_type_none">Không có</string>
+    <string name="connection_alert_type_sound">Chỉ âm thanh</string>
+    <string name="connection_alert_type_vibration">Chỉ rung</string>
+    <string name="connection_alert_type_both">Âm thanh và rung</string>
+    <string name="devices_indicator_alert">Cảnh báo</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -243,6 +243,7 @@
     <string name="managed_devices_empty_message">没有配置蓝牙设备。\n点击 + 按钮添加您的第一个设备。</string>
     <string name="general_delete_action">删除</string>
     <string name="general_cancel_action">取消</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_clear_action">清除</string>
     <string name="general_configure_action">配置</string>
     <string name="general_navigate_back_action">返回</string>
@@ -282,4 +283,12 @@
     <string name="devices_indicator_auto">自动</string>
     <string name="devices_indicator_home">主页</string>
     <string name="devices_indicator_dnd">勿扰</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">连接提醒</string>
+    <string name="connection_alert_dialog_title">连接提醒</string>
+    <string name="connection_alert_type_none">无</string>
+    <string name="connection_alert_type_sound">仅声音</string>
+    <string name="connection_alert_type_vibration">仅振动</string>
+    <string name="connection_alert_type_both">声音和振动</string>
+    <string name="devices_indicator_alert">提醒</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -242,6 +242,7 @@
     <string name="managed_devices_empty_message">沒有設定藍牙裝置。\n點擊 + 按鈕來新增您的第一個裝置。</string>
     <string name="general_delete_action">刪除</string>
     <string name="general_cancel_action">取消</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">設定</string>
     <string name="battery_optimization_hint_title">電池最佳化</string>
     <string name="battery_optimization_hint_message">電池最佳化已啟用，可能會影響正常運作。請考慮停用它們。</string>
@@ -256,4 +257,12 @@
     <string name="error_iap_owned_message">您已經擁有此項目</string>
     <string name="label_no_devices_title">沒有裝置</string>
     <string name="bluemusic_mascot_description">應用程式圖示</string>
+    <!-- Connection alert -->
+    <string name="devices_device_config_connection_alert_label">連線提醒</string>
+    <string name="connection_alert_dialog_title">連線提醒</string>
+    <string name="connection_alert_type_none">無</string>
+    <string name="connection_alert_type_sound">僅聲音</string>
+    <string name="connection_alert_type_vibration">僅震動</string>
+    <string name="connection_alert_type_both">聲音和震動</string>
+    <string name="devices_indicator_alert">提醒</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -108,6 +108,13 @@
     <string name="dnd_mode_alarms_only">Alarms only</string>
     <string name="dnd_mode_total_silence">Total silence</string>
 
+    <string name="devices_device_config_connection_alert_label">Connection alert</string>
+    <string name="connection_alert_dialog_title">Connection alert</string>
+    <string name="connection_alert_type_none">None</string>
+    <string name="connection_alert_type_sound">Sound only</string>
+    <string name="connection_alert_type_vibration">Vibration only</string>
+    <string name="connection_alert_type_both">Sound and vibration</string>
+
     <string name="devices_stream_music_label">Music</string>
     <string name="devices_audio_stream_call_label">Call</string>
     <string name="devices_audio_stream_ring_label">Ring</string>
@@ -288,6 +295,7 @@
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
+    <string name="general_ok_action">OK</string>
     <string name="general_configure_action">Configure</string>
 
     <string name="battery_optimization_hint_title">Battery optimization</string>
@@ -329,4 +337,5 @@
     <string name="devices_indicator_auto">Auto</string>
     <string name="devices_indicator_home">Home</string>
     <string name="devices_indicator_dnd">DND</string>
+    <string name="devices_indicator_alert">Alert</string>
 </resources>


### PR DESCRIPTION
## Summary
- Allow users to configure sound and/or vibration alerts when a Bluetooth device connects
- Pro feature with four modes: none, sound only, vibration only, or both
- Alert badge indicator on dashboard device cards
- Database migration to v4 for storing alert preferences
- Translations for all 52 supported locales

## Code quality fixes
- Fix ringtone resource leak by tracking and stopping previous ringtone
- Fix race condition with rapid connect/disconnect via job cancellation
- Add vibrator hardware check before attempting vibration
- Add fallback to default sound when custom URI is unavailable

Closes #47
Closes #3