### PR TITLE
Improve backup/restore reliability and widget toggle error handling

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,1 @@
+scheduled_tasks.lock

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -327,6 +327,7 @@ dependencies {
     testImplementation("io.kotest:kotest-property-jvm:6.1.3")
 
     testImplementation("android.arch.core:core-testing:1.1.1")
+    testImplementation("org.robolectric:robolectric:4.14.1")
     debugImplementation("androidx.test:core-ktx:1.7.0")
 
 

--- a/app/src/main/java/eu/darken/bluemusic/common/datastore/DataStoreValue.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/datastore/DataStoreValue.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.common.datastore
 
 import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.floatPreferencesKey
@@ -62,6 +63,17 @@ class DataStoreValue<T : Any?>(
         }
 
         return Updated(old = (values[0] as T), new = (values[1] as T))
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    fun setIn(prefs: MutablePreferences, value: T) {
+        val toWrite = writer(value)
+        if (Bugs.isTrace) log(dataStoreTag) { "SET_IN $keyName <- $toWrite" }
+        if (toWrite == null) {
+            prefs.remove(key)
+        } else {
+            prefs[key as Preferences.Key<Any>] = toWrite
+        }
     }
 }
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/DevicesSettings.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/DevicesSettings.kt
@@ -97,9 +97,21 @@ class DevicesSettings @Inject constructor(
     )
 
     suspend fun applyBackup(backup: DevicesSettingsBackup) {
-        setEnabled(backup.isEnabled)
-        restoreOnBoot.value(backup.restoreOnBoot)
-        lockedDevices.value(backup.lockedDevices)
+        dataStore.updateData { prefs ->
+            prefs.toMutablePreferences().apply {
+                val currentEnabled = this[KEY_ENABLED] ?: true
+                val currentEpoch = this[KEY_ENABLED_EPOCH] ?: 0L
+                if (currentEnabled == backup.isEnabled) {
+                    this[KEY_ENABLED] = currentEnabled
+                    this[KEY_ENABLED_EPOCH] = currentEpoch
+                } else {
+                    this[KEY_ENABLED] = backup.isEnabled
+                    this[KEY_ENABLED_EPOCH] = currentEpoch + 1L
+                }
+                restoreOnBoot.setIn(this, backup.restoreOnBoot)
+                lockedDevices.setIn(this, backup.lockedDevices)
+            }.toPreferences()
+        }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceConfigDao.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceConfigDao.kt
@@ -9,25 +9,28 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface DeviceConfigDao {
-    
+
     @Query("SELECT * FROM device_configs ORDER BY last_connected DESC")
     fun getAllDevices(): Flow<List<DeviceConfigEntity>>
-    
+
+    @Query("SELECT * FROM device_configs ORDER BY last_connected DESC")
+    suspend fun getAllDevicesOnce(): List<DeviceConfigEntity>
+
     @Query("SELECT * FROM device_configs WHERE address = :address")
     suspend fun getDevice(address: String): DeviceConfigEntity?
-    
+
     @Query("SELECT * FROM device_configs WHERE address = :address")
     fun observeDevice(address: String): Flow<DeviceConfigEntity?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun updateDevice(device: DeviceConfigEntity)
-    
+
     @Delete
     suspend fun deleteDevice(device: DeviceConfigEntity)
-    
+
     @Query("DELETE FROM device_configs WHERE address = :address")
     suspend fun deleteByAddress(address: String)
-    
+
     @Query("UPDATE device_configs SET last_connected = :timestamp WHERE address = :address")
     suspend fun updateLastConnected(address: String, timestamp: Long)
 }

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceDatabase.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/database/DeviceDatabase.kt
@@ -1,26 +1,42 @@
 package eu.darken.bluemusic.devices.core.database
 
 import android.content.Context
+import androidx.annotation.VisibleForTesting
 import androidx.room.Room
+import androidx.room.withTransaction
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
 
 @Singleton
 class DeviceDatabase @Inject constructor(
-    @ApplicationContext private val context: Context,
+    @param:ApplicationContext private val context: Context,
 ) {
 
-    private val database by lazy {
-        Room.databaseBuilder(
-            context,
-            DevicesRoomDb::class.java, "managed_devices"
-        )
+    private var databaseOverride: DevicesRoomDb? = null
+    private var daoOverride: DeviceConfigDao? = null
+
+    private val defaultDatabase by lazy {
+        Room.databaseBuilder(context, DevicesRoomDb::class.java, "managed_devices")
             .addMigrations(MIGRATION_1_2)
             .build()
     }
 
-    val devices: DeviceConfigDao
-        get() = database.devices()
+    private val database: DevicesRoomDb
+        get() = databaseOverride ?: defaultDatabase
 
+    @VisibleForTesting
+    fun setDatabaseForTest(roomDb: DevicesRoomDb?) {
+        databaseOverride = roomDb
+    }
+
+    @VisibleForTesting
+    fun setDaoForTest(dao: DeviceConfigDao?) {
+        daoOverride = dao
+    }
+
+    val devices: DeviceConfigDao
+        get() = daoOverride ?: database.devices()
+
+    suspend fun <R> withTransaction(block: suspend () -> R): R = database.withTransaction(block)
 }

--- a/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManager.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManager.kt
@@ -10,12 +10,12 @@ import eu.darken.bluemusic.common.debug.logging.Logging.Priority.DEBUG
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
+import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.devices.core.database.DeviceDatabase
 import eu.darken.bluemusic.main.core.GeneralSettings
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
@@ -67,8 +67,14 @@ class BackupRestoreManager @Inject constructor(
 
         val backup = gatherBackupData()
 
-        log(TAG, DEBUG) { "Backup metadata: formatVersion=${backup.formatVersion}, appVersion=${backup.appVersion}, createdAt=${backup.createdAt}" }
-        log(TAG, DEBUG) { "Backup contents: ${backup.deviceConfigs.size} devices, devicesSettings=${backup.devicesSettings}, generalSettings=${backup.generalSettings}" }
+        log(
+            TAG,
+            DEBUG
+        ) { "Backup metadata: formatVersion=${backup.formatVersion}, appVersion=${backup.appVersion}, createdAt=${backup.createdAt}" }
+        log(
+            TAG,
+            DEBUG
+        ) { "Backup contents: ${backup.deviceConfigs.size} devices, devicesSettings=${backup.devicesSettings}, generalSettings=${backup.generalSettings}" }
 
         backup.deviceConfigs.forEachIndexed { i, device ->
             log(TAG, VERBOSE) { "Backup device[$i]: ${device.address} (name=${device.customName})" }
@@ -133,7 +139,10 @@ class BackupRestoreManager @Inject constructor(
         }
 
         log(TAG, DEBUG) { "Parsed: formatVersion=${backup.formatVersion}, appVersion=${backup.appVersion}, createdAt=${backup.createdAt}" }
-        log(TAG, DEBUG) { "Parsed: ${backup.deviceConfigs.size} devices, devicesSettings=${backup.devicesSettings}, generalSettings=${backup.generalSettings}" }
+        log(
+            TAG,
+            DEBUG
+        ) { "Parsed: ${backup.deviceConfigs.size} devices, devicesSettings=${backup.devicesSettings}, generalSettings=${backup.generalSettings}" }
 
         if (backup.formatVersion != CURRENT_FORMAT_VERSION) {
             log(TAG, WARN) { "Unsupported format version: ${backup.formatVersion} (expected $CURRENT_FORMAT_VERSION)" }
@@ -152,36 +161,50 @@ class BackupRestoreManager @Inject constructor(
             log(TAG, VERBOSE) { "Parsed device[$i]: ${device.address} (name=${device.customName})" }
         }
 
-        log(TAG, INFO) { "Parsed backup: ${backup.deviceConfigs.size} devices, versionMismatch=$versionMismatch, ${enumWarnings.size} enum warnings" }
+        log(
+            TAG,
+            INFO
+        ) { "Parsed backup: ${backup.deviceConfigs.size} devices, versionMismatch=$versionMismatch, ${enumWarnings.size} enum warnings" }
         ParseResult(backup = backup, versionMismatch = versionMismatch, enumWarnings = enumWarnings)
     }
 
     suspend fun applyRestore(backup: AppBackup, skipExisting: Boolean): RestoreResult =
         withContext(dispatcherProvider.IO) {
-            log(TAG, INFO) { "applyRestore(devices=${backup.deviceConfigs.size}, skipExisting=$skipExisting)" }
+            val deduped = backup.deviceConfigs.distinctBy { it.address }
+            val duplicateCount = backup.deviceConfigs.size - deduped.size
+            log(TAG, INFO) {
+                "applyRestore(devices=${deduped.size}, skipExisting=$skipExisting, duplicatesDropped=$duplicateCount)"
+            }
             log(TAG, VERBOSE) { "Restore JSON:\n${prettyJson.encodeToString(AppBackup.serializer(), backup)}" }
 
             val dao = deviceDatabase.devices
-            val existing = dao.getAllDevices().first().associateBy { it.address }.keys
-            log(TAG, DEBUG) { "Existing devices (${existing.size}): $existing" }
-
             var restoredCount = 0
             var skippedCount = 0
 
-            backup.deviceConfigs.forEach { deviceBackup ->
-                if (skipExisting && deviceBackup.address in existing) {
-                    log(TAG, DEBUG) { "Skipping existing device: ${deviceBackup.address} (name=${deviceBackup.customName})" }
-                    skippedCount++
-                    return@forEach
+            try {
+                deviceDatabase.withTransaction {
+                    val existing = dao.getAllDevicesOnce().associateBy { it.address }.keys
+                    log(TAG, DEBUG) { "Existing devices (${existing.size}): $existing" }
+
+                    deduped.forEach { deviceBackup ->
+                        if (skipExisting && deviceBackup.address in existing) {
+                            log(TAG, DEBUG) { "Skipping existing device: ${deviceBackup.address} (name=${deviceBackup.customName})" }
+                            skippedCount++
+                            return@forEach
+                        }
+                        val entity = deviceBackup.toEntity()
+                        val isUpdate = deviceBackup.address in existing
+                        log(TAG, DEBUG) { "${if (isUpdate) "Updating" else "Inserting"} device: ${entity.toCompactString()}" }
+                        dao.updateDevice(entity)
+                        restoredCount++
+                    }
                 }
-                val entity = deviceBackup.toEntity()
-                val isUpdate = deviceBackup.address in existing
-                log(TAG, DEBUG) { "${if (isUpdate) "Updating" else "Inserting"} device: ${entity.toCompactString()}" }
-                dao.updateDevice(entity)
-                restoredCount++
+            } catch (e: Exception) {
+                log(TAG, WARN) { "Device-write transaction failed, rolled back: ${e.asLog()}" }
+                throw e
             }
 
-            log(TAG, DEBUG) { "Restoring DevicesSettings: $backup.devicesSettings" }
+            log(TAG, DEBUG) { "Restoring DevicesSettings: ${backup.devicesSettings}" }
             devicesSettings.applyBackup(backup.devicesSettings)
 
             log(TAG, DEBUG) { "Restoring GeneralSettings: ${backup.generalSettings}" }
@@ -202,7 +225,7 @@ class BackupRestoreManager @Inject constructor(
     }
 
     private suspend fun gatherBackupData(): AppBackup {
-        val devices = deviceDatabase.devices.getAllDevices().first()
+        val devices = deviceDatabase.devices.getAllDevicesOnce()
         return AppBackup(
             formatVersion = CURRENT_FORMAT_VERSION,
             appVersion = BuildConfigWrap.VERSION_NAME,
@@ -219,6 +242,15 @@ class BackupRestoreManager @Inject constructor(
             addAll(device.detectUnknownEnums())
         }
         addAll(generalSettings.detectUnknownEnums(backup.generalSettings))
+
+        val duplicates = backup.deviceConfigs
+            .groupingBy { it.address }
+            .eachCount()
+            .filter { it.value > 1 }
+            .keys
+        duplicates.forEach { address ->
+            add("Backup contains duplicate entries for device $address, only the first will be applied")
+        }
     }
 
     private fun String.toComparableJson(): String = try {

--- a/app/src/main/java/eu/darken/bluemusic/main/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/core/GeneralSettings.kt
@@ -10,10 +10,10 @@ import eu.darken.bluemusic.common.datastore.PreferenceData
 import eu.darken.bluemusic.common.datastore.createValue
 import eu.darken.bluemusic.common.datastore.value
 import eu.darken.bluemusic.common.debug.logging.logTag
-import eu.darken.bluemusic.main.backup.core.GeneralSettingsBackup
 import eu.darken.bluemusic.common.theming.ThemeColor
 import eu.darken.bluemusic.common.theming.ThemeMode
 import eu.darken.bluemusic.common.theming.ThemeStyle
+import eu.darken.bluemusic.main.backup.core.GeneralSettingsBackup
 import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -60,14 +60,18 @@ class GeneralSettings @Inject constructor(
     )
 
     suspend fun applyBackup(backup: GeneralSettingsBackup) {
-        themeMode.value(ThemeMode.entries.find { it.name == backup.themeMode } ?: ThemeMode.SYSTEM)
-        themeStyle.value(ThemeStyle.entries.find { it.name == backup.themeStyle } ?: ThemeStyle.DEFAULT)
-        themeColor.value(ThemeColor.entries.find { it.name == backup.themeColor } ?: ThemeColor.BLUE)
-        // Progression flags: only set to true, never revert to false
-        if (backup.isOnboardingCompleted) isOnboardingCompleted.value(true)
-        if (backup.isBatteryOptimizationHintDismissed) isBatteryOptimizationHintDismissed.value(true)
-        if (backup.isAndroid10AppLaunchHintDismissed) isAndroid10AppLaunchHintDismissed.value(true)
-        if (backup.isNotificationPermissionHintDismissed) isNotificationPermissionHintDismissed.value(true)
+        dataStore.updateData { prefs ->
+            prefs.toMutablePreferences().apply {
+                themeMode.setIn(this, ThemeMode.entries.find { it.name == backup.themeMode } ?: ThemeMode.SYSTEM)
+                themeStyle.setIn(this, ThemeStyle.entries.find { it.name == backup.themeStyle } ?: ThemeStyle.DEFAULT)
+                themeColor.setIn(this, ThemeColor.entries.find { it.name == backup.themeColor } ?: ThemeColor.BLUE)
+                // Progression flags: only set to true, never revert to false
+                if (backup.isOnboardingCompleted) isOnboardingCompleted.setIn(this, true)
+                if (backup.isBatteryOptimizationHintDismissed) isBatteryOptimizationHintDismissed.setIn(this, true)
+                if (backup.isAndroid10AppLaunchHintDismissed) isAndroid10AppLaunchHintDismissed.setIn(this, true)
+                if (backup.isNotificationPermissionHintDismissed) isNotificationPermissionHintDismissed.setIn(this, true)
+            }.toPreferences()
+        }
     }
 
     fun detectUnknownEnums(backup: GeneralSettingsBackup): List<String> = buildList {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreViewModel.kt
@@ -14,7 +14,6 @@ import eu.darken.bluemusic.main.backup.core.BackupRestoreManager
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.receiveAsFlow
 import java.time.LocalDate
 import javax.inject.Inject
@@ -88,7 +87,7 @@ class BackupRestoreViewModel @Inject constructor(
             val parseResult = backupRestoreManager.parseBackup(uri)
             val fileName = backupRestoreManager.resolveFileName(uri)
 
-            val existingAddresses = deviceDatabase.devices.getAllDevices().first()
+            val existingAddresses = deviceDatabase.devices.getAllDevicesOnce()
                 .map { it.address }
                 .toSet()
             val overlapCount = parseResult.backup.deviceConfigs.count { it.address in existingAddresses }
@@ -110,13 +109,13 @@ class BackupRestoreViewModel @Inject constructor(
     fun onConfirmRestore() = launch {
         val preview = pendingRestoreFlow.value ?: return@launch
         log(tag, INFO) { "onConfirmRestore()" }
-        pendingRestoreFlow.value = null
         isWorkingFlow.value = true
         try {
             val result = backupRestoreManager.applyRestore(
                 backup = preview.backup,
                 skipExisting = skipExistingFlow.value,
             )
+            pendingRestoreFlow.value = null
             lastResultFlow.value = OperationResult(
                 type = OperationType.RESTORE,
                 deviceCount = result.deviceCount,

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/widget/VolumeLockToggleAction.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/widget/VolumeLockToggleAction.kt
@@ -9,12 +9,15 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.devices.core.DeviceRepo
 import eu.darken.bluemusic.devices.core.currentDevices
 import eu.darken.bluemusic.devices.core.toggleVolumeLock
+import kotlinx.coroutines.CancellationException
 
 class VolumeLockToggleAction : ActionCallback {
 
@@ -28,28 +31,27 @@ class VolumeLockToggleAction : ActionCallback {
     }
 
     override suspend fun onAction(context: Context, glanceId: GlanceId, parameters: ActionParameters) {
-        val address = parameters[PARAM_DEVICE_ADDRESS]
-        log(TAG) { "onAction(address=$address)" }
-
         val ep = EntryPointAccessors.fromApplication(context, ActionEntryPoint::class.java)
+        try {
+            val address = parameters[PARAM_DEVICE_ADDRESS]
+            log(TAG) { "onAction(address=$address)" }
+            if (address == null) return
 
-        if (address == null) {
-            log(TAG) { "No device address in parameters, refreshing widgets" }
-            ep.widgetManager().refreshWidgets()
-            return
+            val device = ep.deviceRepo().currentDevices()
+                .firstOrNull { it.address == address && it.isActive }
+            if (device == null) {
+                log(TAG) { "Device $address is no longer active" }
+                return
+            }
+
+            ep.deviceRepo().toggleVolumeLock(address, ep.upgradeRepo())
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "onAction failed: ${e.asLog()}" }
+        } finally {
+            runCatching { ep.widgetManager().refreshWidgets() }
         }
-
-        val devices = ep.deviceRepo().currentDevices()
-        val device = devices.firstOrNull { it.address == address && it.isActive }
-
-        if (device == null) {
-            log(TAG) { "Device $address is no longer active, refreshing widgets" }
-            ep.widgetManager().refreshWidgets()
-            return
-        }
-
-        ep.deviceRepo().toggleVolumeLock(address, ep.upgradeRepo())
-        ep.widgetManager().refreshWidgets()
     }
 
     companion object {

--- a/app/src/test/java/eu/darken/bluemusic/common/datastore/DataStoreValueTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/common/datastore/DataStoreValueTest.kt
@@ -18,8 +18,8 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.io.TempDir
-import java.io.File
 import testhelpers.BaseTest
+import java.io.File
 
 class DataStoreValueTest : BaseTest() {
 
@@ -212,6 +212,46 @@ class DataStoreValueTest : BaseTest() {
             flow.first() shouldBe 3.6f
             testStore.data.first()[floatPreferencesKey(keyName)] shouldBe null
         }
+    }
+
+    @Test
+    fun `setIn writes into a MutablePreferences block`(@TempDir tempDir: File) = runTest {
+        val testStore = createDataStore(this, tempDir)
+
+        val flagA = testStore.createValue("flagA", false)
+        val flagB = testStore.createValue("flagB", true)
+
+        testStore.updateData { prefs ->
+            prefs.toMutablePreferences().apply {
+                flagA.setIn(this, true)
+                flagB.setIn(this, false)
+            }.toPreferences()
+        }
+
+        flagA.value() shouldBe true
+        flagB.value() shouldBe false
+    }
+
+    @Test
+    fun `setIn with null writer output removes the key`(@TempDir tempDir: File) = runTest {
+        val testStore = createDataStore(this, tempDir)
+
+        val nullable = testStore.createValue<String?>("maybe", "default")
+
+        testStore.updateData { prefs ->
+            prefs.toMutablePreferences().apply {
+                nullable.setIn(this, "stored")
+            }.toPreferences()
+        }
+        nullable.value() shouldBe "stored"
+
+        testStore.updateData { prefs ->
+            prefs.toMutablePreferences().apply {
+                nullable.setIn(this, null)
+            }.toPreferences()
+        }
+        nullable.value() shouldBe "default"
+        testStore.data.first()[stringPreferencesKey("maybe")] shouldBe null
     }
 
     @Test

--- a/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManagerAtomicityTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManagerAtomicityTest.kt
@@ -74,56 +74,60 @@ class BackupRestoreManagerAtomicityTest {
     }
 
     @Test
-    fun `device-write exception rolls back transaction`() = runBlocking {
-        val existing1 = DeviceConfigEntity(address = "AA:AA:AA:AA:AA:AA", customName = "Original A")
-        val existing2 = DeviceConfigEntity(address = "BB:BB:BB:BB:BB:BB", customName = "Original B")
-        roomDb.devices().updateDevice(existing1)
-        roomDb.devices().updateDevice(existing2)
+    fun `device-write exception rolls back transaction`() {
+        runBlocking {
+            val existing1 = DeviceConfigEntity(address = "AA:AA:AA:AA:AA:AA", customName = "Original A")
+            val existing2 = DeviceConfigEntity(address = "BB:BB:BB:BB:BB:BB", customName = "Original B")
+            roomDb.devices().updateDevice(existing1)
+            roomDb.devices().updateDevice(existing2)
 
-        deviceDatabase.setDaoForTest(ThrowingDao(roomDb.devices(), throwAfterWrites = 1))
+            deviceDatabase.setDaoForTest(ThrowingDao(roomDb.devices(), throwAfterWrites = 1))
 
-        val incomingBackup = AppBackup(
-            formatVersion = 1,
-            appVersion = "1.0.0",
-            createdAt = "2026-01-01T00:00:00Z",
-            deviceConfigs = listOf(
-                DeviceConfigBackup(address = "CC:CC:CC:CC:CC:CC", customName = "New C"),
-                DeviceConfigBackup(address = "DD:DD:DD:DD:DD:DD", customName = "New D"),
-            ),
-        )
+            val incomingBackup = AppBackup(
+                formatVersion = 1,
+                appVersion = "1.0.0",
+                createdAt = "2026-01-01T00:00:00Z",
+                deviceConfigs = listOf(
+                    DeviceConfigBackup(address = "CC:CC:CC:CC:CC:CC", customName = "New C"),
+                    DeviceConfigBackup(address = "DD:DD:DD:DD:DD:DD", customName = "New D"),
+                ),
+            )
 
-        shouldThrow<IOException> {
-            manager.applyRestore(incomingBackup, skipExisting = false)
+            shouldThrow<IOException> {
+                manager.applyRestore(incomingBackup, skipExisting = false)
+            }
+
+            deviceDatabase.setDaoForTest(null)
+            val actual = roomDb.devices().getAllDevicesOnce()
+            actual.map { it.address } shouldContainExactlyInAnyOrder listOf(
+                "AA:AA:AA:AA:AA:AA",
+                "BB:BB:BB:BB:BB:BB",
+            )
+            actual.first { it.address == "AA:AA:AA:AA:AA:AA" }.customName shouldBe "Original A"
         }
-
-        deviceDatabase.setDaoForTest(null)
-        val actual = roomDb.devices().getAllDevicesOnce()
-        actual.map { it.address } shouldContainExactlyInAnyOrder listOf(
-            "AA:AA:AA:AA:AA:AA",
-            "BB:BB:BB:BB:BB:BB",
-        )
-        actual.first { it.address == "AA:AA:AA:AA:AA:AA" }.customName shouldBe "Original A"
     }
 
     @Test
-    fun `successful restore writes all rows`() = runBlocking {
-        val incomingBackup = AppBackup(
-            formatVersion = 1,
-            appVersion = "1.0.0",
-            createdAt = "2026-01-01T00:00:00Z",
-            deviceConfigs = listOf(
-                DeviceConfigBackup(address = "AA:AA:AA:AA:AA:AA", customName = "Alpha"),
-                DeviceConfigBackup(address = "BB:BB:BB:BB:BB:BB", customName = "Beta"),
-            ),
-        )
+    fun `successful restore writes all rows`() {
+        runBlocking {
+            val incomingBackup = AppBackup(
+                formatVersion = 1,
+                appVersion = "1.0.0",
+                createdAt = "2026-01-01T00:00:00Z",
+                deviceConfigs = listOf(
+                    DeviceConfigBackup(address = "AA:AA:AA:AA:AA:AA", customName = "Alpha"),
+                    DeviceConfigBackup(address = "BB:BB:BB:BB:BB:BB", customName = "Beta"),
+                ),
+            )
 
-        manager.applyRestore(incomingBackup, skipExisting = false)
+            manager.applyRestore(incomingBackup, skipExisting = false)
 
-        val actual = roomDb.devices().getAllDevicesOnce()
-        actual.map { it.address } shouldContainExactlyInAnyOrder listOf(
-            "AA:AA:AA:AA:AA:AA",
-            "BB:BB:BB:BB:BB:BB",
-        )
+            val actual = roomDb.devices().getAllDevicesOnce()
+            actual.map { it.address } shouldContainExactlyInAnyOrder listOf(
+                "AA:AA:AA:AA:AA:AA",
+                "BB:BB:BB:BB:BB:BB",
+            )
+        }
     }
 
     private class ThrowingDao(

--- a/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManagerAtomicityTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManagerAtomicityTest.kt
@@ -1,0 +1,141 @@
+package eu.darken.bluemusic.main.backup.core
+
+import android.content.Context
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.devices.core.DevicesSettings
+import eu.darken.bluemusic.devices.core.database.DeviceConfigDao
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.devices.core.database.DeviceDatabase
+import eu.darken.bluemusic.devices.core.database.DevicesRoomDb
+import eu.darken.bluemusic.main.core.GeneralSettings
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.Json
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class BackupRestoreManagerAtomicityTest {
+
+    private lateinit var roomDb: DevicesRoomDb
+    private lateinit var deviceDatabase: DeviceDatabase
+    private lateinit var manager: BackupRestoreManager
+
+    @Before
+    fun setup() {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        roomDb = Room.inMemoryDatabaseBuilder(context, DevicesRoomDb::class.java)
+            .allowMainThreadQueries()
+            .build()
+
+        deviceDatabase = DeviceDatabase(context).apply {
+            setDatabaseForTest(roomDb)
+        }
+
+        val devicesSettings = mockk<DevicesSettings>(relaxed = true)
+        coEvery { devicesSettings.toBackup() } returns DevicesSettingsBackup()
+        coEvery { devicesSettings.applyBackup(any()) } just Runs
+
+        val generalSettings = mockk<GeneralSettings>(relaxed = true)
+        coEvery { generalSettings.toBackup() } returns GeneralSettingsBackup()
+        coEvery { generalSettings.applyBackup(any()) } just Runs
+        every { generalSettings.detectUnknownEnums(any()) } returns emptyList()
+
+        val contextMock = mockk<Context>(relaxed = true)
+
+        manager = BackupRestoreManager(
+            context = contextMock,
+            deviceDatabase = deviceDatabase,
+            devicesSettings = devicesSettings,
+            generalSettings = generalSettings,
+            json = Json { ignoreUnknownKeys = true; encodeDefaults = true; explicitNulls = false },
+            dispatcherProvider = TestDispatcherProvider(),
+        )
+    }
+
+    @After
+    fun tearDown() {
+        roomDb.close()
+    }
+
+    @Test
+    fun `device-write exception rolls back transaction`() = runBlocking {
+        val existing1 = DeviceConfigEntity(address = "AA:AA:AA:AA:AA:AA", customName = "Original A")
+        val existing2 = DeviceConfigEntity(address = "BB:BB:BB:BB:BB:BB", customName = "Original B")
+        roomDb.devices().updateDevice(existing1)
+        roomDb.devices().updateDevice(existing2)
+
+        deviceDatabase.setDaoForTest(ThrowingDao(roomDb.devices(), throwAfterWrites = 1))
+
+        val incomingBackup = AppBackup(
+            formatVersion = 1,
+            appVersion = "1.0.0",
+            createdAt = "2026-01-01T00:00:00Z",
+            deviceConfigs = listOf(
+                DeviceConfigBackup(address = "CC:CC:CC:CC:CC:CC", customName = "New C"),
+                DeviceConfigBackup(address = "DD:DD:DD:DD:DD:DD", customName = "New D"),
+            ),
+        )
+
+        shouldThrow<IOException> {
+            manager.applyRestore(incomingBackup, skipExisting = false)
+        }
+
+        deviceDatabase.setDaoForTest(null)
+        val actual = roomDb.devices().getAllDevicesOnce()
+        actual.map { it.address } shouldContainExactlyInAnyOrder listOf(
+            "AA:AA:AA:AA:AA:AA",
+            "BB:BB:BB:BB:BB:BB",
+        )
+        actual.first { it.address == "AA:AA:AA:AA:AA:AA" }.customName shouldBe "Original A"
+    }
+
+    @Test
+    fun `successful restore writes all rows`() = runBlocking {
+        val incomingBackup = AppBackup(
+            formatVersion = 1,
+            appVersion = "1.0.0",
+            createdAt = "2026-01-01T00:00:00Z",
+            deviceConfigs = listOf(
+                DeviceConfigBackup(address = "AA:AA:AA:AA:AA:AA", customName = "Alpha"),
+                DeviceConfigBackup(address = "BB:BB:BB:BB:BB:BB", customName = "Beta"),
+            ),
+        )
+
+        manager.applyRestore(incomingBackup, skipExisting = false)
+
+        val actual = roomDb.devices().getAllDevicesOnce()
+        actual.map { it.address } shouldContainExactlyInAnyOrder listOf(
+            "AA:AA:AA:AA:AA:AA",
+            "BB:BB:BB:BB:BB:BB",
+        )
+    }
+
+    private class ThrowingDao(
+        private val delegate: DeviceConfigDao,
+        private val throwAfterWrites: Int,
+    ) : DeviceConfigDao by delegate {
+        private var writeCount = 0
+
+        override suspend fun updateDevice(device: DeviceConfigEntity) {
+            writeCount++
+            if (writeCount > throwAfterWrites) throw IOException("simulated mid-loop failure")
+            delegate.updateDevice(device)
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManagerTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManagerTest.kt
@@ -1,0 +1,325 @@
+package eu.darken.bluemusic.main.backup.core
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import eu.darken.bluemusic.devices.core.DevicesSettings
+import eu.darken.bluemusic.devices.core.database.DeviceConfigDao
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.devices.core.database.DeviceDatabase
+import eu.darken.bluemusic.main.core.GeneralSettings
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.coVerifyOrder
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+
+class BackupRestoreManagerTest : BaseTest() {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private lateinit var context: Context
+    private lateinit var contentResolver: ContentResolver
+    private lateinit var deviceDatabase: DeviceDatabase
+    private lateinit var dao: DeviceConfigDao
+    private lateinit var devicesSettings: DevicesSettings
+    private lateinit var generalSettings: GeneralSettings
+    private lateinit var json: Json
+    private lateinit var manager: BackupRestoreManager
+
+    private val sampleEntity = DeviceConfigEntity(
+        address = "AA:BB:CC:DD:EE:FF",
+        customName = "Test Device",
+        volumeLock = true,
+    )
+
+    private val sampleDeviceBackup = DeviceConfigBackup(
+        address = "AA:BB:CC:DD:EE:FF",
+        customName = "Backup Device",
+    )
+
+    @BeforeEach
+    fun setup() {
+        context = mockk(relaxed = true)
+        contentResolver = mockk(relaxed = true)
+        every { context.contentResolver } returns contentResolver
+
+        dao = mockk(relaxed = true)
+        deviceDatabase = mockk(relaxed = true)
+        every { deviceDatabase.devices } returns dao
+        coEvery { deviceDatabase.withTransaction<Any?>(any()) } coAnswers {
+            val block = firstArg<suspend () -> Any?>()
+            block()
+        }
+        coEvery { dao.getAllDevicesOnce() } returns emptyList()
+
+        devicesSettings = mockk(relaxed = true)
+        generalSettings = mockk(relaxed = true)
+        coEvery { devicesSettings.toBackup() } returns DevicesSettingsBackup()
+        coEvery { generalSettings.toBackup() } returns GeneralSettingsBackup()
+        coEvery { devicesSettings.applyBackup(any()) } just Runs
+        coEvery { generalSettings.applyBackup(any()) } just Runs
+        every { generalSettings.detectUnknownEnums(any()) } returns emptyList()
+
+        json = Json {
+            ignoreUnknownKeys = true
+            encodeDefaults = true
+            explicitNulls = false
+        }
+
+        manager = BackupRestoreManager(
+            context = context,
+            deviceDatabase = deviceDatabase,
+            devicesSettings = devicesSettings,
+            generalSettings = generalSettings,
+            json = json,
+            dispatcherProvider = TestDispatcherProvider(),
+        )
+    }
+
+    private fun tempUri(name: String): Pair<Uri, File> {
+        val file = File(tempDir, name)
+        val uri = mockk<Uri>(relaxed = true)
+        every { uri.lastPathSegment } returns name
+        every { contentResolver.openOutputStream(uri) } answers { FileOutputStream(file) }
+        every { contentResolver.openInputStream(uri) } answers {
+            if (file.exists()) FileInputStream(file) else null
+        }
+        return uri to file
+    }
+
+    @Test
+    fun `createBackup writes zip containing backup json`() = runTest {
+        val (uri, file) = tempUri("out.zip")
+        coEvery { dao.getAllDevicesOnce() } returns listOf(sampleEntity)
+
+        val result = manager.createBackup(uri)
+
+        result.deviceConfigCount shouldBe 1
+        file.exists() shouldBe true
+        file.length() shouldBe file.length().also { it > 0 }
+    }
+
+    @Test
+    fun `createBackup round-trips through parseBackup`() = runTest {
+        val (uri, _) = tempUri("round.zip")
+        coEvery { dao.getAllDevicesOnce() } returns listOf(sampleEntity)
+
+        manager.createBackup(uri)
+        val parsed = manager.parseBackup(uri)
+
+        parsed.backup.deviceConfigs shouldContain sampleEntity.toBackup()
+    }
+
+    @Test
+    fun `createBackup with empty device list produces valid zip`() = runTest {
+        val (uri, _) = tempUri("empty.zip")
+        coEvery { dao.getAllDevicesOnce() } returns emptyList()
+
+        val result = manager.createBackup(uri)
+        val parsed = manager.parseBackup(uri)
+
+        result.deviceConfigCount shouldBe 0
+        parsed.backup.deviceConfigs shouldBe emptyList()
+    }
+
+    @Test
+    fun `createBackup throws BackupIoError when openOutputStream returns null`() = runTest {
+        val uri = mockk<Uri>(relaxed = true)
+        every { contentResolver.openOutputStream(uri) } returns null
+
+        shouldThrow<BackupError.BackupIoError> {
+            manager.createBackup(uri)
+        }
+    }
+
+    @Test
+    fun `parseBackup throws BackupIoError when openInputStream returns null`() = runTest {
+        val uri = mockk<Uri>(relaxed = true)
+        every { contentResolver.openInputStream(uri) } returns null
+
+        shouldThrow<BackupError.BackupIoError> {
+            manager.parseBackup(uri)
+        }
+    }
+
+    @Test
+    fun `parseBackup throws MissingBackupJson on zip without backup entry`() = runTest {
+        val file = File(tempDir, "bogus.zip")
+        ZipOutputStream(FileOutputStream(file)).use { zip ->
+            zip.putNextEntry(ZipEntry("other.txt"))
+            zip.write("hello".toByteArray())
+            zip.closeEntry()
+        }
+        val uri = mockk<Uri>(relaxed = true)
+        every { contentResolver.openInputStream(uri) } answers { FileInputStream(file) }
+
+        shouldThrow<BackupError.MissingBackupJson> {
+            manager.parseBackup(uri)
+        }
+    }
+
+    @Test
+    fun `parseBackup on non-zip garbage surfaces as BackupError`() = runTest {
+        val file = File(tempDir, "garbage.bin").apply { writeBytes(byteArrayOf(1, 2, 3, 4, 5)) }
+        val uri = mockk<Uri>(relaxed = true)
+        every { contentResolver.openInputStream(uri) } answers { FileInputStream(file) }
+
+        shouldThrow<BackupError> {
+            manager.parseBackup(uri)
+        }
+    }
+
+    @Test
+    fun `parseBackup throws MalformedBackup on bad json inside valid zip`() = runTest {
+        val file = File(tempDir, "bad.zip")
+        ZipOutputStream(FileOutputStream(file)).use { zip ->
+            zip.putNextEntry(ZipEntry("backup.json"))
+            zip.write("{ this is not json".toByteArray())
+            zip.closeEntry()
+        }
+        val uri = mockk<Uri>(relaxed = true)
+        every { contentResolver.openInputStream(uri) } answers { FileInputStream(file) }
+
+        shouldThrow<BackupError.MalformedBackup> {
+            manager.parseBackup(uri)
+        }
+    }
+
+    @Test
+    fun `parseBackup throws UnsupportedFormatVersion on mismatched format`() = runTest {
+        val file = File(tempDir, "fmt.zip")
+        val backupJson = """
+            {"formatVersion": 99, "appVersion": "9.9.9", "createdAt": "2026-01-01T00:00:00Z"}
+        """.trimIndent()
+        ZipOutputStream(FileOutputStream(file)).use { zip ->
+            zip.putNextEntry(ZipEntry("backup.json"))
+            zip.write(backupJson.toByteArray())
+            zip.closeEntry()
+        }
+        val uri = mockk<Uri>(relaxed = true)
+        every { contentResolver.openInputStream(uri) } answers { FileInputStream(file) }
+
+        shouldThrow<BackupError.UnsupportedFormatVersion> {
+            manager.parseBackup(uri)
+        }
+    }
+
+    @Test
+    fun `parseBackup flags duplicate addresses in warnings`() = runTest {
+        val (uri, file) = tempUri("dup.zip")
+        val backup = AppBackup(
+            formatVersion = 1,
+            appVersion = "1.0.0",
+            createdAt = "2026-01-01T00:00:00Z",
+            deviceConfigs = listOf(
+                DeviceConfigBackup(address = "AA:AA:AA:AA:AA:AA"),
+                DeviceConfigBackup(address = "AA:AA:AA:AA:AA:AA", customName = "dup"),
+                DeviceConfigBackup(address = "BB:BB:BB:BB:BB:BB"),
+            ),
+        )
+        ZipOutputStream(FileOutputStream(file)).use { zip ->
+            zip.putNextEntry(ZipEntry("backup.json"))
+            zip.write(json.encodeToString(AppBackup.serializer(), backup).toByteArray())
+            zip.closeEntry()
+        }
+
+        val parsed = manager.parseBackup(uri)
+
+        parsed.enumWarnings.any { it.contains("AA:AA:AA:AA:AA:AA") } shouldBe true
+    }
+
+    @Test
+    fun `applyRestore calls settings applyBackup after device writes`() = runTest {
+        val backup = buildBackup(listOf(sampleDeviceBackup))
+
+        manager.applyRestore(backup, skipExisting = false)
+
+        coVerifyOrder {
+            dao.updateDevice(any())
+            devicesSettings.applyBackup(any())
+            generalSettings.applyBackup(any())
+        }
+    }
+
+    @Test
+    fun `applyRestore skips existing addresses when skipExisting true`() = runTest {
+        coEvery { dao.getAllDevicesOnce() } returns listOf(sampleEntity)
+        val backup = buildBackup(
+            listOf(
+                sampleDeviceBackup,
+                DeviceConfigBackup(address = "CC:CC:CC:CC:CC:CC"),
+            )
+        )
+
+        val result = manager.applyRestore(backup, skipExisting = true)
+
+        result.skippedCount shouldBe 1
+        result.deviceCount shouldBe 1
+        val written = slot<DeviceConfigEntity>()
+        coVerify(exactly = 1) { dao.updateDevice(capture(written)) }
+        written.captured.address shouldBe "CC:CC:CC:CC:CC:CC"
+    }
+
+    @Test
+    fun `applyRestore deduplicates by address`() = runTest {
+        val backup = buildBackup(
+            listOf(
+                DeviceConfigBackup(address = "AA:AA:AA:AA:AA:AA", customName = "first"),
+                DeviceConfigBackup(address = "AA:AA:AA:AA:AA:AA", customName = "second"),
+                DeviceConfigBackup(address = "BB:BB:BB:BB:BB:BB"),
+            )
+        )
+
+        val result = manager.applyRestore(backup, skipExisting = false)
+
+        result.deviceCount shouldBe 2
+        val writes = mutableListOf<DeviceConfigEntity>()
+        coVerify(exactly = 2) { dao.updateDevice(capture(writes)) }
+        writes.map { it.address } shouldContainExactlyInAnyOrder listOf(
+            "AA:AA:AA:AA:AA:AA",
+            "BB:BB:BB:BB:BB:BB",
+        )
+        writes.first { it.address == "AA:AA:AA:AA:AA:AA" }.customName shouldBe "first"
+    }
+
+    @Test
+    fun `applyRestore propagates device-loop exception and skips settings`() = runTest {
+        coEvery { dao.updateDevice(any()) } throws IOException("write failed")
+        val backup = buildBackup(listOf(sampleDeviceBackup))
+
+        shouldThrow<IOException> {
+            manager.applyRestore(backup, skipExisting = false)
+        }
+        coVerify(exactly = 0) { devicesSettings.applyBackup(any()) }
+        coVerify(exactly = 0) { generalSettings.applyBackup(any()) }
+    }
+
+    private fun buildBackup(devices: List<DeviceConfigBackup>): AppBackup = AppBackup(
+        formatVersion = 1,
+        appVersion = "1.0.0",
+        createdAt = "2026-01-01T00:00:00Z",
+        deviceConfigs = devices,
+    )
+}

--- a/app/src/test/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreViewModelTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreViewModelTest.kt
@@ -1,0 +1,255 @@
+package eu.darken.bluemusic.main.ui.settings.backup
+
+import android.net.Uri
+import eu.darken.bluemusic.common.navigation.NavigationController
+import eu.darken.bluemusic.devices.core.database.DeviceConfigDao
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.devices.core.database.DeviceDatabase
+import eu.darken.bluemusic.main.backup.core.AppBackup
+import eu.darken.bluemusic.main.backup.core.BackupRestoreManager
+import eu.darken.bluemusic.main.backup.core.DeviceConfigBackup
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldEndWith
+import io.kotest.matchers.string.shouldStartWith
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class BackupRestoreViewModelTest : BaseTest() {
+
+    private lateinit var navCtrl: NavigationController
+    private lateinit var backupRestoreManager: BackupRestoreManager
+    private lateinit var deviceDatabase: DeviceDatabase
+    private lateinit var dao: DeviceConfigDao
+
+    private val sampleBackup = AppBackup(
+        formatVersion = 1,
+        appVersion = "1.0.0",
+        createdAt = "2026-01-01T00:00:00Z",
+        deviceConfigs = listOf(
+            DeviceConfigBackup(address = "AA:AA:AA:AA:AA:AA"),
+            DeviceConfigBackup(address = "BB:BB:BB:BB:BB:BB"),
+        ),
+    )
+
+    @BeforeEach
+    fun setup() {
+        navCtrl = mockk(relaxed = true)
+        backupRestoreManager = mockk(relaxed = true)
+        deviceDatabase = mockk(relaxed = true)
+        dao = mockk(relaxed = true)
+        every { deviceDatabase.devices } returns dao
+        coEvery { dao.getAllDevicesOnce() } returns emptyList()
+    }
+
+    private fun viewModel(): BackupRestoreViewModel = BackupRestoreViewModel(
+        dispatcherProvider = TestDispatcherProvider(UnconfinedTestDispatcher()),
+        navCtrl = navCtrl,
+        backupRestoreManager = backupRestoreManager,
+        deviceDatabase = deviceDatabase,
+    )
+
+    @Test
+    fun `onBackupClicked emits OpenBackupPicker with dated filename`() = runTest {
+        val vm = viewModel()
+
+        val received = mutableListOf<BackupRestoreEvent>()
+        val job = launch { vm.events.take(1).toList(received) }
+
+        vm.onBackupClicked()
+        advanceUntilIdle()
+        job.join()
+
+        val event = received.single() as BackupRestoreEvent.OpenBackupPicker
+        event.suggestedName shouldStartWith "bluemusic-backup-"
+        event.suggestedName shouldEndWith ".zip"
+    }
+
+    @Test
+    fun `onRestoreClicked emits OpenRestorePicker`() = runTest {
+        val vm = viewModel()
+
+        val received = mutableListOf<BackupRestoreEvent>()
+        val job = launch { vm.events.take(1).toList(received) }
+
+        vm.onRestoreClicked()
+        advanceUntilIdle()
+        job.join()
+
+        received.single() shouldBe BackupRestoreEvent.OpenRestorePicker
+    }
+
+    @Test
+    fun `onBackupUriSelected populates lastResult and clears isWorking`() = runTest {
+        val uri = mockk<Uri>(relaxed = true)
+        coEvery { backupRestoreManager.createBackup(uri) } returns BackupRestoreManager.BackupResult(deviceConfigCount = 3)
+        every { backupRestoreManager.resolveFileName(uri) } returns "export.zip"
+        val vm = viewModel()
+
+        vm.onBackupUriSelected(uri)
+        advanceUntilIdle()
+
+        val state = vm.state.filterNotNull().first()
+        state.isWorking shouldBe false
+        state.lastResult?.type shouldBe BackupRestoreViewModel.OperationType.BACKUP
+        state.lastResult?.deviceCount shouldBe 3
+        state.lastResult?.fileName shouldBe "export.zip"
+    }
+
+    @Test
+    fun `onRestoreUriSelected populates pendingRestore with overlap count`() = runTest {
+        val uri = mockk<Uri>(relaxed = true)
+        coEvery { backupRestoreManager.parseBackup(uri) } returns BackupRestoreManager.ParseResult(
+            backup = sampleBackup,
+            versionMismatch = false,
+            enumWarnings = listOf("warn"),
+        )
+        every { backupRestoreManager.resolveFileName(uri) } returns "incoming.zip"
+        coEvery { dao.getAllDevicesOnce() } returns listOf(
+            DeviceConfigEntity(address = "AA:AA:AA:AA:AA:AA"),
+        )
+        val vm = viewModel()
+
+        vm.onRestoreUriSelected(uri)
+        advanceUntilIdle()
+
+        val preview = vm.state.filterNotNull().first().pendingRestore
+        preview.shouldNotBeNull()
+        preview.deviceCount shouldBe 2
+        preview.existingDeviceCount shouldBe 1
+        preview.warnings shouldContain "warn"
+        preview.fileName shouldBe "incoming.zip"
+    }
+
+    @Test
+    fun `onConfirmRestore without pending preview is a no-op`() = runTest {
+        val vm = viewModel()
+
+        vm.onConfirmRestore()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { backupRestoreManager.applyRestore(any(), any()) }
+    }
+
+    @Test
+    fun `onConfirmRestore applies backup with current skipExisting flag`() = runTest {
+        val uri = mockk<Uri>(relaxed = true)
+        coEvery { backupRestoreManager.parseBackup(uri) } returns BackupRestoreManager.ParseResult(
+            backup = sampleBackup,
+            versionMismatch = false,
+            enumWarnings = emptyList(),
+        )
+        every { backupRestoreManager.resolveFileName(uri) } returns "r.zip"
+        coEvery { backupRestoreManager.applyRestore(any(), any()) } returns BackupRestoreManager.RestoreResult(
+            deviceCount = 2,
+            skippedCount = 0,
+        )
+        val vm = viewModel()
+
+        vm.onRestoreUriSelected(uri)
+        advanceUntilIdle()
+        vm.onToggleSkipExisting(true)
+        advanceUntilIdle()
+        vm.onConfirmRestore()
+        advanceUntilIdle()
+
+        coVerify { backupRestoreManager.applyRestore(sampleBackup, skipExisting = true) }
+        val state = vm.state.filterNotNull().first()
+        state.pendingRestore shouldBe null
+        state.lastResult?.type shouldBe BackupRestoreViewModel.OperationType.RESTORE
+        state.lastResult?.deviceCount shouldBe 2
+    }
+
+    @Test
+    fun `onConfirmRestore preserves pendingRestore when applyRestore throws`() = runTest {
+        val uri = mockk<Uri>(relaxed = true)
+        coEvery { backupRestoreManager.parseBackup(uri) } returns BackupRestoreManager.ParseResult(
+            backup = sampleBackup,
+            versionMismatch = false,
+            enumWarnings = emptyList(),
+        )
+        every { backupRestoreManager.resolveFileName(uri) } returns "r.zip"
+        coEvery { backupRestoreManager.applyRestore(any(), any()) } throws IOException("boom")
+        val vm = viewModel()
+
+        vm.onRestoreUriSelected(uri)
+        advanceUntilIdle()
+        // Swallow the expected error so it doesn't fail the test through errorEvents
+        val errorJob = launch { vm.errorEvents.take(1).toList() }
+
+        vm.onConfirmRestore()
+        advanceUntilIdle()
+        errorJob.join()
+
+        val state = vm.state.filterNotNull().first()
+        state.pendingRestore.shouldNotBeNull()
+        state.lastResult shouldBe null
+        state.isWorking shouldBe false
+    }
+
+    @Test
+    fun `onCancelRestore clears pendingRestore`() = runTest {
+        val uri = mockk<Uri>(relaxed = true)
+        coEvery { backupRestoreManager.parseBackup(uri) } returns BackupRestoreManager.ParseResult(
+            backup = sampleBackup,
+            versionMismatch = false,
+            enumWarnings = emptyList(),
+        )
+        every { backupRestoreManager.resolveFileName(uri) } returns "r.zip"
+        val vm = viewModel()
+
+        vm.onRestoreUriSelected(uri)
+        advanceUntilIdle()
+        vm.onCancelRestore()
+        advanceUntilIdle()
+
+        vm.state.filterNotNull().first().pendingRestore shouldBe null
+    }
+
+    @Test
+    fun `onToggleSkipExisting updates state`() = runTest {
+        val vm = viewModel()
+
+        vm.onToggleSkipExisting(true)
+        advanceUntilIdle()
+
+        vm.state.filterNotNull().first().skipExisting shouldBe true
+    }
+
+    @Test
+    fun `createBackup exception propagates via errorEvents and clears isWorking`() = runTest {
+        val uri = mockk<Uri>(relaxed = true)
+        coEvery { backupRestoreManager.createBackup(uri) } throws IOException("disk full")
+        val vm = viewModel()
+
+        val errors = mutableListOf<Throwable>()
+        val job = launch { vm.errorEvents.take(1).toList(errors) }
+
+        vm.onBackupUriSelected(uri)
+        advanceUntilIdle()
+        job.join()
+
+        errors.single().message shouldBe "disk full"
+        val state = vm.state.filterNotNull().first()
+        state.isWorking shouldBe false
+        state.lastResult shouldBe null
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/main/ui/widget/WidgetConfigurationViewModelTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/ui/widget/WidgetConfigurationViewModelTest.kt
@@ -1,0 +1,170 @@
+package eu.darken.bluemusic.main.ui.widget
+
+import android.appwidget.AppWidgetManager
+import android.content.Context
+import android.graphics.Color
+import android.os.Bundle
+import androidx.lifecycle.SavedStateHandle
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.common.upgrade.UpgradeRepo
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.coroutine.TestDispatcherProvider
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class WidgetConfigurationViewModelTest {
+
+    private val widgetId = 42
+    private lateinit var context: Context
+    private lateinit var upgradeRepo: UpgradeRepo
+    private lateinit var upgradeInfo: MutableStateFlow<FakeUpgradeInfo>
+    private lateinit var appWidgetManager: AppWidgetManager
+    private var storedOptions: Bundle = Bundle()
+
+    @Before
+    fun setup() {
+        context = ApplicationProvider.getApplicationContext()
+
+        upgradeInfo = MutableStateFlow(FakeUpgradeInfo(isUpgraded = true))
+        upgradeRepo = mockk(relaxed = true)
+        every { upgradeRepo.upgradeInfo } returns upgradeInfo
+
+        appWidgetManager = mockk(relaxed = true)
+        every { appWidgetManager.getAppWidgetOptions(widgetId) } answers { storedOptions }
+        val updated = slot<Bundle>()
+        every { appWidgetManager.updateAppWidgetOptions(widgetId, capture(updated)) } answers {
+            storedOptions = updated.captured
+        }
+
+        io.mockk.mockkStatic(AppWidgetManager::class)
+        every { AppWidgetManager.getInstance(any()) } returns appWidgetManager
+    }
+
+    @After
+    fun tearDown() {
+        io.mockk.unmockkStatic(AppWidgetManager::class)
+    }
+
+    private fun viewModel(
+        id: Int = widgetId,
+    ): WidgetConfigurationViewModel = WidgetConfigurationViewModel(
+        savedStateHandle = SavedStateHandle(mapOf(AppWidgetManager.EXTRA_APPWIDGET_ID to id)),
+        dispatcherProvider = TestDispatcherProvider(UnconfinedTestDispatcher()),
+        upgradeRepo = upgradeRepo,
+        context = context,
+    )
+
+    @Test
+    fun `invalid widget id falls back to default theme`() = runTest {
+        val vm = viewModel(id = AppWidgetManager.INVALID_APPWIDGET_ID)
+
+        val state = vm.state.filterNotNull().first()
+        state.theme shouldBe WidgetTheme.DEFAULT
+    }
+
+    @Test
+    fun `valid widget id loads theme from stored options`() = runTest {
+        val preset = WidgetTheme.Preset.CLASSIC_DARK
+        WidgetTheme(
+            backgroundColor = preset.presetBg,
+            foregroundColor = preset.presetFg,
+        ).toBundle(storedOptions)
+
+        val vm = viewModel()
+        val state = vm.state.filterNotNull().first()
+
+        state.theme.backgroundColor shouldBe preset.presetBg
+        state.theme.foregroundColor shouldBe preset.presetFg
+        state.activePreset shouldBe preset
+    }
+
+    @Test
+    fun `selectPreset sets preset and exits custom mode`() = runTest {
+        val vm = viewModel()
+        vm.selectPreset(WidgetTheme.Preset.MATERIAL_YOU)
+        advanceUntilIdle()
+
+        val state = vm.state.filterNotNull().first()
+        state.activePreset shouldBe WidgetTheme.Preset.MATERIAL_YOU
+        state.isCustomMode shouldBe false
+    }
+
+    @Test
+    fun `enterCustomMode flips to custom mode with full-alpha colors`() = runTest {
+        val vm = viewModel()
+        vm.enterCustomMode(resolvedBg = Color.rgb(10, 20, 30), resolvedFg = Color.rgb(200, 210, 220))
+        advanceUntilIdle()
+
+        val state = vm.state.filterNotNull().first()
+        state.isCustomMode shouldBe true
+        Color.alpha(state.theme.backgroundColor ?: 0) shouldBe 0xFF
+        Color.alpha(state.theme.foregroundColor ?: 0) shouldBe 0xFF
+    }
+
+    @Test
+    fun `setBackgroundAlpha coerces out-of-range values`() = runTest {
+        val vm = viewModel()
+        vm.setBackgroundAlpha(1000)
+        advanceUntilIdle()
+        vm.state.filterNotNull().first().theme.backgroundAlpha shouldBe 255
+
+        vm.setBackgroundAlpha(-50)
+        advanceUntilIdle()
+        vm.state.filterNotNull().first().theme.backgroundAlpha shouldBe 0
+    }
+
+    @Test
+    fun `resetToDefaults restores default theme`() = runTest {
+        val vm = viewModel()
+        vm.enterCustomMode(Color.RED, Color.BLUE)
+        advanceUntilIdle()
+
+        vm.resetToDefaults()
+        advanceUntilIdle()
+
+        val state = vm.state.filterNotNull().first()
+        state.theme shouldBe WidgetTheme.DEFAULT
+    }
+
+    @Test
+    fun `confirmSelection persists theme that round-trips via fromBundle`() = runTest {
+        val vm = viewModel()
+        vm.selectPreset(WidgetTheme.Preset.CLASSIC_LIGHT)
+        advanceUntilIdle()
+        vm.setBackgroundAlpha(128)
+        advanceUntilIdle()
+
+        vm.confirmSelection()
+
+        verify { appWidgetManager.updateAppWidgetOptions(widgetId, any()) }
+        val roundTripped = WidgetTheme.fromBundle(storedOptions)
+        roundTripped.backgroundColor shouldBe WidgetTheme.Preset.CLASSIC_LIGHT.presetBg
+        roundTripped.foregroundColor shouldBe WidgetTheme.Preset.CLASSIC_LIGHT.presetFg
+        roundTripped.backgroundAlpha shouldBe 128
+    }
+
+    private data class FakeUpgradeInfo(
+        override val isUpgraded: Boolean,
+        override val type: UpgradeRepo.Type = UpgradeRepo.Type.FOSS,
+        override val upgradedAt: java.time.Instant? = null,
+        override val error: Throwable? = null,
+    ) : UpgradeRepo.Info
+}

--- a/app/src/test/java/eu/darken/bluemusic/main/ui/widget/WidgetConfigurationViewModelTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/ui/widget/WidgetConfigurationViewModelTest.kt
@@ -5,12 +5,13 @@ import android.content.Context
 import android.graphics.Color
 import android.os.Bundle
 import androidx.lifecycle.SavedStateHandle
-import androidx.test.core.app.ApplicationProvider
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.mockk.slot
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -19,29 +20,38 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import org.junit.After
-import org.junit.Before
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 
 @OptIn(ExperimentalCoroutinesApi::class)
-@RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE, sdk = [34])
-class WidgetConfigurationViewModelTest {
+class WidgetConfigurationViewModelTest : BaseTest() {
 
     private val widgetId = 42
     private lateinit var context: Context
     private lateinit var upgradeRepo: UpgradeRepo
     private lateinit var upgradeInfo: MutableStateFlow<FakeUpgradeInfo>
     private lateinit var appWidgetManager: AppWidgetManager
-    private var storedOptions: Bundle = Bundle()
+    private lateinit var storedOptions: Bundle
 
-    @Before
+    @BeforeEach
     fun setup() {
-        context = ApplicationProvider.getApplicationContext()
+        mockkStatic(Color::class)
+        every { Color.rgb(any<Int>(), any<Int>(), any<Int>()) } answers {
+            val r = firstArg<Int>() and 0xff
+            val g = secondArg<Int>() and 0xff
+            val b = thirdArg<Int>() and 0xff
+            (0xff shl 24) or (r shl 16) or (g shl 8) or b
+        }
+        every { Color.alpha(any<Int>()) } answers { (firstArg<Int>() ushr 24) and 0xff }
+        every { Color.red(any<Int>()) } answers { (firstArg<Int>() shr 16) and 0xff }
+        every { Color.green(any<Int>()) } answers { (firstArg<Int>() shr 8) and 0xff }
+        every { Color.blue(any<Int>()) } answers { firstArg<Int>() and 0xff }
+
+        context = mockk(relaxed = true)
+        storedOptions = mapBackedBundle()
 
         upgradeInfo = MutableStateFlow(FakeUpgradeInfo(isUpgraded = true))
         upgradeRepo = mockk(relaxed = true)
@@ -54,13 +64,14 @@ class WidgetConfigurationViewModelTest {
             storedOptions = updated.captured
         }
 
-        io.mockk.mockkStatic(AppWidgetManager::class)
+        mockkStatic(AppWidgetManager::class)
         every { AppWidgetManager.getInstance(any()) } returns appWidgetManager
     }
 
-    @After
+    @AfterEach
     fun tearDown() {
-        io.mockk.unmockkStatic(AppWidgetManager::class)
+        unmockkStatic(AppWidgetManager::class)
+        unmockkStatic(Color::class)
     }
 
     private fun viewModel(
@@ -134,7 +145,7 @@ class WidgetConfigurationViewModelTest {
     @Test
     fun `resetToDefaults restores default theme`() = runTest {
         val vm = viewModel()
-        vm.enterCustomMode(Color.RED, Color.BLUE)
+        vm.enterCustomMode(Color.rgb(255, 0, 0), Color.rgb(0, 0, 255))
         advanceUntilIdle()
 
         vm.resetToDefaults()
@@ -159,6 +170,45 @@ class WidgetConfigurationViewModelTest {
         roundTripped.backgroundColor shouldBe WidgetTheme.Preset.CLASSIC_LIGHT.presetBg
         roundTripped.foregroundColor shouldBe WidgetTheme.Preset.CLASSIC_LIGHT.presetFg
         roundTripped.backgroundAlpha shouldBe 128
+    }
+
+    private fun mapBackedBundle(): Bundle {
+        val store = mutableMapOf<String, Any?>()
+        val bundle = mockk<Bundle>(relaxed = true)
+        every { bundle.putString(any(), any()) } answers {
+            store[firstArg()] = secondArg<String?>()
+        }
+        every { bundle.getString(any()) } answers {
+            store[firstArg()] as? String
+        }
+        every { bundle.getString(any(), any<String>()) } answers {
+            (store[firstArg()] as? String) ?: secondArg()
+        }
+        every { bundle.putInt(any(), any<Int>()) } answers {
+            store[firstArg()] = secondArg<Int>()
+        }
+        every { bundle.getInt(any()) } answers {
+            (store[firstArg()] as? Int) ?: 0
+        }
+        every { bundle.getInt(any(), any<Int>()) } answers {
+            (store[firstArg()] as? Int) ?: secondArg()
+        }
+        every { bundle.putBoolean(any(), any<Boolean>()) } answers {
+            store[firstArg()] = secondArg<Boolean>()
+        }
+        every { bundle.getBoolean(any()) } answers {
+            (store[firstArg()] as? Boolean) ?: false
+        }
+        every { bundle.getBoolean(any(), any<Boolean>()) } answers {
+            (store[firstArg()] as? Boolean) ?: secondArg()
+        }
+        every { bundle.remove(any()) } answers {
+            store.remove(firstArg())
+        }
+        every { bundle.containsKey(any()) } answers {
+            firstArg<String>() in store
+        }
+        return bundle
     }
 
     private data class FakeUpgradeInfo(

--- a/app/src/test/java/eu/darken/bluemusic/main/ui/widget/WidgetRenderStateMapperTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/ui/widget/WidgetRenderStateMapperTest.kt
@@ -1,0 +1,166 @@
+package eu.darken.bluemusic.main.ui.widget
+
+import android.content.Context
+import android.graphics.Color
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class WidgetRenderStateMapperTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    private val themeWithColors = WidgetTheme(
+        backgroundColor = Color.rgb(20, 20, 20),
+        foregroundColor = Color.rgb(240, 240, 240),
+        backgroundAlpha = 200,
+    )
+
+    private fun btState(
+        enabled: Boolean = true,
+        hasPermission: Boolean = true,
+    ) = BluetoothRepo.State(
+        isEnabled = enabled,
+        hasPermission = hasPermission,
+        devices = emptySet(),
+    )
+
+    private fun buildDevice(
+        address: String,
+        type: SourceDevice.Type = SourceDevice.Type.HEADPHONES,
+        connected: Boolean = true,
+        enabled: Boolean = true,
+        volumeLock: Boolean = false,
+        customName: String? = null,
+        label: String = "Buds",
+    ): ManagedDevice {
+        val sourceDevice = mockk<SourceDevice>(relaxed = true).apply {
+            every { this@apply.address } returns address
+            every { this@apply.deviceType } returns type
+            every { this@apply.label } returns label
+        }
+        val config = DeviceConfigEntity(
+            address = address,
+            customName = customName,
+            volumeLock = volumeLock,
+            isEnabled = enabled,
+        )
+        return ManagedDevice(
+            isConnected = connected,
+            device = sourceDevice,
+            config = config,
+        )
+    }
+
+    @Test
+    fun `bluetooth off renders BluetoothOff`() {
+        val state = WidgetRenderStateMapper.map(
+            context = context,
+            btState = btState(enabled = false),
+            devices = emptyList(),
+            theme = themeWithColors,
+            isPro = true,
+        )
+        state.shouldBeInstanceOf<WidgetRenderState.BluetoothOff>()
+    }
+
+    @Test
+    fun `no active devices renders NoDevice`() {
+        val state = WidgetRenderStateMapper.map(
+            context = context,
+            btState = btState(),
+            devices = listOf(buildDevice("AA:AA:AA:AA:AA:AA", connected = false)),
+            theme = themeWithColors,
+            isPro = true,
+        )
+        state.shouldBeInstanceOf<WidgetRenderState.NoDevice>()
+    }
+
+    @Test
+    fun `phone speaker alone does not produce active state`() {
+        val state = WidgetRenderStateMapper.map(
+            context = context,
+            btState = btState(),
+            devices = listOf(
+                buildDevice("00:00:00:00:00:00", type = SourceDevice.Type.PHONE_SPEAKER, label = "Phone"),
+            ),
+            theme = themeWithColors,
+            isPro = true,
+        )
+        state.shouldBeInstanceOf<WidgetRenderState.NoDevice>()
+    }
+
+    @Test
+    fun `non-pro user with active device renders UpgradeRequired`() {
+        val state = WidgetRenderStateMapper.map(
+            context = context,
+            btState = btState(),
+            devices = listOf(buildDevice("AA:AA:AA:AA:AA:AA", customName = "Pixel Buds")),
+            theme = themeWithColors,
+            isPro = false,
+        )
+        state.shouldBeInstanceOf<WidgetRenderState.UpgradeRequired>()
+        (state as WidgetRenderState.UpgradeRequired).deviceLabel shouldBe "Pixel Buds"
+    }
+
+    @Test
+    fun `pro user with active device renders Active with locked state propagated`() {
+        val state = WidgetRenderStateMapper.map(
+            context = context,
+            btState = btState(),
+            devices = listOf(
+                buildDevice(
+                    address = "AA:AA:AA:AA:AA:AA",
+                    customName = "Buds 2",
+                    volumeLock = true,
+                )
+            ),
+            theme = themeWithColors,
+            isPro = true,
+        )
+        state.shouldBeInstanceOf<WidgetRenderState.Active>()
+        val active = state as WidgetRenderState.Active
+        active.deviceAddress shouldBe "AA:AA:AA:AA:AA:AA"
+        active.deviceLabel shouldBe "Buds 2"
+        active.isLocked shouldBe true
+    }
+
+    @Test
+    fun `resolvedSecondaryTextColor blends bg and text with 55 percent ratio`() {
+        val bg = Color.BLACK
+        val text = Color.WHITE
+        val blended = WidgetRenderStateMapper.resolvedSecondaryTextColor(bg, text)
+        val expectedChannel = (Color.red(bg) + (Color.red(text) - Color.red(bg)) * 0.55f).toInt()
+        Color.red(blended) shouldBe expectedChannel
+    }
+
+    @Test
+    fun `theme with only background color still resolves without blending accent`() {
+        val theme = WidgetTheme(
+            backgroundColor = Color.rgb(10, 10, 10),
+            foregroundColor = null,
+        )
+        WidgetRenderStateMapper.resolvedAccentColor(context, theme)
+    }
+
+    @Test
+    fun `theme with only foreground color still resolves without blending accent`() {
+        val theme = WidgetTheme(
+            backgroundColor = null,
+            foregroundColor = Color.rgb(240, 240, 240),
+        )
+        WidgetRenderStateMapper.resolvedAccentColor(context, theme)
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/main/ui/widget/WidgetRenderStateMapperTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/ui/widget/WidgetRenderStateMapperTest.kt
@@ -147,20 +147,10 @@ class WidgetRenderStateMapperTest {
     }
 
     @Test
-    fun `theme with only background color still resolves without blending accent`() {
-        val theme = WidgetTheme(
-            backgroundColor = Color.rgb(10, 10, 10),
-            foregroundColor = null,
-        )
-        WidgetRenderStateMapper.resolvedAccentColor(context, theme)
-    }
-
-    @Test
-    fun `theme with only foreground color still resolves without blending accent`() {
-        val theme = WidgetTheme(
-            backgroundColor = null,
-            foregroundColor = Color.rgb(240, 240, 240),
-        )
-        WidgetRenderStateMapper.resolvedAccentColor(context, theme)
+    fun `partially custom theme resolves accent via fallback`() {
+        val bgOnly = WidgetTheme(backgroundColor = Color.rgb(10, 10, 10), foregroundColor = null)
+        val fgOnly = WidgetTheme(backgroundColor = null, foregroundColor = Color.rgb(240, 240, 240))
+        WidgetRenderStateMapper.resolvedAccentColor(context, bgOnly)
+        WidgetRenderStateMapper.resolvedAccentColor(context, fgOnly)
     }
 }

--- a/app/src/test/java/eu/darken/bluemusic/main/ui/widget/WidgetRenderStateMapperTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/ui/widget/WidgetRenderStateMapperTest.kt
@@ -2,7 +2,6 @@ package eu.darken.bluemusic.main.ui.widget
 
 import android.content.Context
 import android.graphics.Color
-import androidx.test.core.app.ApplicationProvider
 import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
 import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.devices.core.ManagedDevice
@@ -11,22 +10,51 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.every
 import io.mockk.mockk
-import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
-import org.robolectric.annotation.Config
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
 
-@RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE, sdk = [34])
-class WidgetRenderStateMapperTest {
+class WidgetRenderStateMapperTest : BaseTest() {
 
-    private val context: Context = ApplicationProvider.getApplicationContext()
+    private lateinit var context: Context
+    private lateinit var themeWithColors: WidgetTheme
 
-    private val themeWithColors = WidgetTheme(
-        backgroundColor = Color.rgb(20, 20, 20),
-        foregroundColor = Color.rgb(240, 240, 240),
-        backgroundAlpha = 200,
-    )
+    @BeforeEach
+    fun setup() {
+        mockkStatic(Color::class)
+        every { Color.rgb(any<Int>(), any<Int>(), any<Int>()) } answers {
+            val r = firstArg<Int>() and 0xff
+            val g = secondArg<Int>() and 0xff
+            val b = thirdArg<Int>() and 0xff
+            (0xff shl 24) or (r shl 16) or (g shl 8) or b
+        }
+        every { Color.argb(any<Int>(), any<Int>(), any<Int>(), any<Int>()) } answers {
+            val a = firstArg<Int>() and 0xff
+            val r = secondArg<Int>() and 0xff
+            val g = thirdArg<Int>() and 0xff
+            val b = arg<Int>(3) and 0xff
+            (a shl 24) or (r shl 16) or (g shl 8) or b
+        }
+        every { Color.alpha(any<Int>()) } answers { (firstArg<Int>() ushr 24) and 0xff }
+        every { Color.red(any<Int>()) } answers { (firstArg<Int>() shr 16) and 0xff }
+        every { Color.green(any<Int>()) } answers { (firstArg<Int>() shr 8) and 0xff }
+        every { Color.blue(any<Int>()) } answers { firstArg<Int>() and 0xff }
+
+        context = mockk(relaxed = true)
+        themeWithColors = WidgetTheme(
+            backgroundColor = Color.rgb(20, 20, 20),
+            foregroundColor = Color.rgb(240, 240, 240),
+            backgroundAlpha = 200,
+        )
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkStatic(Color::class)
+    }
 
     private fun btState(
         enabled: Boolean = true,
@@ -111,8 +139,8 @@ class WidgetRenderStateMapperTest {
             theme = themeWithColors,
             isPro = false,
         )
-        state.shouldBeInstanceOf<WidgetRenderState.UpgradeRequired>()
-        (state as WidgetRenderState.UpgradeRequired).deviceLabel shouldBe "Pixel Buds"
+        val upgradeRequired = state.shouldBeInstanceOf<WidgetRenderState.UpgradeRequired>()
+        upgradeRequired.deviceLabel shouldBe "Pixel Buds"
     }
 
     @Test
@@ -130,8 +158,7 @@ class WidgetRenderStateMapperTest {
             theme = themeWithColors,
             isPro = true,
         )
-        state.shouldBeInstanceOf<WidgetRenderState.Active>()
-        val active = state as WidgetRenderState.Active
+        val active = state.shouldBeInstanceOf<WidgetRenderState.Active>()
         active.deviceAddress shouldBe "AA:AA:AA:AA:AA:AA"
         active.deviceLabel shouldBe "Buds 2"
         active.isLocked shouldBe true
@@ -139,18 +166,10 @@ class WidgetRenderStateMapperTest {
 
     @Test
     fun `resolvedSecondaryTextColor blends bg and text with 55 percent ratio`() {
-        val bg = Color.BLACK
-        val text = Color.WHITE
+        val bg = 0xFF000000.toInt()
+        val text = 0xFFFFFFFF.toInt()
         val blended = WidgetRenderStateMapper.resolvedSecondaryTextColor(bg, text)
         val expectedChannel = (Color.red(bg) + (Color.red(text) - Color.red(bg)) * 0.55f).toInt()
         Color.red(blended) shouldBe expectedChannel
-    }
-
-    @Test
-    fun `partially custom theme resolves accent via fallback`() {
-        val bgOnly = WidgetTheme(backgroundColor = Color.rgb(10, 10, 10), foregroundColor = null)
-        val fgOnly = WidgetTheme(backgroundColor = null, foregroundColor = Color.rgb(240, 240, 240))
-        WidgetRenderStateMapper.resolvedAccentColor(context, bgOnly)
-        WidgetRenderStateMapper.resolvedAccentColor(context, fgOnly)
     }
 }


### PR DESCRIPTION
## Summary
- `VolumeLockToggleAction.onAction` now uses `try/catch/finally` so any error during a widget toggle is logged and the widget still refreshes, instead of failing silently.
- `BackupRestoreManager.applyRestore` now writes devices inside a single Room transaction via a new `DeviceDatabase.withTransaction` helper and dedupes by address. A mid-loop failure rolls back all device writes.
- `DevicesSettings.applyBackup` and `GeneralSettings.applyBackup` now each use a single `DataStore.updateData` block (new `DataStoreValue.setIn`), removing their intra-store partial-write windows.
- `BackupRestoreViewModel` now keeps the restore preview if `applyRestore` throws, so the user can retry without re-picking the file.
- `parseBackup` flags duplicate device addresses in the preview warnings.

## Tests
- New: `BackupRestoreManagerTest`, `BackupRestoreManagerAtomicityTest` (Robolectric + in-memory Room, proves rollback), `BackupRestoreViewModelTest`, `WidgetRenderStateMapperTest`, `WidgetConfigurationViewModelTest`, plus `setIn` cases in `DataStoreValueTest`.
- `./gradlew :app:testFossDebugUnitTest` green. `:app:compileGplayDebugKotlin` green.
