### PR TITLE
Fix rate limiter using stale reference after app-triggered volume changes

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeRateLimiterModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeRateLimiterModule.kt
@@ -45,9 +45,12 @@ internal class VolumeRateLimiterModule @Inject constructor(
         val newVolume = event.newVolume
         val oldVolume = event.oldVolume
 
-        // Ignore changes triggered by us
+        // Ignore changes triggered by us, but update our reference
         if (volumeTool.wasUs(id, newVolume)) {
             log(TAG, VERBOSE) { "Volume change was triggered by us, ignoring it." }
+            mutex.withLock {
+                volumeStates[id] = VolumeState(newVolume, System.currentTimeMillis())
+            }
             return
         }
 


### PR DESCRIPTION
## Summary
- When the app sets volume (e.g., 4→9), the `VolumeRateLimiterModule` correctly detects it as self-triggered via `wasUs()` and returns early — but did not update `volumeStates`, leaving a stale reference
- Subsequent hardware volume button presses calculated diffs against the stale reference, causing unexpected volume jumps (e.g., pressing vol- from 9 would jump to 5 instead of 8)
- Fix: update `volumeStates` with the new volume in the `wasUs()` early-return path

## Test plan
- [ ] Connect a Bluetooth device with rate limiter enabled
- [ ] Set volume via app UI
- [ ] Press hardware volume buttons — should change by 1 step from the app-set level