### PR TITLE
Fix race conditions in volume monitoring and device event handling

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
@@ -27,7 +27,7 @@ abstract class BaseVolumeModule(
     private val volumeTool: VolumeTool,
     private val volumeObserver: VolumeObserver,
     private val observationGate: VolumeObservationGate,
-    private val ownerRegistry: AudioStreamOwnerRegistry,
+    protected val ownerRegistry: AudioStreamOwnerRegistry,
     private val deviceRepo: DeviceRepo,
 ) : ConnectionModule {
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeWithModesModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeWithModesModule.kt
@@ -57,25 +57,30 @@ abstract class BaseVolumeWithModesModule(
 
     override suspend fun monitor(device: ManagedDevice, volumeMode: VolumeMode, generationAtStart: Long) {
         when (volumeMode) {
-            is VolumeMode.Silent -> monitorRingerMode(device, RingerMode.SILENT)
-            is VolumeMode.Vibrate -> monitorRingerMode(device, RingerMode.VIBRATE)
+            is VolumeMode.Silent -> monitorRingerMode(device, RingerMode.SILENT, generationAtStart)
+            is VolumeMode.Vibrate -> monitorRingerMode(device, RingerMode.VIBRATE, generationAtStart)
             is VolumeMode.Normal -> super.monitor(device, volumeMode, generationAtStart)
         }
     }
 
-    private suspend fun monitorRingerMode(device: ManagedDevice, targetMode: RingerMode) {
+    private suspend fun monitorRingerMode(device: ManagedDevice, targetMode: RingerMode, generationAtStart: Long) {
         log(tag, INFO) { "Monitoring ringer mode (target=$targetMode) for ${device.address}/${device.label}" }
 
-        // Set to true inside collect to exit cleanly via takeWhile on the next element.
         var yielded = false
         withTimeoutOrNull(device.monitoringDuration.toMillis()) {
             ringerModeObserver.ringerMode
                 .filter { it.newMode != targetMode }
                 .takeWhile { !yielded }
                 .collect { event ->
+                    if (generationAtStart >= 0 && ownerRegistry.ownershipGeneration() != generationAtStart) {
+                        log(tag, INFO) { "Monitor($type) ringer mode yielding, ownership changed" }
+                        yielded = true
+                        return@collect
+                    }
+
                     if (!ringerTool.wasUs(targetMode)) {
                         log(tag, INFO) {
-                            "Monitor($type) yielding to external ringer mode change on $device"
+                            "Monitor($type) yielding to external ringer mode change on ${device.address}/${device.label}"
                         }
                         yielded = true
                         return@collect

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/ConnectionAlertModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/ConnectionAlertModule.kt
@@ -17,6 +17,7 @@ import eu.darken.bluemusic.monitor.core.modules.delayForReactionDelay
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -26,7 +27,7 @@ class ConnectionAlertModule @Inject constructor(
     private val upgradeRepo: UpgradeRepo,
 ) : ConnectionModule {
 
-    private val activeAlertJobs = mutableMapOf<String, Job>()
+    private val activeAlertJobs = ConcurrentHashMap<String, Job>()
 
     override val tag: String
         get() = TAG

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeObservationGate.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeObservationGate.kt
@@ -48,12 +48,10 @@ class VolumeObservationGate @Inject constructor() {
 
     fun unsuppress(token: SuppressionToken) {
         for (s in token.streamIds) {
-            val ref = refCounts[s]
-            if (ref != null) {
-                val newVal = ref.decrementAndGet()
-                if (newVal <= 0) {
-                    refCounts.remove(s)
-                }
+            refCounts.compute(s) { _, ref ->
+                if (ref == null) null
+                else if (ref.decrementAndGet() <= 0) null
+                else ref
             }
         }
         log(TAG, VERBOSE) { "unsuppress(token=${token.id}), refs=${refSnapshot()}" }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/ownership/AudioStreamOwnerRegistry.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/ownership/AudioStreamOwnerRegistry.kt
@@ -8,6 +8,7 @@ import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.devices.core.DeviceAddr
 import eu.darken.bluemusic.devices.core.ManagedDevice
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -100,7 +101,6 @@ class AudioStreamOwnerRegistry @Inject constructor() {
     }
 
     suspend fun ownerAddressesFor(streamId: AudioStream.Id): List<DeviceAddr> = mutex.withLock {
-        normalizeStream(streamId)
         val ownerGroup = resolveOwnerGroupLocked() ?: return@withLock emptyList()
         // Purely topological: return all addresses in the owner group.
         // Modules check device config (volumeObserving, volumeLock, etc.) themselves.
@@ -131,11 +131,11 @@ class AudioStreamOwnerRegistry @Inject constructor() {
 
     /**
      * Non-suspending reset for use in [android.app.Service.onDestroy] where no coroutine
-     * context is available.  Safe because the mutex is uncontested at service teardown —
-     * the service scope is cancelled immediately after this call.
+     * context is available.  Uses [runBlocking] to acquire the mutex, ensuring no
+     * concurrent readers (e.g. in-flight appScope jobs) observe a partially-cleared state.
      */
     fun resetBlocking() {
-        resetInternal()
+        runBlocking { mutex.withLock { resetInternal() } }
     }
 
     private fun resetInternal() {
@@ -197,11 +197,6 @@ class AudioStreamOwnerRegistry @Inject constructor() {
         if (a.approximate && b.approximate) return true
         // Fresh entries group within the 10s window.
         return kotlin.math.abs(a.connectedAt - b.connectedAt) <= GROUPING_WINDOW_MS
-    }
-
-    private fun normalizeStream(streamId: AudioStream.Id): AudioStream.Id = when (streamId) {
-        AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE -> AudioStream.Id.STREAM_VOICE_CALL
-        else -> streamId
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
@@ -24,6 +24,11 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -49,116 +54,128 @@ class EventDispatcher @Inject constructor(
     private val ownerRegistry: AudioStreamOwnerRegistry,
 ) {
 
-    private val activeJobs = mutableMapOf<DeviceAddr, Job>()
+    private val activeJobs = ConcurrentHashMap<DeviceAddr, Job>()
+    private val nonCancellableJobs: MutableSet<Job> = ConcurrentHashMap.newKeySet()
+    private val shutdown = AtomicBoolean(false)
+    private val dispatchMutex = Mutex()
 
     suspend fun dispatch(bluetoothEvent: BluetoothEventQueue.Event) {
-        log(TAG) { "dispatch: Handling $bluetoothEvent" }
-        val managedDevice = deviceRepo.getDevice(bluetoothEvent.sourceDevice.address)
+        dispatchMutex.withLock {
+            if (shutdown.get()) {
+                log(TAG, WARN) { "dispatch: Dropping event after shutdown: $bluetoothEvent" }
+                return@withLock
+            }
 
-        if (managedDevice == null) {
-            log(TAG, WARN) { "dispatch: Can't find managed device for $bluetoothEvent" }
-            return
-        }
+            log(TAG) { "dispatch: Handling $bluetoothEvent" }
+            val managedDevice = deviceRepo.getDevice(bluetoothEvent.sourceDevice.address)
 
-        val isFakeSpeakerEvent = bluetoothEvent.sourceDevice.deviceType == SourceDevice.Type.PHONE_SPEAKER
-        if (isFakeSpeakerEvent
-            && bluetoothEvent.type == BluetoothEventQueue.Event.Type.CONNECTED
-            && !managedDevice.isConnected
-        ) {
-            log(TAG, INFO) { "Dropping stale fake speaker CONNECTED, speaker is not currently the active device" }
-            return
-        }
+            if (managedDevice == null) {
+                log(TAG, WARN) { "dispatch: Can't find managed device for $bluetoothEvent" }
+                return@withLock
+            }
 
-        eventTypeDedupTracker.observeEnabledState(devicesSettings.currentEnabledState())
+            val isFakeSpeakerEvent = bluetoothEvent.sourceDevice.deviceType == SourceDevice.Type.PHONE_SPEAKER
+            if (isFakeSpeakerEvent
+                && bluetoothEvent.type == BluetoothEventQueue.Event.Type.CONNECTED
+                && !managedDevice.isConnected
+            ) {
+                log(TAG, INFO) { "Dropping stale fake speaker CONNECTED, speaker is not currently the active device" }
+                return@withLock
+            }
 
-        if (!eventTypeDedupTracker.shouldProcess(bluetoothEvent.sourceDevice.address, bluetoothEvent.type)) {
-            return
-        }
+            eventTypeDedupTracker.observeEnabledState(devicesSettings.currentEnabledState())
 
-        // --- Fast acceptance lane: ownership + state updates (synchronous) ---
+            if (!eventTypeDedupTracker.shouldProcess(bluetoothEvent.sourceDevice.address, bluetoothEvent.type)) {
+                return@withLock
+            }
 
-        var displacedOwnerAddresses: List<String> = emptyList()
+            // --- Fast acceptance lane: ownership + state updates (synchronous) ---
 
-        val deviceEvent = when (bluetoothEvent.type) {
-            BluetoothEventQueue.Event.Type.CONNECTED -> {
-                val connectResult = ownerRegistry.onDeviceConnected(
-                    address = managedDevice.address,
-                    label = managedDevice.label,
-                    deviceType = managedDevice.type,
-                    receivedAtElapsedMs = bluetoothEvent.receivedAtElapsedMs,
-                    sequence = bluetoothEvent.sequence,
-                )
-                if (connectResult.ownershipChanged) {
-                    displacedOwnerAddresses = connectResult.previousOwnerAddresses
+            var displacedOwnerAddresses: List<String> = emptyList()
+
+            val deviceEvent = when (bluetoothEvent.type) {
+                BluetoothEventQueue.Event.Type.CONNECTED -> {
+                    val connectResult = ownerRegistry.onDeviceConnected(
+                        address = managedDevice.address,
+                        label = managedDevice.label,
+                        deviceType = managedDevice.type,
+                        receivedAtElapsedMs = bluetoothEvent.receivedAtElapsedMs,
+                        sequence = bluetoothEvent.sequence,
+                    )
+                    if (connectResult.ownershipChanged) {
+                        displacedOwnerAddresses = connectResult.previousOwnerAddresses
+                    }
+                    DeviceEvent.Connected(managedDevice)
                 }
-                DeviceEvent.Connected(managedDevice)
+
+                BluetoothEventQueue.Event.Type.DISCONNECTED -> {
+                    val disconnectResult = ownerRegistry.resolveDisconnect(
+                        address = managedDevice.address,
+                        receivedAtElapsedMs = bluetoothEvent.receivedAtElapsedMs,
+                    )
+                    DeviceEvent.Disconnected(
+                        device = managedDevice,
+                        volumeSnapshot = bluetoothEvent.volumeSnapshot,
+                        disconnectResult = disconnectResult,
+                    )
+                }
             }
 
-            BluetoothEventQueue.Event.Type.DISCONNECTED -> {
-                val disconnectResult = ownerRegistry.resolveDisconnect(
-                    address = managedDevice.address,
-                    receivedAtElapsedMs = bluetoothEvent.receivedAtElapsedMs,
-                )
-                DeviceEvent.Disconnected(
-                    device = managedDevice,
-                    volumeSnapshot = bluetoothEvent.volumeSnapshot,
-                    disconnectResult = disconnectResult,
-                )
+            if (bluetoothEvent.type == BluetoothEventQueue.Event.Type.CONNECTED) {
+                deviceRepo.updateDevice(managedDevice.address) {
+                    it.copy(lastConnected = System.currentTimeMillis())
+                }
             }
-        }
 
-        if (bluetoothEvent.type == BluetoothEventQueue.Event.Type.CONNECTED) {
-            deviceRepo.updateDevice(managedDevice.address) {
-                it.copy(lastConnected = System.currentTimeMillis())
+            // --- Async module execution (non-blocking) ---
+
+            val address = managedDevice.address
+
+            // Cancel displaced owner's in-flight cancellable jobs when ownership transfers.
+            // e.g., AirPods ramping to 100% should stop when speaker takes ownership.
+            //
+            // Known limitation: real BT devices always take ownership from PHONE_SPEAKER
+            // (see resolveOwnerGroupLocked), so a reconnecting device will cancel the
+            // speaker's ramp and apply its own volumes — even if the speaker was just
+            // set up.  In chaotic connect/disconnect cycles (e.g., AirPods firmware
+            // briefly reconnecting after case closure), this causes visible volume churn:
+            // the device ramps up, disconnects, then the speaker restarts its ramp down.
+            // We can't suppress the device's connect because we can't distinguish an
+            // intentional connect from a firmware ghost reconnect at the ACL level.
+            for (displacedAddr in displacedOwnerAddresses) {
+                if (displacedAddr == address) continue
+                val displacedJob = activeJobs[displacedAddr]
+                if (displacedJob != null && displacedJob.isActive) {
+                    log(TAG, INFO) { "dispatch: Cancelling displaced owner job for $displacedAddr" }
+                    displacedJob.cancel(CancellationException("Ownership transferred to $address"))
+                }
             }
-        }
 
-        // --- Async module execution (non-blocking) ---
-
-        val address = managedDevice.address
-
-        // Cancel displaced owner's in-flight cancellable jobs when ownership transfers.
-        // e.g., AirPods ramping to 100% should stop when speaker takes ownership.
-        //
-        // Known limitation: real BT devices always take ownership from PHONE_SPEAKER
-        // (see resolveOwnerGroupLocked), so a reconnecting device will cancel the
-        // speaker's ramp and apply its own volumes — even if the speaker was just
-        // set up.  In chaotic connect/disconnect cycles (e.g., AirPods firmware
-        // briefly reconnecting after case closure), this causes visible volume churn:
-        // the device ramps up, disconnects, then the speaker restarts its ramp down.
-        // We can't suppress the device's connect because we can't distinguish an
-        // intentional connect from a firmware ghost reconnect at the ACL level.
-        for (displacedAddr in displacedOwnerAddresses) {
-            if (displacedAddr == address) continue
-            val displacedJob = activeJobs[displacedAddr]
-            if (displacedJob != null && displacedJob.isActive) {
-                log(TAG, INFO) { "dispatch: Cancelling displaced owner job for $displacedAddr" }
-                displacedJob.cancel(CancellationException("Ownership transferred to $address"))
+            val existingJob = activeJobs[address]
+            if (existingJob != null && existingJob.isActive) {
+                log(TAG, INFO) { "dispatch: Cancelling superseded cancellable job for $address" }
+                existingJob.cancel(CancellationException("Superseded by new ${bluetoothEvent.type} event"))
             }
-        }
 
-        val existingJob = activeJobs[address]
-        if (existingJob != null && existingJob.isActive) {
-            log(TAG, INFO) { "dispatch: Cancelling superseded cancellable job for $address" }
-            existingJob.cancel(CancellationException("Superseded by new ${bluetoothEvent.type} event"))
-        }
+            val cancellableModules = connectionModuleMap.filter { it.cancellable }
+            val nonCancellableModules = connectionModuleMap.filter { !it.cancellable }
 
-        val cancellableModules = connectionModuleMap.filter { it.cancellable }
-        val nonCancellableModules = connectionModuleMap.filter { !it.cancellable }
+            log(TAG) { "dispatch: Launching module work for $deviceEvent (${cancellableModules.size} cancellable, ${nonCancellableModules.size} non-cancellable)" }
 
-        log(TAG) { "dispatch: Launching module work for $deviceEvent (${cancellableModules.size} cancellable, ${nonCancellableModules.size} non-cancellable)" }
-
-        // Non-cancellable modules survive supersession — not tracked per device.
-        // Still children of appScope, so service shutdown cancels them.
-        if (nonCancellableModules.isNotEmpty()) {
-            appScope.launch(dispatcherProvider.IO) {
-                executeModules(deviceEvent, nonCancellableModules)
+            // Non-cancellable modules survive supersession but are tracked for teardown cleanup.
+            if (nonCancellableModules.isNotEmpty()) {
+                appScope.launch(dispatcherProvider.IO) {
+                    executeModules(deviceEvent, nonCancellableModules)
+                }.also { job ->
+                    nonCancellableJobs.add(job)
+                    job.invokeOnCompletion { nonCancellableJobs.remove(job) }
+                }
             }
-        }
 
-        // Cancellable modules are tracked and cancelled when a superseding event arrives.
-        activeJobs[address] = appScope.launch(dispatcherProvider.IO) {
-            executeModules(deviceEvent, cancellableModules)
+            // Cancellable modules are tracked and cancelled when a superseding event arrives.
+            activeJobs[address] = appScope.launch(dispatcherProvider.IO) {
+                executeModules(deviceEvent, cancellableModules)
+            }.also { job -> job.invokeOnCompletion { activeJobs.remove(address, job) } }
         }
     }
 
@@ -190,10 +207,26 @@ class EventDispatcher @Inject constructor(
         }
     }
 
+    fun resetForNewSession() {
+        runBlocking {
+            dispatchMutex.withLock {
+                shutdown.set(false)
+                log(TAG, INFO) { "resetForNewSession: Dispatcher ready for new events" }
+            }
+        }
+    }
+
     fun cancelAllJobs() {
-        log(TAG, INFO) { "cancelAllJobs: Cancelling ${activeJobs.size} in-flight jobs" }
-        activeJobs.values.forEach { it.cancel() }
-        activeJobs.clear()
+        shutdown.set(true)
+        runBlocking {
+            dispatchMutex.withLock {
+                log(TAG, INFO) { "cancelAllJobs: Cancelling ${activeJobs.size} cancellable + ${nonCancellableJobs.size} non-cancellable jobs" }
+                activeJobs.values.forEach { it.cancel() }
+                activeJobs.clear()
+                nonCancellableJobs.forEach { it.cancel() }
+                nonCancellableJobs.clear()
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestrator.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestrator.kt
@@ -65,6 +65,7 @@ class MonitorOrchestrator @Inject constructor(
         val initialDevices = deviceRepo.currentDevices()
         ownerRegistry.reset()
         ownerRegistry.bootstrap(initialDevices)
+        eventDispatcher.resetForNewSession()
 
         onActiveDevicesChanged(initialDevices.filter { it.isActive })
 

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeWithModesModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeWithModesModuleTest.kt
@@ -1,0 +1,159 @@
+package eu.darken.bluemusic.monitor.core.modules.connection
+
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import eu.darken.bluemusic.bluetooth.core.SourceDeviceWrapper
+import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import eu.darken.bluemusic.monitor.core.audio.RingerMode
+import eu.darken.bluemusic.monitor.core.audio.RingerModeEvent
+import eu.darken.bluemusic.monitor.core.audio.RingerModeObserver
+import eu.darken.bluemusic.monitor.core.audio.RingerTool
+import eu.darken.bluemusic.monitor.core.audio.VolumeMode
+import eu.darken.bluemusic.monitor.core.audio.VolumeModeTool
+import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
+import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
+import eu.darken.bluemusic.monitor.core.ownership.AudioStreamOwnerRegistry
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.time.Duration
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BaseVolumeWithModesModuleTest : BaseTest() {
+
+    private val testAddress = "AA:BB:CC:DD:EE:FF"
+
+    private lateinit var volumeTool: VolumeTool
+    private lateinit var volumeObserver: VolumeObserver
+    private lateinit var volumeModeTool: VolumeModeTool
+    private lateinit var ringerTool: RingerTool
+    private lateinit var ringerModeObserver: RingerModeObserver
+    private lateinit var observationGate: VolumeObservationGate
+    private lateinit var ringerEvents: MutableSharedFlow<RingerModeEvent>
+
+    private val testSourceDevice = SourceDeviceWrapper(
+        address = testAddress,
+        alias = "TestDevice",
+        name = "TestDevice",
+        deviceType = SourceDevice.Type.HEADPHONES,
+        isConnected = true,
+    )
+
+    @BeforeEach
+    fun setup() {
+        volumeTool = mockk(relaxed = true)
+        volumeObserver = mockk(relaxed = true)
+        volumeModeTool = mockk(relaxed = true)
+        ringerTool = mockk(relaxed = true)
+        ringerModeObserver = mockk(relaxed = true)
+        observationGate = VolumeObservationGate()
+
+        ringerEvents = MutableSharedFlow()
+        every { ringerModeObserver.ringerMode } returns ringerEvents
+        every { volumeTool.getMaxVolume(any()) } returns 15
+        coEvery { volumeModeTool.alignSystemState(any(), any()) } returns true
+    }
+
+    private fun realDevice(
+        actionDelayMs: Long = 0L,
+        monitoringDurationMs: Long = 10000L,
+        ringVolume: Float? = VolumeMode.LEGACY_SILENT_VALUE,
+    ): ManagedDevice = ManagedDevice(
+        isConnected = true,
+        device = testSourceDevice,
+        config = DeviceConfigEntity(
+            address = testAddress,
+            ringVolume = ringVolume,
+            actionDelay = actionDelayMs,
+            monitoringDuration = monitoringDurationMs,
+            isEnabled = true,
+        ),
+    )
+
+    private fun createModule(
+        registry: AudioStreamOwnerRegistry = AudioStreamOwnerRegistry(),
+        devicesFlow: MutableStateFlow<List<ManagedDevice>> = MutableStateFlow(emptyList()),
+    ): Pair<BaseVolumeWithModesModule, AudioStreamOwnerRegistry> {
+        val deviceRepo = mockk<DeviceRepo>(relaxed = true)
+        every { deviceRepo.devices } returns devicesFlow
+        val module = object : BaseVolumeWithModesModule(
+            volumeTool, volumeObserver, observationGate, registry, deviceRepo,
+            volumeModeTool, ringerTool, ringerModeObserver,
+        ) {
+            override val type = AudioStream.Type.RINGTONE
+            override val priority = 10
+        }
+        return module to registry
+    }
+
+    @Test
+    fun `ringer mode monitor yields on ownership change`() = runTest(UnconfinedTestDispatcher()) {
+        val devicesFlow = MutableStateFlow<List<ManagedDevice>>(emptyList())
+        val registry = AudioStreamOwnerRegistry()
+        val (module, _) = createModule(registry, devicesFlow)
+        val dev = realDevice(actionDelayMs = 0L, monitoringDurationMs = 10000L)
+        devicesFlow.value = listOf(dev)
+
+        registry.onDeviceConnected(testAddress, "TestDevice", SourceDevice.Type.HEADPHONES, 1000L, 0L)
+
+        val job = launch { module.handle(DeviceEvent.Connected(dev)) }
+
+        advanceTimeBy(100) // In monitor now
+
+        // Change ownership
+        registry.onDeviceConnected("NEW:ADDR:00:00:00:01", "NewDevice", SourceDevice.Type.HEADPHONES, 5000L, 1L)
+
+        // Emit a ringer mode event to trigger the collect loop
+        ringerEvents.emit(RingerModeEvent(RingerMode.SILENT, RingerMode.NORMAL))
+
+        advanceTimeBy(100)
+        job.join()
+
+        // Should NOT re-enforce because ownership changed
+        coVerify(exactly = 0) { ringerTool.setRingerMode(any()) }
+    }
+
+    @Test
+    fun `ringer mode monitor re-enforces when ownership stable`() = runTest(UnconfinedTestDispatcher()) {
+        val devicesFlow = MutableStateFlow<List<ManagedDevice>>(emptyList())
+        val registry = AudioStreamOwnerRegistry()
+        val (module, _) = createModule(registry, devicesFlow)
+        val dev = realDevice(actionDelayMs = 0L, monitoringDurationMs = 10000L)
+        devicesFlow.value = listOf(dev)
+
+        registry.onDeviceConnected(testAddress, "TestDevice", SourceDevice.Type.HEADPHONES, 1000L, 0L)
+
+        // ringerTool.wasUs returns true so the module re-enforces instead of yielding
+        every { ringerTool.wasUs(RingerMode.SILENT) } returns true
+
+        val job = launch { module.handle(DeviceEvent.Connected(dev)) }
+
+        advanceTimeBy(100)
+
+        // Emit event — ownership stable, wasUs=true → re-enforce
+        ringerEvents.emit(RingerModeEvent(RingerMode.SILENT, RingerMode.NORMAL))
+
+        advanceTimeBy(100)
+
+        coVerify(atLeast = 1) { ringerTool.setRingerMode(RingerMode.SILENT) }
+
+        // Let monitor time out
+        advanceTimeBy(11000)
+        job.join()
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/ownership/AudioStreamOwnerRegistryTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/ownership/AudioStreamOwnerRegistryTest.kt
@@ -404,6 +404,17 @@ class AudioStreamOwnerRegistryTest : BaseTest() {
         }
 
         @Test
+        fun `resetBlocking clears all entries and generation`() = runTest {
+            registry.onDeviceConnected("AA:BB:CC:DD:EE:01", "DeviceA", SourceDevice.Type.HEADPHONES, 1000L, 0L)
+            registry.onDeviceConnected("AA:BB:CC:DD:EE:02", "DeviceB", SourceDevice.Type.HEADPHONES, 5000L, 1L)
+
+            registry.resetBlocking()
+
+            registry.ownerAddressesFor(AudioStream.Id.STREAM_MUSIC).shouldBeEmpty()
+            registry.ownershipGeneration() shouldBe 0L
+        }
+
+        @Test
         fun `sequence breaks ties for same timestamp`() = runTest {
             registry.onDeviceConnected("AA:BB:CC:DD:EE:01", "DeviceA", SourceDevice.Type.HEADPHONES, 1000L, 0L)
             registry.onDeviceConnected("AA:BB:CC:DD:EE:02", "DeviceB", SourceDevice.Type.HEADPHONES, 1000L, 1L)

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
@@ -15,11 +15,13 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -29,6 +31,8 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.asDispatcherProvider
 import testhelpers.time.FakeMonotonicClock
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 
 class EventDispatcherTest : BaseTest() {
 
@@ -428,6 +432,74 @@ class EventDispatcherTest : BaseTest() {
     }
 
     @Test
+    fun `dispatch drops events after cancelAllJobs`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+        val dispatcher = createDispatcher()
+
+        dispatcher.cancelAllJobs()
+
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { module1.handle(any()) }
+    }
+
+    @Test
+    fun `cancelAllJobs waits for in-flight dispatch and cancels what it launches`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        val dispatchEntered = CompletableDeferred<Unit>()
+        val releaseDispatch = CompletableDeferred<Unit>()
+        coEvery { devicesSettings.currentEnabledState() } coAnswers {
+            dispatchEntered.complete(Unit)
+            releaseDispatch.await()
+            currentEnabledState
+        }
+
+        val dispatcher = createDispatcher()
+        val dispatchJob = launch { dispatcher.dispatch(event(budsAddress, CONNECTED)) }
+
+        dispatchEntered.await()
+
+        val cancelFinished = CountDownLatch(1)
+        val cancelThread = Thread {
+            dispatcher.cancelAllJobs()
+            cancelFinished.countDown()
+        }
+        cancelThread.start()
+
+        cancelFinished.await(100, TimeUnit.MILLISECONDS) shouldBe false
+
+        releaseDispatch.complete(Unit)
+        dispatchJob.join()
+
+        cancelFinished.await(1, TimeUnit.SECONDS) shouldBe true
+        cancelThread.join()
+
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { module1.handle(any()) }
+        coVerify(exactly = 0) { module2.handle(any()) }
+    }
+
+    @Test
+    fun `resetForNewSession re-enables dispatch after shutdown`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+        val dispatcher = createDispatcher()
+
+        dispatcher.cancelAllJobs()
+        dispatcher.resetForNewSession()
+
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { module1.handle(any<DeviceEvent.Connected>()) }
+    }
+
+    @Test
     fun `two events for different addresses dispatch independently`() = runTest {
         val buds = managedDevice(budsAddress, connected = true)
         val watch = managedDevice(watchAddress, connected = true)
@@ -574,6 +646,80 @@ class EventDispatcherTest : BaseTest() {
 
         // Buds' slow ramp should NOT have completed — it was cancelled by ownership transfer
         budsRampCompleted shouldBe false
+    }
+
+    @Test
+    fun `cancelAllJobs cancels non-cancellable jobs too`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        val nonCancellable = mockk<ConnectionModule>(relaxed = true) {
+            every { priority } returns 1
+            every { tag } returns "NonCancellable"
+            every { cancellable } returns false
+        }
+
+        var jobCompleted = false
+        coEvery { nonCancellable.handle(any<DeviceEvent.Disconnected>()) } coAnswers {
+            kotlinx.coroutines.delay(10_000)
+            jobCompleted = true
+        }
+
+        val dispatcher = EventDispatcher(
+            appScope = this,
+            dispatcherProvider = asDispatcherProvider(),
+            deviceRepo = deviceRepo,
+            devicesSettings = devicesSettings,
+            connectionModuleMap = setOf(nonCancellable),
+            eventTypeDedupTracker = tracker,
+            ownerRegistry = AudioStreamOwnerRegistry(),
+        )
+
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+        dispatcher.cancelAllJobs()
+        advanceUntilIdle()
+
+        jobCompleted shouldBe false
+    }
+
+    @Test
+    fun `multiple non-cancellable jobs from same device all tracked`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        val nonCancellable = mockk<ConnectionModule>(relaxed = true) {
+            every { priority } returns 1
+            every { tag } returns "NonCancellable"
+            every { cancellable } returns false
+        }
+
+        var completionCount = java.util.concurrent.atomic.AtomicInteger(0)
+        coEvery { nonCancellable.handle(any<DeviceEvent.Disconnected>()) } coAnswers {
+            kotlinx.coroutines.delay(5000)
+            completionCount.incrementAndGet()
+        }
+
+        val dispatcher = EventDispatcher(
+            appScope = this,
+            dispatcherProvider = asDispatcherProvider(),
+            deviceRepo = deviceRepo,
+            devicesSettings = devicesSettings,
+            connectionModuleMap = setOf(nonCancellable),
+            eventTypeDedupTracker = tracker,
+            ownerRegistry = AudioStreamOwnerRegistry(),
+        )
+
+        // D1, C1 (clears dedup), D2 — two disconnect events for the same device
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+
+        // Cancel all before they finish
+        dispatcher.cancelAllJobs()
+        advanceUntilIdle()
+
+        // Both non-cancellable disconnect jobs should have been cancelled
+        completionCount.get() shouldBe 0
     }
 
     @Test


### PR DESCRIPTION
## Summary

Fixes several concurrency and thread-safety issues in the monitor event pipeline identified during code review:

- **EventDispatcher**: Replace plain `mutableMapOf` with `ConcurrentHashMap` for job tracking, add mutex to prevent race between `dispatch()` and `cancelAllJobs()`, track non-cancellable jobs in a set for proper teardown cleanup, add shutdown gate to prevent new work after teardown starts
- **AudioStreamOwnerRegistry**: `resetBlocking()` now acquires the mutex via `runBlocking` instead of bypassing it, preventing data races with in-flight ownership queries. Remove dead `normalizeStream()` call
- **VolumeObservationGate**: Use `ConcurrentHashMap.compute()` for atomic ref-count decrement+remove in `unsuppress()`, preventing a TOCTOU race that could drop a live suppression
- **ConnectionAlertModule**: Replace `mutableMapOf` with `ConcurrentHashMap` for concurrent job tracking
- **BaseVolumeWithModesModule**: Pass ownership generation to ringer mode monitoring so Silent/Vibrate monitors yield when a new device takes ownership
- **MonitorOrchestrator**: Reset dispatcher shutdown gate before starting a new monitoring session

## Test plan

- [x] `resetBlocking clears all entries and generation` — verifies mutex-guarded reset
- [x] `cancelAllJobs cancels non-cancellable jobs too` — verifies teardown reaches non-cancellable work
- [x] `multiple non-cancellable jobs from same device all tracked` — verifies no job overwrites in the set
- [x] `dispatch drops events after cancelAllJobs` — verifies shutdown gate blocks new work
- [x] `cancelAllJobs waits for in-flight dispatch and cancels what it launches` — verifies mutex handshake
- [x] `resetForNewSession re-enables dispatch after shutdown` — verifies gate reset for new lifecycle
- [x] `ringer mode monitor yields on ownership change` — verifies Silent/Vibrate ownership displacement
- [x] `ringer mode monitor re-enforces when ownership stable` — verifies normal re-enforcement still works
- [x] All 438 existing tests pass
