### PR TITLE
Fix notification volume resetting when switching from silent to ring mode

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorService.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorService.kt
@@ -28,13 +28,8 @@ import eu.darken.bluemusic.common.hasApiLevel
 import eu.darken.bluemusic.common.ui.Service2
 import eu.darken.bluemusic.devices.core.DeviceRepo
 import eu.darken.bluemusic.devices.core.currentDevices
-import eu.darken.bluemusic.devices.core.updateVolume
-import eu.darken.bluemusic.monitor.core.audio.AudioStream
-import eu.darken.bluemusic.monitor.core.audio.RingerMode
-import eu.darken.bluemusic.monitor.core.audio.RingerModeEvent
 import eu.darken.bluemusic.monitor.core.audio.RingerModeObserver
 import eu.darken.bluemusic.monitor.core.audio.VolumeEvent
-import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.modules.VolumeModule
 import eu.darken.bluemusic.monitor.ui.MonitorNotifications
@@ -72,6 +67,7 @@ class MonitorService : Service2() {
     @Inject lateinit var ringerModeObserver: RingerModeObserver
     @Inject lateinit var bluetoothEventQueue: BluetoothEventQueue
     @Inject lateinit var eventDispatcher: EventDispatcher
+    @Inject lateinit var ringerModeTransitionHandler: RingerModeTransitionHandler
 
     private val serviceScope by lazy {
         CoroutineScope(SupervisorJob() + dispatcherProvider.IO)
@@ -173,7 +169,7 @@ class MonitorService : Service2() {
         ringerModeObserver.ringerMode
             .setupCommonEventHandlers(TAG) { "RingerMode monitor" }
             .distinctUntilChanged()
-            .onEach { handleRingerMode(it) }
+            .onEach { ringerModeTransitionHandler.handle(it) }
             .catch { log(TAG, WARN) { "RingerMode monitor flow failed:\n${it.asLog()}" } }
             .launchIn(serviceScope)
 
@@ -280,36 +276,6 @@ class MonitorService : Service2() {
                     }
                 }.awaitAll()
             }
-        }
-    }
-
-    private suspend fun handleRingerMode(event: RingerModeEvent) {
-        log(TAG, VERBOSE) { "handleRingerMode: $event" }
-        val activeDevice = deviceRepo.currentDevices().firstOrNull { it.isActive }
-        if (activeDevice == null) {
-            log(TAG, INFO) { "handleRingerMode: No active device, skipping." }
-            return
-        }
-        if (activeDevice.getVolume(AudioStream.Type.RINGTONE) == null) {
-            log(TAG, INFO) { "handleRingerMode: No ringtone volume configured, skipping." }
-            return
-        }
-
-        val volumeMode = when (event.newMode) {
-            RingerMode.SILENT -> VolumeMode.Silent
-            RingerMode.VIBRATE -> VolumeMode.Vibrate
-            RingerMode.NORMAL -> {
-                val currentVolume = activeDevice.getVolume(AudioStream.Type.RINGTONE)
-                if (currentVolume != null && currentVolume >= 0f) {
-                    VolumeMode.Normal(currentVolume)
-                } else {
-                    VolumeMode.Normal(0.5f)
-                }
-            }
-        }
-
-        deviceRepo.updateDevice(activeDevice.address) {
-            it.updateVolume(AudioStream.Type.RINGTONE, volumeMode)
         }
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/RingerModeTransitionHandler.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/RingerModeTransitionHandler.kt
@@ -1,0 +1,82 @@
+package eu.darken.bluemusic.monitor.core.service
+
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.currentDevices
+import eu.darken.bluemusic.devices.core.updateVolume
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import eu.darken.bluemusic.monitor.core.audio.RingerMode
+import eu.darken.bluemusic.monitor.core.audio.RingerModeEvent
+import eu.darken.bluemusic.monitor.core.audio.VolumeMode
+import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class RingerModeTransitionHandler @Inject constructor(
+    private val deviceRepo: DeviceRepo,
+    private val volumeTool: VolumeTool,
+    private val observationGate: VolumeObservationGate,
+) {
+
+    suspend fun handle(event: RingerModeEvent) {
+        log(TAG, VERBOSE) { "handle: $event" }
+        val activeDevice = deviceRepo.currentDevices().firstOrNull { it.isActive }
+        if (activeDevice == null) {
+            log(TAG, INFO) { "No active device, skipping." }
+            return
+        }
+        if (activeDevice.getVolume(AudioStream.Type.RINGTONE) == null) {
+            log(TAG, INFO) { "No ringtone volume configured, skipping." }
+            return
+        }
+
+        val volumeMode = when (event.newMode) {
+            RingerMode.SILENT -> VolumeMode.Silent
+            RingerMode.VIBRATE -> VolumeMode.Vibrate
+            RingerMode.NORMAL -> {
+                val currentVolume = activeDevice.getVolume(AudioStream.Type.RINGTONE)
+                if (currentVolume != null && currentVolume >= 0f) {
+                    VolumeMode.Normal(currentVolume)
+                } else {
+                    VolumeMode.Normal(0.5f)
+                }
+            }
+        }
+
+        val storedNotification = activeDevice.getVolume(AudioStream.Type.NOTIFICATION)
+            ?.takeIf { it >= 0f }
+        val suppressNotification = event.newMode == RingerMode.NORMAL && storedNotification != null
+
+        if (suppressNotification) {
+            observationGate.suppress(AudioStream.Id.STREAM_NOTIFICATION)
+        }
+        try {
+            deviceRepo.updateDevice(activeDevice.address) {
+                it.updateVolume(AudioStream.Type.RINGTONE, volumeMode)
+            }
+
+            if (storedNotification != null && suppressNotification) {
+                val streamId = activeDevice.getStreamId(AudioStream.Type.NOTIFICATION)
+                log(TAG, INFO) { "Re-applying stored notification volume ($storedNotification) for ${activeDevice.label}" }
+                volumeTool.changeVolume(
+                    streamId = streamId,
+                    percent = storedNotification,
+                    visible = false,
+                )
+            }
+        } finally {
+            if (suppressNotification) {
+                observationGate.unsuppress(AudioStream.Id.STREAM_NOTIFICATION)
+            }
+        }
+    }
+
+    companion object {
+        private val TAG = logTag("Monitor", "RingerMode", "TransitionHandler")
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/RingerModeTransitionHandlerTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/RingerModeTransitionHandlerTest.kt
@@ -1,0 +1,158 @@
+package eu.darken.bluemusic.monitor.core.service
+
+import android.media.AudioManager
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import eu.darken.bluemusic.bluetooth.core.SourceDeviceWrapper
+import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import eu.darken.bluemusic.monitor.core.audio.RingerMode
+import eu.darken.bluemusic.monitor.core.audio.RingerModeEvent
+import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class RingerModeTransitionHandlerTest : BaseTest() {
+
+    private val address = "AA:BB:CC:DD:EE:FF"
+    private val device = SourceDeviceWrapper(
+        address = address,
+        alias = "Test Headphones",
+        name = "Test Headphones",
+        deviceType = SourceDevice.Type.HEADPHONES,
+        isConnected = true,
+    )
+
+    private val devicesFlow = MutableStateFlow(emptyList<ManagedDevice>())
+    private val deviceRepo = mockk<DeviceRepo>(relaxed = true)
+    private val volumeTool = mockk<VolumeTool>(relaxed = true)
+    private val observationGate = VolumeObservationGate()
+
+    private val handler = RingerModeTransitionHandler(
+        deviceRepo = deviceRepo,
+        volumeTool = volumeTool,
+        observationGate = observationGate,
+    )
+
+    @BeforeEach
+    fun setup() {
+        every { deviceRepo.devices } returns devicesFlow
+    }
+
+    @Test
+    fun `transition to NORMAL suppresses notification and re-applies stored volume`() = runTest {
+        setActiveDevice(notificationVolume = 0.6f)
+
+        handler.handle(RingerModeEvent(oldMode = RingerMode.SILENT, newMode = RingerMode.NORMAL))
+
+        coVerify(exactly = 1) {
+            volumeTool.changeVolume(
+                streamId = AudioStream.Id.STREAM_NOTIFICATION,
+                percent = 0.6f,
+                visible = false,
+            )
+        }
+    }
+
+    @Test
+    fun `notification is unsuppressed after transition to NORMAL completes`() = runTest {
+        setActiveDevice(notificationVolume = 0.6f)
+
+        handler.handle(RingerModeEvent(oldMode = RingerMode.SILENT, newMode = RingerMode.NORMAL))
+
+        observationGate.isSuppressed(AudioStream.Id.STREAM_NOTIFICATION) shouldBe false
+    }
+
+    @Test
+    fun `transition to NORMAL without stored notification volume skips suppression`() = runTest {
+        setActiveDevice(notificationVolume = null)
+
+        handler.handle(RingerModeEvent(oldMode = RingerMode.SILENT, newMode = RingerMode.NORMAL))
+
+        coVerify(exactly = 0) { volumeTool.changeVolume(any<AudioStream.Id>(), any<Float>(), any<Boolean>()) }
+        observationGate.isSuppressed(AudioStream.Id.STREAM_NOTIFICATION) shouldBe false
+    }
+
+    @Test
+    fun `transition to SILENT does not suppress notification`() = runTest {
+        setActiveDevice(notificationVolume = 0.6f)
+
+        handler.handle(RingerModeEvent(oldMode = RingerMode.NORMAL, newMode = RingerMode.SILENT))
+
+        coVerify(exactly = 0) { volumeTool.changeVolume(any<AudioStream.Id>(), any<Float>(), any<Boolean>()) }
+        observationGate.isSuppressed(AudioStream.Id.STREAM_NOTIFICATION) shouldBe false
+    }
+
+    @Test
+    fun `transition to VIBRATE does not suppress notification`() = runTest {
+        setActiveDevice(notificationVolume = 0.6f)
+
+        handler.handle(RingerModeEvent(oldMode = RingerMode.NORMAL, newMode = RingerMode.VIBRATE))
+
+        coVerify(exactly = 0) { volumeTool.changeVolume(any<AudioStream.Id>(), any<Float>(), any<Boolean>()) }
+        observationGate.isSuppressed(AudioStream.Id.STREAM_NOTIFICATION) shouldBe false
+    }
+
+    @Test
+    fun `no active device is a no-op`() = runTest {
+        devicesFlow.value = emptyList()
+
+        handler.handle(RingerModeEvent(oldMode = RingerMode.SILENT, newMode = RingerMode.NORMAL))
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    @Test
+    fun `device without ringtone volume configured is a no-op`() = runTest {
+        setActiveDevice(ringVolume = null, notificationVolume = 0.6f)
+
+        handler.handle(RingerModeEvent(oldMode = RingerMode.SILENT, newMode = RingerMode.NORMAL))
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    @Test
+    fun `notification suppression is released even when updateDevice throws`() = runTest {
+        setActiveDevice(notificationVolume = 0.6f)
+        coEvery { deviceRepo.updateDevice(any(), any()) } throws RuntimeException("DB error")
+
+        try {
+            handler.handle(RingerModeEvent(oldMode = RingerMode.SILENT, newMode = RingerMode.NORMAL))
+        } catch (_: RuntimeException) {
+            // expected
+        }
+
+        observationGate.isSuppressed(AudioStream.Id.STREAM_NOTIFICATION) shouldBe false
+    }
+
+    private fun setActiveDevice(
+        ringVolume: Float? = 0.5f,
+        notificationVolume: Float? = null,
+    ) {
+        devicesFlow.value = listOf(
+            ManagedDevice(
+                isConnected = true,
+                device = device,
+                config = DeviceConfigEntity(
+                    address = address,
+                    lastConnected = 0L,
+                    ringVolume = ringVolume,
+                    notificationVolume = notificationVolume,
+                    isEnabled = true,
+                ),
+            )
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- When switching from silent/vibrate to normal ringer mode, Android raises STREAM_NOTIFICATION to a low platform default (typically ~14% depending on device)
- The volume observer picked up this transient value and persisted it, overwriting the user's stored notification volume
- Extract `RingerModeTransitionHandler` from `MonitorService` to handle ringer mode transitions with notification volume protection
- On transitions to NORMAL: suppress notification observation via `VolumeObservationGate`, re-apply stored notification volume to hardware, then unsuppress
