### PR TITLE
Fix edge-to-edge display for navigation bar

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverScreen.kt
@@ -6,11 +6,12 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -44,6 +45,8 @@ import eu.darken.bluemusic.R
 import eu.darken.bluemusic.bluetooth.core.MockDevice
 import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import eu.darken.bluemusic.common.error.ErrorEventHandler
 import eu.darken.bluemusic.common.navigation.Nav
 import eu.darken.bluemusic.common.ui.waitForState
@@ -109,7 +112,8 @@ fun DiscoverScreen(
         },
         snackbarHost = {
             SnackbarHost(hostState = snackbarHostState)
-        }
+        },
+        contentWindowInsets = WindowInsets.statusBars
     ) { paddingValues ->
         Box(
             modifier = Modifier
@@ -159,9 +163,10 @@ fun DiscoverScreen(
                 }
 
                 else -> {
+                    val navBarPadding = navigationBarBottomPadding()
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(vertical = 8.dp)
+                        contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp + navBarPadding)
                     ) {
                         items(state.devices) { device ->
                             DeviceItem(

--- a/app/src/main/java/eu/darken/bluemusic/common/compose/WindowInsetsExtensions.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/compose/WindowInsetsExtensions.kt
@@ -2,7 +2,9 @@ package eu.darken.bluemusic.common.compose
 
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.displayCutout
+import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.runtime.Composable
@@ -12,3 +14,6 @@ import androidx.compose.ui.Modifier
 fun Modifier.horizontalCutoutPadding(): Modifier = windowInsetsPadding(
     WindowInsets.displayCutout.only(WindowInsetsSides.Horizontal)
 )
+
+@Composable
+fun navigationBarBottomPadding() = WindowInsets.navigationBars.asPaddingValues().calculateBottomPadding()

--- a/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/ui/RecorderScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/ui/RecorderScreen.kt
@@ -13,12 +13,14 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
@@ -64,6 +66,7 @@ import androidx.compose.ui.unit.dp
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import java.io.File
 
 @Composable
@@ -109,6 +112,7 @@ private fun RecorderScreen(
 
     Scaffold(
         containerColor = MaterialTheme.colorScheme.background,
+        contentWindowInsets = WindowInsets.statusBars,
         bottomBar = {
             AnimatedVisibility(
                 visible = !isScrollingDown.value,
@@ -132,12 +136,13 @@ private fun RecorderScreen(
             }
         }
     ) { paddingValues ->
+        val navBarPadding = navigationBarBottomPadding()
         LazyColumn(
             state = listState,
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues),
-            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 16.dp)
+            contentPadding = PaddingValues(start = 16.dp, top = 16.dp, end = 16.dp, bottom = 16.dp + navBarPadding)
         ) {
             item {
                 HeroSection()

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/appselection/AppSelectionScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/appselection/AppSelectionScreen.kt
@@ -7,15 +7,16 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
-import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyColumn
@@ -61,6 +62,8 @@ import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.apps.AppInfo
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import eu.darken.bluemusic.common.ui.waitForState
 import eu.darken.bluemusic.devices.core.DeviceAddr
 
@@ -103,7 +106,7 @@ fun AppSelectionScreen(
             setLocalSearchQuery(state.searchQuery)
         }
     }
-    
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -139,7 +142,8 @@ fun AppSelectionScreen(
                     }
                 }
             )
-        }
+        },
+        contentWindowInsets = WindowInsets.statusBars
     ) { paddingValues ->
         Column(
             modifier = Modifier
@@ -188,7 +192,7 @@ fun AppSelectionScreen(
                 val selectedApps = state.apps.filter { app ->
                     app.packageName in state.selectedPackages
                 }
-                
+
                 Card(
                     modifier = Modifier
                         .fillMaxWidth()
@@ -238,9 +242,10 @@ fun AppSelectionScreen(
                 }
             } else {
                 // App list
+                val navBarPadding = navigationBarBottomPadding()
                 LazyColumn(
                     modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(vertical = 8.dp)
+                    contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp + navBarPadding)
                 ) {
                     items(
                         items = state.filteredApps,

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
@@ -4,11 +4,12 @@ import android.os.Build
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
@@ -56,6 +57,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.bluetooth.core.MockDevice
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import eu.darken.bluemusic.common.hasApiLevel
 import eu.darken.bluemusic.common.navigation.Nav
 import eu.darken.bluemusic.common.ui.waitForState
@@ -125,10 +128,12 @@ fun DeviceConfigScreenHost(
                     dndModeValue = event.currentMode
                     showDndModeDialog = true
                 }
+
                 is ConfigEvent.ShowConnectionAlertDialog -> {
                     connectionAlertTypeValue = event.currentType
                     showConnectionAlertDialog = true
                 }
+
                 is ConfigEvent.NavigateBack -> vm.navUp()
                 is ConfigEvent.RequiresPro -> {
                     val result = snackbarHostState.showSnackbar(
@@ -140,6 +145,7 @@ fun DeviceConfigScreenHost(
                         vm.navTo(Nav.Main.Upgrade)
                     }
                 }
+
                 is ConfigEvent.RequiresNotificationPolicyAccess -> {
                     val message = when (event.feature) {
                         ConfigEvent.RequiresNotificationPolicyAccess.Feature.RINGTONE ->
@@ -357,14 +363,16 @@ fun DeviceConfigScreen(
                 scrollBehavior = scrollBehavior
             )
         },
+        contentWindowInsets = WindowInsets.statusBars,
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection)
     ) { paddingValues ->
+        val navBarPadding = navigationBarBottomPadding()
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
                 .horizontalCutoutPadding(),
-            contentPadding = PaddingValues(vertical = 8.dp)
+            contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp + navBarPadding)
         ) {
             // Device Header Card
             item {

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
@@ -6,12 +6,14 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
@@ -46,6 +48,8 @@ import eu.darken.bluemusic.bluetooth.core.MockDevice
 import eu.darken.bluemusic.common.compose.ColoredTitleText
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.navigation.Nav
@@ -111,11 +115,13 @@ fun DevicesScreen(
                 onNavigateToUpgrade = onNavigateToUpgrade
             )
         },
+        contentWindowInsets = WindowInsets.statusBars,
         floatingActionButton = {
             if (state.hasBluetoothPermission && state.isBluetoothEnabled && state.devicesWithApps.isNotEmpty()) {
                 FloatingActionButton(
                     onClick = { onAddDevice() },
-                    containerColor = MaterialTheme.colorScheme.primary
+                    containerColor = MaterialTheme.colorScheme.primary,
+                    modifier = Modifier.navigationBarsPadding()
                 ) {
                     Icon(
                         imageVector = Icons.TwoTone.Add,
@@ -125,12 +131,13 @@ fun DevicesScreen(
             }
         }
     ) { paddingValues ->
+        val navBarPadding = navigationBarBottomPadding()
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
                 .horizontalCutoutPadding(),
-            contentPadding = PaddingValues(vertical = 8.dp)
+            contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp + navBarPadding)
         ) {
             // Critical permission/state cards - these block normal functionality
             if (!state.hasBluetoothPermission) {
@@ -205,7 +212,7 @@ private fun ManagedDevicesTopBar(
     onNavigateToUpgrade: () -> Unit
 ) {
     val context = LocalContext.current
-    
+
     TopAppBar(
         title = {
             if (isProVersion) {

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsScreen.kt
@@ -1,9 +1,11 @@
 package eu.darken.bluemusic.devices.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
-import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -25,6 +27,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import eu.darken.bluemusic.common.error.ErrorEventHandler
 import eu.darken.bluemusic.common.settings.SettingsDivider
 import eu.darken.bluemusic.common.settings.SettingsSwitchItem
@@ -75,13 +79,16 @@ fun DevicesSettingsScreen(
                     }
                 }
             )
-        }
+        },
+        contentWindowInsets = WindowInsets.statusBars
     ) { paddingValues ->
+        val navBarPadding = navigationBarBottomPadding()
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
                 .horizontalCutoutPadding(),
+            contentPadding = PaddingValues(bottom = navBarPadding),
             verticalArrangement = Arrangement.Top
         ) {
             item {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreen.kt
@@ -2,9 +2,11 @@ package eu.darken.bluemusic.main.ui.settings
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -35,6 +37,8 @@ import eu.darken.bluemusic.common.BlueMusicLinks
 import eu.darken.bluemusic.common.compose.ColoredTitleText
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import eu.darken.bluemusic.common.error.ErrorEventHandler
 import eu.darken.bluemusic.common.navigation.Nav
 import eu.darken.bluemusic.common.navigation.NavigationDestination
@@ -116,13 +120,16 @@ fun SettingsIndexScreen(
                     }
                 }
             )
-        }
+        },
+        contentWindowInsets = WindowInsets.statusBars
     ) { paddingValues ->
+        val navBarPadding = navigationBarBottomPadding()
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
                 .horizontalCutoutPadding(),
+            contentPadding = PaddingValues(bottom = navBarPadding),
             verticalArrangement = Arrangement.Top
         ) {
             item {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/acknowledgements/AcknowledgementsScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/acknowledgements/AcknowledgementsScreen.kt
@@ -1,9 +1,11 @@
 package eu.darken.bluemusic.main.ui.settings.acknowledgements
 
 import androidx.compose.foundation.layout.Arrangement
-import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -22,6 +24,8 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import eu.darken.bluemusic.common.error.ErrorEventHandler
 import eu.darken.bluemusic.common.settings.SettingsBaseItem
 import eu.darken.bluemusic.common.settings.SettingsCategoryHeader
@@ -47,13 +51,16 @@ fun AcknowledgementsScreen(
                     }
                 }
             )
-        }
+        },
+        contentWindowInsets = WindowInsets.statusBars
     ) { paddingValues ->
+        val navBarPadding = navigationBarBottomPadding()
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
                 .horizontalCutoutPadding(),
+            contentPadding = PaddingValues(bottom = navBarPadding),
             verticalArrangement = Arrangement.Top
         ) {
             item {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/general/GeneralSettingsScreen.kt
@@ -1,9 +1,11 @@
 package eu.darken.bluemusic.main.ui.settings.general
 
 import androidx.compose.foundation.layout.Arrangement
-import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -30,6 +32,8 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import eu.darken.bluemusic.common.error.ErrorEventHandler
 import eu.darken.bluemusic.common.settings.EnumSelectorDialog
 import eu.darken.bluemusic.common.settings.SettingsCategoryHeader
@@ -88,13 +92,16 @@ fun GeneralSettingsScreen(
                     }
                 }
             )
-        }
+        },
+        contentWindowInsets = WindowInsets.statusBars
     ) { paddingValues ->
+        val navBarPadding = navigationBarBottomPadding()
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
                 .horizontalCutoutPadding(),
+            contentPadding = PaddingValues(bottom = navBarPadding),
             verticalArrangement = Arrangement.Top
         ) {
             item {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/support/SupportScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/support/SupportScreen.kt
@@ -1,9 +1,11 @@
 package eu.darken.bluemusic.main.ui.settings.support
 
 import androidx.compose.foundation.layout.Arrangement
-import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
@@ -28,7 +30,9 @@ import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.BlueMusicLinks
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import eu.darken.bluemusic.common.compose.icons.Discord
+import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import eu.darken.bluemusic.common.debug.recorder.ui.RecorderConsentDialog
 import eu.darken.bluemusic.common.error.ErrorEventHandler
 import eu.darken.bluemusic.common.settings.SettingsCategoryHeader
@@ -89,13 +93,16 @@ fun SupportScreen(
                     }
                 }
             )
-        }
+        },
+        contentWindowInsets = WindowInsets.statusBars
     ) { paddingValues ->
+        val navBarPadding = navigationBarBottomPadding()
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(paddingValues)
                 .horizontalCutoutPadding(),
+            contentPadding = PaddingValues(bottom = navBarPadding),
             verticalArrangement = Arrangement.Top
         ) {
             item {


### PR DESCRIPTION
## Summary
- Add `contentWindowInsets = WindowInsets.statusBars` to all Scaffolds to prevent double-padding from status bar
- Add `navigationBarBottomPadding()` helper extension for consistent nav bar padding in LazyColumn content
- Add `navigationBarsPadding()` to FAB in DashboardScreen for proper placement
- Simplify `enableEdgeToEdge()` calls in MainActivity and RecorderActivity (removed unnecessary transparent style override)

## Test plan
- [x] Test with gesture navigation - nav bar should be transparent with content scrolling behind
- [x] Test with 3-button navigation - nav bar should be translucent
- [x] Verify no gap between top bar and content on devices with display cutouts
- [x] Check all screens: Dashboard, Settings, Device Config, App Selection, Discover, Recorder

Fixes #135