### PR TITLE
Fix SecurityException when launching settings intents

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverScreen.kt
@@ -1,6 +1,8 @@
 package eu.darken.bluemusic.bluetooth.ui.discover
 
 import android.content.Intent
+import android.provider.Settings
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -47,6 +49,8 @@ import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.common.compose.PreviewWrapper
 import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.error.ErrorEventHandler
 import eu.darken.bluemusic.common.navigation.Nav
 import eu.darken.bluemusic.common.ui.waitForState
@@ -153,8 +157,23 @@ fun DiscoverScreen(
                         Spacer(modifier = Modifier.height(24.dp))
                         Button(
                             onClick = {
-                                val intent = Intent(android.provider.Settings.ACTION_BLUETOOTH_SETTINGS)
-                                context.startActivity(intent)
+                                try {
+                                    val intent = Intent(Settings.ACTION_BLUETOOTH_SETTINGS)
+                                    context.startActivity(intent)
+                                } catch (e: Exception) {
+                                    log(TAG) { "Failed to open Bluetooth settings: $e" }
+                                    try {
+                                        val fallback = Intent(Settings.ACTION_SETTINGS)
+                                        context.startActivity(fallback)
+                                    } catch (e2: Exception) {
+                                        log(TAG) { "Failed to open general settings: $e2" }
+                                        Toast.makeText(
+                                            context,
+                                            R.string.general_error_no_compatible_app_found_msg,
+                                            Toast.LENGTH_SHORT
+                                        ).show()
+                                    }
+                                }
                             }
                         ) {
                             Text(stringResource(R.string.discover_pair_new_device_action))
@@ -180,6 +199,8 @@ fun DiscoverScreen(
         }
     }
 }
+
+private val TAG = logTag("Discover", "Screen")
 
 @Preview
 @Composable

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/Android10AppLaunchHintCard.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/Android10AppLaunchHintCard.kt
@@ -1,6 +1,8 @@
 package eu.darken.bluemusic.devices.ui.dashboard.rows
 
 import android.content.Intent
+import android.provider.Settings
+import android.widget.Toast
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -29,6 +31,8 @@ import androidx.compose.ui.unit.dp
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
 
 @Composable
 fun Android10AppLaunchHintCard(
@@ -82,7 +86,24 @@ fun Android10AppLaunchHintCard(
                     Text(stringResource(R.string.action_dismiss))
                 }
                 Button(
-                    onClick = { context.startActivity(intent) },
+                    onClick = {
+                        try {
+                            context.startActivity(intent)
+                        } catch (e: Exception) {
+                            log(TAG) { "Failed to open app launch settings: $e" }
+                            try {
+                                val fallback = Intent(Settings.ACTION_SETTINGS)
+                                context.startActivity(fallback)
+                            } catch (e2: Exception) {
+                                log(TAG) { "Failed to open general settings: $e2" }
+                                Toast.makeText(
+                                    context,
+                                    R.string.general_error_no_compatible_app_found_msg,
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        }
+                    },
                     colors = androidx.compose.material3.ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.primary
                     )
@@ -93,6 +114,8 @@ fun Android10AppLaunchHintCard(
         }
     }
 }
+
+private val TAG = logTag("Android10AppLaunch", "HintCard")
 
 @Preview2
 @Composable

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/BatteryOptimizationHintCard.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/BatteryOptimizationHintCard.kt
@@ -1,6 +1,8 @@
 package eu.darken.bluemusic.devices.ui.dashboard.rows
 
 import android.content.Intent
+import android.provider.Settings
+import android.widget.Toast
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -29,6 +31,8 @@ import androidx.compose.ui.unit.dp
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
 
 @Composable
 fun BatteryOptimizationHintCard(
@@ -82,7 +86,24 @@ fun BatteryOptimizationHintCard(
                     Text(stringResource(R.string.action_dismiss))
                 }
                 Button(
-                    onClick = { context.startActivity(intent) },
+                    onClick = {
+                        try {
+                            context.startActivity(intent)
+                        } catch (e: Exception) {
+                            log(TAG) { "Failed to open battery optimization settings: $e" }
+                            try {
+                                val fallback = Intent(Settings.ACTION_SETTINGS)
+                                context.startActivity(fallback)
+                            } catch (e2: Exception) {
+                                log(TAG) { "Failed to open general settings: $e2" }
+                                Toast.makeText(
+                                    context,
+                                    R.string.general_error_no_compatible_app_found_msg,
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        }
+                    },
                     colors = androidx.compose.material3.ButtonDefaults.buttonColors(
                         containerColor = MaterialTheme.colorScheme.primary
                     )
@@ -93,6 +114,8 @@ fun BatteryOptimizationHintCard(
         }
     }
 }
+
+private val TAG = logTag("BatteryOptimization", "HintCard")
 
 @Preview2
 @Composable


### PR DESCRIPTION
## Summary
- Wrap `startActivity()` calls in try-catch blocks in `DiscoverScreen`, `BatteryOptimizationHintCard`, and `Android10AppLaunchHintCard`
- On failure (e.g. `SecurityException` on certain OEM devices), fall back to opening general settings via `ACTION_SETTINGS`
- If the fallback also fails, show a toast to the user

## Test plan
- [x] `assembleFossDebug` builds successfully
- [x] `testFossDebugUnitTest` passes
- [ ] Verify "Pair new device" button on Discover screen opens Bluetooth settings normally
- [ ] Verify battery optimization and Android 10 app launch hint cards open their respective settings