### PR TITLE
Fix receiver registration and clarify operator precedence

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/RingerModeObserver.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/RingerModeObserver.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.media.AudioManager
+import androidx.core.content.ContextCompat
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.bluemusic.common.debug.logging.log
@@ -50,7 +51,7 @@ class RingerModeObserver @Inject constructor(
         }
 
         val filter = IntentFilter(AudioManager.RINGER_MODE_CHANGED_ACTION)
-        context.registerReceiver(receiver, filter)
+        ContextCompat.registerReceiver(context, receiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED)
         log(TAG) { "Now listening for ringer mode change events" }
 
         awaitClose {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
@@ -49,7 +49,7 @@ class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
     }
 
     fun wasUs(id: AudioStream.Id, volume: Int): Boolean {
-        return lastUs.containsKey(id) && lastUs[id] == volume || adjusting
+        return (lastUs.containsKey(id) && lastUs[id] == volume) || adjusting
     }
 
     fun getVolumePercentage(streamId: AudioStream.Id): Float {


### PR DESCRIPTION
## Summary
- Use `ContextCompat.registerReceiver()` with `RECEIVER_NOT_EXPORTED` in `RingerModeObserver` for Android 14+ compliance, consistent with the rest of the codebase
- Add explicit parentheses in `VolumeTool.wasUs()` to clarify `&&`/`||` operator precedence

## Test plan
- [x] `assembleFossDebug` builds successfully
- [x] `testFossDebugUnitTest` passes
- [x] `lintVitalFossRelease` passes with no fatal issues