### PR TITLE
Revive main Looper after suppressing foreground service timing exception

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/App.kt
+++ b/app/src/main/java/eu/darken/bluemusic/App.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic
 
 import android.app.Application
+import android.os.Looper
 import dagger.hilt.android.HiltAndroidApp
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.coroutine.DispatcherProvider
@@ -40,10 +41,13 @@ class App : Application() {
             curriculumVitae.updateAppLaunch()
         }
 
+        var foregroundExceptionHandled = false
         val oldHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
-            if (throwable.isForegroundServiceTimingException()) {
+            if (throwable.isForegroundServiceTimingException() && !foregroundExceptionHandled) {
+                foregroundExceptionHandled = true
                 log(TAG, WARN) { "Suppressed foreground service timing exception: ${throwable.asLog()}" }
+                Looper.loop()
                 return@setDefaultUncaughtExceptionHandler
             }
             log(TAG, ERROR) { "UNCAUGHT EXCEPTION: ${throwable.asLog()}" }


### PR DESCRIPTION
## Summary
- The existing uncaught exception handler suppresses ForegroundServiceDidNotStartInTimeException but doesn't revive the main Looper, leaving the app as a frozen zombie (main thread dead, no UI, no auto-restart)
- Adds Looper.loop() call after suppression to re-enter the message loop and keep the app functional
- Adds a one-shot guard so if the same exception fires again after revival, we let it crash normally instead of nesting Looper.loop() calls

## Test plan
- [ ] Build assembleFossDebug
- [ ] Verify handler only suppresses ForegroundServiceDidNotStartInTimeException, not other exceptions
- [ ] Verify second occurrence of same exception falls through to default handler