### PR TITLE
Fix volume slider touching percentage pill in mode controls

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/device/VolumeControlWithModes.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/device/VolumeControlWithModes.kt
@@ -202,6 +202,8 @@ fun VolumeControlWithModes(
                 }
             }
 
+            Spacer(modifier = Modifier.width(8.dp))
+
             val isNormal = volumeMode is VolumeMode.Normal
             val canTap = isNormal && !isLocked
             Text(


### PR DESCRIPTION
## Summary
- Add missing 8dp spacer between the volume slider and the percentage info pill in `VolumeControlWithModes`
- Matches the existing spacing already present in the regular `VolumeControl` composable
- Previously at 100% the slider thumb would visually touch the text pill with no gap