### PR TITLE
Refactor pro-gated settings to inline upgrade badges

### DIFF
--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
     <string name="app_name_upgrade_postfix">FOSS</string>
+    <string name="upgrade_badge_label">FOSS</string>
 
     <string name="upgrade_feature_requires_pro">Requires BVM FOSS</string>
 

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="app_name_upgraded">BVM Pro</string>
     <string name="app_name_upgrade_postfix">Pro</string>
+    <string name="upgrade_badge_label">PRO</string>
 
     <string name="upgrade_feature_requires_pro">Requires BVM Pro</string>
 

--- a/app/src/main/java/eu/darken/bluemusic/common/compose/UpgradeBadge.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/compose/UpgradeBadge.kt
@@ -1,0 +1,39 @@
+package eu.darken.bluemusic.common.compose
+
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Stars
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.bluemusic.R
+
+@Composable
+fun UpgradeBadge(modifier: Modifier = Modifier) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.TwoTone.Stars,
+            contentDescription = stringResource(R.string.common_upgrade_required_label),
+            tint = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.size(16.dp),
+        )
+        Spacer(modifier = Modifier.width(2.dp))
+        Text(
+            text = stringResource(R.string.upgrade_badge_label),
+            color = MaterialTheme.colorScheme.primary,
+            style = MaterialTheme.typography.labelSmall,
+            maxLines = 1,
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/common/settings/SettingsBaseItem.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/settings/SettingsBaseItem.kt
@@ -27,6 +27,7 @@ fun SettingsBaseItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     icon: ImageVector? = null,
+    titleContent: @Composable (() -> Unit)? = null,
     subtitle: String? = null,
     onLongClick: (() -> Unit)? = null,
     trailingContent: @Composable (() -> Unit)? = null,
@@ -61,12 +62,16 @@ fun SettingsBaseItem(
                 .weight(1f)
                 .padding(start = if (icon != null) 16.dp else 0.dp)
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodyLarge,
-                fontWeight = FontWeight.Normal,
-                color = MaterialTheme.colorScheme.onSurface
-            )
+            if (titleContent != null) {
+                titleContent()
+            } else {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    fontWeight = FontWeight.Normal,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
             if (subtitle != null) {
                 Text(
                     text = subtitle,

--- a/app/src/main/java/eu/darken/bluemusic/common/settings/SettingsPreferenceItem.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/settings/SettingsPreferenceItem.kt
@@ -18,6 +18,7 @@ fun SettingsPreferenceItem(
     title: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    titleContent: @Composable (() -> Unit)? = null,
     subtitle: String? = null,
     value: String? = null,
     trailingContent: @Composable (() -> Unit)? = null,
@@ -27,6 +28,7 @@ fun SettingsPreferenceItem(
         title = title,
         onClick = onClick,
         modifier = modifier,
+        titleContent = titleContent,
         subtitle = subtitle,
         trailingContent = trailingContent ?: if (value != null) {
             {

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/components/PreferenceComponents.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/components/PreferenceComponents.kt
@@ -3,12 +3,13 @@ package eu.darken.bluemusic.devices.ui.config.components
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.GraphicEq
 import androidx.compose.material.icons.twotone.Lock
-import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Timer
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -19,11 +20,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.UpgradeBadge
 
 @Composable
 fun SwitchPreference(
@@ -57,11 +57,17 @@ fun SwitchPreference(
         Column(
             modifier = Modifier.weight(1f)
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.onSurface
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                if (requiresPro && !isProVersion) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    UpgradeBadge()
+                }
+            }
             Text(
                 text = description,
                 style = MaterialTheme.typography.bodyMedium,
@@ -69,21 +75,11 @@ fun SwitchPreference(
             )
         }
 
-        // Switch or Upgrade icon
-        if (requiresPro && !isProVersion) {
-            Icon(
-                imageVector = Icons.TwoTone.Stars,
-                contentDescription = stringResource(R.string.label_pro_feature),
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(start = 16.dp)
-            )
-        } else {
-            Switch(
-                checked = isChecked,
-                onCheckedChange = null, // Disable direct switch interaction
-                modifier = Modifier.padding(start = 16.dp)
-            )
-        }
+        Switch(
+            checked = isChecked,
+            onCheckedChange = null, // Disable direct switch interaction
+            modifier = Modifier.padding(start = 16.dp)
+        )
     }
 }
 
@@ -117,11 +113,17 @@ fun ClickablePreference(
         Column(
             modifier = Modifier.weight(1f)
         ) {
-            Text(
-                text = title,
-                style = MaterialTheme.typography.bodyLarge,
-                color = textColor ?: MaterialTheme.colorScheme.onSurface
-            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = textColor ?: MaterialTheme.colorScheme.onSurface
+                )
+                if (requiresPro && !isProVersion) {
+                    Spacer(modifier = Modifier.width(6.dp))
+                    UpgradeBadge()
+                }
+            }
             description?.let {
                 Text(
                     text = it,
@@ -129,16 +131,6 @@ fun ClickablePreference(
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
             }
-        }
-
-        // Upgrade icon for pro features
-        if (requiresPro && !isProVersion) {
-            Icon(
-                imageVector = Icons.TwoTone.Stars,
-                contentDescription = stringResource(R.string.label_pro_feature),
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(start = 16.dp)
-            )
         }
     }
 }

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/general/GeneralSettingsScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/general/GeneralSettingsScreen.kt
@@ -2,16 +2,17 @@ package eu.darken.bluemusic.main.ui.settings.general
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.twotone.Palette
-import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Translate
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -32,6 +33,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.UpgradeBadge
 import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
 import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import eu.darken.bluemusic.common.error.ErrorEventHandler
@@ -97,13 +99,16 @@ fun GeneralSettingsScreen(
     ) { paddingValues ->
         val navBarPadding = navigationBarBottomPadding()
         val isMaterialYou = state.themeState.style == ThemeStyle.MATERIAL_YOU
-        val proStarIcon: @Composable (() -> Unit) = {
-            Icon(
-                imageVector = Icons.TwoTone.Stars,
-                contentDescription = stringResource(R.string.general_upgrade_action),
-                tint = MaterialTheme.colorScheme.primary,
-                modifier = Modifier.padding(start = 16.dp).size(24.dp),
-            )
+        val proTitleBadge: @Composable (String) -> Unit = { title ->
+            Row {
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                Spacer(modifier = Modifier.width(6.dp))
+                UpgradeBadge()
+            }
         }
         LazyColumn(
             modifier = Modifier
@@ -121,9 +126,13 @@ fun GeneralSettingsScreen(
                 SettingsPreferenceItem(
                     icon = Icons.TwoTone.Palette,
                     title = stringResource(R.string.ui_theme_mode_setting_label),
+                    titleContent = if (!state.isUpgraded) {
+                        { proTitleBadge(stringResource(R.string.ui_theme_mode_setting_label)) }
+                    } else {
+                        null
+                    },
                     subtitle = stringResource(R.string.ui_theme_mode_setting_explanation),
                     value = if (state.isUpgraded) state.themeState.mode.label.get(context) else null,
-                    trailingContent = if (!state.isUpgraded) proStarIcon else null,
                     onClick = if (state.isUpgraded) {{ showThemeModeDialog = true }} else onUpgrade,
                 )
                 SettingsDivider()
@@ -133,9 +142,13 @@ fun GeneralSettingsScreen(
                 SettingsPreferenceItem(
                     icon = Icons.TwoTone.Palette,
                     title = stringResource(R.string.ui_theme_style_setting_label),
+                    titleContent = if (!state.isUpgraded) {
+                        { proTitleBadge(stringResource(R.string.ui_theme_style_setting_label)) }
+                    } else {
+                        null
+                    },
                     subtitle = stringResource(R.string.ui_theme_style_setting_explanation),
                     value = if (state.isUpgraded) state.themeState.style.label.get(context) else null,
-                    trailingContent = if (!state.isUpgraded) proStarIcon else null,
                     onClick = if (state.isUpgraded) {{ showThemeStyleDialog = true }} else onUpgrade,
                 )
                 SettingsDivider()
@@ -145,13 +158,17 @@ fun GeneralSettingsScreen(
                 SettingsPreferenceItem(
                     icon = Icons.TwoTone.Palette,
                     title = stringResource(R.string.ui_theme_color_setting_label),
+                    titleContent = if (!state.isUpgraded) {
+                        { proTitleBadge(stringResource(R.string.ui_theme_color_setting_label)) }
+                    } else {
+                        null
+                    },
                     subtitle = if (isMaterialYou) {
                         stringResource(R.string.ui_theme_color_material_you_note)
                     } else {
                         stringResource(R.string.ui_theme_color_setting_explanation)
                     },
                     value = if (state.isUpgraded && !isMaterialYou) state.themeState.color.label.get(context) else null,
-                    trailingContent = if (!state.isUpgraded) proStarIcon else null,
                     onClick = if (!state.isUpgraded) onUpgrade else {{ showThemeColorDialog = true }},
                 )
                 SettingsDivider()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -317,6 +317,7 @@
     <string name="label_status_adjusting_volumes">Adjusting volumes</string>
     <string name="label_premium_version">Premium version</string>
     <string name="general_upgrade_action">Upgrade</string>
+    <string name="common_upgrade_required_label">Upgrade required</string>
     <string name="description_premium_required_additional_devices">Managing additional devices requires the premium version.</string>
     <string name="description_premium_required_this_extra_option">This extra option requires the premium version of this app.</string>
     <string name="description_premium_upgrade_explanation">Get the premium version to enable additional features and support development.</string>


### PR DESCRIPTION
## Summary
Refactors pro-gated setting presentation to use an inline upgrade badge instead of replacing trailing controls with a standalone star icon.

### What changed
- Added a reusable UpgradeBadge composable.
- Updated pro-gated device config rows to show inline title badges (PRO/FOSS) while preserving current click behavior.
- Extended shared settings row components to support custom title content.
- Updated general theme settings rows to show the same inline badge style when locked.
- Added flavor-specific badge label resources and shared accessibility label.

## Why
This unifies pro-gate UX with the pattern used in the other project and makes gated rows clearer while keeping interaction semantics unchanged.

## Validation
- ./gradlew :app:compileFossDebugKotlin
- ./gradlew :app:compileGplayDebugKotlin