### PR TITLE
Fix upgrade Snackbar drawn under navigation bar on DiscoverScreen

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
@@ -115,7 +116,10 @@ fun DiscoverScreen(
             )
         },
         snackbarHost = {
-            SnackbarHost(hostState = snackbarHostState)
+            SnackbarHost(
+                hostState = snackbarHostState,
+                modifier = Modifier.navigationBarsPadding()
+            )
         },
         contentWindowInsets = WindowInsets.statusBars
     ) { paddingValues ->


### PR DESCRIPTION
## Summary
- Add `navigationBarsPadding()` modifier to the `SnackbarHost` on the Discover screen so it renders above the system navigation bar in edge-to-edge mode.

## Test plan
- [ ] On a device with gesture navigation, add a 3rd device without PRO to trigger the upgrade Snackbar
- [ ] Verify the Snackbar appears above the navigation bar