### PR TITLE
Extract shared ringtone volume mode handling

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
@@ -20,10 +20,8 @@ import eu.darken.bluemusic.devices.core.getDevice
 import eu.darken.bluemusic.devices.core.updateVolume
 import eu.darken.bluemusic.main.core.GeneralSettings
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
-import eu.darken.bluemusic.monitor.core.audio.RingerMode
-import eu.darken.bluemusic.monitor.core.audio.RingerTool
 import eu.darken.bluemusic.monitor.core.audio.VolumeMode
-import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import eu.darken.bluemusic.monitor.core.audio.VolumeModeTool
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.combine
@@ -36,8 +34,7 @@ import javax.inject.Inject
 class DashboardViewModel @Inject constructor(
     private val permissionHelper: PermissionHelper,
     private val deviceRepo: DeviceRepo,
-    private val volumeTool: VolumeTool,
-    private val ringerTool: RingerTool,
+    private val volumeModeTool: VolumeModeTool,
     upgradeRepo: UpgradeRepo,
     bluetoothSource: BluetoothRepo,
     private val generalSettings: GeneralSettings,
@@ -205,27 +202,12 @@ class DashboardViewModel @Inject constructor(
                 val device = deviceRepo.getDevice(action.addr)
                 if (device?.isActive != true) return@launch
 
-                when (action.volumeMode) {
-                    is VolumeMode.Normal -> {
-                        volumeTool.changeVolume(
-                            streamId = device.getStreamId(action.type),
-                            percent = action.volumeMode.percentage,
-                            visible = device.visibleAdjustments,
-                        )
-                    }
-
-                    is VolumeMode.Silent -> {
-                        if (action.type == AudioStream.Type.RINGTONE) {
-                            ringerTool.setRingerMode(RingerMode.SILENT)
-                        }
-                    }
-
-                    is VolumeMode.Vibrate -> {
-                        if (action.type == AudioStream.Type.RINGTONE) {
-                            ringerTool.setRingerMode(RingerMode.VIBRATE)
-                        }
-                    }
-                }
+                volumeModeTool.apply(
+                    streamId = device.getStreamId(action.type),
+                    streamType = action.type,
+                    volumeMode = action.volumeMode,
+                    visible = device.visibleAdjustments,
+                )
             }
         }
     }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeModeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeModeTool.kt
