### PR TITLE
Fix NavDisplay backstack cannot be empty crash

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/common/navigation/NavigationController.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/navigation/NavigationController.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.common.navigation
 
+import androidx.compose.runtime.snapshots.Snapshot
 import androidx.navigation3.runtime.NavBackStack
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
@@ -37,24 +38,28 @@ class NavigationController @Inject constructor() {
     ) {
         log(TAG) { "goTo($destination, popUpTo=$popUpTo, inclusive=$inclusive)" }
 
-        if (popUpTo != null) {
-            while (backStack.isNotEmpty() && backStack.last() != popUpTo) {
-                val removed = backStack.removeLastOrNull()
-                log(TAG) { "Popping $removed while looking for $popUpTo" }
+        Snapshot.withMutableSnapshot {
+            if (popUpTo != null) {
+                while (backStack.size > 1 && backStack.last() != popUpTo) {
+                    val removed = backStack.removeLastOrNull()
+                    log(TAG) { "Popping $removed while looking for $popUpTo" }
+                }
+
+                if (inclusive && backStack.isNotEmpty() && backStack.last() == popUpTo) {
+                    val removed = backStack.removeLastOrNull()
+                    log(TAG) { "Popping $removed (inclusive)" }
+                }
             }
 
-            if (inclusive && backStack.isNotEmpty() && backStack.last() == popUpTo) {
-                val removed = backStack.removeLastOrNull()
-                log(TAG) { "Popping $removed (inclusive)" }
-            }
+            backStack.add(destination)
         }
-
-        backStack.add(destination)
     }
 
     fun replace(destination: NavigationDestination) {
-        backStack.removeLastOrNull()
-        backStack.add(destination)
+        Snapshot.withMutableSnapshot {
+            backStack.removeLastOrNull()
+            backStack.add(destination)
+        }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/onboarding/OnboardingViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/onboarding/OnboardingViewModel.kt
@@ -50,7 +50,7 @@ class OnboardingViewModel @Inject constructor(
         generalSettings.isOnboardingCompleted.value(true)
         navTo(
             Nav.Main.ManageDevices,
-            popUpTo = Nav.Main.ManageDevices,
+            popUpTo = Nav.Main.Onboarding,
             inclusive = true
         )
     }


### PR DESCRIPTION
## Summary
- Wrap `NavigationController.goTo()` and `replace()` backstack mutations in `Snapshot.withMutableSnapshot` so Compose observers only see the final state, never an intermediate empty backstack
- Guard the popUpTo while loop with `backStack.size > 1` to never pop the last element
- Fix `OnboardingViewModel.completeOnboarding()` using `popUpTo = Nav.Main.ManageDevices` (not on the stack) → `popUpTo = Nav.Main.Onboarding` (actually on the stack)

## Test plan
- [ ] Fresh install → complete onboarding → verify navigation to ManageDevices without crash
- [ ] Verify back button doesn't return to onboarding after completing it
- [ ] Rapid navigation between screens to stress-test atomic snapshot protection