### PR TITLE
Replace MonitorWorker with ForegroundService to fix excessive wakelocks

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -276,12 +276,6 @@ dependencies {
     implementation("androidx.room:room-ktx:2.7.2")
     ksp("androidx.room:room-compiler:2.7.2")
 
-    implementation("androidx.work:work-runtime:2.10.3")
-    testImplementation("androidx.work:work-testing:2.10.3")
-    implementation("androidx.work:work-runtime-ktx:2.10.3")
-
-    implementation("androidx.hilt:hilt-work:1.2.0")
-    ksp("androidx.hilt:hilt-compiler:1.2.0")
 
 
     implementation("androidx.activity:activity-ktx:1.10.1")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -67,22 +67,9 @@
         </receiver>
 
         <service
-            android:name="androidx.work.impl.foreground.SystemForegroundService"
+            android:name="eu.darken.bluemusic.monitor.core.service.MonitorService"
             android:foregroundServiceType="connectedDevice"
-            tools:node="merge" />
-
-        <provider
-            android:name="androidx.startup.InitializationProvider"
-            android:authorities="${applicationId}.androidx-startup"
-            android:exported="false"
-            tools:node="merge">
-
-            <meta-data
-                android:name="androidx.work.WorkManagerInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
-
-        </provider>
+            android:exported="false" />
 
         <provider
             android:name="androidx.core.content.FileProvider"

--- a/app/src/main/java/eu/darken/bluemusic/AndroidModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/AndroidModule.kt
@@ -7,7 +7,6 @@ import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.media.AudioManager
 import android.preference.PreferenceManager
-import androidx.work.WorkManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -43,8 +42,4 @@ class AndroidModule {
     @Provides
     @Singleton
     fun packageManager(@ApplicationContext context: Context): PackageManager = context.packageManager
-
-    @Provides
-    @Singleton
-    fun workerManager(@ApplicationContext context: Context): WorkManager = WorkManager.getInstance(context)
 }

--- a/app/src/main/java/eu/darken/bluemusic/App.kt
+++ b/app/src/main/java/eu/darken/bluemusic/App.kt
@@ -1,10 +1,7 @@
 package eu.darken.bluemusic
 
 import android.app.Application
-import androidx.hilt.work.HiltWorkerFactory
-import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
-import eu.darken.bluemusic.common.BuildConfigWrap
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.coroutine.DispatcherProvider
 import eu.darken.bluemusic.common.debug.DebugSettings
@@ -17,18 +14,17 @@ import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.main.core.CurriculumVitae
 import eu.darken.bluemusic.main.core.GeneralSettings
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
-import eu.darken.bluemusic.monitor.core.worker.MonitorControl
+import eu.darken.bluemusic.monitor.core.service.MonitorControl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import kotlin.system.exitProcess
 
 @HiltAndroidApp
-class App : Application(), Configuration.Provider {
+class App : Application() {
 
     @Inject @AppScope lateinit var appScope: CoroutineScope
     @Inject lateinit var dispatcherProvider: DispatcherProvider
-    @Inject lateinit var workerFactory: HiltWorkerFactory
     @Inject lateinit var generalSettings: GeneralSettings
     @Inject lateinit var debugSettings: DebugSettings
     @Inject lateinit var curriculumVitae: CurriculumVitae
@@ -67,26 +63,10 @@ class App : Application(), Configuration.Provider {
 //            }
 //        }
 
-        appScope.launch {
-            monitorControl.startMonitor(forceStart = true)
-        }
+        monitorControl.startMonitor(forceStart = true)
 
         log(TAG) { "onCreate() done! ${Exception().asLog()}" }
     }
-
-    override val workManagerConfiguration: Configuration
-        get() = Configuration.Builder()
-            .setMinimumLoggingLevel(
-                when {
-                    BuildConfigWrap.DEBUG -> android.util.Log.VERBOSE
-                    BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.DEV -> android.util.Log.DEBUG
-                    BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.BETA -> android.util.Log.INFO
-                    BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.RELEASE -> android.util.Log.WARN
-                    else -> android.util.Log.VERBOSE
-                }
-            )
-            .setWorkerFactory(workerFactory)
-            .build()
 
     companion object {
         private val TAG = logTag("App")

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/BootCheckReceiver.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/BootCheckReceiver.kt
@@ -16,7 +16,7 @@ import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.devices.core.DeviceRepo
 import eu.darken.bluemusic.devices.core.DevicesSettings
-import eu.darken.bluemusic.monitor.core.worker.MonitorControl
+import eu.darken.bluemusic.monitor.core.service.MonitorControl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
@@ -24,8 +24,8 @@ import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.devices.core.currentDevices
 import eu.darken.bluemusic.devices.core.getDevice
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
-import eu.darken.bluemusic.monitor.core.worker.BluetoothEventQueue
-import eu.darken.bluemusic.monitor.core.worker.MonitorControl
+import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue
+import eu.darken.bluemusic.monitor.core.service.MonitorControl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/BluetoothEventQueue.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/BluetoothEventQueue.kt
@@ -1,4 +1,4 @@
-package eu.darken.bluemusic.monitor.core.worker
+package eu.darken.bluemusic.monitor.core.service
 
 import android.os.Parcelable
 import eu.darken.bluemusic.bluetooth.core.SourceDevice

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorControl.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorControl.kt
@@ -1,31 +1,27 @@
-package eu.darken.bluemusic.monitor.core.worker
+package eu.darken.bluemusic.monitor.core.service
 
-import androidx.work.Data
-import androidx.work.ExistingWorkPolicy
-import androidx.work.OneTimeWorkRequestBuilder
-import androidx.work.WorkManager
-import eu.darken.bluemusic.common.BuildConfigWrap
+import android.content.Context
+import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.bluemusic.common.coroutine.AppScope
-import eu.darken.bluemusic.common.coroutine.DispatcherProvider
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.flow.setupCommonEventHandlers
+import eu.darken.bluemusic.common.startServiceCompat
 import eu.darken.bluemusic.devices.core.DeviceRepo
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class MonitorControl @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
-    private val workerManager: WorkManager,
-    private val dispatcherProvider: DispatcherProvider,
+    @ApplicationContext private val context: Context,
     deviceRepo: DeviceRepo,
 ) {
 
@@ -47,28 +43,20 @@ class MonitorControl @Inject constructor(
             .launchIn(appScope)
     }
 
-    suspend fun startMonitor(
-        forceStart: Boolean = false,
-    ): Unit = withContext(dispatcherProvider.IO) {
-        val workerData = Data.Builder().apply {
+    fun startMonitor(forceStart: Boolean = false) {
+        log(TAG, VERBOSE) { "startMonitor(forceStart=$forceStart)" }
+        try {
+            context.startServiceCompat(MonitorService.intent(context, forceStart))
+            log(TAG) { "Monitor start request sent." }
+        } catch (e: IllegalStateException) {
+            log(TAG, WARN) { "Failed to start monitor service: ${e.message}" }
+        }
+    }
 
-        }.build()
-        log(TAG, VERBOSE) { "Worker data: $workerData" }
-
-        val workRequest = OneTimeWorkRequestBuilder<MonitorWorker>().apply {
-            setInputData(workerData)
-        }.build()
-
-        log(TAG, VERBOSE) { "Worker request: $workRequest" }
-
-        val operation = workerManager.enqueueUniqueWork(
-            "${BuildConfigWrap.APPLICATION_ID}.monitor.worker",
-            if (forceStart) ExistingWorkPolicy.REPLACE else ExistingWorkPolicy.KEEP,
-            workRequest,
-        )
-
-        operation.result.get()
-        log(TAG) { "Monitor start request send." }
+    fun stopMonitor() {
+        log(TAG, VERBOSE) { "stopMonitor()" }
+        context.stopService(MonitorService.intent(context))
+        log(TAG) { "Monitor stop request sent." }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/ui/MonitorNotifications.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/ui/MonitorNotifications.kt
@@ -1,15 +1,14 @@
 package eu.darken.bluemusic.monitor.ui
 
 import android.annotation.SuppressLint
+import android.app.Notification
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
-import android.content.pm.ServiceInfo
 import android.os.Build
 import androidx.core.app.NotificationCompat
-import androidx.work.ForegroundInfo
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.PendingIntentCompat
@@ -111,28 +110,14 @@ class MonitorNotifications @Inject constructor(
         addAction(NotificationCompat.Action.Builder(0, context.getString(R.string.action_exit), stopPi).build())
     }
 
-    suspend fun getDevicesNotification(devices: Collection<ManagedDevice>) = builderLock.withLock {
+    fun getInitialNotification(): Notification {
+        log(TAG) { "getInitialNotification()" }
+        return getBuilder(emptyList()).build()
+    }
+
+    suspend fun getDevicesNotification(devices: Collection<ManagedDevice>): Notification = builderLock.withLock {
         log(TAG) { "getDevicesNotification(devices=$devices)" }
         return@withLock getBuilder(devices).build()
-    }
-
-    suspend fun getForegroundInfo(devices: Collection<ManagedDevice>): ForegroundInfo = builderLock.withLock {
-        log(TAG) { "getForegroundInfo(devices=$devices)" }
-        getBuilder(devices).toForegroundInfo()
-    }
-
-    @SuppressLint("InlinedApi")
-    private fun NotificationCompat.Builder.toForegroundInfo(): ForegroundInfo = if (hasApiLevel(29)) {
-        ForegroundInfo(
-            NOTIFICATION_ID,
-            this.build(),
-            ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
-        )
-    } else {
-        ForegroundInfo(
-            NOTIFICATION_ID,
-            this.build()
-        )
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- Replace WorkManager-based `MonitorWorker` with a `ForegroundService` (`MonitorService`) to eliminate excessive `ProcessorForegroundLck` wakelocks reported in Google Play Console (720+ min at 99th percentile)
- Align service lifecycle with capod's proven pattern: monitoring in `onStartCommand` with generation tracking, `START_STICKY`, `forceStart` intent extra
- Add `IllegalStateException` guard for Android 12+ background start restrictions

## Test plan
- [ ] `./gradlew assembleFossDebug` builds successfully
- [ ] Service starts on app launch with `forceStart=true`
- [ ] Duplicate `startMonitor()` calls without `forceStart` are no-ops
- [ ] Service restarts after system kill (`START_STICKY`)
- [ ] Notification "Exit" action stops the service
- [ ] Boot receiver starts monitoring when devices are connected