### PR TITLE
Add backup and restore for device configs and settings

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/common/navigation/Nav.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/navigation/Nav.kt
@@ -64,6 +64,11 @@ sealed interface Nav : NavigationDestination {
         }
 
         @Serializable
+        data object BackupRestore : Settings {
+            private fun readResolve(): Any = BackupRestore
+        }
+
+        @Serializable
         data object ContactSupport : Settings {
             private fun readResolve(): Any = ContactSupport
         }

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/DevicesSettings.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/DevicesSettings.kt
@@ -10,7 +10,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.bluemusic.common.BuildConfigWrap
 import eu.darken.bluemusic.common.datastore.PreferenceData
 import eu.darken.bluemusic.common.datastore.createValue
+import eu.darken.bluemusic.common.datastore.value
 import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.main.backup.core.DevicesSettingsBackup
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
@@ -87,6 +89,18 @@ class DevicesSettings @Inject constructor(
         val isEnabled: Boolean,
         val toggleEpoch: Long,
     )
+
+    suspend fun toBackup(): DevicesSettingsBackup = DevicesSettingsBackup(
+        isEnabled = isEnabled.value(),
+        restoreOnBoot = restoreOnBoot.value(),
+        lockedDevices = lockedDevices.value(),
+    )
+
+    suspend fun applyBackup(backup: DevicesSettingsBackup) {
+        setEnabled(backup.isEnabled)
+        restoreOnBoot.value(backup.restoreOnBoot)
+        lockedDevices.value(backup.lockedDevices)
+    }
 
     companion object {
         internal val TAG = logTag("Devices", "Settings")

--- a/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupData.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupData.kt
@@ -1,0 +1,64 @@
+package eu.darken.bluemusic.main.backup.core
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AppBackup(
+    val formatVersion: Int,
+    val appVersion: String,
+    val appVersionCode: Long = 0L,
+    val createdAt: String,
+    val deviceConfigs: List<DeviceConfigBackup> = emptyList(),
+    val devicesSettings: DevicesSettingsBackup = DevicesSettingsBackup(),
+    val generalSettings: GeneralSettingsBackup = GeneralSettingsBackup(),
+)
+
+@Serializable
+data class DeviceConfigBackup(
+    val address: String,
+    val customName: String? = null,
+    val lastConnected: Long = 0L,
+    val actionDelay: Long? = null,
+    val adjustmentDelay: Long? = null,
+    val monitoringDuration: Long? = null,
+    val musicVolume: Float? = null,
+    val callVolume: Float? = null,
+    val ringVolume: Float? = null,
+    val notificationVolume: Float? = null,
+    val alarmVolume: Float? = null,
+    val volumeLock: Boolean = false,
+    val volumeObserving: Boolean = false,
+    val volumeRateLimiter: Boolean = false,
+    val volumeRateLimitIncreaseMs: Long? = null,
+    val volumeRateLimitDecreaseMs: Long? = null,
+    val volumeSaveOnDisconnect: Boolean = false,
+    val keepAwake: Boolean = false,
+    val nudgeVolume: Boolean = false,
+    val autoplay: Boolean = false,
+    val launchPkgs: List<String> = emptyList(),
+    val showHomeScreen: Boolean = false,
+    val autoplayKeycodes: List<Int> = emptyList(),
+    val isEnabled: Boolean = true,
+    val visibleAdjustments: Boolean? = true,
+    val dndMode: String? = null,
+    val connectionAlertType: String = "none",
+    val connectionAlertSoundUri: String? = null,
+)
+
+@Serializable
+data class DevicesSettingsBackup(
+    val isEnabled: Boolean = true,
+    val restoreOnBoot: Boolean = true,
+    val lockedDevices: Set<String> = emptySet(),
+)
+
+@Serializable
+data class GeneralSettingsBackup(
+    val themeMode: String = "SYSTEM",
+    val themeStyle: String = "DEFAULT",
+    val themeColor: String = "BLUE",
+    val isOnboardingCompleted: Boolean = false,
+    val isBatteryOptimizationHintDismissed: Boolean = false,
+    val isAndroid10AppLaunchHintDismissed: Boolean = false,
+    val isNotificationPermissionHintDismissed: Boolean = false,
+)

--- a/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupError.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupError.kt
@@ -1,0 +1,16 @@
+package eu.darken.bluemusic.main.backup.core
+
+sealed class BackupError(message: String, cause: Throwable? = null) : Exception(message, cause) {
+
+    class UnsupportedFormatVersion(val version: Int) :
+        BackupError("Unsupported backup format version: $version")
+
+    class MalformedBackup(cause: Throwable) :
+        BackupError("Backup file is malformed: ${cause.message}", cause)
+
+    class MissingBackupJson :
+        BackupError("ZIP archive does not contain a valid backup.json entry")
+
+    class BackupIoError(cause: Throwable) :
+        BackupError("I/O error during backup operation: ${cause.message}", cause)
+}

--- a/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupMappers.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupMappers.kt
@@ -1,0 +1,82 @@
+package eu.darken.bluemusic.main.backup.core
+
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.monitor.core.alert.AlertType
+import eu.darken.bluemusic.monitor.core.audio.DndMode
+
+fun DeviceConfigEntity.toBackup(): DeviceConfigBackup = DeviceConfigBackup(
+    address = address,
+    customName = customName,
+    lastConnected = lastConnected,
+    actionDelay = actionDelay,
+    adjustmentDelay = adjustmentDelay,
+    monitoringDuration = monitoringDuration,
+    musicVolume = musicVolume,
+    callVolume = callVolume,
+    ringVolume = ringVolume,
+    notificationVolume = notificationVolume,
+    alarmVolume = alarmVolume,
+    volumeLock = volumeLock,
+    volumeObserving = volumeObserving,
+    volumeRateLimiter = volumeRateLimiter,
+    volumeRateLimitIncreaseMs = volumeRateLimitIncreaseMs,
+    volumeRateLimitDecreaseMs = volumeRateLimitDecreaseMs,
+    volumeSaveOnDisconnect = volumeSaveOnDisconnect,
+    keepAwake = keepAwake,
+    nudgeVolume = nudgeVolume,
+    autoplay = autoplay,
+    launchPkgs = launchPkgs,
+    showHomeScreen = showHomeScreen,
+    autoplayKeycodes = autoplayKeycodes,
+    isEnabled = isEnabled,
+    visibleAdjustments = visibleAdjustments,
+    dndMode = dndMode?.key,
+    connectionAlertType = connectionAlertType.key,
+    connectionAlertSoundUri = connectionAlertSoundUri,
+)
+
+fun DeviceConfigBackup.toEntity(): DeviceConfigEntity = DeviceConfigEntity(
+    address = address,
+    customName = customName,
+    lastConnected = lastConnected,
+    actionDelay = actionDelay,
+    adjustmentDelay = adjustmentDelay,
+    monitoringDuration = monitoringDuration,
+    musicVolume = musicVolume,
+    callVolume = callVolume,
+    ringVolume = ringVolume,
+    notificationVolume = notificationVolume,
+    alarmVolume = alarmVolume,
+    volumeLock = volumeLock,
+    volumeObserving = volumeObserving,
+    volumeRateLimiter = volumeRateLimiter,
+    volumeRateLimitIncreaseMs = volumeRateLimitIncreaseMs,
+    volumeRateLimitDecreaseMs = volumeRateLimitDecreaseMs,
+    volumeSaveOnDisconnect = volumeSaveOnDisconnect,
+    keepAwake = keepAwake,
+    nudgeVolume = nudgeVolume,
+    autoplay = autoplay,
+    launchPkgs = launchPkgs,
+    showHomeScreen = showHomeScreen,
+    autoplayKeycodes = autoplayKeycodes,
+    isEnabled = isEnabled,
+    visibleAdjustments = visibleAdjustments,
+    dndMode = DndMode.fromKey(dndMode),
+    connectionAlertType = AlertType.fromKey(connectionAlertType),
+    connectionAlertSoundUri = connectionAlertSoundUri,
+)
+
+/**
+ * Checks for enum values in the backup that are not recognized by the current app version.
+ * Returns a list of human-readable warning strings.
+ */
+fun DeviceConfigBackup.detectUnknownEnums(): List<String> = buildList {
+    dndMode?.let { key ->
+        if (DndMode.fromKey(key) == null && key != "null") {
+            add("Unknown DnD mode '$key' for device $address, will be ignored")
+        }
+    }
+    if (AlertType.fromKey(connectionAlertType) == AlertType.NONE && connectionAlertType != "none") {
+        add("Unknown alert type '$connectionAlertType' for device $address, defaulting to none")
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManager.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManager.kt
@@ -1,0 +1,236 @@
+package eu.darken.bluemusic.main.backup.core
+
+import android.content.Context
+import android.net.Uri
+import android.provider.OpenableColumns
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.bluemusic.common.BuildConfigWrap
+import eu.darken.bluemusic.common.coroutine.DispatcherProvider
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.DEBUG
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.devices.core.DevicesSettings
+import eu.darken.bluemusic.devices.core.database.DeviceDatabase
+import eu.darken.bluemusic.main.core.GeneralSettings
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.IOException
+import java.time.Instant
+import java.util.zip.ZipEntry
+import java.util.zip.ZipInputStream
+import java.util.zip.ZipOutputStream
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class BackupRestoreManager @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val deviceDatabase: DeviceDatabase,
+    private val devicesSettings: DevicesSettings,
+    private val generalSettings: GeneralSettings,
+    private val json: Json,
+    private val dispatcherProvider: DispatcherProvider,
+) {
+
+    private val prettyJson = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+        prettyPrint = true
+        prettyPrintIndent = "  "
+    }
+
+    data class BackupResult(
+        val deviceConfigCount: Int,
+    )
+
+    data class ParseResult(
+        val backup: AppBackup,
+        val versionMismatch: Boolean,
+        val enumWarnings: List<String>,
+    )
+
+    data class RestoreResult(
+        val deviceCount: Int,
+        val skippedCount: Int,
+    )
+
+    suspend fun createBackup(outputUri: Uri): BackupResult = withContext(dispatcherProvider.IO) {
+        log(TAG, INFO) { "createBackup(uri=$outputUri)" }
+
+        val backup = gatherBackupData()
+
+        log(TAG, DEBUG) { "Backup metadata: formatVersion=${backup.formatVersion}, appVersion=${backup.appVersion}, createdAt=${backup.createdAt}" }
+        log(TAG, DEBUG) { "Backup contents: ${backup.deviceConfigs.size} devices, devicesSettings=${backup.devicesSettings}, generalSettings=${backup.generalSettings}" }
+
+        backup.deviceConfigs.forEachIndexed { i, device ->
+            log(TAG, VERBOSE) { "Backup device[$i]: ${device.address} (name=${device.customName})" }
+        }
+
+        val jsonString = json.encodeToString(AppBackup.serializer(), backup)
+        log(TAG, VERBOSE) { "Backup JSON:\n${prettyJson.encodeToString(AppBackup.serializer(), backup)}" }
+
+        try {
+            val outputStream = context.contentResolver.openOutputStream(outputUri)
+                ?: throw BackupError.BackupIoError(IOException("Could not open output stream for $outputUri"))
+
+            outputStream.use { raw ->
+                ZipOutputStream(BufferedOutputStream(raw)).use { zip ->
+                    zip.putNextEntry(ZipEntry(BACKUP_JSON_ENTRY))
+                    zip.write(jsonString.toByteArray(Charsets.UTF_8))
+                    zip.closeEntry()
+                }
+            }
+        } catch (e: BackupError) {
+            throw e
+        } catch (e: Exception) {
+            throw BackupError.BackupIoError(e)
+        }
+
+        log(TAG, INFO) { "Backup created: ${backup.deviceConfigs.size} devices, ${jsonString.length} bytes JSON" }
+        BackupResult(deviceConfigCount = backup.deviceConfigs.size)
+    }
+
+    suspend fun parseBackup(inputUri: Uri): ParseResult = withContext(dispatcherProvider.IO) {
+        log(TAG, INFO) { "parseBackup(uri=$inputUri)" }
+
+        val jsonString = try {
+            val inputStream = context.contentResolver.openInputStream(inputUri)
+                ?: throw BackupError.BackupIoError(IOException("Could not open input stream for $inputUri"))
+
+            inputStream.use { raw ->
+                ZipInputStream(BufferedInputStream(raw)).use { zip ->
+                    var foundBytes: ByteArray? = null
+                    var entry = zip.nextEntry
+                    while (entry != null) {
+                        if (entry.name == BACKUP_JSON_ENTRY) {
+                            foundBytes = zip.readBytes()
+                        }
+                        entry = zip.nextEntry
+                    }
+                    foundBytes?.toString(Charsets.UTF_8) ?: throw BackupError.MissingBackupJson()
+                }
+            }
+        } catch (e: BackupError) {
+            throw e
+        } catch (e: Exception) {
+            throw BackupError.BackupIoError(e)
+        }
+
+        log(TAG, VERBOSE) { "Loaded JSON (${jsonString.length} bytes):\n${jsonString.toComparableJson()}" }
+
+        val backup = try {
+            json.decodeFromString(AppBackup.serializer(), jsonString)
+        } catch (e: Exception) {
+            throw BackupError.MalformedBackup(e)
+        }
+
+        log(TAG, DEBUG) { "Parsed: formatVersion=${backup.formatVersion}, appVersion=${backup.appVersion}, createdAt=${backup.createdAt}" }
+        log(TAG, DEBUG) { "Parsed: ${backup.deviceConfigs.size} devices, devicesSettings=${backup.devicesSettings}, generalSettings=${backup.generalSettings}" }
+
+        if (backup.formatVersion != CURRENT_FORMAT_VERSION) {
+            log(TAG, WARN) { "Unsupported format version: ${backup.formatVersion} (expected $CURRENT_FORMAT_VERSION)" }
+            throw BackupError.UnsupportedFormatVersion(backup.formatVersion)
+        }
+
+        val versionMismatch = backup.appVersionCode != BuildConfigWrap.VERSION_CODE
+        val enumWarnings = collectEnumWarnings(backup)
+
+        if (versionMismatch) {
+            log(TAG, WARN) { "Version mismatch: backup=${backup.appVersion}, current=${BuildConfigWrap.VERSION_NAME}" }
+        }
+        enumWarnings.forEach { log(TAG, WARN) { "Enum warning: $it" } }
+
+        backup.deviceConfigs.forEachIndexed { i, device ->
+            log(TAG, VERBOSE) { "Parsed device[$i]: ${device.address} (name=${device.customName})" }
+        }
+
+        log(TAG, INFO) { "Parsed backup: ${backup.deviceConfigs.size} devices, versionMismatch=$versionMismatch, ${enumWarnings.size} enum warnings" }
+        ParseResult(backup = backup, versionMismatch = versionMismatch, enumWarnings = enumWarnings)
+    }
+
+    suspend fun applyRestore(backup: AppBackup, skipExisting: Boolean): RestoreResult =
+        withContext(dispatcherProvider.IO) {
+            log(TAG, INFO) { "applyRestore(devices=${backup.deviceConfigs.size}, skipExisting=$skipExisting)" }
+            log(TAG, VERBOSE) { "Restore JSON:\n${prettyJson.encodeToString(AppBackup.serializer(), backup)}" }
+
+            val dao = deviceDatabase.devices
+            val existing = dao.getAllDevices().first().associateBy { it.address }.keys
+            log(TAG, DEBUG) { "Existing devices (${existing.size}): $existing" }
+
+            var restoredCount = 0
+            var skippedCount = 0
+
+            backup.deviceConfigs.forEach { deviceBackup ->
+                if (skipExisting && deviceBackup.address in existing) {
+                    log(TAG, DEBUG) { "Skipping existing device: ${deviceBackup.address} (name=${deviceBackup.customName})" }
+                    skippedCount++
+                    return@forEach
+                }
+                val entity = deviceBackup.toEntity()
+                val isUpdate = deviceBackup.address in existing
+                log(TAG, DEBUG) { "${if (isUpdate) "Updating" else "Inserting"} device: ${entity.toCompactString()}" }
+                dao.updateDevice(entity)
+                restoredCount++
+            }
+
+            log(TAG, DEBUG) { "Restoring DevicesSettings: $backup.devicesSettings" }
+            devicesSettings.applyBackup(backup.devicesSettings)
+
+            log(TAG, DEBUG) { "Restoring GeneralSettings: ${backup.generalSettings}" }
+            generalSettings.applyBackup(backup.generalSettings)
+
+            log(TAG, INFO) { "Restore complete: $restoredCount restored, $skippedCount skipped" }
+            RestoreResult(deviceCount = restoredCount, skippedCount = skippedCount)
+        }
+
+    fun resolveFileName(uri: Uri): String {
+        context.contentResolver.query(uri, arrayOf(OpenableColumns.DISPLAY_NAME), null, null, null)?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val nameIndex = cursor.getColumnIndex(OpenableColumns.DISPLAY_NAME)
+                if (nameIndex >= 0) return cursor.getString(nameIndex)
+            }
+        }
+        return uri.lastPathSegment ?: uri.toString()
+    }
+
+    private suspend fun gatherBackupData(): AppBackup {
+        val devices = deviceDatabase.devices.getAllDevices().first()
+        return AppBackup(
+            formatVersion = CURRENT_FORMAT_VERSION,
+            appVersion = BuildConfigWrap.VERSION_NAME,
+            appVersionCode = BuildConfigWrap.VERSION_CODE,
+            createdAt = Instant.now().toString(),
+            deviceConfigs = devices.map { it.toBackup() },
+            devicesSettings = devicesSettings.toBackup(),
+            generalSettings = generalSettings.toBackup(),
+        )
+    }
+
+    private fun collectEnumWarnings(backup: AppBackup): List<String> = buildList {
+        backup.deviceConfigs.forEach { device ->
+            addAll(device.detectUnknownEnums())
+        }
+        addAll(generalSettings.detectUnknownEnums(backup.generalSettings))
+    }
+
+    private fun String.toComparableJson(): String = try {
+        val element = Json.parseToJsonElement(this)
+        prettyJson.encodeToString(JsonElement.serializer(), element)
+    } catch (e: Exception) {
+        this
+    }
+
+    companion object {
+        private val TAG = logTag("Backup", "Restore", "Manager")
+        const val CURRENT_FORMAT_VERSION = 1
+        const val BACKUP_JSON_ENTRY = "backup.json"
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/main/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/core/GeneralSettings.kt
@@ -8,7 +8,9 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.bluemusic.common.BuildConfigWrap
 import eu.darken.bluemusic.common.datastore.PreferenceData
 import eu.darken.bluemusic.common.datastore.createValue
+import eu.darken.bluemusic.common.datastore.value
 import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.main.backup.core.GeneralSettingsBackup
 import eu.darken.bluemusic.common.theming.ThemeColor
 import eu.darken.bluemusic.common.theming.ThemeMode
 import eu.darken.bluemusic.common.theming.ThemeStyle
@@ -46,6 +48,39 @@ class GeneralSettings @Inject constructor(
     val isAndroid10AppLaunchHintDismissed = dataStore.createValue("hints.android10.applaunch.dismissed", false)
     val isNotificationPermissionHintDismissed = dataStore.createValue("hints.notification.permission.dismissed", false)
 
+
+    suspend fun toBackup(): GeneralSettingsBackup = GeneralSettingsBackup(
+        themeMode = themeMode.value().name,
+        themeStyle = themeStyle.value().name,
+        themeColor = themeColor.value().name,
+        isOnboardingCompleted = isOnboardingCompleted.value(),
+        isBatteryOptimizationHintDismissed = isBatteryOptimizationHintDismissed.value(),
+        isAndroid10AppLaunchHintDismissed = isAndroid10AppLaunchHintDismissed.value(),
+        isNotificationPermissionHintDismissed = isNotificationPermissionHintDismissed.value(),
+    )
+
+    suspend fun applyBackup(backup: GeneralSettingsBackup) {
+        themeMode.value(ThemeMode.entries.find { it.name == backup.themeMode } ?: ThemeMode.SYSTEM)
+        themeStyle.value(ThemeStyle.entries.find { it.name == backup.themeStyle } ?: ThemeStyle.DEFAULT)
+        themeColor.value(ThemeColor.entries.find { it.name == backup.themeColor } ?: ThemeColor.BLUE)
+        // Progression flags: only set to true, never revert to false
+        if (backup.isOnboardingCompleted) isOnboardingCompleted.value(true)
+        if (backup.isBatteryOptimizationHintDismissed) isBatteryOptimizationHintDismissed.value(true)
+        if (backup.isAndroid10AppLaunchHintDismissed) isAndroid10AppLaunchHintDismissed.value(true)
+        if (backup.isNotificationPermissionHintDismissed) isNotificationPermissionHintDismissed.value(true)
+    }
+
+    fun detectUnknownEnums(backup: GeneralSettingsBackup): List<String> = buildList {
+        if (ThemeMode.entries.none { it.name == backup.themeMode }) {
+            add("Unknown theme mode '${backup.themeMode}', defaulting to System")
+        }
+        if (ThemeStyle.entries.none { it.name == backup.themeStyle }) {
+            add("Unknown theme style '${backup.themeStyle}', defaulting to Default")
+        }
+        if (ThemeColor.entries.none { it.name == backup.themeColor }) {
+            add("Unknown theme color '${backup.themeColor}', defaulting to Blue")
+        }
+    }
 
     companion object {
         internal val TAG = logTag("Core", "Settings")

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ListAlt
+import androidx.compose.material.icons.twotone.Backup
 import androidx.compose.material.icons.twotone.Devices
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.Info
@@ -155,6 +156,16 @@ fun SettingsIndexScreen(
                     title = stringResource(R.string.devices_settings_label),
                     subtitle = stringResource(R.string.devices_settings_desc),
                     onClick = { onNavigateTo(Nav.Settings.Devices) },
+                )
+                SettingsDivider()
+            }
+
+            item {
+                SettingsBaseItem(
+                    icon = Icons.TwoTone.Backup,
+                    title = stringResource(R.string.backup_restore_settings_label),
+                    subtitle = stringResource(R.string.backup_restore_settings_desc),
+                    onClick = { onNavigateTo(Nav.Settings.BackupRestore) },
                 )
                 SettingsDivider()
             }

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreEvent.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreEvent.kt
@@ -1,0 +1,6 @@
+package eu.darken.bluemusic.main.ui.settings.backup
+
+sealed interface BackupRestoreEvent {
+    data class OpenBackupPicker(val suggestedName: String) : BackupRestoreEvent
+    data object OpenRestorePicker : BackupRestoreEvent
+}

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreNavigation.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreNavigation.kt
@@ -1,0 +1,26 @@
+package eu.darken.bluemusic.main.ui.settings.backup
+
+import androidx.navigation3.runtime.EntryProviderScope
+import androidx.navigation3.runtime.NavKey
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import dagger.multibindings.IntoSet
+import eu.darken.bluemusic.common.navigation.Nav
+import eu.darken.bluemusic.common.navigation.NavigationEntry
+import javax.inject.Inject
+
+class BackupRestoreNavigation @Inject constructor() : NavigationEntry {
+    override fun EntryProviderScope<NavKey>.setup() {
+        entry<Nav.Settings.BackupRestore> {
+            BackupRestoreScreenHost()
+        }
+    }
+
+    @Suppress("unused")
+    @Module @InstallIn(SingletonComponent::class)
+    abstract class Mod {
+        @Binds @IntoSet abstract fun bind(entry: BackupRestoreNavigation): NavigationEntry
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreScreen.kt
@@ -1,0 +1,515 @@
+package eu.darken.bluemusic.main.ui.settings.backup
+
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.twotone.Backup
+import androidx.compose.material.icons.twotone.CheckCircle
+import androidx.compose.material.icons.twotone.Restore
+import androidx.compose.material.icons.twotone.Warning
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.compose.Preview2
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.compose.horizontalCutoutPadding
+import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.error.ErrorEventHandler
+import eu.darken.bluemusic.main.backup.core.AppBackup
+
+@Composable
+fun BackupRestoreScreenHost(vm: BackupRestoreViewModel = hiltViewModel()) {
+    ErrorEventHandler(vm)
+
+    val backupLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.CreateDocument("application/zip")
+    ) { uri: Uri? ->
+        uri?.let {
+            log(vm.tag, INFO) { "Backup URI selected: $it" }
+            vm.onBackupUriSelected(it)
+        }
+    }
+
+    val restoreLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri: Uri? ->
+        uri?.let {
+            log(vm.tag, INFO) { "Restore URI selected: $it" }
+            vm.onRestoreUriSelected(it)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        vm.events.collect { event ->
+            when (event) {
+                is BackupRestoreEvent.OpenBackupPicker -> backupLauncher.launch(event.suggestedName)
+                is BackupRestoreEvent.OpenRestorePicker -> restoreLauncher.launch(arrayOf("application/zip", "application/octet-stream"))
+            }
+        }
+    }
+
+    val state by vm.state.collectAsStateWithLifecycle()
+
+    state?.let { s ->
+        BackupRestoreScreen(
+            state = s,
+            onNavigateUp = { vm.navUp() },
+            onBackupClicked = { vm.onBackupClicked() },
+            onRestoreClicked = { vm.onRestoreClicked() },
+            onToggleSkipExisting = { vm.onToggleSkipExisting(it) },
+            onConfirmRestore = { vm.onConfirmRestore() },
+            onCancelRestore = { vm.onCancelRestore() },
+        )
+    }
+}
+
+@Composable
+fun BackupRestoreScreen(
+    state: BackupRestoreViewModel.State,
+    onNavigateUp: () -> Unit,
+    onBackupClicked: () -> Unit,
+    onRestoreClicked: () -> Unit,
+    onToggleSkipExisting: (Boolean) -> Unit,
+    onConfirmRestore: () -> Unit,
+    onCancelRestore: () -> Unit,
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(R.string.backup_restore_screen_title)) },
+                navigationIcon = {
+                    IconButton(onClick = onNavigateUp) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.general_back_action)
+                        )
+                    }
+                }
+            )
+        },
+        contentWindowInsets = WindowInsets.statusBars
+    ) { paddingValues ->
+        val navBarPadding = navigationBarBottomPadding()
+
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+        ) {
+            if (state.isWorking) {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+            }
+
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .horizontalCutoutPadding(),
+                contentPadding = PaddingValues(
+                    start = 16.dp,
+                    end = 16.dp,
+                    top = 8.dp,
+                    bottom = navBarPadding + 16.dp,
+                ),
+                verticalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                item { BackupSection(isWorking = state.isWorking, onBackupClicked = onBackupClicked) }
+
+                item {
+                    RestoreSection(
+                        isWorking = state.isWorking,
+                        skipExisting = state.skipExisting,
+                        hasPendingPreview = state.pendingRestore != null,
+                        onRestoreClicked = onRestoreClicked,
+                        onToggleSkipExisting = onToggleSkipExisting,
+                    )
+                }
+
+                state.pendingRestore?.let { preview ->
+                    item {
+                        RestorePreviewSection(
+                            preview = preview,
+                            isWorking = state.isWorking,
+                            onConfirmRestore = onConfirmRestore,
+                            onCancelRestore = onCancelRestore,
+                        )
+                    }
+                }
+
+                state.lastResult?.let { result ->
+                    item { ResultSection(result = result) }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BackupSection(
+    isWorking: Boolean,
+    onBackupClicked: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.TwoTone.Backup,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.padding(horizontal = 8.dp))
+                Text(
+                    text = stringResource(R.string.backup_restore_backup_action),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.backup_restore_backup_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(
+                onClick = onBackupClicked,
+                enabled = !isWorking,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.backup_restore_backup_action))
+            }
+        }
+    }
+}
+
+@Composable
+private fun RestoreSection(
+    isWorking: Boolean,
+    skipExisting: Boolean,
+    hasPendingPreview: Boolean,
+    onRestoreClicked: () -> Unit,
+    onToggleSkipExisting: (Boolean) -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.TwoTone.Restore,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.padding(horizontal = 8.dp))
+                Text(
+                    text = stringResource(R.string.backup_restore_restore_action),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.backup_restore_restore_desc),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = stringResource(R.string.backup_restore_skip_existing_label),
+                        style = MaterialTheme.typography.bodyLarge,
+                    )
+                    Text(
+                        text = stringResource(R.string.backup_restore_skip_existing_desc),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+                Switch(
+                    checked = skipExisting,
+                    onCheckedChange = onToggleSkipExisting,
+                )
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+            Button(
+                onClick = onRestoreClicked,
+                enabled = !isWorking && !hasPendingPreview,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(stringResource(R.string.backup_restore_restore_action))
+            }
+        }
+    }
+}
+
+@Composable
+private fun RestorePreviewSection(
+    preview: BackupRestoreViewModel.RestorePreview,
+    isWorking: Boolean,
+    onConfirmRestore: () -> Unit,
+    onCancelRestore: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.backup_restore_preview_label),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
+                text = preview.fileName,
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            Text(
+                text = "v${preview.backup.appVersion} — ${preview.backup.createdAt}",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = stringResource(R.string.backup_restore_preview_devices, preview.deviceCount),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+            if (preview.existingDeviceCount > 0) {
+                Text(
+                    text = stringResource(
+                        R.string.backup_restore_preview_overlap,
+                        preview.existingDeviceCount,
+                        preview.deviceCount,
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer.copy(alpha = 0.7f),
+                )
+            }
+
+            if (preview.versionMismatch || preview.warnings.isNotEmpty()) {
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            if (preview.versionMismatch) {
+                WarningCard(
+                    text = stringResource(
+                        R.string.backup_restore_version_warning,
+                        preview.backup.appVersion,
+                        eu.darken.bluemusic.common.BuildConfigWrap.VERSION_NAME,
+                    ),
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+
+            preview.warnings.forEach { warning ->
+                WarningCard(text = warning)
+                Spacer(modifier = Modifier.height(4.dp))
+            }
+
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+            ) {
+                OutlinedButton(
+                    onClick = onCancelRestore,
+                    modifier = Modifier.weight(1f),
+                    enabled = !isWorking,
+                ) {
+                    Text(stringResource(R.string.general_cancel_action))
+                }
+                Button(
+                    onClick = onConfirmRestore,
+                    modifier = Modifier.weight(1f),
+                    enabled = !isWorking,
+                ) {
+                    Text(stringResource(R.string.backup_restore_confirm_action))
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun WarningCard(text: String) {
+    Card(
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+        ),
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Row(
+            modifier = Modifier.padding(12.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Icon(
+                imageVector = Icons.TwoTone.Warning,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.tertiary,
+            )
+            Spacer(modifier = Modifier.padding(horizontal = 6.dp))
+            Text(
+                text = text,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ResultSection(result: BackupRestoreViewModel.OperationResult) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(
+                    imageVector = Icons.TwoTone.CheckCircle,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.padding(horizontal = 8.dp))
+                Text(
+                    text = result.fileName,
+                    style = MaterialTheme.typography.titleSmall,
+                )
+            }
+            Spacer(modifier = Modifier.height(4.dp))
+            val summary = when (result.type) {
+                BackupRestoreViewModel.OperationType.BACKUP -> stringResource(
+                    R.string.backup_restore_success_backup,
+                    result.deviceCount,
+                )
+
+                BackupRestoreViewModel.OperationType.RESTORE -> stringResource(
+                    R.string.backup_restore_success_restore,
+                    result.deviceCount,
+                    result.skippedCount,
+                )
+            }
+            Text(
+                text = summary,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+        }
+    }
+}
+
+@Preview2
+@Composable
+private fun BackupRestoreScreenIdlePreview() {
+    PreviewWrapper {
+        BackupRestoreScreen(
+            state = BackupRestoreViewModel.State(),
+            onNavigateUp = {},
+            onBackupClicked = {},
+            onRestoreClicked = {},
+            onToggleSkipExisting = {},
+            onConfirmRestore = {},
+            onCancelRestore = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun BackupRestoreScreenPreviewPreview() {
+    PreviewWrapper {
+        BackupRestoreScreen(
+            state = BackupRestoreViewModel.State(
+                pendingRestore = BackupRestoreViewModel.RestorePreview(
+                    fileUri = Uri.EMPTY,
+                    fileName = "bluemusic-backup-2026-04-16.zip",
+                    backup = AppBackup(
+                        formatVersion = 1,
+                        appVersion = "3.2.0",
+                        appVersionCode = 32000L,
+                        createdAt = "2026-04-15T10:30:00Z",
+                    ),
+                    versionMismatch = true,
+                    deviceCount = 5,
+                    existingDeviceCount = 2,
+                    warnings = listOf("Unknown DnD mode 'future_mode' for device AA:BB:CC:DD:EE:FF, will be ignored"),
+                ),
+            ),
+            onNavigateUp = {},
+            onBackupClicked = {},
+            onRestoreClicked = {},
+            onToggleSkipExisting = {},
+            onConfirmRestore = {},
+            onCancelRestore = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun BackupRestoreScreenResultPreview() {
+    PreviewWrapper {
+        BackupRestoreScreen(
+            state = BackupRestoreViewModel.State(
+                lastResult = BackupRestoreViewModel.OperationResult(
+                    type = BackupRestoreViewModel.OperationType.RESTORE,
+                    deviceCount = 5,
+                    skippedCount = 2,
+                    fileName = "bluemusic-backup-2026-04-16.zip",
+                ),
+            ),
+            onNavigateUp = {},
+            onBackupClicked = {},
+            onRestoreClicked = {},
+            onToggleSkipExisting = {},
+            onConfirmRestore = {},
+            onCancelRestore = {},
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreViewModel.kt
@@ -1,0 +1,166 @@
+package eu.darken.bluemusic.main.ui.settings.backup
+
+import android.net.Uri
+import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.bluemusic.common.coroutine.DispatcherProvider
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.common.navigation.NavigationController
+import eu.darken.bluemusic.common.ui.ViewModel4
+import eu.darken.bluemusic.devices.core.database.DeviceDatabase
+import eu.darken.bluemusic.main.backup.core.AppBackup
+import eu.darken.bluemusic.main.backup.core.BackupRestoreManager
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.receiveAsFlow
+import java.time.LocalDate
+import javax.inject.Inject
+
+@HiltViewModel
+class BackupRestoreViewModel @Inject constructor(
+    dispatcherProvider: DispatcherProvider,
+    navCtrl: NavigationController,
+    private val backupRestoreManager: BackupRestoreManager,
+    private val deviceDatabase: DeviceDatabase,
+) : ViewModel4(dispatcherProvider, logTag("Settings", "Backup", "VM"), navCtrl) {
+
+    private val eventChannel = Channel<BackupRestoreEvent>()
+    val events = eventChannel.receiveAsFlow()
+
+    private val isWorkingFlow = MutableStateFlow(false)
+    private val skipExistingFlow = MutableStateFlow(false)
+    private val pendingRestoreFlow = MutableStateFlow<RestorePreview?>(null)
+    private val lastResultFlow = MutableStateFlow<OperationResult?>(null)
+
+    val state = combine(
+        isWorkingFlow,
+        skipExistingFlow,
+        pendingRestoreFlow,
+        lastResultFlow,
+    ) { isWorking, skipExisting, pendingRestore, lastResult ->
+        State(
+            isWorking = isWorking,
+            skipExisting = skipExisting,
+            pendingRestore = pendingRestore,
+            lastResult = lastResult,
+        )
+    }.asStateFlow()
+
+    fun onBackupClicked() = launch {
+        log(tag, INFO) { "onBackupClicked()" }
+        lastResultFlow.value = null
+        pendingRestoreFlow.value = null
+        val suggestedName = "bluemusic-backup-${LocalDate.now()}.zip"
+        eventChannel.send(BackupRestoreEvent.OpenBackupPicker(suggestedName))
+    }
+
+    fun onRestoreClicked() = launch {
+        log(tag, INFO) { "onRestoreClicked()" }
+        lastResultFlow.value = null
+        pendingRestoreFlow.value = null
+        eventChannel.send(BackupRestoreEvent.OpenRestorePicker)
+    }
+
+    fun onBackupUriSelected(uri: Uri) = launch {
+        log(tag, INFO) { "onBackupUriSelected(uri=$uri)" }
+        isWorkingFlow.value = true
+        try {
+            val result = backupRestoreManager.createBackup(uri)
+            val fileName = backupRestoreManager.resolveFileName(uri)
+            lastResultFlow.value = OperationResult(
+                type = OperationType.BACKUP,
+                deviceCount = result.deviceConfigCount,
+                skippedCount = 0,
+                fileName = fileName,
+            )
+        } finally {
+            isWorkingFlow.value = false
+        }
+    }
+
+    fun onRestoreUriSelected(uri: Uri) = launch {
+        log(tag, INFO) { "onRestoreUriSelected(uri=$uri)" }
+        isWorkingFlow.value = true
+        try {
+            val parseResult = backupRestoreManager.parseBackup(uri)
+            val fileName = backupRestoreManager.resolveFileName(uri)
+
+            val existingAddresses = deviceDatabase.devices.getAllDevices().first()
+                .map { it.address }
+                .toSet()
+            val overlapCount = parseResult.backup.deviceConfigs.count { it.address in existingAddresses }
+
+            pendingRestoreFlow.value = RestorePreview(
+                fileUri = uri,
+                fileName = fileName,
+                backup = parseResult.backup,
+                versionMismatch = parseResult.versionMismatch,
+                deviceCount = parseResult.backup.deviceConfigs.size,
+                existingDeviceCount = overlapCount,
+                warnings = parseResult.enumWarnings,
+            )
+        } finally {
+            isWorkingFlow.value = false
+        }
+    }
+
+    fun onConfirmRestore() = launch {
+        val preview = pendingRestoreFlow.value ?: return@launch
+        log(tag, INFO) { "onConfirmRestore()" }
+        pendingRestoreFlow.value = null
+        isWorkingFlow.value = true
+        try {
+            val result = backupRestoreManager.applyRestore(
+                backup = preview.backup,
+                skipExisting = skipExistingFlow.value,
+            )
+            lastResultFlow.value = OperationResult(
+                type = OperationType.RESTORE,
+                deviceCount = result.deviceCount,
+                skippedCount = result.skippedCount,
+                fileName = preview.fileName,
+            )
+        } finally {
+            isWorkingFlow.value = false
+        }
+    }
+
+    fun onCancelRestore() {
+        log(tag, INFO) { "onCancelRestore()" }
+        pendingRestoreFlow.value = null
+    }
+
+    fun onToggleSkipExisting(skip: Boolean) {
+        log(tag) { "onToggleSkipExisting($skip)" }
+        skipExistingFlow.value = skip
+    }
+
+    data class State(
+        val isWorking: Boolean = false,
+        val skipExisting: Boolean = false,
+        val pendingRestore: RestorePreview? = null,
+        val lastResult: OperationResult? = null,
+    )
+
+    data class RestorePreview(
+        val fileUri: Uri,
+        val fileName: String,
+        val backup: AppBackup,
+        val versionMismatch: Boolean,
+        val deviceCount: Int,
+        val existingDeviceCount: Int,
+        val warnings: List<String>,
+    )
+
+    enum class OperationType { BACKUP, RESTORE }
+
+    data class OperationResult(
+        val type: OperationType,
+        val deviceCount: Int,
+        val skippedCount: Int,
+        val fileName: String,
+    )
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,6 +227,24 @@
 
     <string name="changelog_label">Changelog</string>
 
+    <!-- Backup & Restore -->
+    <string name="backup_restore_settings_label">Backup &amp; Restore</string>
+    <string name="backup_restore_settings_desc">Back up and restore your device configurations and settings.</string>
+    <string name="backup_restore_screen_title">Backup &amp; Restore</string>
+    <string name="backup_restore_backup_desc">Create a backup of all your device configurations and app settings.</string>
+    <string name="backup_restore_backup_action">Create backup</string>
+    <string name="backup_restore_restore_desc">Restore device configurations and app settings from a backup file.</string>
+    <string name="backup_restore_restore_action">Select backup file</string>
+    <string name="backup_restore_skip_existing_label">Skip existing devices</string>
+    <string name="backup_restore_skip_existing_desc">Don\'t overwrite devices that are already configured.</string>
+    <string name="backup_restore_preview_label">Backup preview</string>
+    <string name="backup_restore_preview_devices">%1$d devices</string>
+    <string name="backup_restore_preview_overlap">%1$d of %2$d devices already configured</string>
+    <string name="backup_restore_confirm_action">Restore now</string>
+    <string name="backup_restore_success_backup">Backup created — %1$d devices saved.</string>
+    <string name="backup_restore_success_restore">Restore complete — %1$d devices restored, %2$d skipped.</string>
+    <string name="backup_restore_version_warning">This backup was created with version %1$s. You\'re running %2$s. Some settings may not restore correctly.</string>
+
     <!-- Debug Log -->
     <string name="debug_notification_channel_label">Debug notifications</string>
     <string name="debug_log_consent_title">Debug log</string>

--- a/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupDataTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupDataTest.kt
@@ -1,0 +1,295 @@
+package eu.darken.bluemusic.main.backup.core
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.json.toComparableJson
+
+class BackupDataTest : BaseTest() {
+
+    private val json = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+        prettyPrint = true
+    }
+
+    private val jsonCompact = Json {
+        ignoreUnknownKeys = true
+        encodeDefaults = true
+        explicitNulls = false
+    }
+
+    private fun createMaximalFixture() = AppBackup(
+        formatVersion = 1,
+        appVersion = "3.3.1",
+        appVersionCode = 33100L,
+        createdAt = "2026-04-16T14:30:00Z",
+        deviceConfigs = listOf(
+            DeviceConfigBackup(
+                address = "AA:BB:CC:DD:EE:FF",
+                customName = "My Headphones",
+                lastConnected = 1713270600000L,
+                actionDelay = 500L,
+                adjustmentDelay = 200L,
+                monitoringDuration = 30000L,
+                musicVolume = 0.75f,
+                callVolume = 0.5f,
+                ringVolume = 0.3f,
+                notificationVolume = 0.4f,
+                alarmVolume = 0.6f,
+                volumeLock = true,
+                volumeObserving = true,
+                volumeRateLimiter = true,
+                volumeRateLimitIncreaseMs = 100L,
+                volumeRateLimitDecreaseMs = 200L,
+                volumeSaveOnDisconnect = true,
+                keepAwake = true,
+                nudgeVolume = true,
+                autoplay = true,
+                launchPkgs = listOf("com.spotify.music", "com.google.android.apps.youtube.music"),
+                showHomeScreen = true,
+                autoplayKeycodes = listOf(126, 85),
+                isEnabled = true,
+                visibleAdjustments = false,
+                dndMode = "priority_only",
+                connectionAlertType = "sound",
+                connectionAlertSoundUri = "content://media/external/audio/123",
+            ),
+            DeviceConfigBackup(
+                address = "11:22:33:44:55:66",
+            ),
+        ),
+        devicesSettings = DevicesSettingsBackup(
+            isEnabled = false,
+            restoreOnBoot = false,
+            lockedDevices = setOf("AA:BB:CC:DD:EE:FF"),
+        ),
+        generalSettings = GeneralSettingsBackup(
+            themeMode = "DARK",
+            themeStyle = "MATERIAL_YOU",
+            themeColor = "SUNSET",
+            isOnboardingCompleted = true,
+            isBatteryOptimizationHintDismissed = true,
+            isAndroid10AppLaunchHintDismissed = true,
+            isNotificationPermissionHintDismissed = true,
+        ),
+    )
+
+    /**
+     * Golden fixture test: if the JSON output changes (field renamed, reordered, removed, type changed),
+     * this test fails. This protects against accidental format breakage.
+     *
+     * Do NOT update the expected JSON unless you are intentionally changing the backup format
+     * (which requires bumping formatVersion).
+     */
+    @Test
+    fun `serialized format matches golden fixture`() {
+        val backup = createMaximalFixture()
+        val actualJson = jsonCompact.encodeToString(AppBackup.serializer(), backup)
+
+        actualJson.toComparableJson() shouldBe """
+            {
+                "formatVersion": 1,
+                "appVersion": "3.3.1",
+                "appVersionCode": 33100,
+                "createdAt": "2026-04-16T14:30:00Z",
+                "deviceConfigs": [
+                    {
+                        "address": "AA:BB:CC:DD:EE:FF",
+                        "customName": "My Headphones",
+                        "lastConnected": 1713270600000,
+                        "actionDelay": 500,
+                        "adjustmentDelay": 200,
+                        "monitoringDuration": 30000,
+                        "musicVolume": 0.75,
+                        "callVolume": 0.5,
+                        "ringVolume": 0.3,
+                        "notificationVolume": 0.4,
+                        "alarmVolume": 0.6,
+                        "volumeLock": true,
+                        "volumeObserving": true,
+                        "volumeRateLimiter": true,
+                        "volumeRateLimitIncreaseMs": 100,
+                        "volumeRateLimitDecreaseMs": 200,
+                        "volumeSaveOnDisconnect": true,
+                        "keepAwake": true,
+                        "nudgeVolume": true,
+                        "autoplay": true,
+                        "launchPkgs": [
+                            "com.spotify.music",
+                            "com.google.android.apps.youtube.music"
+                        ],
+                        "showHomeScreen": true,
+                        "autoplayKeycodes": [
+                            126,
+                            85
+                        ],
+                        "isEnabled": true,
+                        "visibleAdjustments": false,
+                        "dndMode": "priority_only",
+                        "connectionAlertType": "sound",
+                        "connectionAlertSoundUri": "content://media/external/audio/123"
+                    },
+                    {
+                        "address": "11:22:33:44:55:66",
+                        "lastConnected": 0,
+                        "volumeLock": false,
+                        "volumeObserving": false,
+                        "volumeRateLimiter": false,
+                        "volumeSaveOnDisconnect": false,
+                        "keepAwake": false,
+                        "nudgeVolume": false,
+                        "autoplay": false,
+                        "launchPkgs": [],
+                        "showHomeScreen": false,
+                        "autoplayKeycodes": [],
+                        "isEnabled": true,
+                        "visibleAdjustments": true,
+                        "connectionAlertType": "none"
+                    }
+                ],
+                "devicesSettings": {
+                    "isEnabled": false,
+                    "restoreOnBoot": false,
+                    "lockedDevices": [
+                        "AA:BB:CC:DD:EE:FF"
+                    ]
+                },
+                "generalSettings": {
+                    "themeMode": "DARK",
+                    "themeStyle": "MATERIAL_YOU",
+                    "themeColor": "SUNSET",
+                    "isOnboardingCompleted": true,
+                    "isBatteryOptimizationHintDismissed": true,
+                    "isAndroid10AppLaunchHintDismissed": true,
+                    "isNotificationPermissionHintDismissed": true
+                }
+            }
+        """.trimIndent()
+    }
+
+    @Test
+    fun `round-trip serialization preserves all fields`() {
+        val original = createMaximalFixture()
+        val jsonString = json.encodeToString(AppBackup.serializer(), original)
+        val restored = json.decodeFromString(AppBackup.serializer(), jsonString)
+        restored shouldBe original
+    }
+
+    @Test
+    fun `round-trip with minimal device config`() {
+        val original = AppBackup(
+            formatVersion = 1,
+            appVersion = "1.0.0",
+            createdAt = "2026-01-01T00:00:00Z",
+            deviceConfigs = listOf(DeviceConfigBackup(address = "AA:BB:CC:DD:EE:FF")),
+        )
+        val jsonString = json.encodeToString(AppBackup.serializer(), original)
+        val restored = json.decodeFromString(AppBackup.serializer(), jsonString)
+        restored shouldBe original
+    }
+
+    @Test
+    fun `deserialization tolerates unknown fields`() {
+        val jsonString = """
+        {
+            "formatVersion": 1,
+            "appVersion": "3.3.1",
+            "createdAt": "2026-04-16T14:30:00Z",
+            "unknownField": "should be ignored",
+            "deviceConfigs": [{
+                "address": "AA:BB:CC:DD:EE:FF",
+                "futureField": 42
+            }],
+            "devicesSettings": {"unknownSetting": true},
+            "generalSettings": {"newThemeThing": "fancy"}
+        }
+        """.trimIndent()
+
+        val backup = json.decodeFromString(AppBackup.serializer(), jsonString)
+        backup.formatVersion shouldBe 1
+        backup.deviceConfigs.size shouldBe 1
+        backup.deviceConfigs[0].address shouldBe "AA:BB:CC:DD:EE:FF"
+    }
+
+    @Test
+    fun `deserialization with missing optional fields uses defaults`() {
+        val jsonString = """
+        {
+            "formatVersion": 1,
+            "appVersion": "1.0.0",
+            "createdAt": "2026-01-01T00:00:00Z"
+        }
+        """.trimIndent()
+
+        val backup = json.decodeFromString(AppBackup.serializer(), jsonString)
+        backup.deviceConfigs shouldBe emptyList()
+        backup.devicesSettings shouldBe DevicesSettingsBackup()
+        backup.generalSettings shouldBe GeneralSettingsBackup()
+    }
+
+    @Test
+    fun `DeviceConfigBackup defaults match entity defaults`() {
+        val defaults = DeviceConfigBackup(address = "test")
+        defaults.volumeLock shouldBe false
+        defaults.volumeObserving shouldBe false
+        defaults.isEnabled shouldBe true
+        defaults.connectionAlertType shouldBe "none"
+        defaults.launchPkgs shouldBe emptyList()
+        defaults.autoplayKeycodes shouldBe emptyList()
+        defaults.showHomeScreen shouldBe false
+        defaults.visibleAdjustments shouldBe true
+    }
+
+    @Test
+    fun `GeneralSettingsBackup defaults match settings defaults`() {
+        val defaults = GeneralSettingsBackup()
+        defaults.themeMode shouldBe "SYSTEM"
+        defaults.themeStyle shouldBe "DEFAULT"
+        defaults.themeColor shouldBe "BLUE"
+        defaults.isOnboardingCompleted shouldBe false
+    }
+
+    @Test
+    fun `DevicesSettingsBackup defaults match settings defaults`() {
+        val defaults = DevicesSettingsBackup()
+        defaults.isEnabled shouldBe true
+        defaults.restoreOnBoot shouldBe true
+        defaults.lockedDevices shouldBe emptySet()
+    }
+
+    @Test
+    fun `serialized output contains all expected top-level keys`() {
+        val backup = createMaximalFixture()
+        val jsonString = json.encodeToString(AppBackup.serializer(), backup)
+        jsonString shouldContain "\"formatVersion\""
+        jsonString shouldContain "\"appVersion\""
+        jsonString shouldContain "\"createdAt\""
+        jsonString shouldContain "\"deviceConfigs\""
+        jsonString shouldContain "\"devicesSettings\""
+        jsonString shouldContain "\"generalSettings\""
+    }
+
+    @Test
+    fun `enum string fields survive unknown values during deserialization`() {
+        val jsonString = """
+        {
+            "formatVersion": 1,
+            "appVersion": "1.0.0",
+            "createdAt": "2026-01-01T00:00:00Z",
+            "deviceConfigs": [{
+                "address": "AA:BB:CC:DD:EE:FF",
+                "dndMode": "future_silence_mode",
+                "connectionAlertType": "hologram"
+            }]
+        }
+        """.trimIndent()
+
+        val backup = json.decodeFromString(AppBackup.serializer(), jsonString)
+        backup.deviceConfigs[0].dndMode shouldBe "future_silence_mode"
+        backup.deviceConfigs[0].connectionAlertType shouldBe "hologram"
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupMappersTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupMappersTest.kt
@@ -1,0 +1,129 @@
+package eu.darken.bluemusic.main.backup.core
+
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.monitor.core.alert.AlertType
+import eu.darken.bluemusic.monitor.core.audio.DndMode
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class BackupMappersTest : BaseTest() {
+
+    @Test
+    fun `entity to backup round-trip preserves all fields`() {
+        val entity = DeviceConfigEntity(
+            address = "AA:BB:CC:DD:EE:FF",
+            customName = "Test Device",
+            lastConnected = 1713270600000L,
+            actionDelay = 500L,
+            adjustmentDelay = 200L,
+            monitoringDuration = 30000L,
+            musicVolume = 0.75f,
+            callVolume = 0.5f,
+            ringVolume = 0.3f,
+            notificationVolume = 0.4f,
+            alarmVolume = 0.6f,
+            volumeLock = true,
+            volumeObserving = true,
+            volumeRateLimiter = true,
+            volumeRateLimitIncreaseMs = 100L,
+            volumeRateLimitDecreaseMs = 200L,
+            volumeSaveOnDisconnect = true,
+            keepAwake = true,
+            nudgeVolume = true,
+            autoplay = true,
+            launchPkgs = listOf("com.example"),
+            showHomeScreen = true,
+            autoplayKeycodes = listOf(126),
+            isEnabled = false,
+            visibleAdjustments = false,
+            dndMode = DndMode.PRIORITY_ONLY,
+            connectionAlertType = AlertType.SOUND,
+            connectionAlertSoundUri = "content://test/123",
+        )
+
+        val backup = entity.toBackup()
+        val restored = backup.toEntity()
+
+        restored shouldBe entity
+    }
+
+    @Test
+    fun `entity to backup maps DndMode to key string`() {
+        val entity = DeviceConfigEntity(address = "test", dndMode = DndMode.TOTAL_SILENCE)
+        val backup = entity.toBackup()
+        backup.dndMode shouldBe "total_silence"
+    }
+
+    @Test
+    fun `entity to backup maps null DndMode to null`() {
+        val entity = DeviceConfigEntity(address = "test", dndMode = null)
+        val backup = entity.toBackup()
+        backup.dndMode shouldBe null
+    }
+
+    @Test
+    fun `entity to backup maps AlertType to key string`() {
+        val entity = DeviceConfigEntity(address = "test", connectionAlertType = AlertType.BOTH)
+        val backup = entity.toBackup()
+        backup.connectionAlertType shouldBe "both"
+    }
+
+    @Test
+    fun `backup to entity maps unknown DndMode key to null`() {
+        val backup = DeviceConfigBackup(address = "test", dndMode = "future_mode")
+        val entity = backup.toEntity()
+        entity.dndMode shouldBe null
+    }
+
+    @Test
+    fun `backup to entity maps unknown AlertType key to NONE`() {
+        val backup = DeviceConfigBackup(address = "test", connectionAlertType = "hologram")
+        val entity = backup.toEntity()
+        entity.connectionAlertType shouldBe AlertType.NONE
+    }
+
+    @Test
+    fun `detectUnknownEnums returns empty for known values`() {
+        val backup = DeviceConfigBackup(
+            address = "test",
+            dndMode = "priority_only",
+            connectionAlertType = "sound",
+        )
+        backup.detectUnknownEnums().shouldBeEmpty()
+    }
+
+    @Test
+    fun `detectUnknownEnums detects unknown DndMode`() {
+        val backup = DeviceConfigBackup(address = "AA:BB", dndMode = "future_mode")
+        val warnings = backup.detectUnknownEnums()
+        warnings shouldHaveSize 1
+        warnings[0] shouldContain "future_mode"
+        warnings[0] shouldContain "AA:BB"
+    }
+
+    @Test
+    fun `detectUnknownEnums detects unknown AlertType`() {
+        val backup = DeviceConfigBackup(address = "CC:DD", connectionAlertType = "hologram")
+        val warnings = backup.detectUnknownEnums()
+        warnings shouldHaveSize 1
+        warnings[0] shouldContain "hologram"
+        warnings[0] shouldContain "CC:DD"
+    }
+
+    @Test
+    fun `detectUnknownEnums ignores null DndMode`() {
+        val backup = DeviceConfigBackup(address = "test", dndMode = null)
+        backup.detectUnknownEnums().shouldBeEmpty()
+    }
+
+    @Test
+    fun `minimal entity round-trips correctly`() {
+        val entity = DeviceConfigEntity(address = "FF:EE:DD:CC:BB:AA")
+        val restored = entity.toBackup().toEntity()
+        restored shouldBe entity
+    }
+}

--- a/app/src/test/java/testhelpers/json/JsonExtensions.kt
+++ b/app/src/test/java/testhelpers/json/JsonExtensions.kt
@@ -1,0 +1,14 @@
+package testhelpers.json
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+private val prettyJson = Json {
+    prettyPrint = true
+    prettyPrintIndent = "    "
+}
+
+fun String.toComparableJson(): String {
+    val element = Json.parseToJsonElement(this)
+    return prettyJson.encodeToString(JsonElement.serializer(), element)
+}


### PR DESCRIPTION
## Summary

- Add a Backup & Restore screen accessible from Settings, allowing users to export and import their device configurations and app settings as a zipped JSON file
- Backup includes all device configs (volumes, delays, autoplay, alerts, etc.), device monitoring settings, and general app settings (theme, onboarding state)
- Restore uses a parse-preview-confirm flow: after selecting a file, users see a preview with metadata, device count, overlap info, and any warnings before applying
- Users can toggle "skip existing devices" to avoid overwriting already-configured devices during restore

## Details

- Backup format is versioned (`formatVersion: 1`) with strict validation — unsupported versions block restore
- All enum fields use stable string keys in the backup JSON for forward compatibility
- Unknown enum values during restore fall back to defaults and surface as preview warnings
- Version mismatch detection compares `appVersionCode` (numeric) and shows the human-readable version name in the warning
- 21 unit tests covering format regression (golden fixture), round-trip serialization, entity mapping, unknown enum handling, and default validation
