### PR TITLE
Fix duplicate APK upload in GitHub release pipeline

### DIFF
--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -65,7 +65,7 @@ jobs:
           tag_name: ${{ steps.tagger.outputs.tag }}
           name: ${{ steps.tagger.outputs.tag }}
           generate_release_notes: true
-          files: app/build/outputs/apk/foss/beta/*.apk
+          files: app/build/outputs/apk/foss/beta/eu.darken.bluemusic-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -77,7 +77,7 @@ jobs:
           tag_name: ${{ steps.tagger.outputs.tag }}
           name: ${{ steps.tagger.outputs.tag }}
           generate_release_notes: true
-          files: app/build/outputs/apk/foss/release/*.apk
+          files: app/build/outputs/apk/foss/release/eu.darken.bluemusic-*.apk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Narrow APK glob patterns in release workflow to only match renamed APKs (`eu.darken.bluemusic-*.apk`), preventing the original AGP output (`app-*.apk`) from being uploaded as a duplicate

## Context
The AGP 9.0 upgrade switched APK renaming from in-place to copy-based (to preserve Android Studio deployment). This left two APK files in the output directory, and the `*.apk` glob was matching both.

## Test plan
- [x] Verified `assembleFossRelease` produces two APKs but only the renamed one matches the new glob