@@ -1,0 +1,60 @@
+package eu.darken.bluemusic.monitor.core.audio
+
+import java.time.Duration
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class VolumeModeTool @Inject constructor(
+    private val volumeTool: VolumeTool,
+    private val ringerTool: RingerTool,
+) {
+
+    suspend fun alignSystemState(streamType: AudioStream.Type, volumeMode: VolumeMode): Boolean = when (volumeMode) {
+        is VolumeMode.Normal -> {
+            if (streamType == AudioStream.Type.RINGTONE && volumeMode.percentage > 0f) {
+                ringerTool.setRingerMode(RingerMode.NORMAL)
+            } else {
+                false
+            }
+        }
+
+        is VolumeMode.Silent -> {
+            if (streamType == AudioStream.Type.RINGTONE) {
+                ringerTool.setRingerMode(RingerMode.SILENT)
+            } else {
+                false
+            }
+        }
+
+        is VolumeMode.Vibrate -> {
+            if (streamType == AudioStream.Type.RINGTONE) {
+                ringerTool.setRingerMode(RingerMode.VIBRATE)
+            } else {
+                false
+            }
+        }
+    }
+
+    suspend fun apply(
+        streamId: AudioStream.Id,
+        streamType: AudioStream.Type,
+        volumeMode: VolumeMode,
+        visible: Boolean,
+        delay: Duration = Duration.ZERO,
+    ): Boolean {
+        alignSystemState(streamType, volumeMode)
+
+        return when (volumeMode) {
+            is VolumeMode.Normal -> volumeTool.changeVolume(
+                streamId = streamId,
+                percent = volumeMode.percentage,
+                visible = visible,
+                delay = delay,
+            )
+
+            is VolumeMode.Silent,
+            is VolumeMode.Vibrate -> false
+        }
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeWithModesModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeWithModesModule.kt
@@ -7,6 +7,7 @@ import eu.darken.bluemusic.monitor.core.audio.RingerMode
 import eu.darken.bluemusic.monitor.core.audio.RingerModeObserver
 import eu.darken.bluemusic.monitor.core.audio.RingerTool
 import eu.darken.bluemusic.monitor.core.audio.VolumeMode
+import eu.darken.bluemusic.monitor.core.audio.VolumeModeTool
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
@@ -18,6 +19,7 @@ abstract class BaseVolumeWithModesModule(
     volumeTool: VolumeTool,
     volumeObserver: VolumeObserver,
     observationGate: VolumeObservationGate,
+    private val volumeModeTool: VolumeModeTool,
     private val ringerTool: RingerTool,
     private val ringerModeObserver: RingerModeObserver,
 ) : BaseVolumeModule(volumeTool, volumeObserver, observationGate) {
@@ -27,27 +29,23 @@ abstract class BaseVolumeWithModesModule(
 
         when (volumeMode) {
             is VolumeMode.Silent -> {
-                log(tag, INFO) { "Setting ringer mode to SILENT for $device" }
-                if (ringerTool.setRingerMode(RingerMode.SILENT)) {
-                    log(tag) { "Successfully set ringer mode to SILENT" }
+                log(tag, INFO) { "Applying Silent mode for $device" }
+                if (volumeModeTool.alignSystemState(type, volumeMode)) {
+                    log(tag) { "Successfully applied Silent mode" }
                 }
                 return
             }
 
             is VolumeMode.Vibrate -> {
-                log(tag, INFO) { "Setting ringer mode to VIBRATE for $device" }
-                if (ringerTool.setRingerMode(RingerMode.VIBRATE)) {
-                    log(tag) { "Successfully set ringer mode to VIBRATE" }
+                log(tag, INFO) { "Applying Vibrate mode for $device" }
+                if (volumeModeTool.alignSystemState(type, volumeMode)) {
+                    log(tag) { "Successfully applied Vibrate mode" }
                 }
                 return
             }
 
             is VolumeMode.Normal -> {
-                // For normal volume levels, ensure we're in normal ringer mode
-                if (volumeMode.percentage > 0) {
-                    ringerTool.setRingerMode(RingerMode.NORMAL)
-                }
-                // Call parent implementation for normal volume handling
+                volumeModeTool.alignSystemState(type, volumeMode)
                 super.setInitial(device, volumeMode)
             }
         }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/RingVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/RingVolumeModule.kt
@@ -10,6 +10,7 @@ import eu.darken.bluemusic.common.permissions.PermissionHelper
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.RingerModeObserver
 import eu.darken.bluemusic.monitor.core.audio.RingerTool
+import eu.darken.bluemusic.monitor.core.audio.VolumeModeTool
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
@@ -22,10 +23,11 @@ class RingVolumeModule @Inject constructor(
     volumeTool: VolumeTool,
     volumeObserver: VolumeObserver,
     observationGate: VolumeObservationGate,
+    volumeModeTool: VolumeModeTool,
     ringerTool: RingerTool,
     ringerModeObserver: RingerModeObserver,
     private val permissionHelper: PermissionHelper,
-) : BaseVolumeWithModesModule(volumeTool, volumeObserver, observationGate, ringerTool, ringerModeObserver) {
+) : BaseVolumeWithModesModule(volumeTool, volumeObserver, observationGate, volumeModeTool, ringerTool, ringerModeObserver) {
 
     override val type: AudioStream.Type = AudioStream.Type.RINGTONE
 

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeModeToolTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeModeToolTest.kt
@@ -1,0 +1,92 @@
+package eu.darken.bluemusic.monitor.core.audio
+
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Duration
+
+class VolumeModeToolTest : BaseTest() {
+
+    private val volumeTool = mockk<VolumeTool>()
+    private val ringerTool = mockk<RingerTool>()
+    private val tool = VolumeModeTool(
+        volumeTool = volumeTool,
+        ringerTool = ringerTool,
+    )
+
+    @Test
+    fun `apply normal ringtone restores normal ringer mode before updating ring stream`() = runTest {
+        val calls = mutableListOf<String>()
+
+        every { ringerTool.setRingerMode(RingerMode.NORMAL) } answers {
+            calls += "ringer-normal"
+            true
+        }
+        coEvery {
+            volumeTool.changeVolume(
+                AudioStream.Id.STREAM_RINGTONE,
+                0.5f,
+                true,
+                Duration.ZERO,
+            )
+        } coAnswers {
+            calls += "ring-volume"
+            false
+        }
+
+        val changed = tool.apply(
+            streamId = AudioStream.Id.STREAM_RINGTONE,
+            streamType = AudioStream.Type.RINGTONE,
+            volumeMode = VolumeMode.Normal(0.5f),
+            visible = true,
+        )
+
+        changed shouldBe false
+        calls shouldBe listOf("ringer-normal", "ring-volume")
+    }
+
+    @Test
+    fun `apply normal non-ringtone updates stream without touching ringer mode`() = runTest {
+        coEvery {
+            volumeTool.changeVolume(
+                AudioStream.Id.STREAM_MUSIC,
+                0.25f,
+                true,
+                Duration.ZERO,
+            )
+        } returns true
+
+        val changed = tool.apply(
+            streamId = AudioStream.Id.STREAM_MUSIC,
+            streamType = AudioStream.Type.MUSIC,
+            volumeMode = VolumeMode.Normal(0.25f),
+            visible = true,
+        )
+
+        changed shouldBe true
+        coVerify(exactly = 1) { volumeTool.changeVolume(AudioStream.Id.STREAM_MUSIC, 0.25f, true, Duration.ZERO) }
+        verify(exactly = 0) { ringerTool.setRingerMode(any()) }
+    }
+
+    @Test
+    fun `alignSystemState applies silent for ringtone only`() = runTest {
+        every { ringerTool.setRingerMode(RingerMode.SILENT) } returns true
+
+        tool.alignSystemState(AudioStream.Type.RINGTONE, VolumeMode.Silent) shouldBe true
+        tool.alignSystemState(AudioStream.Type.MUSIC, VolumeMode.Silent) shouldBe false
+    }
+
+    @Test
+    fun `alignSystemState applies vibrate for ringtone only`() = runTest {
+        every { ringerTool.setRingerMode(RingerMode.VIBRATE) } returns true
+
+        tool.alignSystemState(AudioStream.Type.RINGTONE, VolumeMode.Vibrate) shouldBe true
+        tool.alignSystemState(AudioStream.Type.ALARM, VolumeMode.Vibrate) shouldBe false
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherVolumeIntegrationTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherVolumeIntegrationTest.kt
@@ -1,0 +1,292 @@
+package eu.darken.bluemusic.monitor.core.service
+
+import android.media.AudioManager
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import eu.darken.bluemusic.bluetooth.core.SourceDeviceWrapper
+import eu.darken.bluemusic.bluetooth.core.speaker.FakeSpeakerDevice
+import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.DevicesSettings
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import eu.darken.bluemusic.monitor.core.audio.RingerMode
+import eu.darken.bluemusic.monitor.core.audio.RingerTool
+import eu.darken.bluemusic.monitor.core.audio.VolumeEvent
+import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
+import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import eu.darken.bluemusic.monitor.core.modules.connection.CallVolumeModule
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeUpdateModule
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.asDispatcherProvider
+import testhelpers.time.FakeMonotonicClock
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventDispatcherVolumeIntegrationTest : BaseTest() {
+
+    @Test
+    fun `mirrored handsfree observation is ignored while fake speaker call dispatch is active`() = runTest {
+        val fixture = Fixture(this)
+        val job = fixture.launchConnectDispatch()
+
+        fixture.advanceToMonitorWindow()
+
+        fixture.observationGate.isSuppressed(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE) shouldBe true
+        fixture.speakerLastConnectedWasUpdated() shouldBe true
+
+        fixture.injectHandsfreeRestore(level = 11)
+        fixture.volumeUpdateModule.handle(
+            VolumeEvent(
+                streamId = AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE,
+                oldVolume = 1,
+                newVolume = 11,
+                self = false,
+            )
+        )
+
+        fixture.headsetCallVolume() shouldBe fixture.initialHeadsetCallVolume
+        fixture.headsetCallWriteCount() shouldBe 0
+
+        fixture.finishDispatch(job)
+    }
+
+    @Test
+    fun `mirrored handsfree observation persists after fake speaker call dispatch finishes`() = runTest {
+        val fixture = Fixture(this)
+        val job = fixture.launchConnectDispatch()
+
+        fixture.advanceToMonitorWindow()
+        fixture.finishDispatch(job)
+
+        fixture.observationGate.isSuppressed(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE) shouldBe false
+        fixture.speakerLastConnectedWasUpdated() shouldBe true
+
+        fixture.injectHandsfreeRestore(level = 11)
+        fixture.volumeUpdateModule.handle(
+            VolumeEvent(
+                streamId = AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE,
+                oldVolume = 1,
+                newVolume = 11,
+                self = false,
+            )
+        )
+
+        fixture.headsetCallVolume() shouldBe (11f / 15f)
+        fixture.headsetCallWriteCount() shouldBe 1
+    }
+
+    private class Fixture(
+        private val scope: TestScope,
+    ) {
+        val initialHeadsetCallVolume = 0.4f
+
+        private val headsetAddress = "34:E3:FB:94:C2:AF"
+        private val speakerAddress = FakeSpeakerDevice.ADDRESS
+        private val actionDelayMs = 1_000L
+        private val monitoringDurationMs = 1_000L
+
+        private val audioLevels = mutableMapOf(
+            AudioStream.Id.STREAM_MUSIC to 5,
+            AudioStream.Id.STREAM_ALARM to 5,
+            AudioStream.Id.STREAM_NOTIFICATION to 5,
+            AudioStream.Id.STREAM_RINGTONE to 5,
+            AudioStream.Id.STREAM_VOICE_CALL to 11,
+            AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE to 11,
+        )
+
+        private val writeLog = mutableListOf<DeviceWrite>()
+        private val volumeEvents = MutableSharedFlow<VolumeEvent>()
+        private val enabledState = DevicesSettings.EnabledState(
+            isEnabled = true,
+            toggleEpoch = 0L,
+        )
+        private val enabledStateFlow = MutableStateFlow(enabledState)
+
+        private val audioManager = mockk<AudioManager>(relaxed = true)
+        private val volumeObserver = mockk<VolumeObserver>()
+        private val ringerTool = mockk<RingerTool>()
+        private val deviceRepo = mockk<DeviceRepo>(relaxed = true)
+        private val devicesSettings = mockk<DevicesSettings>()
+
+        private val stableHeadset = SourceDeviceWrapper(
+            address = headsetAddress,
+            alias = "AirPods",
+            name = "AirPods Pro",
+            deviceType = SourceDevice.Type.HEADPHONES,
+            isConnected = true,
+        )
+        private val fakeSpeaker = FakeSpeakerDevice(
+            label = "Phone speaker",
+            isConnected = true,
+        )
+
+        private val devicesFlow = MutableStateFlow(
+            listOf(
+                ManagedDevice(
+                    isConnected = true,
+                    device = stableHeadset,
+                    config = DeviceConfigEntity(
+                        address = headsetAddress,
+                        lastConnected = 0L,
+                        callVolume = initialHeadsetCallVolume,
+                        volumeObserving = true,
+                        isEnabled = true,
+                    ),
+                ),
+                ManagedDevice(
+                    isConnected = true,
+                    device = fakeSpeaker,
+                    config = DeviceConfigEntity(
+                        address = speakerAddress,
+                        lastConnected = 0L,
+                        callVolume = 1f / 15f,
+                        actionDelay = actionDelayMs,
+                        adjustmentDelay = 0L,
+                        monitoringDuration = monitoringDurationMs,
+                        isEnabled = true,
+                    ),
+                ),
+            )
+        )
+
+        val observationGate = VolumeObservationGate()
+
+        private val volumeTool = VolumeTool(audioManager).apply {
+            clock = { scope.testScheduler.currentTime }
+        }
+        val volumeUpdateModule = VolumeUpdateModule(
+            volumeTool = volumeTool,
+            ringerTool = ringerTool,
+            deviceRepo = deviceRepo,
+            observationGate = observationGate,
+        )
+        private val callVolumeModule = CallVolumeModule(
+            volumeTool = volumeTool,
+            volumeObserver = volumeObserver,
+            observationGate = observationGate,
+        )
+        private val tracker by lazy {
+            EventTypeDedupTracker(
+                appScope = scope.backgroundScope,
+                devicesSettings = devicesSettings,
+                clock = FakeMonotonicClock(),
+            )
+        }
+        private val dispatcher by lazy {
+            EventDispatcher(
+                dispatcherProvider = scope.coroutineContext.asDispatcherProvider(),
+                deviceRepo = deviceRepo,
+                devicesSettings = devicesSettings,
+                connectionModuleMap = setOf(callVolumeModule),
+                eventTypeDedupTracker = tracker,
+            )
+        }
+
+        init {
+            every { volumeObserver.volumes } returns volumeEvents
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+            every { deviceRepo.devices } returns devicesFlow
+            every { devicesSettings.enabledState } returns enabledStateFlow
+            coEvery { devicesSettings.currentEnabledState() } returns enabledState
+
+            every { audioManager.getStreamMaxVolume(any()) } returns 15
+            every { audioManager.getStreamVolume(any()) } answers {
+                audioLevels[toStreamId(firstArg())] ?: 0
+            }
+            every { audioManager.setStreamVolume(any(), any(), any()) } answers {
+                val streamId = toStreamId(firstArg())
+                val level = secondArg<Int>()
+                audioLevels[streamId] = level
+                if (streamId == AudioStream.Id.STREAM_VOICE_CALL) {
+                    audioLevels[AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE] = level
+                }
+            }
+
+            coEvery { deviceRepo.updateDevice(any(), any()) } coAnswers {
+                val address = firstArg<String>()
+                val transform = secondArg<(DeviceConfigEntity) -> DeviceConfigEntity>()
+                val devices = devicesFlow.value.toMutableList()
+                val index = devices.indexOfFirst { it.address == address }
+                check(index >= 0) { "Unknown device update: $address" }
+
+                val current = devices[index]
+                val updatedConfig = transform(current.config)
+                writeLog += DeviceWrite(
+                    address = address,
+                    before = current.config,
+                    after = updatedConfig,
+                )
+                devices[index] = current.copy(config = updatedConfig)
+                devicesFlow.value = devices
+            }
+
+        }
+
+        fun launchConnectDispatch(): Job = scope.launch {
+            dispatcher.dispatch(
+                BluetoothEventQueue.Event(
+                    type = BluetoothEventQueue.Event.Type.CONNECTED,
+                    sourceDevice = fakeSpeaker,
+                )
+            )
+        }
+
+        fun advanceToMonitorWindow() {
+            scope.runCurrent()
+            scope.advanceTimeBy(actionDelayMs + 25L)
+            scope.runCurrent()
+
+            observationGate.isSuppressed(AudioStream.Id.STREAM_VOICE_CALL) shouldBe true
+            audioLevels[AudioStream.Id.STREAM_VOICE_CALL] shouldBe 1
+            audioLevels[AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE] shouldBe 1
+        }
+
+        fun finishDispatch(job: Job) {
+            scope.advanceUntilIdle()
+            scope.runCurrent()
+            job.isCompleted shouldBe true
+        }
+
+        fun injectHandsfreeRestore(level: Int) {
+            audioLevels[AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE] = level
+        }
+
+        fun headsetCallVolume(): Float? = currentConfig(headsetAddress).callVolume
+
+        fun headsetCallWriteCount(): Int = writeLog.count { write ->
+            write.address == headsetAddress && write.before.callVolume != write.after.callVolume
+        }
+
+        fun speakerLastConnectedWasUpdated(): Boolean {
+            val config = currentConfig(speakerAddress)
+            return config.lastConnected > 0L
+        }
+
+        private fun currentConfig(address: String): DeviceConfigEntity =
+            devicesFlow.value.first { it.address == address }.config
+
+        private fun toStreamId(rawStreamId: Int): AudioStream.Id =
+            AudioStream.Id.entries.first { it.id == rawStreamId }
+    }
+
+    private data class DeviceWrite(
+        val address: String,
+        val before: DeviceConfigEntity,
+        val after: DeviceConfigEntity,
+    )
+}


### PR DESCRIPTION
## Summary
- Extract `VolumeModeTool` to consolidate ringer mode + volume changes that were duplicated across `DashboardViewModel` and `BaseVolumeWithModesModule`
- `DashboardViewModel` now delegates to `VolumeModeTool.apply()` instead of branching on `VolumeMode` variants inline
- `BaseVolumeWithModesModule.setInitial()` uses `VolumeModeTool.alignSystemState()` instead of calling `RingerTool` directly
- Add `VolumeModeToolTest` unit tests and `EventDispatcherVolumeIntegrationTest` for cross-device volume contamination prevention
