### PR TITLE
Fix volume settings being corrupted during quick Bluetooth reconnects

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
@@ -1,7 +1,10 @@
 package eu.darken.bluemusic.devices.ui.config
 
 import android.os.Build
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.ui.Alignment
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
@@ -9,6 +12,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.lazy.LazyColumn
@@ -20,6 +25,7 @@ import androidx.compose.material.icons.automirrored.twotone.Launch
 import androidx.compose.material.icons.twotone.BatteryFull
 import androidx.compose.material.icons.twotone.DoNotDisturb
 import androidx.compose.material.icons.twotone.GraphicEq
+import androidx.compose.material.icons.twotone.Info
 import androidx.compose.material.icons.twotone.Home
 import androidx.compose.material.icons.twotone.Lock
 import androidx.compose.material.icons.twotone.Notifications
@@ -494,6 +500,36 @@ fun DeviceConfigScreen(
                             icon = Icons.TwoTone.PowerOff,
                             onCheckedChange = { onAction(ConfigAction.OnToggleVolumeSaveOnDisconnect) }
                         )
+
+                        AnimatedVisibility(visible = device.volumeSaveOnDisconnect) {
+                            Card(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = 16.dp)
+                                    .padding(bottom = 8.dp),
+                                colors = CardDefaults.cardColors(
+                                    containerColor = MaterialTheme.colorScheme.secondaryContainer
+                                )
+                            ) {
+                                Row(
+                                    modifier = Modifier.padding(12.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.TwoTone.Info,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(20.dp),
+                                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    )
+                                    Spacer(modifier = Modifier.width(8.dp))
+                                    Text(
+                                        text = stringResource(R.string.devices_device_config_volume_save_on_disconnect_hint),
+                                        style = MaterialTheme.typography.bodySmall,
+                                        color = MaterialTheme.colorScheme.onSecondaryContainer,
+                                    )
+                                }
+                            }
+                        }
 
                         SwitchPreference(
                             title = stringResource(R.string.devices_device_config_volume_rate_limiter_label),

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
@@ -29,11 +29,17 @@ fun percentageToLevel(percentage: Float, min: Int, max: Int): Int {
 }
 
 @Singleton
-class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
+class VolumeTool @Inject constructor(
+    private val audioManager: AudioManager,
+) {
+
+    private data class RecentWrite(val volume: Int, val timestamp: Long)
+
+    internal var clock: () -> Long = System::currentTimeMillis
 
     @Volatile private var adjusting = false
     private val lock = Mutex()
-    private val lastUs = ConcurrentHashMap<AudioStream.Id, Int>()
+    private val lastUs = ConcurrentHashMap<AudioStream.Id, RecentWrite>()
 
     fun getCurrentVolume(id: AudioStream.Id): Int {
         return audioManager.getStreamVolume(id.id)
@@ -67,7 +73,10 @@ class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
         log(TAG, VERBOSE) { "setVolume(streamId=$streamId, volume=$volume, flags=$flags)." }
         try {
             adjusting = true
-            lastUs[streamId] = volume
+            val now = clock()
+            val write = RecentWrite(volume, now)
+            lastUs[streamId] = write
+            mirroredPeer(streamId)?.let { lastUs[it] = write }
 
             delay(10)
 
@@ -81,7 +90,15 @@ class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
     }
 
     fun wasUs(id: AudioStream.Id, volume: Int): Boolean {
-        return (lastUs.containsKey(id) && lastUs[id] == volume) || adjusting
+        if (adjusting) return true
+        val entry = lastUs[id] ?: return false
+        return entry.volume == volume && (clock() - entry.timestamp) < WRITE_TTL_MS
+    }
+
+    private fun mirroredPeer(id: AudioStream.Id): AudioStream.Id? = when (id) {
+        AudioStream.Id.STREAM_VOICE_CALL -> AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE
+        AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE -> AudioStream.Id.STREAM_VOICE_CALL
+        else -> null
     }
 
     fun getVolumePercentage(streamId: AudioStream.Id): Float {
@@ -148,7 +165,7 @@ class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
 
         val currentLevel = getCurrentVolume(streamId)
         if (currentLevel == targetLevel) {
-            lastUs[streamId] = targetLevel // Record intent so wasUs() reflects this target
+            lastUs[streamId] = RecentWrite(targetLevel, clock())
             log(TAG, VERBOSE) { "Target volume of $targetLevel already set." }
             return false
         }
@@ -178,5 +195,6 @@ class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
 
     companion object {
         private val TAG = logTag("Audio", "StreamHelper")
+        private const val WRITE_TTL_MS = 500L
     }
 }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
@@ -44,7 +44,18 @@ class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
         return try {
             audioManager.getStreamMinVolume(streamId.id)
         } catch (_: IllegalArgumentException) {
-            0
+            // STREAM_BLUETOOTH_HANDSFREE (type 6) is not a public stream type,
+            // so getStreamMinVolume rejects it. It shares the same audio path as
+            // STREAM_VOICE_CALL, so use that stream's min as a proxy.
+            if (streamId == AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE) {
+                try {
+                    audioManager.getStreamMinVolume(AudioStream.Id.STREAM_VOICE_CALL.id)
+                } catch (_: IllegalArgumentException) {
+                    0
+                }
+            } else {
+                0
+            }
         }
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.monitor.core.audio
 
 import android.media.AudioManager
+import android.os.Build
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.DEBUG
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
@@ -17,6 +18,16 @@ import javax.inject.Singleton
 import kotlin.math.roundToInt
 
 
+fun levelToPercentage(current: Int, min: Int, max: Int): Float {
+    val range = max - min
+    if (range <= 0) return 0f
+    return ((current - min).toFloat() / range).coerceIn(0f, 1f)
+}
+
+fun percentageToLevel(percentage: Float, min: Int, max: Int): Int {
+    return (min + (max - min) * percentage).roundToInt()
+}
+
 @Singleton
 class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
 
@@ -26,6 +37,15 @@ class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
 
     fun getCurrentVolume(id: AudioStream.Id): Int {
         return audioManager.getStreamVolume(id.id)
+    }
+
+    fun getMinVolume(streamId: AudioStream.Id): Int {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) return 0
+        return try {
+            audioManager.getStreamMinVolume(streamId.id)
+        } catch (_: IllegalArgumentException) {
+            0
+        }
     }
 
     fun getMaxVolume(streamId: AudioStream.Id): Int {
@@ -54,33 +74,35 @@ class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
     }
 
     fun getVolumePercentage(streamId: AudioStream.Id): Float {
-        return audioManager.getStreamVolume(streamId.id).toFloat() / audioManager.getStreamMaxVolume(streamId.id)
+        return levelToPercentage(getCurrentVolume(streamId), getMinVolume(streamId), getMaxVolume(streamId))
     }
 
     suspend fun lowerByOne(streamId: AudioStream.Id, visible: Boolean): Boolean {
         val current = getCurrentVolume(streamId)
+        val min = getMinVolume(streamId)
         val max = getMaxVolume(streamId)
-        log(TAG, VERBOSE) { "lowerByOne(streamId=$streamId, visible=$visible): current=$current, max=$max" }
+        log(TAG, VERBOSE) { "lowerByOne(streamId=$streamId, visible=$visible): current=$current, min=$min, max=$max" }
 
-        if (current == 0) {
-            log(TAG, WARN) { "Volume was at 0, can't lower by one more." }
+        if (current <= min) {
+            log(TAG, WARN) { "Volume was at min ($min), can't lower by one more." }
             return false
         }
 
-        return changeVolume(streamId, (current - 1f) / max, visible)
+        return changeVolume(streamId, levelToPercentage(current - 1, min, max), visible)
     }
 
     suspend fun increaseByOne(streamId: AudioStream.Id, visible: Boolean): Boolean {
         val current = getCurrentVolume(streamId)
+        val min = getMinVolume(streamId)
         val max = getMaxVolume(streamId)
-        log(TAG, VERBOSE) { "increaseByOne(streamId=$streamId, visible=$visible): current=$current, max=$max" }
+        log(TAG, VERBOSE) { "increaseByOne(streamId=$streamId, visible=$visible): current=$current, min=$min, max=$max" }
 
-        if (current == max) {
-            log(TAG, WARN) { "Volume was at max, can't increase by one more." }
+        if (current >= max) {
+            log(TAG, WARN) { "Volume was at max ($max), can't increase by one more." }
             return false
         }
 
-        return changeVolume(streamId, (current + 1f) / max, visible)
+        return changeVolume(streamId, levelToPercentage(current + 1, min, max), visible)
     }
 
     suspend fun changeVolume(
@@ -90,8 +112,7 @@ class VolumeTool @Inject constructor(private val audioManager: AudioManager) {
         delay: Duration = Duration.ZERO,
     ): Boolean {
         log(TAG, VERBOSE) { "changeVolume(streamId=$streamId, percent=$percent, visible=$visible, delay=$delay)" }
-        val max = getMaxVolume(streamId)
-        val target = (max * percent).roundToInt()
+        val target = percentageToLevel(percent, getMinVolume(streamId), getMaxVolume(streamId))
         return changeVolume(
             streamId = streamId,
             targetLevel = target,

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/DeviceEvent.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/DeviceEvent.kt
@@ -2,6 +2,7 @@ package eu.darken.bluemusic.monitor.core.modules
 
 import eu.darken.bluemusic.devices.core.DeviceAddr
 import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue.VolumeSnapshot
 
 interface DeviceEvent {
 
@@ -16,5 +17,6 @@ interface DeviceEvent {
 
     data class Disconnected(
         override val device: ManagedDevice,
+        val volumeSnapshot: VolumeSnapshot? = null,
     ) : DeviceEvent
 }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/AlarmVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/AlarmVolumeModule.kt
@@ -9,6 +9,7 @@ import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,7 +17,8 @@ import javax.inject.Singleton
 class AlarmVolumeModule @Inject constructor(
     volumeTool: VolumeTool,
     volumeObserver: VolumeObserver,
-) : BaseVolumeModule(volumeTool, volumeObserver) {
+    observationGate: VolumeObservationGate,
+) : BaseVolumeModule(volumeTool, volumeObserver, observationGate) {
 
     override val type: AudioStream.Type = AudioStream.Type.ALARM
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
@@ -10,6 +10,7 @@ import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeMode.Companion.fromFloat
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import eu.darken.bluemusic.monitor.core.audio.percentageToLevel
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
 import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
 import eu.darken.bluemusic.monitor.core.modules.delayForReactionDelay
@@ -17,7 +18,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.withTimeoutOrNull
-import kotlin.math.roundToInt
 
 abstract class BaseVolumeModule(
     private val volumeTool: VolumeTool,
@@ -112,7 +112,7 @@ abstract class BaseVolumeModule(
 
         val streamId = device.getStreamId(type)
         val targetPercentage = volumeMode.percentage
-        val targetLevel = (targetPercentage * volumeTool.getMaxVolume(streamId)).roundToInt()
+        val targetLevel = percentageToLevel(targetPercentage, volumeTool.getMinVolume(streamId), volumeTool.getMaxVolume(streamId))
 
         log(tag, INFO) { "Monitoring volume (target=$volumeMode, level=$targetLevel) for $device" }
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
@@ -14,6 +14,7 @@ import eu.darken.bluemusic.monitor.core.audio.percentageToLevel
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
 import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
 import eu.darken.bluemusic.monitor.core.modules.delayForReactionDelay
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.takeWhile
@@ -22,6 +23,7 @@ import kotlinx.coroutines.withTimeoutOrNull
 abstract class BaseVolumeModule(
     private val volumeTool: VolumeTool,
     private val volumeObserver: VolumeObserver,
+    private val observationGate: VolumeObservationGate,
 ) : ConnectionModule {
 
     abstract val type: AudioStream.Type
@@ -44,12 +46,17 @@ abstract class BaseVolumeModule(
             return
         }
 
+        val streamId = device.getStreamId(type)
+        observationGate.suppress(streamId)
+        try {
+            delayForReactionDelay(event)
 
-        delayForReactionDelay(event)
+            setInitial(device, volumeMode)
 
-        setInitial(device, volumeMode)
-
-        monitor(device, volumeMode)
+            monitor(device, volumeMode)
+        } finally {
+            observationGate.unsuppress(streamId)
+        }
     }
 
     protected open suspend fun setInitial(device: ManagedDevice, volumeMode: VolumeMode) {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeWithModesModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeWithModesModule.kt
@@ -9,6 +9,7 @@ import eu.darken.bluemusic.monitor.core.audio.RingerTool
 import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.takeWhile
 import kotlinx.coroutines.withTimeoutOrNull
@@ -16,9 +17,10 @@ import kotlinx.coroutines.withTimeoutOrNull
 abstract class BaseVolumeWithModesModule(
     volumeTool: VolumeTool,
     volumeObserver: VolumeObserver,
+    observationGate: VolumeObservationGate,
     private val ringerTool: RingerTool,
     private val ringerModeObserver: RingerModeObserver,
-) : BaseVolumeModule(volumeTool, volumeObserver) {
+) : BaseVolumeModule(volumeTool, volumeObserver, observationGate) {
 
     override suspend fun setInitial(device: ManagedDevice, volumeMode: VolumeMode) {
         log(tag, INFO) { "Setting initial volume/mode ($volumeMode) for $device" }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/CallVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/CallVolumeModule.kt
@@ -9,6 +9,7 @@ import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,7 +17,8 @@ import javax.inject.Singleton
 class CallVolumeModule @Inject constructor(
     volumeTool: VolumeTool,
     volumeObserver: VolumeObserver,
-) : BaseVolumeModule(volumeTool, volumeObserver) {
+    observationGate: VolumeObservationGate,
+) : BaseVolumeModule(volumeTool, volumeObserver, observationGate) {
 
     override val type: AudioStream.Type = AudioStream.Type.CALL
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/MusicVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/MusicVolumeModule.kt
@@ -9,6 +9,7 @@ import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,7 +17,8 @@ import javax.inject.Singleton
 class MusicVolumeModule @Inject constructor(
     volumeTool: VolumeTool,
     volumeObserver: VolumeObserver,
-) : BaseVolumeModule(volumeTool, volumeObserver) {
+    observationGate: VolumeObservationGate,
+) : BaseVolumeModule(volumeTool, volumeObserver, observationGate) {
 
     override val type: AudioStream.Type = AudioStream.Type.MUSIC
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/NotificationVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/NotificationVolumeModule.kt
@@ -11,6 +11,7 @@ import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -18,8 +19,9 @@ import javax.inject.Singleton
 class NotificationVolumeModule @Inject constructor(
     volumeTool: VolumeTool,
     volumeObserver: VolumeObserver,
+    observationGate: VolumeObservationGate,
     private val permissionHelper: PermissionHelper,
-) : BaseVolumeModule(volumeTool, volumeObserver) {
+) : BaseVolumeModule(volumeTool, volumeObserver, observationGate) {
 
     override val type: AudioStream.Type = AudioStream.Type.NOTIFICATION
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/RingVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/RingVolumeModule.kt
@@ -13,6 +13,7 @@ import eu.darken.bluemusic.monitor.core.audio.RingerTool
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -20,10 +21,11 @@ import javax.inject.Singleton
 class RingVolumeModule @Inject constructor(
     volumeTool: VolumeTool,
     volumeObserver: VolumeObserver,
+    observationGate: VolumeObservationGate,
     ringerTool: RingerTool,
     ringerModeObserver: RingerModeObserver,
     private val permissionHelper: PermissionHelper,
-) : BaseVolumeWithModesModule(volumeTool, volumeObserver, ringerTool, ringerModeObserver) {
+) : BaseVolumeWithModesModule(volumeTool, volumeObserver, observationGate, ringerTool, ringerModeObserver) {
 
     override val type: AudioStream.Type = AudioStream.Type.RINGTONE
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
@@ -112,9 +112,18 @@ class VolumeDisconnectModule @Inject constructor(
 
                 val currentMode: VolumeMode? = when (snap.type) {
                     AudioStream.Type.RINGTONE -> when (ringerMode) {
-                        RingerMode.SILENT -> VolumeMode.Silent
-                        RingerMode.VIBRATE -> VolumeMode.Vibrate
+                        // The ringer mode is a system-wide singleton that may
+                        // have been set by a DIFFERENT device's connect modules
+                        // (e.g. AirPods set Silent, then FakeSpeaker disconnects
+                        // — the speaker's save-on-disconnect sees Silent even
+                        // though the speaker's own config says Normal).
+                        //
+                        // Disconnect-save can only reliably capture the volume
+                        // level. Ringer mode sentinels (Silent/Vibrate) should
+                        // come from the BVM UI or volumeObserving, not from
+                        // reading shared system state at disconnect time.
                         RingerMode.NORMAL -> hardwareNormal
+                        else -> null
                     }
 
                     AudioStream.Type.NOTIFICATION -> when (ringerMode) {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
@@ -18,11 +18,12 @@ import eu.darken.bluemusic.monitor.core.audio.RingerMode
 import eu.darken.bluemusic.monitor.core.audio.RingerTool
 import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import eu.darken.bluemusic.monitor.core.audio.levelToPercentage
+import eu.darken.bluemusic.monitor.core.audio.percentageToLevel
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
 import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.math.roundToInt
 
 @Singleton
 class VolumeDisconnectModule @Inject constructor(
@@ -46,6 +47,8 @@ class VolumeDisconnectModule @Inject constructor(
             return
         }
 
+
+
         log(TAG, INFO) { "Saving volumes on disconnect for device ${device.label}" }
 
         // TODO: RingerTool.getCurrentRingerMode() falls back to NORMAL on unknown
@@ -54,17 +57,29 @@ class VolumeDisconnectModule @Inject constructor(
         // RingerTool to expose an unknown/null state if the need arises.
         val ringerMode = ringerTool.getCurrentRingerMode()
 
-        // Phase 1: capture hardware facts only — no DB access yet. Using
-        // event.device (a snapshot) to decide "is this stream configured at all?"
-        // is acceptable because an unset-at-dispatch-time stream cannot
-        // legitimately become set again by the time the disconnect module runs
-        // at priority 1.
+        // Phase 1: use the pre-reroute volume snapshot captured synchronously
+        // in MonitorEventReceiver.onReceive (~2ms after ACL_DISCONNECTED).
+        // Falls back to a live hardware read if no snapshot is available
+        // (e.g. events from FakeSpeakerEventDebouncer or test harnesses).
         val snapshots = AudioStream.Type.entries.mapNotNull { type ->
             if (device.getVolume(type) == null) return@mapNotNull null
 
             val streamId = device.getStreamId(type)
-            val maxLevel = volumeTool.getMaxVolume(streamId)
-            val currentLevel = volumeTool.getCurrentVolume(streamId)
+            val snapshotLevel = event.volumeSnapshot?.levels?.get(streamId)
+            val currentLevel: Int
+            val maxLevel: Int
+            val minLevel: Int
+            if (snapshotLevel != null) {
+                currentLevel = snapshotLevel.current
+                minLevel = snapshotLevel.min
+                maxLevel = snapshotLevel.max
+                log(TAG, VERBOSE) { "$type: using pre-reroute snapshot (level=$currentLevel, min=$minLevel, max=$maxLevel)" }
+            } else {
+                currentLevel = volumeTool.getCurrentVolume(streamId)
+                minLevel = volumeTool.getMinVolume(streamId)
+                maxLevel = volumeTool.getMaxVolume(streamId)
+                log(TAG, VERBOSE) { "$type: no snapshot, falling back to hardware read (level=$currentLevel, min=$minLevel, max=$maxLevel)" }
+            }
             if (maxLevel <= 0 || currentLevel !in 0..maxLevel) {
                 log(TAG, WARN) {
                     "Skipping $type, bad hardware read (level=$currentLevel max=$maxLevel)"
@@ -72,7 +87,7 @@ class VolumeDisconnectModule @Inject constructor(
                 return@mapNotNull null
             }
 
-            Snapshot(type, currentLevel, maxLevel)
+            Snapshot(type, currentLevel, minLevel, maxLevel)
         }
 
         if (snapshots.isEmpty()) {
@@ -91,18 +106,12 @@ class VolumeDisconnectModule @Inject constructor(
                 val rawStored = oldConfig.getVolume(snap.type) ?: continue
                 val savedMode = VolumeMode.fromFloat(rawStored)
 
-                val percent = (snap.currentLevel.toFloat() / snap.maxLevel).coerceIn(0f, 1f)
-                val hardwareNormal = VolumeMode.Normal(percent)
+                val hardwareNormal = VolumeMode.Normal(
+                    levelToPercentage(snap.currentLevel, snap.minLevel, snap.maxLevel)
+                )
 
                 val currentMode: VolumeMode? = when (snap.type) {
                     AudioStream.Type.RINGTONE -> when (ringerMode) {
-                        // RINGTONE has first-class Silent/Vibrate sentinels;
-                        // we own the persistence path together with
-                        // MonitorService.handleRingerMode(). Both writers agree
-                        // on the sentinel value for a given ringer state, so
-                        // dual-writing is safe and closes the race where
-                        // handleRingerMode() bails out (no active device) before
-                        // our disconnect save runs.
                         RingerMode.SILENT -> VolumeMode.Silent
                         RingerMode.VIBRATE -> VolumeMode.Vibrate
                         RingerMode.NORMAL -> hardwareNormal
@@ -158,7 +167,7 @@ class VolumeDisconnectModule @Inject constructor(
                     // rewrite a higher-precision stored float with the
                     // discrete level/max ratio on every disconnect cycle.
                     savedMode is VolumeMode.Normal && currentMode is VolumeMode.Normal -> {
-                        val savedLevel = (savedMode.percentage * snap.maxLevel).roundToInt()
+                        val savedLevel = percentageToLevel(savedMode.percentage, snap.minLevel, snap.maxLevel)
                         savedLevel != snap.currentLevel
                     }
                     // Structural equality on Silent/Vibrate (data objects).
@@ -189,6 +198,7 @@ class VolumeDisconnectModule @Inject constructor(
     private data class Snapshot(
         val type: AudioStream.Type,
         val currentLevel: Int,
+        val minLevel: Int,
         val maxLevel: Int,
     )
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeObservationGate.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeObservationGate.kt
@@ -1,0 +1,47 @@
+package eu.darken.bluemusic.monitor.core.modules.volume
+
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import java.util.concurrent.ConcurrentHashMap
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Tracks which audio streams are currently being adjusted by connection volume modules.
+ *
+ * When a [BaseVolumeModule] is ramping a stream (setInitial + monitor), it suppresses
+ * observation for that stream and its mirrored peer (VOICE_CALL ↔ BLUETOOTH_HANDSFREE).
+ * [VolumeUpdateModule] checks this gate before persisting observed volume changes,
+ * preventing cross-device contamination during device transitions.
+ */
+@Singleton
+class VolumeObservationGate @Inject constructor() {
+
+    private val suppressed = ConcurrentHashMap.newKeySet<AudioStream.Id>()
+
+    fun suppress(streamId: AudioStream.Id) {
+        suppressed.add(streamId)
+        mirroredPeer(streamId)?.let { suppressed.add(it) }
+        log(TAG, VERBOSE) { "Suppressed observation for $streamId (suppressed=$suppressed)" }
+    }
+
+    fun unsuppress(streamId: AudioStream.Id) {
+        suppressed.remove(streamId)
+        mirroredPeer(streamId)?.let { suppressed.remove(it) }
+        log(TAG, VERBOSE) { "Unsuppressed observation for $streamId (suppressed=$suppressed)" }
+    }
+
+    fun isSuppressed(streamId: AudioStream.Id): Boolean = streamId in suppressed
+
+    private fun mirroredPeer(id: AudioStream.Id): AudioStream.Id? = when (id) {
+        AudioStream.Id.STREAM_VOICE_CALL -> AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE
+        AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE -> AudioStream.Id.STREAM_VOICE_CALL
+        else -> null
+    }
+
+    companion object {
+        private val TAG = logTag("Monitor", "Volume", "ObservationGate")
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
@@ -30,6 +30,7 @@ class VolumeUpdateModule @Inject constructor(
     private val volumeTool: VolumeTool,
     private val ringerTool: RingerTool,
     private val deviceRepo: DeviceRepo,
+    private val observationGate: VolumeObservationGate,
 ) : VolumeModule {
 
     override val tag: String
@@ -42,9 +43,14 @@ class VolumeUpdateModule @Inject constructor(
         if (volumeTool.wasUs(id, volume)) {
             log(TAG, VERBOSE) { "Volume change was triggered by us, ignoring it." }
             return
-        } else {
-            log(TAG, DEBUG) { "Volume change $event" }
         }
+
+        if (observationGate.isSuppressed(id)) {
+            log(TAG, VERBOSE) { "Observation suppressed for $id, skipping persist" }
+            return
+        }
+
+        log(TAG, DEBUG) { "Volume change $event" }
 
         val allActive = deviceRepo.currentDevices().filter { it.isActive }
         log(TAG, VERBOSE) { "Active devices (${allActive.size}): $allActive" }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
@@ -46,70 +46,87 @@ class VolumeUpdateModule @Inject constructor(
             log(TAG, DEBUG) { "Volume change $event" }
         }
 
-        val activeDevices = deviceRepo.currentDevices().filter { it.isActive }
-        log(TAG, VERBOSE) { "Active devices (${activeDevices.size}): $activeDevices" }
+        val allActive = deviceRepo.currentDevices().filter { it.isActive }
+        log(TAG, VERBOSE) { "Active devices (${allActive.size}): $allActive" }
+
+        val candidates = allActive.filter { dev ->
+            if (!dev.volumeObserving || dev.volumeLock) return@filter false
+            val streamType = dev.getStreamType(id) ?: return@filter false
+            dev.getVolume(streamType) != null
+        }
+
+        val now = Instant.now()
+        val stabilizing = candidates.filter {
+            Duration.between(it.lastConnected, now) <= it.actionDelay + it.monitoringDuration
+        }
+        val stable = candidates.filter {
+            Duration.between(it.lastConnected, now) > it.actionDelay + it.monitoringDuration
+        }
+
+        if (stabilizing.isNotEmpty() && stable.isNotEmpty()) {
+            log(TAG, VERBOSE) {
+                "Stream candidate in post-connect window alongside stable sibling; " +
+                    "skipping persist for $id to avoid cross-device contamination"
+            }
+            return
+        }
 
         val ringerMode = ringerTool.getCurrentRingerMode()
         val percentage = volumeTool.getVolumePercentage(id).coerceIn(0f, 1f)
 
-        val now = Instant.now()
-        activeDevices
-            .filter { Duration.between(it.lastConnected, now) > it.actionDelay }
-            .filter { it.volumeObserving && !it.volumeLock }
-            .forEach { dev ->
-                val streamType = dev.getStreamType(id) ?: return@forEach
-                if (dev.getVolume(streamType) == null) return@forEach
+        stable.forEach { dev ->
+            val streamType = dev.getStreamType(id)!!
 
-                // Map the raw hardware reading to a VolumeMode that accounts
-                // for the current ringer mode on streams that have sentinel
-                // states (RINGTONE) or unreliable hardware reads in
-                // vibrate/silent (NOTIFICATION).
-                //
-                // Without this, a user flipping the phone to vibrate
-                // mid-session would trigger STREAM_RING → 0 observations that
-                // overwrite the stored Vibrate sentinel (or a legitimate
-                // Normal value) with `Normal(0)`, racing against
-                // MonitorService.handleRingerMode() and losing non-deterministically.
-                val mode: VolumeMode? = when (streamType) {
-                    AudioStream.Type.RINGTONE -> when (ringerMode) {
-                        // RINGTONE owns first-class Silent/Vibrate sentinels.
-                        // Both this path and handleRingerMode() are allowed to
-                        // write them; they always agree on the sentinel value,
-                        // so last-writer-wins is safe.
-                        RingerMode.SILENT -> VolumeMode.Silent
-                        RingerMode.VIBRATE -> VolumeMode.Vibrate
-                        RingerMode.NORMAL -> VolumeMode.Normal(percentage)
-                    }
-
-                    AudioStream.Type.NOTIFICATION -> when (ringerMode) {
-                        RingerMode.NORMAL -> VolumeMode.Normal(percentage)
-                        else -> {
-                            // Same heuristic as VolumeDisconnectModule: in
-                            // non-Normal ringer mode, a 0 reading could be
-                            // either a Pixel-style platform clamp or an
-                            // intentional user mute on a non-coupling device.
-                            // Capture non-zero readings (clearly user intent)
-                            // and preserve stored on 0-readings (safer default
-                            // for the coupling case).
-                            if (event.newVolume > 0) VolumeMode.Normal(percentage) else null
-                        }
-                    }
-
-                    else -> VolumeMode.Normal(percentage)
+            // Map the raw hardware reading to a VolumeMode that accounts
+            // for the current ringer mode on streams that have sentinel
+            // states (RINGTONE) or unreliable hardware reads in
+            // vibrate/silent (NOTIFICATION).
+            //
+            // Without this, a user flipping the phone to vibrate
+            // mid-session would trigger STREAM_RING → 0 observations that
+            // overwrite the stored Vibrate sentinel (or a legitimate
+            // Normal value) with `Normal(0)`, racing against
+            // MonitorService.handleRingerMode() and losing non-deterministically.
+            val mode: VolumeMode? = when (streamType) {
+                AudioStream.Type.RINGTONE -> when (ringerMode) {
+                    // RINGTONE owns first-class Silent/Vibrate sentinels.
+                    // Both this path and handleRingerMode() are allowed to
+                    // write them; they always agree on the sentinel value,
+                    // so last-writer-wins is safe.
+                    RingerMode.SILENT -> VolumeMode.Silent
+                    RingerMode.VIBRATE -> VolumeMode.Vibrate
+                    RingerMode.NORMAL -> VolumeMode.Normal(percentage)
                 }
 
-                if (mode == null) {
-                    log(TAG, VERBOSE) {
-                        "Skipping $streamType update for $dev, ringer=$ringerMode hardware=0"
+                AudioStream.Type.NOTIFICATION -> when (ringerMode) {
+                    RingerMode.NORMAL -> VolumeMode.Normal(percentage)
+                    else -> {
+                        // Same heuristic as VolumeDisconnectModule: in
+                        // non-Normal ringer mode, a 0 reading could be
+                        // either a Pixel-style platform clamp or an
+                        // intentional user mute on a non-coupling device.
+                        // Capture non-zero readings (clearly user intent)
+                        // and preserve stored on 0-readings (safer default
+                        // for the coupling case).
+                        if (event.newVolume > 0) VolumeMode.Normal(percentage) else null
                     }
-                    return@forEach
                 }
 
-                log(TAG, INFO) { "Saving new volume ($mode@$id) for $dev" }
-                deviceRepo.updateDevice(dev.address) { oldConfig ->
-                    oldConfig.updateVolume(streamType, mode)
-                }
+                else -> VolumeMode.Normal(percentage)
             }
+
+            if (mode == null) {
+                log(TAG, VERBOSE) {
+                    "Skipping $streamType update for $dev, ringer=$ringerMode hardware=0"
+                }
+                return@forEach
+            }
+
+            log(TAG, INFO) { "Saving new volume ($mode@$id) for $dev" }
+            deviceRepo.updateDevice(dev.address) { oldConfig ->
+                oldConfig.updateVolume(streamType, mode)
+            }
+        }
     }
 
     @Module @InstallIn(SingletonComponent::class)

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
@@ -22,6 +22,7 @@ import eu.darken.bluemusic.devices.core.DeviceRepo
 import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.devices.core.currentDevices
 import eu.darken.bluemusic.devices.core.getDevice
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue
 import eu.darken.bluemusic.monitor.core.service.EventTypeDedupTracker
@@ -61,6 +62,22 @@ class MonitorEventReceiver : BroadcastReceiver() {
             return
         }
 
+        // Capture volume snapshot synchronously before any async processing.
+        // At this point (~2ms after broadcast), audio routing hasn't changed
+        // yet. By the time the coroutine runs (~80ms+), Android will have
+        // rerouted and getStreamVolume() returns the new device's values.
+        // Needed for both DISCONNECTED (real device save-on-disconnect) and
+        // CONNECTED (the synthetic FakeSpeaker DISCONNECTED side effect).
+        val volumeSnapshot = BluetoothEventQueue.VolumeSnapshot(
+            levels = AudioStream.Id.entries.associateWith { id ->
+                BluetoothEventQueue.VolumeSnapshot.Level(
+                    current = volumeTool.getCurrentVolume(id),
+                    min = volumeTool.getMinVolume(id),
+                    max = volumeTool.getMaxVolume(id),
+                )
+            }
+        )
+
         val pendingResult = goAsync()
 
         appScope.launch {
@@ -85,7 +102,7 @@ class MonitorEventReceiver : BroadcastReceiver() {
                 }
 
                 monitorControl.startMonitor()
-                handleEvent(intent)
+                handleEvent(intent, volumeSnapshot)
             } catch (e: Exception) {
                 log(TAG, ERROR) { "Error handling bluetooth event: ${e.asLog()}" }
             } finally {
@@ -95,7 +112,7 @@ class MonitorEventReceiver : BroadcastReceiver() {
     }
 
     @SuppressLint("MissingPermission")
-    private suspend fun handleEvent(intent: Intent) {
+    private suspend fun handleEvent(intent: Intent, volumeSnapshot: BluetoothEventQueue.VolumeSnapshot?) {
         val bluetoothDevice = intent.getParcelableExtra<BluetoothDevice>(BluetoothDevice.EXTRA_DEVICE)
         if (bluetoothDevice == null) {
             log(TAG, WARN) { "Intent didn't contain a bluetooth device!" }
@@ -139,7 +156,8 @@ class MonitorEventReceiver : BroadcastReceiver() {
             sourceDevice = SourceDeviceWrapper.from(
                 realDevice = bluetoothDevice,
                 isConnected = eventType == BluetoothEventQueue.Event.Type.CONNECTED
-            )
+            ),
+            volumeSnapshot = volumeSnapshot,
         )
 
         val speakerAddress = speakerDeviceProvider.address
@@ -161,6 +179,7 @@ class MonitorEventReceiver : BroadcastReceiver() {
                     sourceDevice = speakerDeviceProvider.getSpeaker(
                         isConnected = eventType == BluetoothEventQueue.Event.Type.DISCONNECTED
                     ),
+                    volumeSnapshot = volumeSnapshot,
                 )
             }
         } else {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/BluetoothEventQueue.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/BluetoothEventQueue.kt
@@ -1,12 +1,11 @@
 package eu.darken.bluemusic.monitor.core.service
 
-import android.os.Parcelable
 import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
-import kotlinx.parcelize.Parcelize
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -22,16 +21,20 @@ class BluetoothEventQueue @Inject constructor() {
         _events.send(event)
     }
 
-    @Parcelize
     data class Event(
         val type: Type,
         val sourceDevice: SourceDevice,
-    ) : Parcelable {
+        val volumeSnapshot: VolumeSnapshot? = null,
+    ) {
         enum class Type {
             CONNECTED,
             DISCONNECTED,
             ;
         }
+    }
+
+    data class VolumeSnapshot(val levels: Map<AudioStream.Id, Level>) {
+        data class Level(val current: Int, val min: Int, val max: Int)
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
@@ -67,7 +67,10 @@ class EventDispatcher @Inject constructor(
 
         val deviceEvent = when (bluetoothEvent.type) {
             BluetoothEventQueue.Event.Type.CONNECTED -> DeviceEvent.Connected(managedDevice)
-            BluetoothEventQueue.Event.Type.DISCONNECTED -> DeviceEvent.Disconnected(managedDevice)
+            BluetoothEventQueue.Event.Type.DISCONNECTED -> DeviceEvent.Disconnected(
+                device = managedDevice,
+                volumeSnapshot = bluetoothEvent.volumeSnapshot,
+            )
         }
 
         // TODO make this a module?

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="devices_device_config_volume_observe_desc">Stay active while this device is connected and save volume changes that have not been caused by this app.</string>
     <string name="devices_device_config_volume_save_on_disconnect_label">Save volume on disconnect</string>
     <string name="devices_device_config_volume_save_on_disconnect_desc">Capture and save the current volume levels when this device disconnects.</string>
+    <string name="devices_device_config_volume_save_on_disconnect_hint">On some devices, the system switches audio routing before we can read the volumes. If the saved values don\'t match what you had set, try enabling \"Observe volume changes\" instead.</string>
     <string name="devices_device_config_volume_lock_label">Volume lock</string>
     <string name="devices_device_config_volume_lock_desc">Any volume changes not made through this app will be reverted while this device is connected.</string>
     <string name="devices_device_config_volume_rate_limiter_label">Volume rate limiter</string>

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeConversionTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeConversionTest.kt
@@ -1,0 +1,106 @@
+package eu.darken.bluemusic.monitor.core.audio
+
+import io.kotest.matchers.floats.shouldBeWithinPercentageOf
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class VolumeConversionTest : BaseTest() {
+
+    @Test
+    fun `levelToPercentage at min returns 0`() {
+        levelToPercentage(current = 0, min = 0, max = 15) shouldBe 0f
+    }
+
+    @Test
+    fun `levelToPercentage at max returns 1`() {
+        levelToPercentage(current = 15, min = 0, max = 15) shouldBe 1f
+    }
+
+    @Test
+    fun `levelToPercentage mid range`() {
+        levelToPercentage(current = 8, min = 0, max = 15).shouldBeWithinPercentageOf(0.533f, 1.0)
+    }
+
+    @Test
+    fun `levelToPercentage with non-zero min at min returns 0`() {
+        levelToPercentage(current = 1, min = 1, max = 15) shouldBe 0f
+    }
+
+    @Test
+    fun `levelToPercentage with non-zero min at max returns 1`() {
+        levelToPercentage(current = 15, min = 1, max = 15) shouldBe 1f
+    }
+
+    @Test
+    fun `levelToPercentage below min clamps to 0`() {
+        levelToPercentage(current = 0, min = 1, max = 15) shouldBe 0f
+    }
+
+    @Test
+    fun `levelToPercentage above max clamps to 1`() {
+        levelToPercentage(current = 20, min = 0, max = 15) shouldBe 1f
+    }
+
+    @Test
+    fun `levelToPercentage zero range returns 0`() {
+        levelToPercentage(current = 5, min = 5, max = 5) shouldBe 0f
+    }
+
+    @Test
+    fun `levelToPercentage negative range returns 0`() {
+        levelToPercentage(current = 5, min = 10, max = 5) shouldBe 0f
+    }
+
+    @Test
+    fun `percentageToLevel 0 percent returns min`() {
+        percentageToLevel(percentage = 0f, min = 0, max = 15) shouldBe 0
+    }
+
+    @Test
+    fun `percentageToLevel 100 percent returns max`() {
+        percentageToLevel(percentage = 1f, min = 0, max = 15) shouldBe 15
+    }
+
+    @Test
+    fun `percentageToLevel 50 percent rounds correctly`() {
+        percentageToLevel(percentage = 0.5f, min = 0, max = 15) shouldBe 8
+    }
+
+    @Test
+    fun `percentageToLevel 0 percent with non-zero min returns min`() {
+        percentageToLevel(percentage = 0f, min = 1, max = 15) shouldBe 1
+    }
+
+    @Test
+    fun `percentageToLevel 50 percent with non-zero min`() {
+        percentageToLevel(percentage = 0.5f, min = 1, max = 15) shouldBe 8
+    }
+
+    @Test
+    fun `percentageToLevel 100 percent with non-zero min returns max`() {
+        percentageToLevel(percentage = 1f, min = 1, max = 15) shouldBe 15
+    }
+
+    @Test
+    fun `roundtrip preserves all levels in range`() {
+        val min = 1
+        val max = 15
+        for (level in min..max) {
+            val percent = levelToPercentage(level, min, max)
+            val restored = percentageToLevel(percent, min, max)
+            restored shouldBe level
+        }
+    }
+
+    @Test
+    fun `roundtrip preserves all levels with zero min`() {
+        val min = 0
+        val max = 15
+        for (level in min..max) {
+            val percent = levelToPercentage(level, min, max)
+            val restored = percentageToLevel(percent, min, max)
+            restored shouldBe level
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
@@ -1,0 +1,114 @@
+package eu.darken.bluemusic.monitor.core.audio
+
+import android.media.AudioManager
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class VolumeToolTest : BaseTest() {
+
+    private lateinit var audioManager: AudioManager
+    private lateinit var volumeTool: VolumeTool
+    private var fakeTime = 0L
+
+    @BeforeEach
+    fun setup() {
+        fakeTime = 1000L
+        audioManager = mockk(relaxed = true)
+        every { audioManager.getStreamMaxVolume(any()) } returns 15
+        every { audioManager.getStreamVolume(any()) } returns 0
+
+        volumeTool = VolumeTool(audioManager).apply {
+            clock = { fakeTime }
+        }
+    }
+
+    @Nested
+    inner class MirroredPeer {
+        @Test
+        fun `VOICE_CALL write marks BLUETOOTH_HANDSFREE as us`() = runTest {
+            volumeTool.changeVolume(AudioStream.Id.STREAM_VOICE_CALL, targetLevel = 10)
+
+            volumeTool.wasUs(AudioStream.Id.STREAM_VOICE_CALL, 10) shouldBe true
+            volumeTool.wasUs(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE, 10) shouldBe true
+        }
+
+        @Test
+        fun `BLUETOOTH_HANDSFREE write marks VOICE_CALL as us`() = runTest {
+            volumeTool.changeVolume(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE, targetLevel = 7)
+
+            volumeTool.wasUs(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE, 7) shouldBe true
+            volumeTool.wasUs(AudioStream.Id.STREAM_VOICE_CALL, 7) shouldBe true
+        }
+
+        @Test
+        fun `MUSIC write does not mirror to other streams`() = runTest {
+            volumeTool.changeVolume(AudioStream.Id.STREAM_MUSIC, targetLevel = 12)
+
+            volumeTool.wasUs(AudioStream.Id.STREAM_MUSIC, 12) shouldBe true
+            volumeTool.wasUs(AudioStream.Id.STREAM_VOICE_CALL, 12) shouldBe false
+            volumeTool.wasUs(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE, 12) shouldBe false
+            volumeTool.wasUs(AudioStream.Id.STREAM_ALARM, 12) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class WriteExpiry {
+        @Test
+        fun `wasUs returns true within TTL`() = runTest {
+            volumeTool.changeVolume(AudioStream.Id.STREAM_MUSIC, targetLevel = 5)
+
+            fakeTime += 400 // 400ms < 500ms TTL
+            volumeTool.wasUs(AudioStream.Id.STREAM_MUSIC, 5) shouldBe true
+        }
+
+        @Test
+        fun `wasUs returns false after TTL expires`() = runTest {
+            volumeTool.changeVolume(AudioStream.Id.STREAM_MUSIC, targetLevel = 5)
+
+            fakeTime += 600 // 600ms > 500ms TTL
+            volumeTool.wasUs(AudioStream.Id.STREAM_MUSIC, 5) shouldBe false
+        }
+
+        @Test
+        fun `mirrored entry also expires`() = runTest {
+            volumeTool.changeVolume(AudioStream.Id.STREAM_VOICE_CALL, targetLevel = 8)
+
+            fakeTime += 600
+            volumeTool.wasUs(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE, 8) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class AlreadyAtTarget {
+        @Test
+        fun `already at target records direct stream only, not mirror`() = runTest {
+            every { audioManager.getStreamVolume(AudioStream.Id.STREAM_VOICE_CALL.id) } returns 10
+
+            volumeTool.changeVolume(AudioStream.Id.STREAM_VOICE_CALL, targetLevel = 10)
+
+            volumeTool.wasUs(AudioStream.Id.STREAM_VOICE_CALL, 10) shouldBe true
+            volumeTool.wasUs(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE, 10) shouldBe false
+        }
+    }
+
+    @Nested
+    inner class WasUsBasics {
+        @Test
+        fun `wasUs returns false for unknown stream`() {
+            volumeTool.wasUs(AudioStream.Id.STREAM_MUSIC, 5) shouldBe false
+        }
+
+        @Test
+        fun `wasUs returns false when volume does not match`() = runTest {
+            volumeTool.changeVolume(AudioStream.Id.STREAM_MUSIC, targetLevel = 5)
+
+            volumeTool.wasUs(AudioStream.Id.STREAM_MUSIC, 3) shouldBe false
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModuleTest.kt
@@ -7,6 +7,7 @@ import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -35,13 +36,15 @@ class BaseVolumeModuleTest : BaseTest() {
     private lateinit var volumeTool: VolumeTool
     private lateinit var volumeEvents: MutableSharedFlow<VolumeEvent>
     private lateinit var volumeObserver: VolumeObserver
+    private lateinit var observationGate: VolumeObservationGate
     private lateinit var device: ManagedDevice
     private lateinit var module: TestVolumeModule
 
     private class TestVolumeModule(
         volumeTool: VolumeTool,
         volumeObserver: VolumeObserver,
-    ) : BaseVolumeModule(volumeTool, volumeObserver) {
+        observationGate: VolumeObservationGate,
+    ) : BaseVolumeModule(volumeTool, volumeObserver, observationGate) {
         override val type = AudioStream.Type.MUSIC
         override val priority = 10
 
@@ -57,8 +60,9 @@ class BaseVolumeModuleTest : BaseTest() {
         volumeObserver = mockk<VolumeObserver>().also {
             every { it.volumes } returns volumeEvents
         }
+        observationGate = VolumeObservationGate()
         device = mockk(relaxed = true)
-        module = TestVolumeModule(volumeTool, volumeObserver)
+        module = TestVolumeModule(volumeTool, volumeObserver, observationGate)
 
         every { device.getStreamId(AudioStream.Type.MUSIC) } returns streamId
         every { device.monitoringDuration } returns Duration.ofSeconds(4)

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
@@ -185,10 +185,14 @@ class VolumeDisconnectModuleTest : BaseTest() {
     }
 
     // ------------------------------------------------------------------------
-    // 6. Ringer VIBRATE, stored Normal(0.48) ringtone → writes Vibrate sentinel
+    // 6. Ringer VIBRATE, stored Normal(0.48) ringtone → preserves stored value
+    //    (ringer mode is system-wide and may have been set by another device's
+    //     connect modules — disconnect-save can't distinguish that from a user
+    //     change, so it preserves the DB value and lets BVM UI or
+    //     volumeObserving handle ringer mode persistence)
     // ------------------------------------------------------------------------
     @Test
-    fun `vibrate ringer with stored normal ringtone writes vibrate sentinel`() = runTest {
+    fun `vibrate ringer with stored normal ringtone preserves stored value`() = runTest {
         val module = createModule()
         val cfg = config(ringVolume = 0.48f)
         val device = managedDevice(cfg)
@@ -198,7 +202,7 @@ class VolumeDisconnectModuleTest : BaseTest() {
 
         val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
 
-        result.ringVolume shouldBe VolumeMode.LEGACY_VIBRATE_VALUE
+        result.ringVolume shouldBe 0.48f
     }
 
     // ------------------------------------------------------------------------
@@ -303,10 +307,11 @@ class VolumeDisconnectModuleTest : BaseTest() {
     }
 
     // ------------------------------------------------------------------------
-    // 10. Ringer SILENT, stored Normal ringtone → writes Silent sentinel
+    // 10. Ringer SILENT, stored Normal ringtone → preserves stored value
+    //     (ringer mode is system-wide shared state, not per-device)
     // ------------------------------------------------------------------------
     @Test
-    fun `silent ringer with stored normal ringtone writes silent sentinel`() = runTest {
+    fun `silent ringer with stored normal ringtone preserves stored value`() = runTest {
         val module = createModule()
         val cfg = config(ringVolume = 0.5f)
         val device = managedDevice(cfg)
@@ -316,7 +321,7 @@ class VolumeDisconnectModuleTest : BaseTest() {
 
         val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
 
-        result.ringVolume shouldBe VolumeMode.LEGACY_SILENT_VALUE
+        result.ringVolume shouldBe 0.5f
     }
 
     // ------------------------------------------------------------------------

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
@@ -186,8 +186,6 @@ class VolumeDisconnectModuleTest : BaseTest() {
 
     // ------------------------------------------------------------------------
     // 6. Ringer VIBRATE, stored Normal(0.48) ringtone → writes Vibrate sentinel
-    //    (closes the race where handleRingerMode() bails out before disconnect
-    //     runs because the device is no longer active)
     // ------------------------------------------------------------------------
     @Test
     fun `vibrate ringer with stored normal ringtone writes vibrate sentinel`() = runTest {
@@ -200,7 +198,6 @@ class VolumeDisconnectModuleTest : BaseTest() {
 
         val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
 
-        // Stored Normal → current Vibrate → mode change → write sentinel.
         result.ringVolume shouldBe VolumeMode.LEGACY_VIBRATE_VALUE
     }
 

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModuleTest.kt
@@ -31,6 +31,7 @@ class VolumeUpdateModuleTest : BaseTest() {
     private lateinit var volumeTool: VolumeTool
     private lateinit var ringerTool: RingerTool
     private lateinit var deviceRepo: DeviceRepo
+    private lateinit var observationGate: VolumeObservationGate
     private lateinit var sourceDevice: SourceDevice
     private lateinit var devicesFlow: MutableStateFlow<List<ManagedDevice>>
 
@@ -39,6 +40,7 @@ class VolumeUpdateModuleTest : BaseTest() {
         volumeTool = mockk(relaxed = true)
         ringerTool = mockk(relaxed = true)
         deviceRepo = mockk(relaxed = true)
+        observationGate = VolumeObservationGate()
         devicesFlow = MutableStateFlow(emptyList())
         every { deviceRepo.devices } returns devicesFlow
         coEvery { deviceRepo.updateDevice(any(), any()) } just Runs
@@ -59,6 +61,7 @@ class VolumeUpdateModuleTest : BaseTest() {
         volumeTool = volumeTool,
         ringerTool = ringerTool,
         deviceRepo = deviceRepo,
+        observationGate = observationGate,
     )
 
     private fun config(
@@ -116,6 +119,61 @@ class VolumeUpdateModuleTest : BaseTest() {
 
         module.handle(
             VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 11, self = false)
+        )
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    // ------------------------------------------------------------------------
+    // observation gate — volume changes for suppressed streams are not persisted
+    // ------------------------------------------------------------------------
+    @Test
+    fun `volume changes for suppressed streams are not persisted`() = runTest {
+        val module = createModule()
+        val cfg = config(musicVolume = 0.5f)
+        seedActive(managedDevice(cfg))
+
+        every { volumeTool.wasUs(any(), any()) } returns false
+        observationGate.suppress(AudioStream.Id.STREAM_MUSIC)
+
+        module.handle(
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 11, self = false)
+        )
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    @Test
+    fun `volume changes for unsuppressed streams are persisted`() = runTest {
+        val module = createModule()
+        val cfg = config(musicVolume = 0.5f)
+        seedActive(managedDevice(cfg))
+
+        every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+        every { volumeTool.getVolumePercentage(AudioStream.Id.STREAM_MUSIC) } returns 0.44f
+        every { volumeTool.wasUs(any(), any()) } returns false
+
+        observationGate.suppress(AudioStream.Id.STREAM_MUSIC)
+        observationGate.unsuppress(AudioStream.Id.STREAM_MUSIC)
+
+        module.handle(
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 11, self = false)
+        )
+
+        coVerify(exactly = 1) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    @Test
+    fun `mirrored stream suppression blocks BLUETOOTH_HANDSFREE when VOICE_CALL is suppressed`() = runTest {
+        val module = createModule()
+        val cfg = config(callVolume = 1.0f)
+        seedActive(managedDevice(cfg))
+
+        every { volumeTool.wasUs(any(), any()) } returns false
+        observationGate.suppress(AudioStream.Id.STREAM_VOICE_CALL)
+
+        module.handle(
+            VolumeEvent(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE, oldVolume = 15, newVolume = 11, self = false)
         )
 
         coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }


### PR DESCRIPTION
## Summary

- Fix saved volume levels (especially call volume) being silently overwritten when a Bluetooth device briefly disconnects and reconnects while volume adjustments are still in progress
- Add per-stream observation gating so volume changes caused by device transitions don't leak into the wrong device's saved config
- Improve volume write tracking with mirrored stream awareness (VOICE_CALL ↔ BLUETOOTH_HANDSFREE) and time-bounded expiry
- Add warning hint for the save-on-disconnect toggle explaining its experimental nature

## Test plan

- [ ] Connect a BT device (all volumes at max) with fake speaker enabled (all volumes at 0%)
- [ ] Rapidly disconnect and reconnect the BT device multiple times
- [ ] Verify call volume on the BT device stays at max (not contaminated by fake speaker ramp-down)
- [ ] Verify that after volumes stabilize, manually changing volume on the BT device still gets saved correctly
- [ ] Run `./gradlew testFossDebugUnitTest` — 284 tests pass
