### PR TITLE
Fix saved volumes being silently overwritten on Bluetooth reconnect

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/common/time/MonotonicClock.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/time/MonotonicClock.kt
@@ -1,0 +1,36 @@
+package eu.darken.bluemusic.common.time
+
+import android.os.SystemClock
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Monotonic time source.
+ *
+ * Returns milliseconds since an arbitrary but consistent epoch (device boot).
+ * Unlike [System.currentTimeMillis], it is NOT affected by wall-clock changes
+ * (NTP resync, user adjustment, time-zone / DST shifts). Use this for interval
+ * measurements (timeouts, TTLs, debouncing) where "how long ago did X happen?"
+ * must remain accurate across clock jumps.
+ *
+ * Backed by [SystemClock.elapsedRealtime] in production. A fake implementation
+ * can be supplied in unit tests since [SystemClock] is part of the Android
+ * framework stubs and throws in plain JVM tests.
+ */
+interface MonotonicClock {
+    fun nowMs(): Long
+}
+
+@Singleton
+class AndroidMonotonicClock @Inject constructor() : MonotonicClock {
+    override fun nowMs(): Long = SystemClock.elapsedRealtime()
+
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class Mod {
+        @Binds abstract fun bind(impl: AndroidMonotonicClock): MonotonicClock
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/DevicesSettings.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/DevicesSettings.kt
@@ -3,12 +3,18 @@ package eu.darken.bluemusic.devices.core
 import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.bluemusic.common.BuildConfigWrap
 import eu.darken.bluemusic.common.datastore.PreferenceData
 import eu.darken.bluemusic.common.datastore.createValue
 import eu.darken.bluemusic.common.debug.logging.logTag
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -24,14 +30,67 @@ class DevicesSettings @Inject constructor(
     override val dataStore: DataStore<Preferences>
         get() = context.dataStore
 
+    /**
+     * Read-only flag for whether monitoring is enabled. Use [setEnabled] for writes so the paired
+     * toggle epoch is advanced in the same DataStore transaction.
+     */
     val isEnabled = dataStore.createValue("devices.enabled", true)
+
+    /**
+     * Atomic snapshot of monitoring enablement plus a monotonic epoch that advances on every
+     * actual toggle. This lets downstream consumers detect a collapsed `true -> false -> true`
+     * cycle even if they only observe the final `true` value.
+     */
+    val enabledState: Flow<EnabledState> = dataStore.data
+        .map { prefs ->
+            EnabledState(
+                isEnabled = prefs[KEY_ENABLED] ?: true,
+                toggleEpoch = prefs[KEY_ENABLED_EPOCH] ?: 0L,
+            )
+        }
+        .distinctUntilChanged()
+
     val restoreOnBoot = dataStore.createValue("devices.volume.restore.boot.enabled", true)
     val lockedDevices = dataStore.createValue(
         "devices.adjustment.locked", emptySet<String>(), json,
         onErrorFallbackToDefault = BuildConfigWrap.BUILD_TYPE == BuildConfigWrap.BuildType.RELEASE,
     )
 
+    suspend fun currentEnabledState(): EnabledState = enabledState.first()
+
+    /**
+     * Updates the enabled flag and paired epoch atomically. The epoch increments only when the
+     * boolean actually changes.
+     */
+    suspend fun setEnabled(enabled: Boolean): EnabledState {
+        var updatedState = EnabledState(isEnabled = enabled, toggleEpoch = 0L)
+        dataStore.updateData { prefs ->
+            val currentState = EnabledState(
+                isEnabled = prefs[KEY_ENABLED] ?: true,
+                toggleEpoch = prefs[KEY_ENABLED_EPOCH] ?: 0L,
+            )
+            updatedState = if (currentState.isEnabled == enabled) {
+                currentState
+            } else {
+                currentState.copy(isEnabled = enabled, toggleEpoch = currentState.toggleEpoch + 1L)
+            }
+
+            prefs.toMutablePreferences().apply {
+                this[KEY_ENABLED] = updatedState.isEnabled
+                this[KEY_ENABLED_EPOCH] = updatedState.toggleEpoch
+            }.toPreferences()
+        }
+        return updatedState
+    }
+
+    data class EnabledState(
+        val isEnabled: Boolean,
+        val toggleEpoch: Long,
+    )
+
     companion object {
         internal val TAG = logTag("Devices", "Settings")
+        private val KEY_ENABLED = booleanPreferencesKey("devices.enabled")
+        private val KEY_ENABLED_EPOCH = longPreferencesKey("devices.enabled.epoch")
     }
 }

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDeviceExtensions.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDeviceExtensions.kt
@@ -23,6 +23,14 @@ fun DeviceConfigEntity.updateVolume(type: AudioStream.Type, volume: Float?): Dev
     AudioStream.Type.ALARM -> copy(alarmVolume = volume)
 }
 
+fun DeviceConfigEntity.getVolume(type: AudioStream.Type): Float? = when (type) {
+    AudioStream.Type.MUSIC -> musicVolume
+    AudioStream.Type.CALL -> callVolume
+    AudioStream.Type.RINGTONE -> ringVolume
+    AudioStream.Type.NOTIFICATION -> notificationVolume
+    AudioStream.Type.ALARM -> alarmVolume
+}
+
 /**
  * Type-safe volume update using VolumeMode
  */

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
@@ -10,6 +10,7 @@ import eu.darken.bluemusic.common.navigation.NavigationController
 import eu.darken.bluemusic.common.ui.ViewModel4
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.devices.core.DevicesSettings
+import eu.darken.bluemusic.monitor.core.service.EventTypeDedupTracker
 import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
 
@@ -20,6 +21,7 @@ constructor(
     dispatcherProvider: DispatcherProvider,
     navCtrl: NavigationController,
     private val devicesSettings: DevicesSettings,
+    private val eventTypeDedupTracker: EventTypeDedupTracker,
     upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider, logTag("Settings", "Devices", "ViewModel"), navCtrl) {
 
@@ -43,6 +45,14 @@ constructor(
     fun onToggleEnabled(enabled: Boolean) = launch {
         log(tag) { "onToggleEnabled($enabled)" }
         devicesSettings.isEnabled.value(enabled)
+        // Notify the dedup tracker synchronously on the same coroutine that
+        // owns the write. This closes the race where a BT broadcast arrives
+        // between the DataStore commit and the tracker's async flow
+        // collector catching up: the tracker's in-memory state is already
+        // aligned with the value the ViewModel just wrote, so a subsequent
+        // receiver read of isEnabled will see a tracker that has already
+        // cleared (if this write transitioned the state).
+        eventTypeDedupTracker.notifyEnabledState(enabled)
     }
 
     fun onToggleRestoreOnBoot(enabled: Boolean) = launch {

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
@@ -10,7 +10,6 @@ import eu.darken.bluemusic.common.navigation.NavigationController
 import eu.darken.bluemusic.common.ui.ViewModel4
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.devices.core.DevicesSettings
-import eu.darken.bluemusic.monitor.core.service.EventTypeDedupTracker
 import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
 
@@ -21,7 +20,6 @@ constructor(
     dispatcherProvider: DispatcherProvider,
     navCtrl: NavigationController,
     private val devicesSettings: DevicesSettings,
-    private val eventTypeDedupTracker: EventTypeDedupTracker,
     upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider, logTag("Settings", "Devices", "ViewModel"), navCtrl) {
 
@@ -44,15 +42,7 @@ constructor(
 
     fun onToggleEnabled(enabled: Boolean) = launch {
         log(tag) { "onToggleEnabled($enabled)" }
-        devicesSettings.isEnabled.value(enabled)
-        // Notify the dedup tracker synchronously on the same coroutine that
-        // owns the write. This closes the race where a BT broadcast arrives
-        // between the DataStore commit and the tracker's async flow
-        // collector catching up: the tracker's in-memory state is already
-        // aligned with the value the ViewModel just wrote, so a subsequent
-        // receiver read of isEnabled will see a tracker that has already
-        // cleared (if this write transitioned the state).
-        eventTypeDedupTracker.notifyEnabledState(enabled)
+        devicesSettings.setEnabled(enabled)
     }
 
     fun onToggleRestoreOnBoot(enabled: Boolean) = launch {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
@@ -115,6 +115,7 @@ class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
 
         val currentLevel = getCurrentVolume(streamId)
         if (currentLevel == targetLevel) {
+            lastUs[streamId] = targetLevel // Record intent so wasUs() reflects this target
             log(TAG, VERBOSE) { "Target volume of $targetLevel already set." }
             return false
         }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
@@ -14,6 +14,7 @@ import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
 import eu.darken.bluemusic.monitor.core.modules.delayForReactionDelay
 import kotlinx.coroutines.delay
 import java.time.Instant
+import kotlin.math.roundToInt
 
 abstract class BaseVolumeModule(
     private val volumeTool: VolumeTool
@@ -93,14 +94,33 @@ abstract class BaseVolumeModule(
         }
 
         val targetPercentage = volumeMode.percentage
+        val streamId = device.getStreamId(type)
+        val targetLevel = (targetPercentage * volumeTool.getMaxVolume(streamId)).roundToInt()
 
         val monitorDuration = device.monitoringDuration
-        log(tag) { "Monitor($type) active for ${monitorDuration}ms." }
+        log(tag) { "Monitor($type) active for ${monitorDuration}ms, targetLevel=$targetLevel." }
 
-        val streamId = device.getStreamId(type)
-
+        // The monitor loop re-enforces the target against Android's own stream-level
+        // resets during BT audio route transitions (A2DP/SCO handoff). It must NOT
+        // fight deliberate writes from other code paths (user dragging the in-app
+        // slider, another module updating via VolumeTool). We detect those by checking
+        // wasUs(targetLevel): the loop only writes targetLevel, so lastUs[id] stays
+        // at targetLevel as long as we're the sole writer. If any other VolumeTool
+        // caller writes a different level, lastUs[id] changes → wasUs returns false
+        // → we yield. Android's own platform writes don't go through VolumeTool, so
+        // they don't affect lastUs and the loop correctly re-enforces against them.
+        //
+        // Known limitation: if a user drags during the actionDelay window (before
+        // setInitial even runs), setInitial will overwrite them with the connect-time
+        // snapshot. That's a separate issue — fixing it would require re-reading
+        // DeviceRepo after the delay.
         val targetTime = Instant.now() + monitorDuration
         while (Instant.now() < targetTime) {
+            if (!volumeTool.wasUs(streamId, targetLevel)) {
+                log(tag, INFO) { "Monitor($type) yielding to external VolumeTool write on $device" }
+                return
+            }
+
             if (volumeTool.changeVolume(streamId, targetPercentage)) {
                 log(tag) { "Monitor($type) adjusted volume." }
             }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
@@ -127,9 +127,10 @@ class VolumeDisconnectModule @Inject constructor(
                             // Known limitation: on non-coupling devices, a
                             // user intentionally setting notification to 0
                             // while in vibrate/silent ringer mode will NOT be
-                            // captured by save-on-disconnect — they'd have to
-                            // use the app UI or rely on volumeObserving=true
-                            // to save the 0.
+                            // captured by save-on-disconnect. This heuristic
+                            // intentionally prefers preserving pre-existing
+                            // values on coupling devices over guessing at the
+                            // meaning of a single 0-read in non-Normal mode.
                             if (snap.currentLevel > 0) hardwareNormal else null
                         }
                     }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
@@ -7,20 +7,27 @@ import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.getVolume
 import eu.darken.bluemusic.devices.core.updateVolume
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import eu.darken.bluemusic.monitor.core.audio.RingerMode
+import eu.darken.bluemusic.monitor.core.audio.RingerTool
+import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
 import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlin.math.roundToInt
 
 @Singleton
 class VolumeDisconnectModule @Inject constructor(
     private val volumeTool: VolumeTool,
+    private val ringerTool: RingerTool,
     private val deviceRepo: DeviceRepo,
 ) : ConnectionModule {
 
@@ -41,31 +48,148 @@ class VolumeDisconnectModule @Inject constructor(
 
         log(TAG, INFO) { "Saving volumes on disconnect for device ${device.label}" }
 
-        val volumeUpdates = buildMap {
-            AudioStream.Type.entries.forEach { streamType ->
-                val currentVolume = device.getVolume(streamType)
-                if (currentVolume == null) return@forEach
+        // TODO: RingerTool.getCurrentRingerMode() falls back to NORMAL on unknown
+        // Android modes. If Android ever adds a new ringer mode, this module will
+        // treat unreliable RINGTONE/NOTIFICATION reads as reliable. Broaden
+        // RingerTool to expose an unknown/null state if the need arises.
+        val ringerMode = ringerTool.getCurrentRingerMode()
 
-                val streamId = device.getStreamId(streamType)
-                val actualVolume = volumeTool.getVolumePercentage(streamId)
-                put(streamType, actualVolume)
-                log(TAG, VERBOSE) { "Capturing $streamType volume: $actualVolume for ${device.label}" }
+        // Phase 1: capture hardware facts only — no DB access yet. Using
+        // event.device (a snapshot) to decide "is this stream configured at all?"
+        // is acceptable because an unset-at-dispatch-time stream cannot
+        // legitimately become set again by the time the disconnect module runs
+        // at priority 1.
+        val snapshots = AudioStream.Type.entries.mapNotNull { type ->
+            if (device.getVolume(type) == null) return@mapNotNull null
+
+            val streamId = device.getStreamId(type)
+            val maxLevel = volumeTool.getMaxVolume(streamId)
+            val currentLevel = volumeTool.getCurrentVolume(streamId)
+            if (maxLevel <= 0 || currentLevel !in 0..maxLevel) {
+                log(TAG, WARN) {
+                    "Skipping $type, bad hardware read (level=$currentLevel max=$maxLevel)"
+                }
+                return@mapNotNull null
             }
+
+            Snapshot(type, currentLevel, maxLevel)
         }
 
-        if (volumeUpdates.isEmpty()) {
-            log(TAG, VERBOSE) { "No volume settings to save for ${device.label}" }
+        if (snapshots.isEmpty()) {
+            log(TAG, VERBOSE) { "No streams to capture for ${device.label}" }
             return
         }
 
+        // Phase 2: compare-and-write inside the updateDevice transaction so we
+        // decide against the DB-fresh oldConfig, not the stale event.device.config
+        // snapshot. A concurrent VolumeUpdateModule write (priority 10) between
+        // dispatch and our turn would otherwise be clobbered.
+        var writeCount = 0
         deviceRepo.updateDevice(device.address) { oldConfig ->
-            volumeUpdates.entries.fold(oldConfig) { config, (streamType, volume) ->
-                config.updateVolume(streamType, volume)
+            var updated = oldConfig
+            for (snap in snapshots) {
+                val rawStored = oldConfig.getVolume(snap.type) ?: continue
+                val savedMode = VolumeMode.fromFloat(rawStored)
+
+                val percent = (snap.currentLevel.toFloat() / snap.maxLevel).coerceIn(0f, 1f)
+                val hardwareNormal = VolumeMode.Normal(percent)
+
+                val currentMode: VolumeMode? = when (snap.type) {
+                    AudioStream.Type.RINGTONE -> when (ringerMode) {
+                        // RINGTONE has first-class Silent/Vibrate sentinels;
+                        // we own the persistence path together with
+                        // MonitorService.handleRingerMode(). Both writers agree
+                        // on the sentinel value for a given ringer state, so
+                        // dual-writing is safe and closes the race where
+                        // handleRingerMode() bails out (no active device) before
+                        // our disconnect save runs.
+                        RingerMode.SILENT -> VolumeMode.Silent
+                        RingerMode.VIBRATE -> VolumeMode.Vibrate
+                        RingerMode.NORMAL -> hardwareNormal
+                    }
+
+                    AudioStream.Type.NOTIFICATION -> when (ringerMode) {
+                        RingerMode.NORMAL -> hardwareNormal
+                        else -> {
+                            // Non-Normal ringer mode + STREAM_NOTIFICATION is
+                            // ambiguous: some devices (Pixel) clamp it to 0 as
+                            // a side effect of vibrate/silent coupling, other
+                            // devices leave it under independent user control.
+                            //
+                            // Heuristic: if the hardware reports > 0, trust the
+                            // user (they set it deliberately). If it reports 0,
+                            // preserve the stored value — we can't distinguish
+                            // "coupling clamp" from "user muted notification"
+                            // on a single read, and preserving the last
+                            // explicit value is the safer default on devices
+                            // that couple.
+                            //
+                            // Known limitation: on non-coupling devices, a
+                            // user intentionally setting notification to 0
+                            // while in vibrate/silent ringer mode will NOT be
+                            // captured by save-on-disconnect — they'd have to
+                            // use the app UI or rely on volumeObserving=true
+                            // to save the 0.
+                            if (snap.currentLevel > 0) hardwareNormal else null
+                        }
+                    }
+
+                    else -> hardwareNormal
+                }
+
+                if (currentMode == null) {
+                    log(TAG, VERBOSE) {
+                        "Skipping ${snap.type}, ringer=$ringerMode hardware=0 (preserving stored $savedMode)"
+                    }
+                    continue
+                }
+
+                val shouldWrite = when {
+                    // Corrupt / unparseable float on disk — heal the record.
+                    savedMode == null -> {
+                        log(TAG, WARN) {
+                            "Corrupt stored ${snap.type} value ($rawStored) for " +
+                                "${device.label}, healing with $currentMode"
+                        }
+                        true
+                    }
+                    // Both Normal: compare discretized levels so we don't
+                    // rewrite a higher-precision stored float with the
+                    // discrete level/max ratio on every disconnect cycle.
+                    savedMode is VolumeMode.Normal && currentMode is VolumeMode.Normal -> {
+                        val savedLevel = (savedMode.percentage * snap.maxLevel).roundToInt()
+                        savedLevel != snap.currentLevel
+                    }
+                    // Structural equality on Silent/Vibrate (data objects).
+                    savedMode == currentMode -> false
+                    // Mode changed (e.g. Normal → Vibrate, or Vibrate → Normal
+                    // after a user-driven ringer mode flip mid-session).
+                    else -> true
+                }
+
+                if (shouldWrite) {
+                    updated = updated.updateVolume(snap.type, currentMode)
+                    writeCount++
+                    log(TAG, VERBOSE) { "Capturing ${snap.type}: $currentMode for ${device.label}" }
+                } else {
+                    log(TAG, VERBOSE) { "Skipping ${snap.type}, no change for ${device.label}" }
+                }
             }
+            updated
         }
 
-        log(TAG, INFO) { "Saved ${volumeUpdates.size} volume settings on disconnect for ${device.label}: $volumeUpdates" }
+        if (writeCount == 0) {
+            log(TAG, VERBOSE) { "No volume changes to save on disconnect for ${device.label}" }
+        } else {
+            log(TAG, INFO) { "Saved $writeCount volume settings on disconnect for ${device.label}" }
+        }
     }
+
+    private data class Snapshot(
+        val type: AudioStream.Type,
+        val currentLevel: Int,
+        val maxLevel: Int,
+    )
 
     @Module @InstallIn(SingletonComponent::class)
     abstract class Mod {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
@@ -13,7 +13,11 @@ import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.devices.core.DeviceRepo
 import eu.darken.bluemusic.devices.core.currentDevices
 import eu.darken.bluemusic.devices.core.updateVolume
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import eu.darken.bluemusic.monitor.core.audio.RingerMode
+import eu.darken.bluemusic.monitor.core.audio.RingerTool
 import eu.darken.bluemusic.monitor.core.audio.VolumeEvent
+import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.modules.VolumeModule
 import java.time.Duration
@@ -24,6 +28,7 @@ import javax.inject.Singleton
 @Singleton
 class VolumeUpdateModule @Inject constructor(
     private val volumeTool: VolumeTool,
+    private val ringerTool: RingerTool,
     private val deviceRepo: DeviceRepo,
 ) : VolumeModule {
 
@@ -44,17 +49,65 @@ class VolumeUpdateModule @Inject constructor(
         val activeDevices = deviceRepo.currentDevices().filter { it.isActive }
         log(TAG, VERBOSE) { "Active devices (${activeDevices.size}): $activeDevices" }
 
-        val percentage = volumeTool.getVolumePercentage(id)
+        val ringerMode = ringerTool.getCurrentRingerMode()
+        val percentage = volumeTool.getVolumePercentage(id).coerceIn(0f, 1f)
 
         val now = Instant.now()
         activeDevices
             .filter { Duration.between(it.lastConnected, now) > it.actionDelay }
             .filter { it.volumeObserving && !it.volumeLock }
-            .filter { dev -> dev.getStreamType(id) != null && dev.getVolume(dev.getStreamType(id)!!) != null }
             .forEach { dev ->
-                log(TAG, INFO) { "Saving new volume ($percentage@$id) for $dev" }
+                val streamType = dev.getStreamType(id) ?: return@forEach
+                if (dev.getVolume(streamType) == null) return@forEach
+
+                // Map the raw hardware reading to a VolumeMode that accounts
+                // for the current ringer mode on streams that have sentinel
+                // states (RINGTONE) or unreliable hardware reads in
+                // vibrate/silent (NOTIFICATION).
+                //
+                // Without this, a user flipping the phone to vibrate
+                // mid-session would trigger STREAM_RING → 0 observations that
+                // overwrite the stored Vibrate sentinel (or a legitimate
+                // Normal value) with `Normal(0)`, racing against
+                // MonitorService.handleRingerMode() and losing non-deterministically.
+                val mode: VolumeMode? = when (streamType) {
+                    AudioStream.Type.RINGTONE -> when (ringerMode) {
+                        // RINGTONE owns first-class Silent/Vibrate sentinels.
+                        // Both this path and handleRingerMode() are allowed to
+                        // write them; they always agree on the sentinel value,
+                        // so last-writer-wins is safe.
+                        RingerMode.SILENT -> VolumeMode.Silent
+                        RingerMode.VIBRATE -> VolumeMode.Vibrate
+                        RingerMode.NORMAL -> VolumeMode.Normal(percentage)
+                    }
+
+                    AudioStream.Type.NOTIFICATION -> when (ringerMode) {
+                        RingerMode.NORMAL -> VolumeMode.Normal(percentage)
+                        else -> {
+                            // Same heuristic as VolumeDisconnectModule: in
+                            // non-Normal ringer mode, a 0 reading could be
+                            // either a Pixel-style platform clamp or an
+                            // intentional user mute on a non-coupling device.
+                            // Capture non-zero readings (clearly user intent)
+                            // and preserve stored on 0-readings (safer default
+                            // for the coupling case).
+                            if (event.newVolume > 0) VolumeMode.Normal(percentage) else null
+                        }
+                    }
+
+                    else -> VolumeMode.Normal(percentage)
+                }
+
+                if (mode == null) {
+                    log(TAG, VERBOSE) {
+                        "Skipping $streamType update for $dev, ringer=$ringerMode hardware=0"
+                    }
+                    return@forEach
+                }
+
+                log(TAG, INFO) { "Saving new volume ($mode@$id) for $dev" }
                 deviceRepo.updateDevice(dev.address) { oldConfig ->
-                    oldConfig.updateVolume(dev.getStreamType(id)!!, percentage)
+                    oldConfig.updateVolume(streamType, mode)
                 }
             }
     }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
@@ -10,7 +10,6 @@ import eu.darken.bluemusic.bluetooth.core.SourceDeviceWrapper
 import eu.darken.bluemusic.bluetooth.core.speaker.SpeakerDeviceProvider
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.coroutine.DispatcherProvider
-import eu.darken.bluemusic.common.datastore.value
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.DEBUG
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
@@ -66,16 +65,10 @@ class MonitorEventReceiver : BroadcastReceiver() {
 
         appScope.launch {
             try {
-                val isEnabled = devicesSettings.isEnabled.value()
-                // Always notify the tracker, including when we are about to
-                // return early below. Driving the tracker's transition clear
-                // from the receiver's own synchronous read closes the
-                // scheduler-race window between the flow collector in
-                // EventTypeDedupTracker.init and the receiver's isDuplicate
-                // call on the same coroutine.
-                eventTypeDedupTracker.notifyEnabledState(isEnabled)
+                val enabledState = devicesSettings.currentEnabledState()
+                eventTypeDedupTracker.observeEnabledState(enabledState)
 
-                if (!isEnabled) {
+                if (!enabledState.isEnabled) {
                     log(TAG, INFO) { "We are disabled." }
                     return@launch
                 }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
@@ -25,6 +25,7 @@ import eu.darken.bluemusic.devices.core.currentDevices
 import eu.darken.bluemusic.devices.core.getDevice
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue
+import eu.darken.bluemusic.monitor.core.service.EventTypeDedupTracker
 import eu.darken.bluemusic.monitor.core.service.FakeSpeakerEventDebouncer
 import eu.darken.bluemusic.monitor.core.service.MonitorControl
 import kotlinx.coroutines.CoroutineScope
@@ -41,6 +42,7 @@ class MonitorEventReceiver : BroadcastReceiver() {
     @Inject lateinit var deviceRepo: DeviceRepo
     @Inject lateinit var dispatcherProvider: DispatcherProvider
     @Inject lateinit var eventQueue: BluetoothEventQueue
+    @Inject lateinit var eventTypeDedupTracker: EventTypeDedupTracker
     @Inject lateinit var fakeSpeakerEventDebouncer: FakeSpeakerEventDebouncer
     @Inject lateinit var monitorControl: MonitorControl
     @Inject @AppScope lateinit var appScope: CoroutineScope
@@ -64,7 +66,16 @@ class MonitorEventReceiver : BroadcastReceiver() {
 
         appScope.launch {
             try {
-                if (!devicesSettings.isEnabled.value()) {
+                val isEnabled = devicesSettings.isEnabled.value()
+                // Always notify the tracker, including when we are about to
+                // return early below. Driving the tracker's transition clear
+                // from the receiver's own synchronous read closes the
+                // scheduler-race window between the flow collector in
+                // EventTypeDedupTracker.init and the receiver's isDuplicate
+                // call on the same coroutine.
+                eventTypeDedupTracker.notifyEnabledState(isEnabled)
+
+                if (!isEnabled) {
                     log(TAG, INFO) { "We are disabled." }
                     return@launch
                 }
@@ -117,6 +128,18 @@ class MonitorEventReceiver : BroadcastReceiver() {
             return
         }
         log(TAG, DEBUG) { "Event concerns device $managedDevice" }
+
+        // Read-only pre-filter against duplicate ACL broadcasts (e.g. Samsung Galaxy Buds 3 Pro
+        // emits a follow-up ACL_DISCONNECTED ~10s after the first one). Skipping the broadcast
+        // here avoids wasted queue submission, debouncer reschedules, and the 10s goAsync delay
+        // at the end of this coroutine. IMPORTANT: isDuplicate is read-only; EventDispatcher is
+        // the single authoritative committer of dedup state via shouldProcess. Calling
+        // shouldProcess here instead would cause the dispatcher's own shouldProcess call to see
+        // this update and drop the first-occurrence event, breaking the entire pipeline.
+        if (eventTypeDedupTracker.isDuplicate(managedDevice.address, eventType)) {
+            log(TAG, INFO) { "Skipping duplicate $eventType broadcast for ${managedDevice.address}" }
+            return
+        }
 
         val actualEvent = BluetoothEventQueue.Event(
             type = eventType,

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
@@ -1,0 +1,108 @@
+package eu.darken.bluemusic.monitor.core.service
+
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import eu.darken.bluemusic.common.coroutine.DispatcherProvider
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
+import eu.darken.bluemusic.common.debug.logging.asLog
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.getDevice
+import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
+import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Dispatches a [BluetoothEventQueue.Event] to all registered
+ * [ConnectionModule]s after applying the fake-speaker safeguard and the
+ * per-device type dedup.
+ *
+ * Extracted from `MonitorService` so the dispatch pipeline can be unit-tested
+ * in isolation (same pattern as [FakeSpeakerEventDebouncer]).
+ */
+@Singleton
+class EventDispatcher @Inject constructor(
+    private val dispatcherProvider: DispatcherProvider,
+    private val deviceRepo: DeviceRepo,
+    private val connectionModuleMap: Set<@JvmSuppressWildcards ConnectionModule>,
+    private val eventTypeDedupTracker: EventTypeDedupTracker,
+) {
+
+    suspend fun dispatch(bluetoothEvent: BluetoothEventQueue.Event) {
+        log(TAG) { "dispatch: Handling $bluetoothEvent" }
+        val managedDevice = deviceRepo.getDevice(bluetoothEvent.sourceDevice.address)
+
+        if (managedDevice == null) {
+            log(TAG, WARN) { "dispatch: Can't find managed device for $bluetoothEvent" }
+            return
+        }
+
+        val isFakeSpeakerEvent = bluetoothEvent.sourceDevice.deviceType == SourceDevice.Type.PHONE_SPEAKER
+        if (isFakeSpeakerEvent
+            && bluetoothEvent.type == BluetoothEventQueue.Event.Type.CONNECTED
+            && !managedDevice.isConnected
+        ) {
+            log(TAG, INFO) { "Dropping stale fake speaker CONNECTED, speaker is not currently the active device" }
+            return
+        }
+
+        // Skip duplicate broadcasts with the same type for the same device.
+        // Placed *after* the fake-speaker safeguard so early-returns there
+        // don't populate the dedup map. See [EventTypeDedupTracker] for the
+        // motivating Samsung Galaxy Buds 3 Pro duplicate-broadcast quirk.
+        if (!eventTypeDedupTracker.shouldProcess(bluetoothEvent.sourceDevice.address, bluetoothEvent.type)) {
+            return
+        }
+
+        val deviceEvent = when (bluetoothEvent.type) {
+            BluetoothEventQueue.Event.Type.CONNECTED -> DeviceEvent.Connected(managedDevice)
+            BluetoothEventQueue.Event.Type.DISCONNECTED -> DeviceEvent.Disconnected(managedDevice)
+        }
+
+        // TODO make this a module?
+        deviceRepo.updateDevice(managedDevice.address) {
+            it.copy(lastConnected = System.currentTimeMillis())
+        }
+
+        log(TAG) { "dispatch: Processing event $deviceEvent" }
+
+        val modulesByPriority = connectionModuleMap
+            .groupBy { it.priority }
+            .toSortedMap()
+
+        for ((priority, modules) in modulesByPriority) {
+            log(TAG, VERBOSE) { "dispatch: ${modules.size} modules at priority $priority" }
+
+            coroutineScope {
+                modules.map { module ->
+                    async(dispatcherProvider.IO) {
+                        try {
+                            log(TAG, VERBOSE) {
+                                "dispatch: ${module.tag} HANDLE-START for $deviceEvent"
+                            }
+                            module.handle(deviceEvent)
+                            log(TAG, VERBOSE) {
+                                "dispatch: ${module.tag} HANDLE-STOP for $deviceEvent"
+                            }
+                        } catch (e: Exception) {
+                            log(TAG, ERROR) {
+                                "dispatch: Error: ${module.tag} for $deviceEvent: ${e.asLog()}"
+                            }
+                        }
+                    }
+                }.awaitAll()
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Monitor", "Event", "Dispatcher")
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
@@ -10,6 +10,7 @@ import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.devices.core.getDevice
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
 import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
@@ -31,6 +32,7 @@ import javax.inject.Singleton
 class EventDispatcher @Inject constructor(
     private val dispatcherProvider: DispatcherProvider,
     private val deviceRepo: DeviceRepo,
+    private val devicesSettings: DevicesSettings,
     private val connectionModuleMap: Set<@JvmSuppressWildcards ConnectionModule>,
     private val eventTypeDedupTracker: EventTypeDedupTracker,
 ) {
@@ -52,6 +54,8 @@ class EventDispatcher @Inject constructor(
             log(TAG, INFO) { "Dropping stale fake speaker CONNECTED, speaker is not currently the active device" }
             return
         }
+
+        eventTypeDedupTracker.observeEnabledState(devicesSettings.currentEnabledState())
 
         // Skip duplicate broadcasts with the same type for the same device.
         // Placed *after* the fake-speaker safeguard so early-returns there

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTracker.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTracker.kt
@@ -43,21 +43,19 @@ import javax.inject.Singleton
  * events while monitoring is disabled — so tracker state from before a
  * disabled gap cannot be trusted to reflect reality after re-enable.
  *
- * Clearing on [DevicesSettings.isEnabled] transitions is driven by two paths:
+ * Reset detection is driven by a monotonic toggle epoch in
+ * [DevicesSettings.EnabledState]. The epoch advances on every actual toggle,
+ * even if a consumer only observes the final boolean value after a rapid
+ * `true -> false -> true` cycle.
  *
- * 1. [MonitorEventReceiver] calls [notifyEnabledState] **synchronously on every
- *    broadcast** (before its own `!isEnabled` early return), so any transition
- *    coincident with a broadcast is observed immediately, before
- *    [isDuplicate] is consulted on the same call path.
- * 2. The [DevicesSettings.isEnabled] flow collector in [init] handles
- *    transitions that happen **while no broadcast is flying** (e.g. user toggles
- *    monitoring off then back on with no BT events in between). Without this
- *    backstop the tracker would never learn about the disabled interval.
+ * Observing that epoch is driven by two paths:
  *
- * Residual race: if a `true → false → true` cycle *and* a BT broadcast all
- * happen inside one scheduler tick (sub-ms), the flow collector may not have
- * drained yet when the receiver consults [isDuplicate]. This requires inputs
- * no human can produce.
+ * 1. [MonitorEventReceiver] and [EventDispatcher] call [observeEnabledState]
+ *    from the same snapshot they use for event handling, so queue consumers
+ *    can synchronously clear stale dedup state before consulting
+ *    [isDuplicate]/[shouldProcess].
+ * 2. The [DevicesSettings.enabledState] collector in [init] handles toggles
+ *    that happen while no event is being processed.
  *
  * Thread-safe via [@Synchronized]. Expected to be called both from the
  * sequential [BluetoothEventQueue.events] consumer in `MonitorService` AND from
@@ -74,51 +72,34 @@ class EventTypeDedupTracker @Inject constructor(
     private val lastProcessedEventType =
         mutableMapOf<String, Pair<BluetoothEventQueue.Event.Type, Long>>()
 
-    /**
-     * Last observed value of [DevicesSettings.isEnabled]. Bootstrapped to
-     * `true`, matching the DataStore default for `devices.enabled` — this is
-     * the state the tracker assumes until either [notifyEnabledState] or the
-     * backstop flow collector reports otherwise. Used to detect transitions
-     * in both code paths so only the first observer of a given transition
-     * triggers the clear.
-     */
-    private var lastSeenEnabled: Boolean = true
+    private var lastSeenEnabledState = DevicesSettings.EnabledState(
+        isEnabled = true,
+        toggleEpoch = 0L,
+    )
 
     init {
-        // Backstop: observes isEnabled changes that happen *without* any BT
-        // broadcast in flight. If the user toggles monitoring off then back on
-        // with no ACL events in between, the receiver-driven path in
-        // [notifyEnabledState] never sees the intermediate `false` value, so
-        // this collector is the only thing that can clear the map.
-        //
-        // When a broadcast *does* coincide with the transition, the receiver's
-        // synchronous [notifyEnabledState] call gets there first and this
-        // collector's later pass is a no-op (lastSeenEnabled already matches).
-        devicesSettings.isEnabled.flow
+        devicesSettings.enabledState
             .drop(1) // ignore initial replay
             .distinctUntilChanged()
-            .onEach { notifyEnabledState(it) }
+            .onEach { observeEnabledState(it) }
             .launchIn(appScope)
     }
 
     /**
-     * Synchronously records the current [DevicesSettings.isEnabled] value. If
-     * the passed value differs from the previously recorded one, the dedup map
-     * is cleared immediately before returning.
-     *
-     * Must be called by [MonitorEventReceiver] on every broadcast, **before**
-     * any `!isEnabled` early-return branch, so every broadcast contributes the
-     * `isEnabled` value the receiver itself used for its decision. This
-     * eliminates the scheduler race between the receiver reading the latest
-     * state and the async flow collector in [init] draining.
+     * Synchronously observes the caller's atomic enabled snapshot. A changed epoch means at least
+     * one toggle happened since the last observation, so stale dedup state must be cleared even if
+     * the current boolean matches the earlier one (for example a collapsed
+     * `true -> false -> true` cycle).
      */
     @Synchronized
-    fun notifyEnabledState(currentEnabled: Boolean) {
-        val previous = lastSeenEnabled
-        lastSeenEnabled = currentEnabled
-        if (previous != currentEnabled) {
+    fun observeEnabledState(currentState: DevicesSettings.EnabledState) {
+        val previousState = lastSeenEnabledState
+        lastSeenEnabledState = currentState
+        if (previousState.toggleEpoch != currentState.toggleEpoch) {
             log(TAG, INFO) {
-                "Monitoring toggled (isEnabled=$previous → $currentEnabled), clearing dedup state"
+                "Monitoring epoch advanced " +
+                    "(${previousState.toggleEpoch} → ${currentState.toggleEpoch}, " +
+                    "enabled=${previousState.isEnabled} → ${currentState.isEnabled}), clearing dedup state"
             }
             lastProcessedEventType.clear()
         }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTracker.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTracker.kt
@@ -2,6 +2,7 @@ package eu.darken.bluemusic.monitor.core.service
 
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.time.MonotonicClock
@@ -145,10 +146,16 @@ class EventTypeDedupTracker @Inject constructor(
         if (last != null && last.first == type) {
             val ageMs = now - last.second
             if (ageMs < TTL_MS) {
-                log(TAG, INFO) { "Ignoring duplicate $type for $address (last seen ${ageMs}ms ago)" }
+                log(TAG, INFO) { "Ignoring duplicate $type for $address (last seen ${ageMs}ms ago, ttl=${TTL_MS}ms)" }
                 return false
             }
-            log(TAG, INFO) { "Accepting same-type $type for $address after TTL (${ageMs}ms ago)" }
+            log(TAG, INFO) { "Accepting same-type $type for $address after TTL (${ageMs}ms ago, ttl=${TTL_MS}ms)" }
+            if (ageMs < EVICTION_AGE_MS) {
+                log(TAG, WARN) {
+                    "DEDUP_NEAR_MISS: $type for $address accepted ${ageMs}ms after last " +
+                        "(ttl=${TTL_MS}ms, margin=${ageMs - TTL_MS}ms)"
+                }
+            }
         }
         evictStaleEntries(now)
         lastProcessedEventType[address] = type to now
@@ -175,27 +182,24 @@ class EventTypeDedupTracker @Inject constructor(
 
         /**
          * Events of the same type for the same device within this window are
-         * treated as duplicates and dropped. 15s covers the observed ~10s
-         * Samsung Galaxy Buds 3 Pro duplicate with a 50% safety margin, while
+         * treated as duplicates and dropped. 20s covers the observed ~10s
+         * Samsung Galaxy Buds 3 Pro duplicate with 100% safety margin, while
          * keeping the window tight enough that rare missed-ACL edge cases
          * (a `C → [missed D] → C` or `D → [missed C] → D` sequence within the
          * TTL) have minimal blast radius.
          *
-         * The tradeoff is asymmetric:
-         * - Samsung duplicates: ~100% reliable on affected devices, always
-         *   within ~10s, always dropped here. Net win.
-         * - Missed ACL broadcasts on modern Android: <1% for foreground
-         *   sessions, higher under aggressive OEM doze. A same-type repeat
-         *   within 15s that isn't a duplicate requires both the missed
-         *   intermediate event *and* a legit reconnect cycle inside the
-         *   window, which is exceedingly rare. If it does happen, the next
-         *   opposite-type event recovers cleanly (no lasting stuck state).
+         * 20s also ensures the dispatcher-level [shouldProcess] catches
+         * Samsung duplicates even when the fake-speaker CONNECTED handler
+         * blocks the queue for ~12s (observed: dispatch gap = 15.7s in
+         * production logs, which was outside the previous 15s TTL).
+         * At 20s both the receiver pre-filter AND the dispatcher agree,
+         * giving defense-in-depth.
          *
-         * Do not widen this back out without a corresponding dispatch-time
-         * state safeguard — anything longer re-introduces the risk of
-         * silently dropping real reconnects in rare-but-real edge cases.
+         * Same-type events accepted just past the TTL are logged at WARN
+         * level with a `DEDUP_NEAR_MISS` prefix so future debug logs
+         * self-diagnose whether the margin is adequate.
          */
-        const val TTL_MS: Long = 15_000L
+        const val TTL_MS: Long = 20_000L
 
         /**
          * Entries older than this age are evicted during [shouldProcess] to

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTracker.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTracker.kt
@@ -1,0 +1,212 @@
+package eu.darken.bluemusic.monitor.core.service
+
+import eu.darken.bluemusic.common.coroutine.AppScope
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.common.time.MonotonicClock
+import eu.darken.bluemusic.devices.core.DevicesSettings
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Per-device dedup for [BluetoothEventQueue.Event.Type].
+ *
+ * Some devices (e.g. Samsung Galaxy Buds 3 Pro) emit a duplicate ACL_DISCONNECTED
+ * broadcast many seconds after the first one. If we run the disconnect pipeline
+ * again, [eu.darken.bluemusic.monitor.core.modules.volume.VolumeDisconnectModule]
+ * captures the *current* (possibly mid-ramp) system volumes and overwrites the
+ * user's previously-saved values.
+ *
+ * This tracker is consulted at two layers sharing one [@Singleton] instance:
+ *
+ * - [eu.darken.bluemusic.monitor.core.receiver.MonitorEventReceiver] calls
+ *   [isDuplicate] as a **read-only pre-filter** to skip wasted broadcast work
+ *   (event building, debouncer reschedule, 10s goAsync delay) when the
+ *   broadcast is an obvious duplicate.
+ * - [EventDispatcher] calls [shouldProcess] as the **authoritative commit** —
+ *   it is the single place that mutates the map. Only events that pass this
+ *   check reach [eu.darken.bluemusic.monitor.core.modules.ConnectionModule]s.
+ *
+ * The split avoids a "double-dedup" bug where both layers mutating state for
+ * the same event would cause the second caller (the dispatcher) to see its own
+ * first-occurrence event as a duplicate.
+ *
+ * Uses a [MonotonicClock] so the dedup window is unaffected by wall-clock
+ * changes (NTP resync, user time adjustment). Also auto-resets on any
+ * [DevicesSettings.isEnabled] toggle, because the receiver short-circuits
+ * events while monitoring is disabled — so tracker state from before a
+ * disabled gap cannot be trusted to reflect reality after re-enable.
+ *
+ * Clearing on [DevicesSettings.isEnabled] transitions is driven by two paths:
+ *
+ * 1. [MonitorEventReceiver] calls [notifyEnabledState] **synchronously on every
+ *    broadcast** (before its own `!isEnabled` early return), so any transition
+ *    coincident with a broadcast is observed immediately, before
+ *    [isDuplicate] is consulted on the same call path.
+ * 2. The [DevicesSettings.isEnabled] flow collector in [init] handles
+ *    transitions that happen **while no broadcast is flying** (e.g. user toggles
+ *    monitoring off then back on with no BT events in between). Without this
+ *    backstop the tracker would never learn about the disabled interval.
+ *
+ * Residual race: if a `true → false → true` cycle *and* a BT broadcast all
+ * happen inside one scheduler tick (sub-ms), the flow collector may not have
+ * drained yet when the receiver consults [isDuplicate]. This requires inputs
+ * no human can produce.
+ *
+ * Thread-safe via [@Synchronized]. Expected to be called both from the
+ * sequential [BluetoothEventQueue.events] consumer in `MonitorService` AND from
+ * multiple `MonitorEventReceiver` coroutines running in parallel on
+ * `Dispatchers.Default`.
+ */
+@Singleton
+class EventTypeDedupTracker @Inject constructor(
+    @AppScope appScope: CoroutineScope,
+    devicesSettings: DevicesSettings,
+    private val clock: MonotonicClock,
+) {
+
+    private val lastProcessedEventType =
+        mutableMapOf<String, Pair<BluetoothEventQueue.Event.Type, Long>>()
+
+    /**
+     * Last observed value of [DevicesSettings.isEnabled]. Bootstrapped to
+     * `true`, matching the DataStore default for `devices.enabled` — this is
+     * the state the tracker assumes until either [notifyEnabledState] or the
+     * backstop flow collector reports otherwise. Used to detect transitions
+     * in both code paths so only the first observer of a given transition
+     * triggers the clear.
+     */
+    private var lastSeenEnabled: Boolean = true
+
+    init {
+        // Backstop: observes isEnabled changes that happen *without* any BT
+        // broadcast in flight. If the user toggles monitoring off then back on
+        // with no ACL events in between, the receiver-driven path in
+        // [notifyEnabledState] never sees the intermediate `false` value, so
+        // this collector is the only thing that can clear the map.
+        //
+        // When a broadcast *does* coincide with the transition, the receiver's
+        // synchronous [notifyEnabledState] call gets there first and this
+        // collector's later pass is a no-op (lastSeenEnabled already matches).
+        devicesSettings.isEnabled.flow
+            .drop(1) // ignore initial replay
+            .distinctUntilChanged()
+            .onEach { notifyEnabledState(it) }
+            .launchIn(appScope)
+    }
+
+    /**
+     * Synchronously records the current [DevicesSettings.isEnabled] value. If
+     * the passed value differs from the previously recorded one, the dedup map
+     * is cleared immediately before returning.
+     *
+     * Must be called by [MonitorEventReceiver] on every broadcast, **before**
+     * any `!isEnabled` early-return branch, so every broadcast contributes the
+     * `isEnabled` value the receiver itself used for its decision. This
+     * eliminates the scheduler race between the receiver reading the latest
+     * state and the async flow collector in [init] draining.
+     */
+    @Synchronized
+    fun notifyEnabledState(currentEnabled: Boolean) {
+        val previous = lastSeenEnabled
+        lastSeenEnabled = currentEnabled
+        if (previous != currentEnabled) {
+            log(TAG, INFO) {
+                "Monitoring toggled (isEnabled=$previous → $currentEnabled), clearing dedup state"
+            }
+            lastProcessedEventType.clear()
+        }
+    }
+
+    /**
+     * Read-only: returns `true` if an event with `(address, type)` would be
+     * treated as a duplicate by [shouldProcess] at this instant, `false`
+     * otherwise. Does **not** mutate internal state.
+     *
+     * Use this for pre-filter optimizations where the authoritative commit
+     * (state mutation) happens in another call site. Calling [isDuplicate]
+     * from any call site is always safe with respect to a later [shouldProcess]
+     * call on a different call site — the commit still runs correctly.
+     */
+    @Synchronized
+    fun isDuplicate(
+        address: String,
+        type: BluetoothEventQueue.Event.Type,
+    ): Boolean {
+        val last = lastProcessedEventType[address] ?: return false
+        if (last.first != type) return false
+        return (clock.nowMs() - last.second) < TTL_MS
+    }
+
+    /**
+     * Read-write: returns `true` if the event should be processed, `false` if
+     * it is a duplicate of the last processed event for the same device
+     * address within [TTL_MS].
+     *
+     * When the event is accepted, the internal state is updated so that a
+     * subsequent call with the same `(address, type)` within the TTL returns
+     * `false`. Opportunistically evicts entries older than [EVICTION_AGE_MS]
+     * to keep the map bounded.
+     */
+    @Synchronized
+    fun shouldProcess(
+        address: String,
+        type: BluetoothEventQueue.Event.Type,
+    ): Boolean {
+        val now = clock.nowMs()
+        val last = lastProcessedEventType[address]
+        if (last != null && last.first == type) {
+            val ageMs = now - last.second
+            if (ageMs < TTL_MS) {
+                log(TAG, INFO) { "Ignoring duplicate $type for $address (last seen ${ageMs}ms ago)" }
+                return false
+            }
+            log(TAG, INFO) { "Accepting same-type $type for $address after TTL (${ageMs}ms ago)" }
+        }
+        evictStaleEntries(now)
+        lastProcessedEventType[address] = type to now
+        return true
+    }
+
+    /**
+     * Clears all dedup state. Called automatically on [DevicesSettings.isEnabled]
+     * transitions, and exposed for tests.
+     */
+    @Synchronized
+    fun clear() {
+        lastProcessedEventType.clear()
+    }
+
+    private fun evictStaleEntries(now: Long) {
+        lastProcessedEventType.entries.removeAll { (_, value) ->
+            (now - value.second) > EVICTION_AGE_MS
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Monitor", "Event", "Dedup")
+
+        /**
+         * Events of the same type for the same device within this window are
+         * treated as duplicates and dropped. 60s gives comfortable headroom
+         * over scott's observed 10s Samsung duplicates while staying well
+         * under any plausible legit same-type repeat (which would require an
+         * intervening opposite-type event to make sense physically).
+         */
+        const val TTL_MS: Long = 60_000L
+
+        /**
+         * Entries older than this age are evicted during [shouldProcess] to
+         * bound map size over long-running sessions. Set to 2x [TTL_MS] so
+         * entries are only dropped well after they stopped being relevant to
+         * the dedup decision.
+         */
+        const val EVICTION_AGE_MS: Long = 2 * TTL_MS
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTracker.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTracker.kt
@@ -175,12 +175,27 @@ class EventTypeDedupTracker @Inject constructor(
 
         /**
          * Events of the same type for the same device within this window are
-         * treated as duplicates and dropped. 60s gives comfortable headroom
-         * over scott's observed 10s Samsung duplicates while staying well
-         * under any plausible legit same-type repeat (which would require an
-         * intervening opposite-type event to make sense physically).
+         * treated as duplicates and dropped. 15s covers the observed ~10s
+         * Samsung Galaxy Buds 3 Pro duplicate with a 50% safety margin, while
+         * keeping the window tight enough that rare missed-ACL edge cases
+         * (a `C → [missed D] → C` or `D → [missed C] → D` sequence within the
+         * TTL) have minimal blast radius.
+         *
+         * The tradeoff is asymmetric:
+         * - Samsung duplicates: ~100% reliable on affected devices, always
+         *   within ~10s, always dropped here. Net win.
+         * - Missed ACL broadcasts on modern Android: <1% for foreground
+         *   sessions, higher under aggressive OEM doze. A same-type repeat
+         *   within 15s that isn't a duplicate requires both the missed
+         *   intermediate event *and* a legit reconnect cycle inside the
+         *   window, which is exceedingly rare. If it does happen, the next
+         *   opposite-type event recovers cleanly (no lasting stuck state).
+         *
+         * Do not widen this back out without a corresponding dispatch-time
+         * state safeguard — anything longer re-introduces the risk of
+         * silently dropping real reconnects in rare-but-real edge cases.
          */
-        const val TTL_MS: Long = 60_000L
+        const val TTL_MS: Long = 15_000L
 
         /**
          * Entries older than this age are evicted during [shouldProcess] to

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorService.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorService.kt
@@ -13,7 +13,6 @@ import androidx.core.content.ContextCompat
 import androidx.core.util.size
 import dagger.hilt.android.AndroidEntryPoint
 import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
-import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.bluetooth.core.currentState
 import eu.darken.bluemusic.common.coroutine.DispatcherProvider
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
@@ -29,7 +28,6 @@ import eu.darken.bluemusic.common.hasApiLevel
 import eu.darken.bluemusic.common.ui.Service2
 import eu.darken.bluemusic.devices.core.DeviceRepo
 import eu.darken.bluemusic.devices.core.currentDevices
-import eu.darken.bluemusic.devices.core.getDevice
 import eu.darken.bluemusic.devices.core.updateVolume
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.RingerMode
@@ -38,8 +36,6 @@ import eu.darken.bluemusic.monitor.core.audio.RingerModeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeEvent
 import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
-import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
-import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
 import eu.darken.bluemusic.monitor.core.modules.VolumeModule
 import eu.darken.bluemusic.monitor.ui.MonitorNotifications
 import kotlinx.coroutines.CancellationException
@@ -71,11 +67,11 @@ class MonitorService : Service2() {
     @Inject lateinit var notificationManager: NotificationManager
     @Inject lateinit var deviceRepo: DeviceRepo
     @Inject lateinit var bluetoothRepo: BluetoothRepo
-    @Inject lateinit var connectionModuleMap: Set<@JvmSuppressWildcards ConnectionModule>
     @Inject lateinit var volumeModuleMap: Set<@JvmSuppressWildcards VolumeModule>
     @Inject lateinit var volumeObserver: VolumeObserver
     @Inject lateinit var ringerModeObserver: RingerModeObserver
     @Inject lateinit var bluetoothEventQueue: BluetoothEventQueue
+    @Inject lateinit var eventDispatcher: EventDispatcher
 
     private val serviceScope by lazy {
         CoroutineScope(SupervisorJob() + dispatcherProvider.IO)
@@ -192,7 +188,7 @@ class MonitorService : Service2() {
             .setupCommonEventHandlers(TAG) { "Event monitor" }
             .onEach { event ->
                 log(TAG, INFO) { "START Handling bluetooth event: $event" }
-                handleEvent(event)
+                eventDispatcher.dispatch(event)
                 log(TAG, INFO) { "STOP Handling bluetooth event: $event" }
             }
             .catch { log(TAG, WARN) { "Event monitor flow failed:\n${it.asLog()}" } }
@@ -249,76 +245,6 @@ class MonitorService : Service2() {
         override fun onReceive(context: Context, intent: Intent) {
             log(TAG) { "Stop monitor action received" }
             stopSelf()
-        }
-    }
-
-    private suspend fun handleEvent(bluetoothEvent: BluetoothEventQueue.Event) {
-        log(TAG) { "handleEvent: Handling $bluetoothEvent" }
-        val managedDevice = deviceRepo.getDevice(bluetoothEvent.sourceDevice.address)
-
-        if (managedDevice == null) {
-            log(TAG, WARN) { "handleEvent: Can't find managed device for $bluetoothEvent" }
-            return
-        }
-
-        val isFakeSpeakerEvent = bluetoothEvent.sourceDevice.deviceType == SourceDevice.Type.PHONE_SPEAKER
-        if (isFakeSpeakerEvent
-            && bluetoothEvent.type == BluetoothEventQueue.Event.Type.CONNECTED
-            && !managedDevice.isConnected
-        ) {
-            log(TAG, INFO) { "Dropping stale fake speaker CONNECTED, speaker is not currently the active device" }
-            return
-        }
-
-        val deviceEvent = when (bluetoothEvent.type) {
-            BluetoothEventQueue.Event.Type.CONNECTED -> DeviceEvent.Connected(managedDevice)
-            BluetoothEventQueue.Event.Type.DISCONNECTED -> DeviceEvent.Disconnected(managedDevice)
-        }
-
-        // TODO make this a module?
-        deviceRepo.updateDevice(managedDevice.address) {
-            it.copy(lastConnected = System.currentTimeMillis())
-        }
-
-        val priorityArray = SparseArray<MutableList<ConnectionModule>>()
-
-        for (module in connectionModuleMap) {
-            val priority = module.priority
-            var list = priorityArray.get(priority)
-            if (list == null) {
-                list = ArrayList()
-                priorityArray.put(priority, list)
-            }
-            list.add(module)
-        }
-
-        log(TAG) { "handleEvent: Processing event $deviceEvent" }
-
-        for (i in 0 until priorityArray.size) {
-            val currentPriorityModules = priorityArray.get(priorityArray.keyAt(i))
-            log(TAG, VERBOSE) {
-                "handleEvent: ${currentPriorityModules.size} modules at priority ${priorityArray.keyAt(i)}"
-            }
-
-            coroutineScope {
-                currentPriorityModules.map { module ->
-                    async(dispatcherProvider.IO) {
-                        try {
-                            log(TAG, VERBOSE) {
-                                "handleEvent: ${module.tag} HANDLE-START for $deviceEvent"
-                            }
-                            module.handle(deviceEvent)
-                            log(TAG, VERBOSE) {
-                                "handleEvent: ${module.tag} HANDLE-STOP for $deviceEvent"
-                            }
-                        } catch (e: Exception) {
-                            log(TAG, ERROR) {
-                                "handleEvent: Error: ${module.tag} for $deviceEvent: ${e.asLog()}"
-                            }
-                        }
-                    }
-                }.awaitAll()
-            }
         }
     }
 

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModuleTest.kt
@@ -1,0 +1,169 @@
+package eu.darken.bluemusic.monitor.core.modules.connection
+
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import eu.darken.bluemusic.monitor.core.audio.VolumeMode
+import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Duration
+
+class BaseVolumeModuleTest : BaseTest() {
+
+    private val streamId = AudioStream.Id.STREAM_MUSIC
+    private val maxLevel = 15
+
+    private lateinit var volumeTool: VolumeTool
+    private lateinit var device: ManagedDevice
+    private lateinit var module: TestVolumeModule
+
+    /**
+     * Concrete subclass that exposes [monitor] for direct testing without
+     * going through [handle]'s actionDelay / setInitial overhead.
+     */
+    private class TestVolumeModule(volumeTool: VolumeTool) : BaseVolumeModule(volumeTool) {
+        override val type = AudioStream.Type.MUSIC
+        override val priority = 10
+
+        suspend fun callMonitor(device: ManagedDevice, volumeMode: VolumeMode) {
+            monitor(device, volumeMode)
+        }
+    }
+
+    @BeforeEach
+    fun setup() {
+        volumeTool = mockk(relaxed = true)
+        device = mockk(relaxed = true)
+        module = TestVolumeModule(volumeTool)
+
+        every { device.getStreamId(AudioStream.Type.MUSIC) } returns streamId
+        every { volumeTool.getMaxVolume(streamId) } returns maxLevel
+    }
+
+    // --- monitor() wasUs-based abort ---
+
+    /**
+     * The monitor loop should run to completion when wasUs(target) stays true.
+     * Using a 10ms wall-clock duration: with mocked delay returning instantly,
+     * the loop runs many iterations. We just verify it ran more than once and
+     * called changeVolume on each pass.
+     */
+    @Test
+    fun `monitor loop runs to completion when wasUs stays true`() = runTest {
+        every { device.monitoringDuration } returns Duration.ofMillis(10)
+        every { volumeTool.wasUs(streamId, any()) } returns true
+        var changeVolumeCount = 0
+        coEvery { volumeTool.changeVolume(streamId, any<Float>()) } answers {
+            changeVolumeCount++
+            true
+        }
+
+        module.callMonitor(device, VolumeMode.Normal(0.44f))
+
+        changeVolumeCount shouldBeGreaterThan 1
+    }
+
+    /**
+     * When another VolumeTool caller writes a different level (e.g. user
+     * drags the slider via AdjustVolume), wasUs(targetLevel) returns false.
+     * The loop should abort immediately, calling changeVolume at most once
+     * (from the first iteration before the abort triggered on the next tick).
+     */
+    @Test
+    fun `monitor loop aborts when wasUs returns false - user slider drag`() = runTest {
+        // 10s duration: without the abort, the test would take 10s of wall time
+        every { device.monitoringDuration } returns Duration.ofSeconds(10)
+        var wasUsCallCount = 0
+        every { volumeTool.wasUs(streamId, any()) } answers {
+            wasUsCallCount++
+            wasUsCallCount <= 1  // true on 1st call, false on 2nd
+        }
+        var changeVolumeCount = 0
+        coEvery { volumeTool.changeVolume(streamId, any<Float>()) } answers {
+            changeVolumeCount++
+            true
+        }
+
+        module.callMonitor(device, VolumeMode.Normal(0.44f))
+
+        // First iteration: wasUs=true → changeVolume called.
+        // Second iteration: wasUs=false → return before changeVolume.
+        changeVolumeCount shouldBe 1
+    }
+
+    /**
+     * When Android's platform writes change the stream level during the BT
+     * routing transition, wasUs(target) stays true (Android doesn't go through
+     * VolumeTool) and the loop correctly re-enforces by calling changeVolume.
+     */
+    @Test
+    fun `monitor loop re-enforces against external platform writes`() = runTest {
+        every { device.monitoringDuration } returns Duration.ofMillis(10)
+        // wasUs always true: the loop believes it's still in control
+        every { volumeTool.wasUs(streamId, any()) } returns true
+        // changeVolume returns true: means it actually wrote (hardware had drifted)
+        var changeVolumeCount = 0
+        coEvery { volumeTool.changeVolume(streamId, any<Float>()) } answers {
+            changeVolumeCount++
+            true
+        }
+
+        module.callMonitor(device, VolumeMode.Normal(0.44f))
+
+        // Multiple writes happened = the loop kept re-enforcing
+        changeVolumeCount shouldBeGreaterThan 1
+    }
+
+    /**
+     * Non-Normal VolumeMode (Silent, Vibrate) → monitor returns immediately
+     * without entering the loop.
+     */
+    @Test
+    fun `monitor returns immediately for non-Normal volumeMode`() = runTest {
+        every { device.monitoringDuration } returns Duration.ofSeconds(10)
+
+        module.callMonitor(device, VolumeMode.Silent)
+
+        verify(exactly = 0) { volumeTool.wasUs(any(), any()) }
+        coVerify(exactly = 0) { volumeTool.changeVolume(any(), any<Float>()) }
+    }
+
+    // --- handle() integration ---
+
+    /**
+     * Disconnected events are ignored by BaseVolumeModule (it only handles
+     * Connected events).
+     */
+    @Test
+    fun `handle ignores disconnected events`() = runTest {
+        val event = DeviceEvent.Disconnected(device)
+        module.handle(event)
+
+        coVerify(exactly = 0) { volumeTool.changeVolume(any(), any<Float>()) }
+    }
+
+    /**
+     * If the device has no configured volume for this stream type,
+     * handle() returns early.
+     */
+    @Test
+    fun `handle returns early for unconfigured stream`() = runTest {
+        every { device.getVolume(AudioStream.Type.MUSIC) } returns null
+        every { device.actionDelay } returns Duration.ZERO
+
+        val event = DeviceEvent.Connected(device)
+        module.handle(event)
+
+        coVerify(exactly = 0) { volumeTool.changeVolume(any(), any<Float>()) }
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
@@ -1,0 +1,506 @@
+package eu.darken.bluemusic.monitor.core.modules.volume
+
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import eu.darken.bluemusic.monitor.core.audio.RingerMode
+import eu.darken.bluemusic.monitor.core.audio.RingerTool
+import eu.darken.bluemusic.monitor.core.audio.VolumeMode
+import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class VolumeDisconnectModuleTest : BaseTest() {
+
+    private val address = "AA:BB:CC:DD:EE:FF"
+
+    private lateinit var volumeTool: VolumeTool
+    private lateinit var ringerTool: RingerTool
+    private lateinit var deviceRepo: DeviceRepo
+    private lateinit var sourceDevice: SourceDevice
+
+    @BeforeEach
+    fun setup() {
+        volumeTool = mockk(relaxed = true)
+        ringerTool = mockk(relaxed = true)
+        deviceRepo = mockk(relaxed = true)
+        coEvery { deviceRepo.updateDevice(any(), any()) } just Runs
+
+        sourceDevice = mockk {
+            every { this@mockk.address } returns this@VolumeDisconnectModuleTest.address
+            every { label } returns "Test Device"
+            every { deviceType } returns SourceDevice.Type.HEADPHONES
+            every { getStreamId(AudioStream.Type.MUSIC) } returns AudioStream.Id.STREAM_MUSIC
+            every { getStreamId(AudioStream.Type.CALL) } returns AudioStream.Id.STREAM_VOICE_CALL
+            every { getStreamId(AudioStream.Type.RINGTONE) } returns AudioStream.Id.STREAM_RINGTONE
+            every { getStreamId(AudioStream.Type.NOTIFICATION) } returns AudioStream.Id.STREAM_NOTIFICATION
+            every { getStreamId(AudioStream.Type.ALARM) } returns AudioStream.Id.STREAM_ALARM
+        }
+    }
+
+    private fun createModule() = VolumeDisconnectModule(
+        volumeTool = volumeTool,
+        ringerTool = ringerTool,
+        deviceRepo = deviceRepo,
+    )
+
+    private fun config(
+        musicVolume: Float? = null,
+        callVolume: Float? = null,
+        ringVolume: Float? = null,
+        notificationVolume: Float? = null,
+        alarmVolume: Float? = null,
+        volumeSaveOnDisconnect: Boolean = true,
+    ): DeviceConfigEntity = DeviceConfigEntity(
+        address = address,
+        musicVolume = musicVolume,
+        callVolume = callVolume,
+        ringVolume = ringVolume,
+        notificationVolume = notificationVolume,
+        alarmVolume = alarmVolume,
+        volumeSaveOnDisconnect = volumeSaveOnDisconnect,
+    )
+
+    private fun managedDevice(config: DeviceConfigEntity) = ManagedDevice(
+        isConnected = true,
+        device = sourceDevice,
+        config = config,
+    )
+
+    private fun mockStream(id: AudioStream.Id, current: Int, max: Int) {
+        every { volumeTool.getCurrentVolume(id) } returns current
+        every { volumeTool.getMaxVolume(id) } returns max
+    }
+
+    /**
+     * Invokes the transform lambda passed to [DeviceRepo.updateDevice] with the
+     * given `seedConfig` and returns the [DeviceConfigEntity] it produced. Use to
+     * assert what the module would write for the captured transform, free of
+     * dependence on `event.device.config`.
+     */
+    private suspend fun runTransform(
+        module: VolumeDisconnectModule,
+        event: DeviceEvent,
+        seedConfig: DeviceConfigEntity,
+    ): DeviceConfigEntity {
+        val slot = slot<(DeviceConfigEntity) -> DeviceConfigEntity>()
+        coEvery { deviceRepo.updateDevice(address, capture(slot)) } just Runs
+        module.handle(event)
+        return slot.captured(seedConfig)
+    }
+
+    // ------------------------------------------------------------------------
+    // 1. Non-disconnect event → no-op
+    // ------------------------------------------------------------------------
+    @Test
+    fun `connected event is ignored`() = runTest {
+        val module = createModule()
+        val device = managedDevice(config(musicVolume = 0.5f))
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+        module.handle(DeviceEvent.Connected(device))
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    // ------------------------------------------------------------------------
+    // 2. volumeSaveOnDisconnect=false → no-op
+    // ------------------------------------------------------------------------
+    @Test
+    fun `save on disconnect disabled - no-op`() = runTest {
+        val module = createModule()
+        val device = managedDevice(
+            config(musicVolume = 0.5f, volumeSaveOnDisconnect = false),
+        )
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+        module.handle(DeviceEvent.Disconnected(device))
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    // ------------------------------------------------------------------------
+    // 3. Drift regression — the exact logcat values
+    // ------------------------------------------------------------------------
+    @Test
+    fun `drift regression - stored 042344 at level 11 of 25 does not write`() = runTest {
+        val module = createModule()
+        val cfg = config(musicVolume = 0.42344147f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        mockStream(AudioStream.Id.STREAM_MUSIC, current = 11, max = 25)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.musicVolume shouldBe 0.42344147f
+    }
+
+    // ------------------------------------------------------------------------
+    // 4. Ringer NORMAL, stored 0.5, hardware level differs → writes new percent
+    // ------------------------------------------------------------------------
+    @Test
+    fun `ringer normal music volume changed writes new percent`() = runTest {
+        val module = createModule()
+        val cfg = config(musicVolume = 0.5f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        mockStream(AudioStream.Id.STREAM_MUSIC, current = 11, max = 25)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.musicVolume shouldBe (11f / 25f)
+    }
+
+    // ------------------------------------------------------------------------
+    // 5. Ringer VIBRATE, stored Vibrate sentinel → structurally equal, no-op
+    // ------------------------------------------------------------------------
+    @Test
+    fun `vibrate ringer with stored vibrate ringtone is a no-op`() = runTest {
+        val module = createModule()
+        val cfg = config(ringVolume = -3.0f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.VIBRATE
+        mockStream(AudioStream.Id.STREAM_RINGTONE, current = 0, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        // Mode structurally matches stored Vibrate → preserved, not rewritten.
+        result.ringVolume shouldBe -3.0f
+    }
+
+    // ------------------------------------------------------------------------
+    // 6. Ringer VIBRATE, stored Normal(0.48) ringtone → writes Vibrate sentinel
+    //    (closes the race where handleRingerMode() bails out before disconnect
+    //     runs because the device is no longer active)
+    // ------------------------------------------------------------------------
+    @Test
+    fun `vibrate ringer with stored normal ringtone writes vibrate sentinel`() = runTest {
+        val module = createModule()
+        val cfg = config(ringVolume = 0.48f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.VIBRATE
+        mockStream(AudioStream.Id.STREAM_RINGTONE, current = 0, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        // Stored Normal → current Vibrate → mode change → write sentinel.
+        result.ringVolume shouldBe VolumeMode.LEGACY_VIBRATE_VALUE
+    }
+
+    // ------------------------------------------------------------------------
+    // 7. Ringer NORMAL, ringtone drift suppression
+    // ------------------------------------------------------------------------
+    @Test
+    fun `normal ringer with matching ringtone level does not drift`() = runTest {
+        val module = createModule()
+        // 0.48 * 7 = 3.36 → level 3 → saving it back would give 3/7 = 0.4285
+        val cfg = config(ringVolume = 0.48f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        mockStream(AudioStream.Id.STREAM_RINGTONE, current = 3, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.ringVolume shouldBe 0.48f
+    }
+
+    // ------------------------------------------------------------------------
+    // 8. Ringer VIBRATE, stored notification=0.19, hardware 0 → preserved
+    //    (Pixel-style platform coupling: STREAM_NOTIFICATION clamps to 0 in
+    //     vibrate. Preserve the stored value rather than zero it out.)
+    // ------------------------------------------------------------------------
+    @Test
+    fun `vibrate ringer with notification hardware zero preserves stored`() = runTest {
+        val module = createModule()
+        val cfg = config(notificationVolume = 0.19f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.VIBRATE
+        mockStream(AudioStream.Id.STREAM_NOTIFICATION, current = 0, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.notificationVolume shouldBe 0.19f
+    }
+
+    // ------------------------------------------------------------------------
+    // 8b. Ringer VIBRATE, non-coupling device, notification hardware > 0 →
+    //     captured (user-visible independent control must be persisted)
+    // ------------------------------------------------------------------------
+    @Test
+    fun `vibrate ringer with non-zero notification hardware captures user change`() = runTest {
+        val module = createModule()
+        val cfg = config(notificationVolume = 0.19f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.VIBRATE
+        // Non-coupling device lets the user set notification independently of
+        // ringer mode; hardware reports level 5 / 7.
+        mockStream(AudioStream.Id.STREAM_NOTIFICATION, current = 5, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.notificationVolume shouldBe (5f / 7f)
+    }
+
+    // ------------------------------------------------------------------------
+    // 8c. KNOWN LIMITATION (documented, intentional):
+    //     Ringer VIBRATE, non-coupling device, user sets notification to 0,
+    //     hardware=0, stored>0 → we cannot distinguish this from Pixel's
+    //     coupling-clamp on a single read, so we preserve stored. A user who
+    //     deliberately mutes notification in vibrate/silent on a non-coupling
+    //     device must use the app UI or volumeObserving=true to persist the 0.
+    // ------------------------------------------------------------------------
+    @Test
+    fun `known limitation - non-coupling user zero in vibrate is not captured`() = runTest {
+        val module = createModule()
+        val cfg = config(notificationVolume = 0.19f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.VIBRATE
+        // Hypothetical non-coupling device where the user has deliberately
+        // set notification to 0 while in vibrate.
+        mockStream(AudioStream.Id.STREAM_NOTIFICATION, current = 0, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        // Pixel-coupling case dominates the heuristic: preserve stored. The
+        // user's intentional 0 is not captured — this is a documented
+        // tradeoff against the (worse) behavior of destroying legitimate
+        // stored notification values on Pixel devices.
+        result.notificationVolume shouldBe 0.19f
+    }
+
+    // ------------------------------------------------------------------------
+    // 9. Ringer NORMAL, notification level differs → writes new percent
+    // ------------------------------------------------------------------------
+    @Test
+    fun `normal ringer notification level differs writes new percent`() = runTest {
+        val module = createModule()
+        val cfg = config(notificationVolume = 0.19f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        // 0.19 * 7 = 1.33 → saved level 1; simulate user bumped it to 5
+        mockStream(AudioStream.Id.STREAM_NOTIFICATION, current = 5, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.notificationVolume shouldBe (5f / 7f)
+    }
+
+    // ------------------------------------------------------------------------
+    // 10. Ringer SILENT, stored Normal ringtone → writes Silent sentinel
+    // ------------------------------------------------------------------------
+    @Test
+    fun `silent ringer with stored normal ringtone writes silent sentinel`() = runTest {
+        val module = createModule()
+        val cfg = config(ringVolume = 0.5f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.SILENT
+        mockStream(AudioStream.Id.STREAM_RINGTONE, current = 0, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.ringVolume shouldBe VolumeMode.LEGACY_SILENT_VALUE
+    }
+
+    // ------------------------------------------------------------------------
+    // 10b. Ringer SILENT, stored Silent sentinel → no-op (structural match)
+    // ------------------------------------------------------------------------
+    @Test
+    fun `silent ringer with stored silent sentinel is a no-op`() = runTest {
+        val module = createModule()
+        val cfg = config(ringVolume = VolumeMode.LEGACY_SILENT_VALUE)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.SILENT
+        mockStream(AudioStream.Id.STREAM_RINGTONE, current = 0, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.ringVolume shouldBe VolumeMode.LEGACY_SILENT_VALUE
+    }
+
+    // ------------------------------------------------------------------------
+    // 11. Ringer NORMAL, stored Vibrate sentinel → user switched out of vibrate;
+    //     handleRingerMode didn't fire for this device → write Normal(current)
+    // ------------------------------------------------------------------------
+    @Test
+    fun `normal ringer with stored vibrate sentinel writes current normal`() = runTest {
+        val module = createModule()
+        val cfg = config(ringVolume = -3.0f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        mockStream(AudioStream.Id.STREAM_RINGTONE, current = 4, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.ringVolume shouldBe (4f / 7f)
+    }
+
+    // ------------------------------------------------------------------------
+    // 12. Normal(0f) edge case for RINGTONE in NORMAL mode
+    // ------------------------------------------------------------------------
+    @Test
+    fun `normal ringer stored normal zero with hardware zero is no-op`() = runTest {
+        val module = createModule()
+        val cfg = config(ringVolume = 0f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        mockStream(AudioStream.Id.STREAM_RINGTONE, current = 0, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.ringVolume shouldBe 0f
+    }
+
+    // ------------------------------------------------------------------------
+    // 13. Corrupt stored value → heal with sanitized Normal
+    // ------------------------------------------------------------------------
+    @Test
+    fun `corrupt stored alarm value is healed`() = runTest {
+        val module = createModule()
+        // 5.5 is outside [0, 1] and not a -2/-3 sentinel → VolumeMode.fromFloat returns null
+        val cfg = config(alarmVolume = 5.5f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        mockStream(AudioStream.Id.STREAM_ALARM, current = 3, max = 7)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.alarmVolume shouldBe (3f / 7f)
+    }
+
+    // ------------------------------------------------------------------------
+    // 14. Pathological hardware: maxLevel = 0 → skip stream
+    // ------------------------------------------------------------------------
+    @Test
+    fun `max level zero is skipped without exception`() = runTest {
+        val module = createModule()
+        val cfg = config(musicVolume = 0.5f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        mockStream(AudioStream.Id.STREAM_MUSIC, current = 0, max = 0)
+
+        module.handle(DeviceEvent.Disconnected(device))
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    // ------------------------------------------------------------------------
+    // 15. Pathological hardware: currentLevel > maxLevel → skip stream
+    // ------------------------------------------------------------------------
+    @Test
+    fun `current level above max is skipped without exception`() = runTest {
+        val module = createModule()
+        val cfg = config(musicVolume = 0.5f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        mockStream(AudioStream.Id.STREAM_MUSIC, current = 30, max = 25)
+
+        module.handle(DeviceEvent.Disconnected(device))
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    // ------------------------------------------------------------------------
+    // 16. Mixed streams: only MUSIC was user-changed, everything else preserved
+    // ------------------------------------------------------------------------
+    @Test
+    fun `mixed streams only music written`() = runTest {
+        val module = createModule()
+        val cfg = config(
+            musicVolume = 0.5f,           // user changed
+            alarmVolume = 0.5714286f,     // level 4 of 7 — unchanged
+            ringVolume = -3.0f,           // vibrate, ringer is vibrate → skipped
+            notificationVolume = 0.19f,   // vibrate, ringer is vibrate → skipped
+        )
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.VIBRATE
+        mockStream(AudioStream.Id.STREAM_MUSIC, current = 20, max = 25)
+        mockStream(AudioStream.Id.STREAM_ALARM, current = 4, max = 7)
+        // RINGTONE and NOTIFICATION skipped before hardware read, but mockk
+        // relaxed returns 0 anyway if they are accessed.
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+
+        result.musicVolume shouldBe (20f / 25f)
+        result.alarmVolume shouldBe 0.5714286f
+        result.ringVolume shouldBe -3.0f
+        result.notificationVolume shouldBe 0.19f
+    }
+
+    // ------------------------------------------------------------------------
+    // 17. Stale snapshot race — event.device.config disagrees with oldConfig
+    // ------------------------------------------------------------------------
+    @Test
+    fun `stale snapshot race uses oldConfig not event device`() = runTest {
+        val module = createModule()
+        // event snapshot says 0.5 (stale)
+        val stale = config(musicVolume = 0.5f)
+        val device = managedDevice(stale)
+        // DB-fresh oldConfig says 0.9 — VolumeUpdateModule wrote it between
+        // dispatch and this module's turn.
+        val fresh = config(musicVolume = 0.9f)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        // Hardware matches the fresh value: 0.9 * 25 = 22.5 → level 22 or 23.
+        // round(0.9 * 25) = 23. Use 23 so the drift check against fresh sees a
+        // match; against the stale 0.5 (round→13) it would mismatch and write.
+        mockStream(AudioStream.Id.STREAM_MUSIC, current = 23, max = 25)
+
+        val result = runTransform(module, DeviceEvent.Disconnected(device), fresh)
+
+        // If the module had compared against the stale snapshot, it would have
+        // overwritten with 23/25 = 0.92. Comparing against fresh oldConfig, the
+        // level matches and we preserve 0.9.
+        result.musicVolume shouldBe 0.9f
+    }
+
+    // ------------------------------------------------------------------------
+    // 18. No notification-policy permission is irrelevant to the disconnect path
+    // ------------------------------------------------------------------------
+    @Test
+    fun `module does not depend on notification policy access`() = runTest {
+        // The disconnect path only reads via AudioManager.getStreamVolume,
+        // which does not require notification policy access. There is no
+        // PermissionHelper dependency to inject at all — this is the test:
+        // constructing and running the module must succeed without one.
+        val module = createModule()
+        val cfg = config(musicVolume = 0.5f)
+        val device = managedDevice(cfg)
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        mockStream(AudioStream.Id.STREAM_MUSIC, current = 13, max = 25)
+
+        // Should not throw. 0.5 * 25 = 12.5 → round → 13. Drift-suppressed.
+        val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
+        result.musicVolume shouldBe 0.5f
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
@@ -265,9 +265,7 @@ class VolumeDisconnectModuleTest : BaseTest() {
     // 8c. KNOWN LIMITATION (documented, intentional):
     //     Ringer VIBRATE, non-coupling device, user sets notification to 0,
     //     hardware=0, stored>0 → we cannot distinguish this from Pixel's
-    //     coupling-clamp on a single read, so we preserve stored. A user who
-    //     deliberately mutes notification in vibrate/silent on a non-coupling
-    //     device must use the app UI or volumeObserving=true to persist the 0.
+    //     coupling-clamp on a single read, so we preserve stored.
     // ------------------------------------------------------------------------
     @Test
     fun `known limitation - non-coupling user zero in vibrate is not captured`() = runTest {

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModuleTest.kt
@@ -1,0 +1,299 @@
+package eu.darken.bluemusic.monitor.core.modules.volume
+
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import eu.darken.bluemusic.monitor.core.audio.RingerMode
+import eu.darken.bluemusic.monitor.core.audio.RingerTool
+import eu.darken.bluemusic.monitor.core.audio.VolumeEvent
+import eu.darken.bluemusic.monitor.core.audio.VolumeMode
+import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class VolumeUpdateModuleTest : BaseTest() {
+
+    private val address = "AA:BB:CC:DD:EE:FF"
+
+    private lateinit var volumeTool: VolumeTool
+    private lateinit var ringerTool: RingerTool
+    private lateinit var deviceRepo: DeviceRepo
+    private lateinit var sourceDevice: SourceDevice
+    private lateinit var devicesFlow: MutableStateFlow<List<ManagedDevice>>
+
+    @BeforeEach
+    fun setup() {
+        volumeTool = mockk(relaxed = true)
+        ringerTool = mockk(relaxed = true)
+        deviceRepo = mockk(relaxed = true)
+        devicesFlow = MutableStateFlow(emptyList())
+        every { deviceRepo.devices } returns devicesFlow
+        coEvery { deviceRepo.updateDevice(any(), any()) } just Runs
+
+        sourceDevice = mockk {
+            every { this@mockk.address } returns this@VolumeUpdateModuleTest.address
+            every { label } returns "Test Device"
+            every { deviceType } returns SourceDevice.Type.HEADPHONES
+            every { getStreamId(AudioStream.Type.MUSIC) } returns AudioStream.Id.STREAM_MUSIC
+            every { getStreamId(AudioStream.Type.CALL) } returns AudioStream.Id.STREAM_VOICE_CALL
+            every { getStreamId(AudioStream.Type.RINGTONE) } returns AudioStream.Id.STREAM_RINGTONE
+            every { getStreamId(AudioStream.Type.NOTIFICATION) } returns AudioStream.Id.STREAM_NOTIFICATION
+            every { getStreamId(AudioStream.Type.ALARM) } returns AudioStream.Id.STREAM_ALARM
+        }
+    }
+
+    private fun createModule() = VolumeUpdateModule(
+        volumeTool = volumeTool,
+        ringerTool = ringerTool,
+        deviceRepo = deviceRepo,
+    )
+
+    private fun config(
+        musicVolume: Float? = null,
+        callVolume: Float? = null,
+        ringVolume: Float? = null,
+        notificationVolume: Float? = null,
+        alarmVolume: Float? = null,
+        volumeObserving: Boolean = true,
+        volumeLock: Boolean = false,
+        lastConnected: Long = 0L,
+    ): DeviceConfigEntity = DeviceConfigEntity(
+        address = address,
+        musicVolume = musicVolume,
+        callVolume = callVolume,
+        ringVolume = ringVolume,
+        notificationVolume = notificationVolume,
+        alarmVolume = alarmVolume,
+        volumeObserving = volumeObserving,
+        volumeLock = volumeLock,
+        lastConnected = lastConnected,
+    )
+
+    private fun managedDevice(config: DeviceConfigEntity) = ManagedDevice(
+        isConnected = true,
+        device = sourceDevice,
+        config = config,
+    )
+
+    private fun seedActive(device: ManagedDevice) {
+        devicesFlow.value = listOf(device)
+    }
+
+    private suspend fun runTransform(
+        module: VolumeUpdateModule,
+        event: VolumeEvent,
+        seedConfig: DeviceConfigEntity,
+    ): DeviceConfigEntity {
+        val slot = slot<(DeviceConfigEntity) -> DeviceConfigEntity>()
+        coEvery { deviceRepo.updateDevice(address, capture(slot)) } just Runs
+        module.handle(event)
+        return slot.captured(seedConfig)
+    }
+
+    // ------------------------------------------------------------------------
+    // wasUs guard — self-triggered events are ignored
+    // ------------------------------------------------------------------------
+    @Test
+    fun `self-triggered events are ignored`() = runTest {
+        val module = createModule()
+        val cfg = config(musicVolume = 0.5f)
+        seedActive(managedDevice(cfg))
+
+        every { volumeTool.wasUs(AudioStream.Id.STREAM_MUSIC, 11) } returns true
+
+        module.handle(
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 11, self = false)
+        )
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    // ------------------------------------------------------------------------
+    // Normal ringer + MUSIC → writes percent
+    // ------------------------------------------------------------------------
+    @Test
+    fun `normal ringer music change writes percent`() = runTest {
+        val module = createModule()
+        val cfg = config(musicVolume = 0.5f)
+        seedActive(managedDevice(cfg))
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        every { volumeTool.getVolumePercentage(AudioStream.Id.STREAM_MUSIC) } returns 0.32f
+        every { volumeTool.wasUs(any(), any()) } returns false
+
+        val result = runTransform(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, 11, 8, self = false),
+            cfg,
+        )
+
+        result.musicVolume shouldBe 0.32f
+    }
+
+    // ------------------------------------------------------------------------
+    // RINGTONE in VIBRATE → writes Vibrate sentinel (not Normal(0))
+    //
+    // Regression: without the ringer-aware mapping, the STREAM_RING→0
+    // observation that Android fires on every vibrate flip would silently
+    // overwrite a stored Vibrate sentinel (or Normal value) with 0.
+    // ------------------------------------------------------------------------
+    @Test
+    fun `vibrate ringer ring change writes vibrate sentinel`() = runTest {
+        val module = createModule()
+        val cfg = config(ringVolume = 0.48f)
+        seedActive(managedDevice(cfg))
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.VIBRATE
+        every { volumeTool.getVolumePercentage(AudioStream.Id.STREAM_RINGTONE) } returns 0f
+        every { volumeTool.wasUs(any(), any()) } returns false
+
+        val result = runTransform(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_RINGTONE, 5, 0, self = false),
+            cfg,
+        )
+
+        result.ringVolume shouldBe VolumeMode.LEGACY_VIBRATE_VALUE
+    }
+
+    // ------------------------------------------------------------------------
+    // RINGTONE in SILENT → writes Silent sentinel
+    // ------------------------------------------------------------------------
+    @Test
+    fun `silent ringer ring change writes silent sentinel`() = runTest {
+        val module = createModule()
+        val cfg = config(ringVolume = 0.48f)
+        seedActive(managedDevice(cfg))
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.SILENT
+        every { volumeTool.getVolumePercentage(AudioStream.Id.STREAM_RINGTONE) } returns 0f
+        every { volumeTool.wasUs(any(), any()) } returns false
+
+        val result = runTransform(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_RINGTONE, 5, 0, self = false),
+            cfg,
+        )
+
+        result.ringVolume shouldBe VolumeMode.LEGACY_SILENT_VALUE
+    }
+
+    // ------------------------------------------------------------------------
+    // NOTIFICATION in VIBRATE with hardware 0 → skipped (preserves stored)
+    //
+    // Matches the disconnect-module heuristic: a 0 reading under non-Normal
+    // ringer is ambiguous, preserve the stored value rather than zero it out.
+    // ------------------------------------------------------------------------
+    @Test
+    fun `vibrate ringer notification zero hardware preserves stored`() = runTest {
+        val module = createModule()
+        val cfg = config(notificationVolume = 0.19f)
+        seedActive(managedDevice(cfg))
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.VIBRATE
+        every { volumeTool.getVolumePercentage(AudioStream.Id.STREAM_NOTIFICATION) } returns 0f
+        every { volumeTool.wasUs(any(), any()) } returns false
+
+        module.handle(
+            VolumeEvent(AudioStream.Id.STREAM_NOTIFICATION, 1, 0, self = false)
+        )
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    // ------------------------------------------------------------------------
+    // NOTIFICATION in VIBRATE with hardware > 0 → captured (non-coupling device)
+    // ------------------------------------------------------------------------
+    @Test
+    fun `vibrate ringer notification nonzero hardware captures change`() = runTest {
+        val module = createModule()
+        val cfg = config(notificationVolume = 0.19f)
+        seedActive(managedDevice(cfg))
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.VIBRATE
+        every { volumeTool.getVolumePercentage(AudioStream.Id.STREAM_NOTIFICATION) } returns (5f / 7f)
+        every { volumeTool.wasUs(any(), any()) } returns false
+
+        val result = runTransform(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_NOTIFICATION, 1, 5, self = false),
+            cfg,
+        )
+
+        result.notificationVolume shouldBe (5f / 7f)
+    }
+
+    // ------------------------------------------------------------------------
+    // volumeObserving=false → no write
+    // ------------------------------------------------------------------------
+    @Test
+    fun `volumeObserving disabled - no write`() = runTest {
+        val module = createModule()
+        val cfg = config(musicVolume = 0.5f, volumeObserving = false)
+        seedActive(managedDevice(cfg))
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        every { volumeTool.getVolumePercentage(AudioStream.Id.STREAM_MUSIC) } returns 0.7f
+        every { volumeTool.wasUs(any(), any()) } returns false
+
+        module.handle(
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, 11, 17, self = false)
+        )
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    // ------------------------------------------------------------------------
+    // volumeLock=true → no write
+    // ------------------------------------------------------------------------
+    @Test
+    fun `volumeLock enabled - no write`() = runTest {
+        val module = createModule()
+        val cfg = config(musicVolume = 0.5f, volumeLock = true)
+        seedActive(managedDevice(cfg))
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        every { volumeTool.getVolumePercentage(AudioStream.Id.STREAM_MUSIC) } returns 0.7f
+        every { volumeTool.wasUs(any(), any()) } returns false
+
+        module.handle(
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, 11, 17, self = false)
+        )
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    // ------------------------------------------------------------------------
+    // Unconfigured stream (no stored value) → no write
+    // ------------------------------------------------------------------------
+    @Test
+    fun `unconfigured stream - no write`() = runTest {
+        val module = createModule()
+        // musicVolume explicitly null — this device does not track music volume
+        val cfg = config(musicVolume = null, callVolume = 0.3f)
+        seedActive(managedDevice(cfg))
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        every { volumeTool.getVolumePercentage(AudioStream.Id.STREAM_MUSIC) } returns 0.7f
+        every { volumeTool.wasUs(any(), any()) } returns false
+
+        module.handle(
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, 11, 17, self = false)
+        )
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
@@ -25,7 +25,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.asDispatcherProvider
-import testhelpers.datastore.FakeDataStoreValue
 import testhelpers.time.FakeMonotonicClock
 
 class EventDispatcherTest : BaseTest() {
@@ -37,7 +36,8 @@ class EventDispatcherTest : BaseTest() {
     private lateinit var deviceRepo: DeviceRepo
     private lateinit var tracker: EventTypeDedupTracker
     private lateinit var devicesSettings: DevicesSettings
-    private lateinit var fakeIsEnabled: FakeDataStoreValue<Boolean>
+    private lateinit var enabledStateFlow: MutableStateFlow<DevicesSettings.EnabledState>
+    private lateinit var currentEnabledState: DevicesSettings.EnabledState
     private lateinit var clock: FakeMonotonicClock
     private lateinit var trackerScope: CoroutineScope
     private lateinit var module1: ConnectionModule
@@ -52,8 +52,10 @@ class EventDispatcherTest : BaseTest() {
         coEvery { deviceRepo.updateDevice(any(), any()) } returns Unit
 
         devicesSettings = mockk()
-        fakeIsEnabled = FakeDataStoreValue(initial = true)
-        every { devicesSettings.isEnabled } returns fakeIsEnabled.mock
+        currentEnabledState = DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 0L)
+        enabledStateFlow = MutableStateFlow(currentEnabledState)
+        every { devicesSettings.enabledState } returns enabledStateFlow
+        coEvery { devicesSettings.currentEnabledState() } answers { currentEnabledState }
 
         clock = FakeMonotonicClock(now = 0L)
         trackerScope = CoroutineScope(Dispatchers.Unconfined + Job())
@@ -105,6 +107,7 @@ class EventDispatcherTest : BaseTest() {
     private fun TestScope.createDispatcher() = EventDispatcher(
         dispatcherProvider = asDispatcherProvider(),
         deviceRepo = deviceRepo,
+        devicesSettings = devicesSettings,
         connectionModuleMap = setOf(module1, module2),
         eventTypeDedupTracker = tracker,
     )

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
@@ -1,0 +1,334 @@
+package eu.darken.bluemusic.monitor.core.service
+
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.DevicesSettings
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
+import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
+import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue.Event.Type.CONNECTED
+import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue.Event.Type.DISCONNECTED
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.asDispatcherProvider
+import testhelpers.datastore.FakeDataStoreValue
+import testhelpers.time.FakeMonotonicClock
+
+class EventDispatcherTest : BaseTest() {
+
+    private val budsAddress = "34:E3:FB:94:C2:AF"
+    private val speakerAddress = "self:speaker:main"
+    private val watchAddress = "11:22:33:44:55:66"
+
+    private lateinit var deviceRepo: DeviceRepo
+    private lateinit var tracker: EventTypeDedupTracker
+    private lateinit var devicesSettings: DevicesSettings
+    private lateinit var fakeIsEnabled: FakeDataStoreValue<Boolean>
+    private lateinit var clock: FakeMonotonicClock
+    private lateinit var trackerScope: CoroutineScope
+    private lateinit var module1: ConnectionModule
+    private lateinit var module2: ConnectionModule
+    private lateinit var devicesFlow: MutableStateFlow<List<ManagedDevice>>
+
+    @BeforeEach
+    fun setup() {
+        devicesFlow = MutableStateFlow(emptyList())
+        deviceRepo = mockk(relaxed = true)
+        every { deviceRepo.devices } returns devicesFlow
+        coEvery { deviceRepo.updateDevice(any(), any()) } returns Unit
+
+        devicesSettings = mockk()
+        fakeIsEnabled = FakeDataStoreValue(initial = true)
+        every { devicesSettings.isEnabled } returns fakeIsEnabled.mock
+
+        clock = FakeMonotonicClock(now = 0L)
+        trackerScope = CoroutineScope(Dispatchers.Unconfined + Job())
+
+        tracker = EventTypeDedupTracker(
+            appScope = trackerScope,
+            devicesSettings = devicesSettings,
+            clock = clock,
+        )
+        module1 = mockk(relaxed = true) {
+            every { priority } returns 10
+            every { tag } returns "Module1"
+        }
+        module2 = mockk(relaxed = true) {
+            every { priority } returns 10
+            every { tag } returns "Module2"
+        }
+    }
+
+    @AfterEach
+    fun teardown() {
+        trackerScope.cancel()
+    }
+
+    private fun managedDevice(
+        address: String,
+        connected: Boolean = true,
+        deviceType: SourceDevice.Type = SourceDevice.Type.HEADPHONES,
+    ): ManagedDevice = mockk(relaxed = true) {
+        every { this@mockk.address } returns address
+        every { isConnected } returns connected
+        every { device } returns mockk(relaxed = true) {
+            every { this@mockk.deviceType } returns deviceType
+        }
+    }
+
+    private fun event(
+        address: String,
+        type: BluetoothEventQueue.Event.Type,
+        deviceType: SourceDevice.Type = SourceDevice.Type.HEADPHONES,
+    ): BluetoothEventQueue.Event = BluetoothEventQueue.Event(
+        type = type,
+        sourceDevice = mockk {
+            every { this@mockk.address } returns address
+            every { this@mockk.deviceType } returns deviceType
+        },
+    )
+
+    private fun TestScope.createDispatcher() = EventDispatcher(
+        dispatcherProvider = asDispatcherProvider(),
+        deviceRepo = deviceRepo,
+        connectionModuleMap = setOf(module1, module2),
+        eventTypeDedupTracker = tracker,
+    )
+
+    /**
+     * The user's bug from scott's log (`bluemusic_3.2.4-rc0_20260408T123558Z`):
+     * buds disconnect, speaker takes over, buds re-emit a stale DISCONNECTED
+     * ~10s later. Without the dedup, the second Disconnected runs the module
+     * pipeline and `VolumeDisconnectModule` captures mid-ramp (near-zero) system
+     * volumes. With the dedup, the second dispatch is a no-op for modules.
+     */
+    @Test
+    fun `user's actual bug - duplicate disconnect does not re-run modules`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+        val dispatcher = createDispatcher()
+
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED)) // Samsung duplicate
+
+        coVerify(exactly = 1) { module1.handle(any<DeviceEvent.Disconnected>()) }
+        coVerify(exactly = 1) { module2.handle(any<DeviceEvent.Disconnected>()) }
+    }
+
+    @Test
+    fun `fresh event is dispatched to all modules`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+        val dispatcher = createDispatcher()
+
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+
+        coVerify(exactly = 1) { module1.handle(any<DeviceEvent.Connected>()) }
+        coVerify(exactly = 1) { module2.handle(any<DeviceEvent.Connected>()) }
+    }
+
+    @Test
+    fun `real transition D1 C1 D2 dispatches all three`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+        val dispatcher = createDispatcher()
+
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+
+        coVerify(exactly = 2) { module1.handle(any<DeviceEvent.Disconnected>()) }
+        coVerify(exactly = 1) { module1.handle(any<DeviceEvent.Connected>()) }
+        coVerify(exactly = 2) { module2.handle(any<DeviceEvent.Disconnected>()) }
+        coVerify(exactly = 1) { module2.handle(any<DeviceEvent.Connected>()) }
+    }
+
+    /**
+     * When a stale fake speaker CONNECTED arrives while the speaker isn't the
+     * active device, the safeguard early-returns. It must NOT populate the
+     * dedup map — otherwise a subsequent legit fake speaker CONNECTED would be
+     * silently swallowed.
+     */
+    @Test
+    fun `fake speaker safeguard drops stale event without poisoning dedup`() = runTest {
+        val speakerDisconnected = managedDevice(
+            speakerAddress,
+            connected = false,
+            deviceType = SourceDevice.Type.PHONE_SPEAKER,
+        )
+        devicesFlow.value = listOf(speakerDisconnected)
+        val dispatcher = createDispatcher()
+
+        // Stale fake speaker CONNECTED — safeguard drops it
+        dispatcher.dispatch(event(speakerAddress, CONNECTED, SourceDevice.Type.PHONE_SPEAKER))
+
+        coVerify(exactly = 0) { module1.handle(any()) }
+        coVerify(exactly = 0) { module2.handle(any()) }
+
+        // Now the speaker is active and a legit CONNECTED arrives — must process
+        val speakerConnected = managedDevice(
+            speakerAddress,
+            connected = true,
+            deviceType = SourceDevice.Type.PHONE_SPEAKER,
+        )
+        devicesFlow.value = listOf(speakerConnected)
+
+        dispatcher.dispatch(event(speakerAddress, CONNECTED, SourceDevice.Type.PHONE_SPEAKER))
+
+        coVerify(exactly = 1) { module1.handle(any<DeviceEvent.Connected>()) }
+        coVerify(exactly = 1) { module2.handle(any<DeviceEvent.Connected>()) }
+    }
+
+    @Test
+    fun `unknown device is skipped before dedup tracking`() = runTest {
+        devicesFlow.value = emptyList() // No managed devices
+        val dispatcher = createDispatcher()
+
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+
+        coVerify(exactly = 0) { module1.handle(any()) }
+        coVerify(exactly = 0) { module2.handle(any()) }
+
+        // If the device later becomes managed, the first DISCONNECTED must still process
+        // (dedup state for the unknown-device address should not be poisoned)
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+
+        coVerify(exactly = 1) { module1.handle(any<DeviceEvent.Disconnected>()) }
+        coVerify(exactly = 1) { module2.handle(any<DeviceEvent.Disconnected>()) }
+    }
+
+    @Test
+    fun `events for different devices are independent`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        val watch = managedDevice(watchAddress, connected = true)
+        devicesFlow.value = listOf(buds, watch)
+        val dispatcher = createDispatcher()
+
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+        dispatcher.dispatch(event(watchAddress, DISCONNECTED))
+
+        // Both processed
+        coVerify(exactly = 2) { module1.handle(any<DeviceEvent.Disconnected>()) }
+        coVerify(exactly = 2) { module2.handle(any<DeviceEvent.Disconnected>()) }
+
+        // Duplicates of each are blocked
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+        dispatcher.dispatch(event(watchAddress, DISCONNECTED))
+
+        coVerify(exactly = 2) { module1.handle(any<DeviceEvent.Disconnected>()) }
+        coVerify(exactly = 2) { module2.handle(any<DeviceEvent.Disconnected>()) }
+    }
+
+    // --- Integration tests (W3): shared real tracker between receiver-side and
+    // dispatcher-side call sites. These would have caught the C1 double-dedup bug.
+
+    /**
+     * Regression test for the C1 double-dedup bug. A receiver-side `isDuplicate`
+     * call must be a pure read — it must not prevent the dispatcher's
+     * `shouldProcess` from accepting the same event as a first occurrence.
+     */
+    @Test
+    fun `receiver isDuplicate does not poison dispatcher shouldProcess`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+        val dispatcher = createDispatcher()
+
+        // Simulate receiver-side pre-filter check — first event is not a duplicate.
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+
+        // Dispatcher commits the event — modules MUST run.
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+
+        coVerify(exactly = 1) { module1.handle(any<DeviceEvent.Disconnected>()) }
+        coVerify(exactly = 1) { module2.handle(any<DeviceEvent.Disconnected>()) }
+    }
+
+    /**
+     * Full receiver→dispatcher flow for a Samsung-style duplicate. The
+     * receiver-side `isDuplicate` check catches the duplicate before the
+     * dispatcher runs.
+     */
+    @Test
+    fun `receiver isDuplicate blocks Samsung-style duplicate from reaching dispatcher`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+        val dispatcher = createDispatcher()
+
+        // First event: receiver passes, dispatcher commits.
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+
+        coVerify(exactly = 1) { module1.handle(any<DeviceEvent.Disconnected>()) }
+
+        // Samsung duplicate arrives ~10s later: receiver-side check catches it.
+        // (In production the receiver would `return` before reaching the dispatcher.)
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
+
+        // Modules still called exactly once.
+        coVerify(exactly = 1) { module1.handle(any<DeviceEvent.Disconnected>()) }
+    }
+
+    /**
+     * Race case: two concurrent receiver coroutines on Dispatchers.Default both
+     * see the map as empty, both pass `isDuplicate`, both submit the event to
+     * the queue. The dispatcher (single-threaded consumer) catches the duplicate
+     * via `shouldProcess` and runs modules exactly once.
+     */
+    @Test
+    fun `concurrent receiver passes caught by dispatcher shouldProcess`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+        val dispatcher = createDispatcher()
+
+        // Both receiver "coroutines" see empty map and pass.
+        tracker.isDuplicate(budsAddress, CONNECTED) shouldBe false
+        tracker.isDuplicate(budsAddress, CONNECTED) shouldBe false
+
+        // Both reach the dispatcher (simulating the queue delivering both events).
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+
+        // Dispatcher caught the second → modules run exactly once.
+        coVerify(exactly = 1) { module1.handle(any<DeviceEvent.Connected>()) }
+        coVerify(exactly = 1) { module2.handle(any<DeviceEvent.Connected>()) }
+    }
+
+    /**
+     * W1 resolution check: a cancelled receiver coroutine that called
+     * `isDuplicate` and then died (before reaching the dispatcher) must not
+     * leave stale state that blocks the next real event.
+     */
+    @Test
+    fun `cancelled receiver isDuplicate does not leave stale state`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+        val dispatcher = createDispatcher()
+
+        // Simulated receiver coroutine reads state and then "dies" before
+        // reaching eventQueue.submit. No dispatcher call for this event.
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+
+        // Next real event arrives later. Dispatcher should accept it as first
+        // occurrence — receiver's read-only check didn't poison anything.
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+
+        coVerify(exactly = 1) { module1.handle(any<DeviceEvent.Disconnected>()) }
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTrackerTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTrackerTest.kt
@@ -160,6 +160,22 @@ class EventTypeDedupTrackerTest : BaseTest() {
         tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
     }
 
+    /**
+     * Symmetric missed-ACL recovery for the `C → [missed D] → C` direction.
+     * Documents the rationale for keeping [EventTypeDedupTracker.TTL_MS]
+     * narrow: once the window has elapsed, a legitimate reconnect after a
+     * missed intermediate DISCONNECTED must process so the user's audio
+     * route and volume restore actually run.
+     */
+    @Test
+    fun `recovers from dropped intermediate disconnect after TTL`() {
+        clock.now = 0
+        tracker.shouldProcess(budsAddress, CONNECTED) shouldBe true
+        // Intermediate DISCONNECTED was missed (doze, system load, OEM kill).
+        clock.now = EventTypeDedupTracker.TTL_MS + 100
+        tracker.shouldProcess(budsAddress, CONNECTED) shouldBe true
+    }
+
     @Test
     fun `TTL is per device, not global`() {
         clock.now = 0
@@ -297,7 +313,10 @@ class EventTypeDedupTrackerTest : BaseTest() {
 
     /**
      * Reproduces the exact Codex scenario: D → disable → (CONN dropped at
-     * receiver) → re-enable → D within TTL must NOT be suppressed.
+     * receiver) → re-enable → D within TTL must NOT be suppressed. Timeline
+     * is compressed to fit inside the 15s TTL so the test still exercises the
+     * "second D would be suppressed by TTL without the clear-on-toggle fix"
+     * path.
      */
     @Test
     fun `codex scenario - toggle gap does not suppress later events`() {
@@ -305,24 +324,24 @@ class EventTypeDedupTrackerTest : BaseTest() {
         clock.now = 0
         tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
 
-        // t=5s: monitoring disabled
-        clock.now = 5_000
+        // t=2s: monitoring disabled
+        clock.now = 2_000
         setEnabled(false)
 
-        // t=10s: device reconnects. Receiver would early-return on isEnabled=false,
+        // t=5s: device reconnects. Receiver would early-return on isEnabled=false,
         // so the CONNECTED event never reaches the tracker.
-        clock.now = 10_000
+        clock.now = 5_000
         // (no tracker call)
 
-        // t=20s: monitoring re-enabled
-        clock.now = 20_000
+        // t=8s: monitoring re-enabled
+        clock.now = 8_000
         setEnabled(true)
 
-        // t=25s: device disconnects again. Without the clear-on-toggle fix,
-        // isDuplicate would see last=(DISCONNECTED, 0), age=25s < 60s → TRUE
+        // t=12s: device disconnects again. Without the clear-on-toggle fix,
+        // isDuplicate would see last=(DISCONNECTED, 0), age=12s < 15s → TRUE
         // and silently drop the real disconnect. With the fix, the map was
-        // cleared at t=5s → isDuplicate returns false → event processes.
-        clock.now = 25_000
+        // cleared at t=2s → isDuplicate returns false → event processes.
+        clock.now = 12_000
         tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
         tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
     }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTrackerTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTrackerTest.kt
@@ -1,0 +1,495 @@
+package eu.darken.bluemusic.monitor.core.service
+
+import eu.darken.bluemusic.devices.core.DevicesSettings
+import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue.Event.Type.CONNECTED
+import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue.Event.Type.DISCONNECTED
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.datastore.FakeDataStoreValue
+import testhelpers.time.FakeMonotonicClock
+
+class EventTypeDedupTrackerTest : BaseTest() {
+
+    private val budsAddress = "34:E3:FB:94:C2:AF"
+    private val speakerAddress = "self:speaker:main"
+    private val watchAddress = "11:22:33:44:55:66"
+
+    private lateinit var tracker: EventTypeDedupTracker
+    private lateinit var devicesSettings: DevicesSettings
+    private lateinit var fakeIsEnabled: FakeDataStoreValue<Boolean>
+    private lateinit var clock: FakeMonotonicClock
+    private lateinit var trackerScope: CoroutineScope
+
+    @BeforeEach
+    fun setup() {
+        devicesSettings = mockk()
+        fakeIsEnabled = FakeDataStoreValue(initial = true)
+        every { devicesSettings.isEnabled } returns fakeIsEnabled.mock
+
+        clock = FakeMonotonicClock(now = 0L)
+        trackerScope = CoroutineScope(Dispatchers.Unconfined + Job())
+
+        tracker = EventTypeDedupTracker(
+            appScope = trackerScope,
+            devicesSettings = devicesSettings,
+            clock = clock,
+        )
+    }
+
+    @AfterEach
+    fun teardown() {
+        trackerScope.cancel()
+    }
+
+    // --- shouldProcess basics ---
+
+    @Test
+    fun `first event for fresh device is processed`() {
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    @Test
+    fun `duplicate event with same type is skipped`() {
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe false
+    }
+
+    @Test
+    fun `real transition D1 C1 D2 all process`() {
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        tracker.shouldProcess(budsAddress, CONNECTED) shouldBe true
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    /**
+     * Captures the exact sequence from scott's log
+     * (bluemusic_3.2.4-rc0_20260408T123558Z): buds disconnect, speaker takes
+     * over, then a stale buds DISCONNECTED arrives ~10s later.
+     */
+    @Test
+    fun `user's actual bug - stale buds disconnect skipped`() {
+        clock.now = 100_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        clock.now = 103_000
+        tracker.shouldProcess(speakerAddress, CONNECTED) shouldBe true
+        // Buds ACL_DISCONNECTED #2 (Samsung duplicate, ~10s later)
+        clock.now = 110_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe false
+    }
+
+    @Test
+    fun `different devices are independent`() {
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        tracker.shouldProcess(watchAddress, DISCONNECTED) shouldBe true
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe false
+        tracker.shouldProcess(watchAddress, DISCONNECTED) shouldBe false
+    }
+
+    @Test
+    fun `same type after opposite type is processed`() {
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        tracker.shouldProcess(budsAddress, CONNECTED) shouldBe true
+        tracker.shouldProcess(budsAddress, CONNECTED) shouldBe false
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    @Test
+    fun `duplicate within TTL window is skipped`() {
+        clock.now = 1_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        // Within TTL
+        clock.now = EventTypeDedupTracker.TTL_MS - 1
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe false
+    }
+
+    @Test
+    fun `same type at TTL boundary is processed`() {
+        clock.now = 0
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        // Exactly at TTL boundary — ageMs == TTL_MS, NOT < TTL_MS → processed
+        clock.now = EventTypeDedupTracker.TTL_MS
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    @Test
+    fun `same type well past TTL is processed`() {
+        clock.now = 0
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        clock.now = EventTypeDedupTracker.TTL_MS * 3
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    /**
+     * Recovery from a dropped upstream event: if a CONNECTED event was lost
+     * somewhere between two DISCONNECTED events, the second DISCONNECTED would
+     * be suppressed by pure type-only dedup. With TTL, once enough time has
+     * passed, the second DISCONNECTED processes again.
+     */
+    @Test
+    fun `recovers from dropped intermediate event after TTL`() {
+        clock.now = 0
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        // (upstream CONNECTED event was dropped — never reached the tracker)
+        clock.now = EventTypeDedupTracker.TTL_MS + 1_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    @Test
+    fun `TTL is per device, not global`() {
+        clock.now = 0
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        clock.now = 100
+        tracker.shouldProcess(watchAddress, DISCONNECTED) shouldBe true
+        clock.now = 5_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe false
+        tracker.shouldProcess(watchAddress, DISCONNECTED) shouldBe false
+    }
+
+    // --- isDuplicate (read-only pre-filter) ---
+
+    @Test
+    fun `isDuplicate returns false for fresh device`() {
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+    }
+
+    @Test
+    fun `isDuplicate returns true for same type within TTL`() {
+        clock.now = 1_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        clock.now = 10_000
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    @Test
+    fun `isDuplicate returns false for same type past TTL`() {
+        clock.now = 0
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        clock.now = EventTypeDedupTracker.TTL_MS
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+        clock.now = EventTypeDedupTracker.TTL_MS + 1
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+    }
+
+    @Test
+    fun `isDuplicate returns false for different type`() {
+        clock.now = 0
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        clock.now = 100
+        tracker.isDuplicate(budsAddress, CONNECTED) shouldBe false
+    }
+
+    @Test
+    fun `isDuplicate does not mutate state`() {
+        repeat(5) { tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false }
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    /**
+     * The critical invariant that fixes the C1 double-dedup bug: calling
+     * isDuplicate before shouldProcess on the same (address, type) must still
+     * allow shouldProcess to accept the event as a first occurrence.
+     */
+    @Test
+    fun `isDuplicate before shouldProcess does not poison first-occurrence event`() {
+        clock.now = 1_000
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+        clock.now = 1_001
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        clock.now = 11_000
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    @Test
+    fun `isDuplicate is per device`() {
+        clock.now = 0
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        clock.now = 100
+        tracker.isDuplicate(watchAddress, DISCONNECTED) shouldBe false
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    // --- Eviction (W2) ---
+
+    @Test
+    fun `shouldProcess evicts entries older than eviction age`() {
+        clock.now = 0
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        tracker.shouldProcess(watchAddress, CONNECTED) shouldBe true
+        tracker.shouldProcess(speakerAddress, DISCONNECTED) shouldBe true
+
+        // Trigger a put well past the eviction age
+        clock.now = EventTypeDedupTracker.EVICTION_AGE_MS + 1_000
+        tracker.shouldProcess("aa:bb:cc:dd:ee:ff", CONNECTED) shouldBe true
+
+        // Original entries should be evicted — isDuplicate returns false for them
+        clock.now = EventTypeDedupTracker.EVICTION_AGE_MS + 1_100
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+        tracker.isDuplicate(watchAddress, CONNECTED) shouldBe false
+        tracker.isDuplicate(speakerAddress, DISCONNECTED) shouldBe false
+    }
+
+    // --- isEnabled reset (Codex #2) ---
+
+    /**
+     * Regression test for the Codex finding: if monitoring is disabled while a
+     * real device state transition happens (receiver early-returns before
+     * reaching the tracker), the singleton tracker still holds the pre-disable
+     * state. When re-enabled, the next real event within TTL would be
+     * incorrectly suppressed. Clearing the tracker on any `isEnabled` toggle
+     * prevents this.
+     */
+    @Test
+    fun `clears dedup state on isEnabled toggle`() {
+        // Seed state while enabled
+        clock.now = 1_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
+
+        // Toggle off (simulates user disabling monitoring)
+        fakeIsEnabled.value = false
+
+        // Toggle back on (simulates user re-enabling)
+        fakeIsEnabled.value = true
+
+        // Map should be cleared — the same event should no longer be a duplicate
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    @Test
+    fun `clears dedup state on disabled transition even without re-enable`() {
+        clock.now = 1_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+        // Transition to disabled — the state is cleared as soon as we detect
+        // the change, so re-enabling after an arbitrary delay still starts fresh.
+        fakeIsEnabled.value = false
+
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+    }
+
+    /**
+     * Reproduces the exact Codex scenario: D → disable → (CONN dropped at
+     * receiver) → re-enable → D within TTL must NOT be suppressed.
+     */
+    @Test
+    fun `codex scenario - toggle gap does not suppress later events`() {
+        // t=0: first disconnect while enabled
+        clock.now = 0
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+        // t=5s: monitoring disabled
+        clock.now = 5_000
+        fakeIsEnabled.value = false
+
+        // t=10s: device reconnects. Receiver would early-return on isEnabled=false,
+        // so the CONNECTED event never reaches the tracker.
+        clock.now = 10_000
+        // (no tracker call)
+
+        // t=20s: monitoring re-enabled
+        clock.now = 20_000
+        fakeIsEnabled.value = true
+
+        // t=25s: device disconnects again. Without the clear-on-toggle fix,
+        // isDuplicate would see last=(DISCONNECTED, 0), age=25s < 60s → TRUE
+        // and silently drop the real disconnect. With the fix, the map was
+        // cleared at t=5s → isDuplicate returns false → event processes.
+        clock.now = 25_000
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    // --- notifyEnabledState (receiver-driven synchronous clear) ---
+
+    @Test
+    fun `notifyEnabledState - true to false clears state synchronously`() {
+        clock.now = 1_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
+
+        // Receiver hands us the new enabled value directly; must clear
+        // without waiting for the backstop flow collector.
+        tracker.notifyEnabledState(false)
+
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+    }
+
+    @Test
+    fun `notifyEnabledState - false to true clears state synchronously`() {
+        clock.now = 1_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+        tracker.notifyEnabledState(false)
+        // State is gone after the first transition
+
+        // Seed something new while "disabled" (hypothetical path; real
+        // receiver would early-return, but the tracker itself is a singleton
+        // that can be called from anywhere).
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+        // Re-enable transition clears again
+        tracker.notifyEnabledState(true)
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+    }
+
+    @Test
+    fun `notifyEnabledState - repeated same value does not clear`() {
+        clock.now = 1_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+        // Receiver gets called with isEnabled=true on every broadcast, which is
+        // the normal running state — must not clear on every ping.
+        tracker.notifyEnabledState(true)
+        tracker.notifyEnabledState(true)
+        tracker.notifyEnabledState(true)
+
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    @Test
+    fun `notifyEnabledState - first call matching bootstrap does not clear`() {
+        clock.now = 1_000
+        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+        // The tracker bootstraps `lastSeenEnabled=true` to match the
+        // `devices.enabled` DataStore default. A notifyEnabledState(true) call
+        // issued before any real transition must therefore be a no-op — it
+        // must NOT falsely clear a map populated by earlier shouldProcess
+        // calls.
+        tracker.notifyEnabledState(true)
+
+        tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
+    }
+
+    /**
+     * Simulates the scheduler race Codex flagged, under the write-site-notify
+     * architecture:
+     *
+     * - The ViewModel write path calls [notifyEnabledState] **synchronously**
+     *   alongside the DataStore write (see
+     *   [eu.darken.bluemusic.devices.ui.settings.DevicesSettingsViewModel.onToggleEnabled]).
+     * - A broadcast arriving between the write and the async flow collector
+     *   draining will still see an up-to-date tracker because the write path
+     *   already aligned it.
+     *
+     * Uses a [StandardTestDispatcher] so the tracker's init-block backstop
+     * collector stays queued until the test explicitly advances the
+     * scheduler. Without the write-site notify, the receiver's observation of
+     * `true` would not be able to detect the intermediate `false` and the map
+     * would remain stale. With it, the map is correctly cleared before the
+     * backstop ever runs.
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `race - write-site notify clears before backstop drains`() {
+        val testDispatcher = StandardTestDispatcher()
+        val testScope = TestScope(testDispatcher)
+        val raceFakeEnabled = FakeDataStoreValue(initial = true)
+        val raceSettings = mockk<DevicesSettings>().also {
+            every { it.isEnabled } returns raceFakeEnabled.mock
+        }
+        val raceClock = FakeMonotonicClock(now = 0L)
+        val raceTracker = EventTypeDedupTracker(
+            appScope = testScope,
+            devicesSettings = raceSettings,
+            clock = raceClock,
+        )
+
+        // Drain the tracker's init subscription to its initial state so the
+        // drop(1) pipeline is ready (but no real emissions yet).
+        testScope.advanceUntilIdle()
+
+        // Seed state with an entry that would be "stale" after a toggle.
+        raceClock.now = 1_000
+        raceTracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+        // Simulate the ViewModel write path: write to DataStore AND notify
+        // the tracker synchronously in the same coroutine. The test scope is
+        // NOT advanced between these calls, so the async flow collector
+        // queued by the DataStore write has NOT run yet — only the synchronous
+        // notify has touched the tracker.
+        raceFakeEnabled.value = false
+        raceTracker.notifyEnabledState(false)
+        raceFakeEnabled.value = true
+        raceTracker.notifyEnabledState(true)
+
+        // At this point, the map MUST be cleared purely via the write-site
+        // notifications. The backstop collector is still queued in the
+        // scheduler and has not drained.
+        raceClock.now = 10_000
+        raceTracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+        raceTracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+        // Draining the backstop collector afterwards must be idempotent — it
+        // may perceive the end-state only (due to StateFlow conflation on
+        // rapid writes), and its notifyEnabledState call must not clobber the
+        // entry we just legitimately seeded.
+        testScope.advanceUntilIdle()
+
+        raceClock.now = 11_000
+        raceTracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
+
+        testScope.cancel()
+    }
+
+    /**
+     * Verifies the async backstop collector clears the map when it gets a
+     * chance to observe a transition. This guards against accidentally making
+     * the backstop a pure no-op (which would cripple the path in scenarios
+     * where no broadcast coincides with the toggle).
+     */
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `backstop collector clears state on observed transition`() {
+        val testDispatcher = StandardTestDispatcher()
+        val testScope = TestScope(testDispatcher)
+        val raceFakeEnabled = FakeDataStoreValue(initial = true)
+        val raceSettings = mockk<DevicesSettings>().also {
+            every { it.isEnabled } returns raceFakeEnabled.mock
+        }
+        val raceClock = FakeMonotonicClock(now = 0L)
+        val raceTracker = EventTypeDedupTracker(
+            appScope = testScope,
+            devicesSettings = raceSettings,
+            clock = raceClock,
+        )
+        testScope.advanceUntilIdle()
+
+        raceClock.now = 1_000
+        raceTracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+        // Toggle and drain between each write so the collector actually sees
+        // both emissions (StateFlow conflation would otherwise collapse rapid
+        // writes to the end state only).
+        raceFakeEnabled.value = false
+        testScope.advanceUntilIdle()
+
+        // After observing the transition to `false`, the map is cleared.
+        raceClock.now = 10_000
+        raceTracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+
+        raceFakeEnabled.value = true
+        testScope.advanceUntilIdle()
+
+        // And after flipping back, we're still in a clean state for the
+        // next broadcast.
+        raceClock.now = 11_000
+        raceTracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
+
+        testScope.cancel()
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTrackerTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTrackerTest.kt
@@ -1,9 +1,11 @@
 package eu.darken.bluemusic.monitor.core.service
 
+import eu.darken.bluemusic.common.debug.logging.Logging
 import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue.Event.Type.CONNECTED
 import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue.Event.Type.DISCONNECTED
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
@@ -314,7 +316,7 @@ class EventTypeDedupTrackerTest : BaseTest() {
     /**
      * Reproduces the exact Codex scenario: D → disable → (CONN dropped at
      * receiver) → re-enable → D within TTL must NOT be suppressed. Timeline
-     * is compressed to fit inside the 15s TTL so the test still exercises the
+     * is compressed to fit inside the 20s TTL so the test still exercises the
      * "second D would be suppressed by TTL without the clear-on-toggle fix"
      * path.
      */
@@ -338,7 +340,7 @@ class EventTypeDedupTrackerTest : BaseTest() {
         setEnabled(true)
 
         // t=12s: device disconnects again. Without the clear-on-toggle fix,
-        // isDuplicate would see last=(DISCONNECTED, 0), age=12s < 15s → TRUE
+        // isDuplicate would see last=(DISCONNECTED, 0), age=12s < 20s → TRUE
         // and silently drop the real disconnect. With the fix, the map was
         // cleared at t=2s → isDuplicate returns false → event processes.
         clock.now = 12_000
@@ -505,5 +507,99 @@ class EventTypeDedupTrackerTest : BaseTest() {
         raceTracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
 
         testScope.cancel()
+    }
+
+    // --- DEDUP_NEAR_MISS observability ---
+
+    private class CapturingLogger : Logging.Logger {
+        data class Entry(val priority: Logging.Priority, val tag: String, val message: String)
+
+        val entries = mutableListOf<Entry>()
+
+        override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+            entries.add(Entry(priority, tag, message))
+        }
+    }
+
+    @Test
+    fun `near-miss WARN fires when same-type accepted within eviction window`() {
+        val logger = CapturingLogger()
+        Logging.install(logger)
+        try {
+            clock.now = 0
+            tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+            // Accept just past TTL — within [TTL_MS, EVICTION_AGE_MS]
+            clock.now = EventTypeDedupTracker.TTL_MS + 1_000
+            tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+            val warnEntries = logger.entries.filter {
+                it.priority == Logging.Priority.WARN && it.message.contains("DEDUP_NEAR_MISS")
+            }
+            warnEntries.size shouldBe 1
+            warnEntries[0].message shouldContain budsAddress
+            warnEntries[0].message shouldContain "margin="
+        } finally {
+            Logging.remove(logger)
+        }
+    }
+
+    @Test
+    fun `near-miss WARN does not fire for drop within TTL`() {
+        val logger = CapturingLogger()
+        Logging.install(logger)
+        try {
+            clock.now = 0
+            tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+            clock.now = 5_000
+            tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe false
+
+            val warnEntries = logger.entries.filter {
+                it.priority == Logging.Priority.WARN && it.message.contains("DEDUP_NEAR_MISS")
+            }
+            warnEntries.size shouldBe 0
+        } finally {
+            Logging.remove(logger)
+        }
+    }
+
+    @Test
+    fun `near-miss WARN does not fire for fresh first-occurrence events`() {
+        val logger = CapturingLogger()
+        Logging.install(logger)
+        try {
+            clock.now = 0
+            tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+            tracker.shouldProcess(watchAddress, CONNECTED) shouldBe true
+
+            val warnEntries = logger.entries.filter {
+                it.priority == Logging.Priority.WARN && it.message.contains("DEDUP_NEAR_MISS")
+            }
+            warnEntries.size shouldBe 0
+        } finally {
+            Logging.remove(logger)
+        }
+    }
+
+    @Test
+    fun `near-miss WARN does not fire for acceptance well past eviction window`() {
+        val logger = CapturingLogger()
+        Logging.install(logger)
+        try {
+            clock.now = 0
+            tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+            // Well past EVICTION_AGE_MS — entry was evicted, treated as first-occurrence
+            clock.now = EventTypeDedupTracker.EVICTION_AGE_MS * 2
+            tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
+
+            val warnEntries = logger.entries.filter {
+                it.priority == Logging.Priority.WARN && it.message.contains("DEDUP_NEAR_MISS")
+            }
+            warnEntries.size shouldBe 0
+        } finally {
+            Logging.remove(logger)
+        }
     }
 }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTrackerTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventTypeDedupTrackerTest.kt
@@ -4,6 +4,7 @@ import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue.Event.Type.CONNECTED
 import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue.Event.Type.DISCONNECTED
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
@@ -11,6 +12,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -18,7 +20,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
-import testhelpers.datastore.FakeDataStoreValue
 import testhelpers.time.FakeMonotonicClock
 
 class EventTypeDedupTrackerTest : BaseTest() {
@@ -29,15 +30,18 @@ class EventTypeDedupTrackerTest : BaseTest() {
 
     private lateinit var tracker: EventTypeDedupTracker
     private lateinit var devicesSettings: DevicesSettings
-    private lateinit var fakeIsEnabled: FakeDataStoreValue<Boolean>
+    private lateinit var enabledStateFlow: MutableStateFlow<DevicesSettings.EnabledState>
+    private lateinit var currentEnabledState: DevicesSettings.EnabledState
     private lateinit var clock: FakeMonotonicClock
     private lateinit var trackerScope: CoroutineScope
 
     @BeforeEach
     fun setup() {
         devicesSettings = mockk()
-        fakeIsEnabled = FakeDataStoreValue(initial = true)
-        every { devicesSettings.isEnabled } returns fakeIsEnabled.mock
+        currentEnabledState = DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 0L)
+        enabledStateFlow = MutableStateFlow(currentEnabledState)
+        every { devicesSettings.enabledState } returns enabledStateFlow
+        coEvery { devicesSettings.currentEnabledState() } answers { currentEnabledState }
 
         clock = FakeMonotonicClock(now = 0L)
         trackerScope = CoroutineScope(Dispatchers.Unconfined + Job())
@@ -52,6 +56,15 @@ class EventTypeDedupTrackerTest : BaseTest() {
     @AfterEach
     fun teardown() {
         trackerScope.cancel()
+    }
+
+    private fun setEnabled(enabled: Boolean) {
+        currentEnabledState = if (currentEnabledState.isEnabled == enabled) {
+            currentEnabledState
+        } else {
+            currentEnabledState.copy(isEnabled = enabled, toggleEpoch = currentEnabledState.toggleEpoch + 1L)
+        }
+        enabledStateFlow.value = currentEnabledState
     }
 
     // --- shouldProcess basics ---
@@ -260,10 +273,10 @@ class EventTypeDedupTrackerTest : BaseTest() {
         tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
 
         // Toggle off (simulates user disabling monitoring)
-        fakeIsEnabled.value = false
+        setEnabled(false)
 
         // Toggle back on (simulates user re-enabling)
-        fakeIsEnabled.value = true
+        setEnabled(true)
 
         // Map should be cleared — the same event should no longer be a duplicate
         tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
@@ -277,7 +290,7 @@ class EventTypeDedupTrackerTest : BaseTest() {
 
         // Transition to disabled — the state is cleared as soon as we detect
         // the change, so re-enabling after an arbitrary delay still starts fresh.
-        fakeIsEnabled.value = false
+        setEnabled(false)
 
         tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
     }
@@ -294,7 +307,7 @@ class EventTypeDedupTrackerTest : BaseTest() {
 
         // t=5s: monitoring disabled
         clock.now = 5_000
-        fakeIsEnabled.value = false
+        setEnabled(false)
 
         // t=10s: device reconnects. Receiver would early-return on isEnabled=false,
         // so the CONNECTED event never reaches the tracker.
@@ -303,7 +316,7 @@ class EventTypeDedupTrackerTest : BaseTest() {
 
         // t=20s: monitoring re-enabled
         clock.now = 20_000
-        fakeIsEnabled.value = true
+        setEnabled(true)
 
         // t=25s: device disconnects again. Without the clear-on-toggle fix,
         // isDuplicate would see last=(DISCONNECTED, 0), age=25s < 60s → TRUE
@@ -314,93 +327,76 @@ class EventTypeDedupTrackerTest : BaseTest() {
         tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
     }
 
-    // --- notifyEnabledState (receiver-driven synchronous clear) ---
+    // --- observeEnabledState (receiver/dispatcher-driven synchronous clear) ---
 
     @Test
-    fun `notifyEnabledState - true to false clears state synchronously`() {
+    fun `observeEnabledState - toggle to disabled clears state synchronously`() {
         clock.now = 1_000
         tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
         tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
 
-        // Receiver hands us the new enabled value directly; must clear
-        // without waiting for the backstop flow collector.
-        tracker.notifyEnabledState(false)
+        tracker.observeEnabledState(
+            DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
+        )
 
         tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
     }
 
     @Test
-    fun `notifyEnabledState - false to true clears state synchronously`() {
+    fun `observeEnabledState - epoch change clears even when boolean is true`() {
         clock.now = 1_000
         tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
-        tracker.notifyEnabledState(false)
-        // State is gone after the first transition
 
-        // Seed something new while "disabled" (hypothetical path; real
-        // receiver would early-return, but the tracker itself is a singleton
-        // that can be called from anywhere).
-        tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
-
-        // Re-enable transition clears again
-        tracker.notifyEnabledState(true)
+        // Collapsed true -> false -> true cycle: the observer only sees the final
+        // `true`, but the epoch proves a toggle happened and must still clear.
+        tracker.observeEnabledState(
+            DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 2L)
+        )
         tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
     }
 
     @Test
-    fun `notifyEnabledState - repeated same value does not clear`() {
+    fun `observeEnabledState - repeated same epoch does not clear`() {
         clock.now = 1_000
         tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
 
-        // Receiver gets called with isEnabled=true on every broadcast, which is
-        // the normal running state — must not clear on every ping.
-        tracker.notifyEnabledState(true)
-        tracker.notifyEnabledState(true)
-        tracker.notifyEnabledState(true)
+        tracker.observeEnabledState(DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 0L))
+        tracker.observeEnabledState(DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 0L))
+        tracker.observeEnabledState(DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 0L))
 
         tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
     }
 
     @Test
-    fun `notifyEnabledState - first call matching bootstrap does not clear`() {
+    fun `observeEnabledState - first call matching bootstrap does not clear`() {
         clock.now = 1_000
         tracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
 
-        // The tracker bootstraps `lastSeenEnabled=true` to match the
-        // `devices.enabled` DataStore default. A notifyEnabledState(true) call
-        // issued before any real transition must therefore be a no-op — it
-        // must NOT falsely clear a map populated by earlier shouldProcess
-        // calls.
-        tracker.notifyEnabledState(true)
+        tracker.observeEnabledState(DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 0L))
 
         tracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe true
     }
 
     /**
-     * Simulates the scheduler race Codex flagged, under the write-site-notify
-     * architecture:
+     * Simulates the collapsed-toggle race:
      *
-     * - The ViewModel write path calls [notifyEnabledState] **synchronously**
-     *   alongside the DataStore write (see
-     *   [eu.darken.bluemusic.devices.ui.settings.DevicesSettingsViewModel.onToggleEnabled]).
-     * - A broadcast arriving between the write and the async flow collector
-     *   draining will still see an up-to-date tracker because the write path
-     *   already aligned it.
-     *
-     * Uses a [StandardTestDispatcher] so the tracker's init-block backstop
-     * collector stays queued until the test explicitly advances the
-     * scheduler. Without the write-site notify, the receiver's observation of
-     * `true` would not be able to detect the intermediate `false` and the map
-     * would remain stale. With it, the map is correctly cleared before the
-     * backstop ever runs.
+     * - DataStore commits `enabled=false, epoch=1`, then `enabled=true, epoch=2`
+     *   before the backstop collector drains.
+     * - The receiver/dispatcher only observes the final `enabled=true`, but its
+     *   atomic snapshot still carries `epoch=2`.
+     * - Observing that snapshot must clear the map immediately, before the
+     *   queued flow collector runs.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
     @Test
-    fun `race - write-site notify clears before backstop drains`() {
+    fun `race - observed epoch clears before backstop drains`() {
         val testDispatcher = StandardTestDispatcher()
         val testScope = TestScope(testDispatcher)
-        val raceFakeEnabled = FakeDataStoreValue(initial = true)
+        var raceState = DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 0L)
+        val raceStateFlow = MutableStateFlow(raceState)
         val raceSettings = mockk<DevicesSettings>().also {
-            every { it.isEnabled } returns raceFakeEnabled.mock
+            every { it.enabledState } returns raceStateFlow
+            coEvery { it.currentEnabledState() } answers { raceState }
         }
         val raceClock = FakeMonotonicClock(now = 0L)
         val raceTracker = EventTypeDedupTracker(
@@ -417,27 +413,22 @@ class EventTypeDedupTrackerTest : BaseTest() {
         raceClock.now = 1_000
         raceTracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
 
-        // Simulate the ViewModel write path: write to DataStore AND notify
-        // the tracker synchronously in the same coroutine. The test scope is
-        // NOT advanced between these calls, so the async flow collector
-        // queued by the DataStore write has NOT run yet — only the synchronous
-        // notify has touched the tracker.
-        raceFakeEnabled.value = false
-        raceTracker.notifyEnabledState(false)
-        raceFakeEnabled.value = true
-        raceTracker.notifyEnabledState(true)
+        // Two writes happen before the backstop collector drains. StateFlow may
+        // conflate them to the final `true`, but the epoch still reflects both
+        // toggles.
+        raceState = DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
+        raceStateFlow.value = raceState
+        raceState = DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 2L)
+        raceStateFlow.value = raceState
 
-        // At this point, the map MUST be cleared purely via the write-site
-        // notifications. The backstop collector is still queued in the
-        // scheduler and has not drained.
+        // The receiver/dispatcher path sees only the final `true`, but the
+        // epoch proves a toggle happened and must clear synchronously.
+        raceTracker.observeEnabledState(raceState)
         raceClock.now = 10_000
         raceTracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
         raceTracker.shouldProcess(budsAddress, DISCONNECTED) shouldBe true
 
-        // Draining the backstop collector afterwards must be idempotent — it
-        // may perceive the end-state only (due to StateFlow conflation on
-        // rapid writes), and its notifyEnabledState call must not clobber the
-        // entry we just legitimately seeded.
+        // Draining the backstop collector afterwards must be idempotent.
         testScope.advanceUntilIdle()
 
         raceClock.now = 11_000
@@ -457,9 +448,11 @@ class EventTypeDedupTrackerTest : BaseTest() {
     fun `backstop collector clears state on observed transition`() {
         val testDispatcher = StandardTestDispatcher()
         val testScope = TestScope(testDispatcher)
-        val raceFakeEnabled = FakeDataStoreValue(initial = true)
+        var raceState = DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 0L)
+        val raceStateFlow = MutableStateFlow(raceState)
         val raceSettings = mockk<DevicesSettings>().also {
-            every { it.isEnabled } returns raceFakeEnabled.mock
+            every { it.enabledState } returns raceStateFlow
+            coEvery { it.currentEnabledState() } answers { raceState }
         }
         val raceClock = FakeMonotonicClock(now = 0L)
         val raceTracker = EventTypeDedupTracker(
@@ -475,14 +468,16 @@ class EventTypeDedupTrackerTest : BaseTest() {
         // Toggle and drain between each write so the collector actually sees
         // both emissions (StateFlow conflation would otherwise collapse rapid
         // writes to the end state only).
-        raceFakeEnabled.value = false
+        raceState = DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
+        raceStateFlow.value = raceState
         testScope.advanceUntilIdle()
 
         // After observing the transition to `false`, the map is cleared.
         raceClock.now = 10_000
         raceTracker.isDuplicate(budsAddress, DISCONNECTED) shouldBe false
 
-        raceFakeEnabled.value = true
+        raceState = DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 2L)
+        raceStateFlow.value = raceState
         testScope.advanceUntilIdle()
 
         // And after flipping back, we're still in a clean state for the

--- a/app/src/test/java/testhelpers/time/FakeMonotonicClock.kt
+++ b/app/src/test/java/testhelpers/time/FakeMonotonicClock.kt
@@ -1,0 +1,7 @@
+package testhelpers.time
+
+import eu.darken.bluemusic.common.time.MonotonicClock
+
+class FakeMonotonicClock(var now: Long = 0L) : MonotonicClock {
+    override fun nowMs(): Long = now
+}


### PR DESCRIPTION
## Summary

Three related bugs that all corrupted stored device volumes during connect/disconnect cycles, all manifesting on Pixel-style devices where the system ringtone/notification streams clamp to 0 in vibrate or silent mode.

### 1. Save-on-disconnect overwriting Vibrate sentinel and notification volume

`VolumeDisconnectModule` read raw stream levels at disconnect time and wrote them back to the device config. With the phone in vibrate mode, that meant:

- The stored ringtone Vibrate sentinel (`-3.0f`) got overwritten with `0.0f` (silent ring), losing the user's vibrate-mode preference.
- The stored notification volume (e.g. `0.19`) got overwritten with `0.0f` because Pixel-style devices clamp `STREAM_NOTIFICATION` to 0 alongside the ring stream.
- Other stream volumes slowly drifted on every disconnect cycle because the saved float was rounded to the nearest discrete level (e.g. `0.42344147` → level 11/25 → saved as `0.44`).

The module now:
- Maps ringer mode directly to `Silent` / `Vibrate` / `Normal(percent)` for the RINGTONE stream and persists the sentinel — co-owning the path with `MonitorService.handleRingerMode()` so the race where `handleRingerMode` bails out (no active device) before disconnect runs is closed. Both writers always agree on the sentinel value.
- Skips NOTIFICATION writes when the hardware reads 0 in non-Normal ringer mode (preserves stored), captures it normally otherwise.
- Drift-suppresses Normal writes when the discrete level matches the stored value, so no-op disconnects don't slowly rewrite stored floats.
- Performs all compare-and-write logic inside the `deviceRepo.updateDevice` lambda against the DB-fresh `oldConfig`, not the stale `event.device.config` snapshot, closing a race with concurrent `VolumeUpdateModule` writes.
- Bootstraps defensively against pathological hardware reads (`maxLevel <= 0`, out-of-range current level) and heals corrupt stored floats.

### 2. Live volume observation had the same data-loss race

`VolumeUpdateModule` (used by devices with `volumeObserving=true`) had the analogous bug at runtime: flipping the phone to vibrate during a session would fire a `STREAM_RING → 0` observation that overwrote the stored Vibrate sentinel with `Normal(0)`, racing non-deterministically against `handleRingerMode()`. Notification was similarly affected on coupling devices.

The same ringer-aware logic now applies on the live-update path, so both writers always agree on the sentinel value and the in-session race is closed.

### 3. Dedup tracker missed monitoring toggles under scheduler races

`EventTypeDedupTracker` cleared its per-device dedup map on monitoring toggles via an async flow collector. Three scenarios bypassed it:

- A broadcast arriving in the scheduler window before the collector drained would consult stale entries and silently drop the first real event after a re-enable.
- The receiver short-circuited on `!isEnabled` *before* reaching the tracker, so the tracker never observed the disabled side of a `true → false → true` cycle if no broadcast fired during the disabled phase.
- A rapid `true → false → true` cycle could collapse via StateFlow conflation so consumers only ever observed the final `true`, indistinguishable from "no toggle happened" — even though stale dedup entries from before the cycle were still poisoning the map.

Fix: `DevicesSettings` now exposes an atomic `EnabledState(isEnabled, toggleEpoch)` snapshot. The epoch is incremented inside the same `dataStore.updateData {}` transaction as the boolean, so any reader gets a self-consistent pair. `MonitorEventReceiver` and `EventDispatcher` both call `tracker.observeEnabledState(devicesSettings.currentEnabledState())` from the same snapshot they use for event handling, and the tracker compares **epochs** (not booleans) to detect transitions. A different epoch — even with the same boolean — proves a toggle happened and clears the dedup state. The async flow collector is retained as a backstop for toggles that happen with no event in flight.

This approach also persists across process restart: the epoch is in DataStore, so a toggle that crossed an app session is still detectable.

## Test plan

- [x] `./gradlew :app:testFossDebugUnitTest` — 242 unit tests pass (up from 224), including 18 new `VolumeDisconnectModuleTest`, 9 new `VolumeUpdateModuleTest`, and 6 new `EventTypeDedupTrackerTest` cases (covering the epoch-observation API, the collapsed-toggle race, and the backstop collector).
- [x] `./gradlew assembleFossDebug` — clean build.
- [x] **On-device verification on Pixel 8** (phone in VIBRATE ringer mode, AirPods stored `ringVolume=Vibrate`, `notificationVolume=0.28`, `alarmVolume=0.17`):
  - Disconnected via Settings → Bluetooth → Verbindung trennen. Logcat showed every new branch firing:
    - `Skipping RINGTONE, no change` (Vibrate sentinel structurally matches)
    - `Skipping NOTIFICATION, ringer=VIBRATE hardware=0 (preserving stored Normal(percentage=0.28256303))`
    - `Skipping ALARM, no change` (drift-suppressed)
    - `Capturing MUSIC` / `Capturing CALL` for legitimate hardware changes
  - Verified in BlueMusic UI: stored AirPods config unchanged across the disconnect (Klingeln=Vibrate, Benachrichtigung=28%, Alarm=17%).
  - Verified the new sentinel write path on the speaker: a fake-speaker disconnect with phone in vibrate logged `Capturing RINGTONE: Vibrate for Gerätelautsprecher (Pixel 8)`, proving the disconnect path independently persists Silent/Vibrate without depending on `handleRingerMode()`.
  - Toggled BlueMusic monitoring off → on in app settings; logcat showed both epoch transitions clearing the dedup state:
    ```
    Monitoring epoch advanced (0 → 1, enabled=true → false), clearing dedup state
    Monitoring epoch advanced (1 → 2, enabled=false → true), clearing dedup state
    ```

## Known limitation

On non-coupling devices where `STREAM_NOTIFICATION` is independently controllable, a user who deliberately sets notification to 0 while in vibrate/silent ringer mode will not have that 0 captured by save-on-disconnect — the module preserves the previous stored value rather than overwriting it, because we cannot distinguish "Pixel coupling clamp" from "user deliberately muted" on a single hardware read. Documented as an intentional tradeoff against the much worse alternative (destroying real stored values on Pixel devices). Affected users can set notification volume via the app UI or enable `volumeObserving`. Tested by `known limitation - non-coupling user zero in vibrate is not captured` in `VolumeDisconnectModuleTest`.
