### PR TITLE
Update Navigation3 to 1.0.0 stable

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -292,11 +292,11 @@ dependencies {
     implementation("com.google.accompanist:accompanist-drawablepainter:0.37.3")
 
 
-    implementation("androidx.navigation3:navigation3-runtime:1.0.0-alpha08")
-    implementation("androidx.navigation3:navigation3-ui:1.0.0-alpha08")
+    implementation("androidx.navigation3:navigation3-runtime:1.0.0")
+    implementation("androidx.navigation3:navigation3-ui:1.0.0")
 
-    implementation("androidx.compose.material3.adaptive:adaptive-navigation3:1.0.0-alpha01")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-navigation3:1.0.0-alpha04")
+    implementation("androidx.compose.material3.adaptive:adaptive-navigation3:1.3.0-alpha06")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-navigation3:2.10.0")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-core:1.9.0")
 
 

--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeNavigation.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeNavigation.kt
@@ -1,8 +1,7 @@
 package eu.darken.bluemusic.upgrade.ui
 
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,7 +12,7 @@ import eu.darken.bluemusic.common.navigation.NavigationEntry
 import javax.inject.Inject
 
 class UpgradeNavigation @Inject constructor() : NavigationEntry {
-    override fun EntryProviderBuilder<NavKey>.setup() {
+    override fun EntryProviderScope<NavKey>.setup() {
         entry<Nav.Main.Upgrade> {
             UpgradeScreenHost()
         }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeNavigation.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeNavigation.kt
@@ -1,8 +1,7 @@
 package eu.darken.bluemusic.upgrade.ui
 
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,7 +12,7 @@ import eu.darken.bluemusic.common.navigation.NavigationEntry
 import javax.inject.Inject
 
 class UpgradeNavigation @Inject constructor() : NavigationEntry {
-    override fun EntryProviderBuilder<NavKey>.setup() {
+    override fun EntryProviderScope<NavKey>.setup() {
         entry<Nav.Main.Upgrade> {
             UpgradeScreenHost()
         }

--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverNavigation.kt
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverNavigation.kt
@@ -1,8 +1,7 @@
 package eu.darken.bluemusic.bluetooth.ui.discover
 
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,7 +12,7 @@ import eu.darken.bluemusic.common.navigation.NavigationEntry
 import javax.inject.Inject
 
 class DiscoverNavigation @Inject constructor() : NavigationEntry {
-    override fun EntryProviderBuilder<NavKey>.setup() {
+    override fun EntryProviderScope<NavKey>.setup() {
         entry<Nav.Main.DiscoverDevices> {
             DiscoverScreenHost()
         }

--- a/app/src/main/java/eu/darken/bluemusic/common/navigation/NavigationController.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/navigation/NavigationController.kt
@@ -2,20 +2,20 @@ package eu.darken.bluemusic.common.navigation
 
 import androidx.compose.runtime.snapshots.Snapshot
 import androidx.navigation3.runtime.NavBackStack
+import androidx.navigation3.runtime.NavKey
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
-import eu.darken.bluemusic.common.navigation.NavigationDestination
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class NavigationController @Inject constructor() {
-    private var _backStack: NavBackStack? = null
+    private var _backStack: NavBackStack<NavKey>? = null
 
-    private val backStack: NavBackStack
+    private val backStack: NavBackStack<NavKey>
         get() = _backStack ?: error("NavigationController not initialized")
 
-    fun setup(backStack: NavBackStack) {
+    fun setup(backStack: NavBackStack<NavKey>) {
         log(TAG) { "setup()" }
         _backStack = backStack
     }

--- a/app/src/main/java/eu/darken/bluemusic/common/navigation/NavigationEntry.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/navigation/NavigationEntry.kt
@@ -1,8 +1,8 @@
 package eu.darken.bluemusic.common.navigation
 
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 
 interface NavigationEntry {
-    fun EntryProviderBuilder<NavKey>.setup()
+    fun EntryProviderScope<NavKey>.setup()
 }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/appselection/AppSelectionNavigation.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/appselection/AppSelectionNavigation.kt
@@ -1,8 +1,7 @@
 package eu.darken.bluemusic.devices.ui.appselection
 
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,7 +12,7 @@ import eu.darken.bluemusic.common.navigation.NavigationEntry
 import javax.inject.Inject
 
 class AppSelectionNavigation @Inject constructor() : NavigationEntry {
-    override fun EntryProviderBuilder<NavKey>.setup() {
+    override fun EntryProviderScope<NavKey>.setup() {
         entry<Nav.Main.AppSelection> {
             AppSelectionScreenHost(it.addr)
         }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigNavigation.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigNavigation.kt
@@ -1,8 +1,7 @@
 package eu.darken.bluemusic.devices.ui.config
 
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,7 +12,7 @@ import eu.darken.bluemusic.common.navigation.NavigationEntry
 import javax.inject.Inject
 
 class DeviceConfigNavigation @Inject constructor() : NavigationEntry {
-    override fun EntryProviderBuilder<NavKey>.setup() {
+    override fun EntryProviderScope<NavKey>.setup() {
         entry<Nav.Main.DeviceConfig> {
             DeviceConfigScreenHost(it.addr)
         }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardNavigation.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardNavigation.kt
@@ -1,8 +1,7 @@
 package eu.darken.bluemusic.devices.ui.dashboard
 
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,7 +12,7 @@ import eu.darken.bluemusic.common.navigation.NavigationEntry
 import javax.inject.Inject
 
 class DashboardNavigation @Inject constructor() : NavigationEntry {
-    override fun EntryProviderBuilder<NavKey>.setup() {
+    override fun EntryProviderScope<NavKey>.setup() {
         entry<Nav.Main.ManageDevices> {
             DevicesScreenHost()
         }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsNavigation.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsNavigation.kt
@@ -1,8 +1,7 @@
 package eu.darken.bluemusic.devices.ui.settings
 
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,7 +12,7 @@ import eu.darken.bluemusic.common.navigation.NavigationEntry
 import javax.inject.Inject
 
 class DevicesSettingsNavigation @Inject constructor() : NavigationEntry {
-    override fun EntryProviderBuilder<NavKey>.setup() {
+    override fun EntryProviderScope<NavKey>.setup() {
         entry<Nav.Settings.Devices> {
             DevicesSettingsScreenHost()
         }

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/MainActivity.kt
@@ -79,7 +79,7 @@ class MainActivity : Activity2() {
             MainViewModel.State.StartScreen.HOME -> Nav.Main.ManageDevices
         }
 
-        val backStack = rememberNavBackStack<NavigationDestination>(start)
+        val backStack = rememberNavBackStack(start)
 
         LaunchedEffect(Unit) { navCtrl.setup(backStack) }
 

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/onboarding/OnboardingNavigation.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/onboarding/OnboardingNavigation.kt
@@ -1,8 +1,7 @@
 package eu.darken.bluemusic.main.ui.onboarding
 
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -13,7 +12,7 @@ import eu.darken.bluemusic.common.navigation.NavigationEntry
 import javax.inject.Inject
 
 class OnboardingNavigation @Inject constructor() : NavigationEntry {
-    override fun EntryProviderBuilder<NavKey>.setup() {
+    override fun EntryProviderScope<NavKey>.setup() {
         entry<Nav.Main.Onboarding> {
             OnboardingScreenHost()
         }

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsNavigation.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsNavigation.kt
@@ -1,8 +1,7 @@
 package eu.darken.bluemusic.main.ui.settings
 
-import androidx.navigation3.runtime.EntryProviderBuilder
+import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
-import androidx.navigation3.runtime.entry
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
@@ -16,7 +15,7 @@ import eu.darken.bluemusic.main.ui.settings.support.SupportScreenHost
 import javax.inject.Inject
 
 class SettingsNavigation @Inject constructor() : NavigationEntry {
-    override fun EntryProviderBuilder<NavKey>.setup() {
+    override fun EntryProviderScope<NavKey>.setup() {
         entry<Nav.Main.SettingsIndex> {
             SettingsIndexScreenHost()
         }


### PR DESCRIPTION
## Summary
- Upgrade Navigation3 from `1.0.0-alpha08` to `1.0.0` stable, along with companion libraries (`adaptive-navigation3` to `1.3.0-alpha06`, `lifecycle-viewmodel-navigation3` to `2.10.0`)
- Migrate `EntryProviderBuilder` → `EntryProviderScope` (API rename)
- Remove unused `entry` imports (now resolved via scope)
- Add generic type parameter to `NavBackStack<NavKey>` (now required)
- Drop explicit type parameter from `rememberNavBackStack` call

## Test plan
- [x] `./gradlew assembleFossDebug` builds successfully
- [x] `./gradlew testFossDebugUnitTest` passes