### PR TITLE
Show dashboard hint when Do Not Disturb access is missing

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/common/permissions/PermissionHelper.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/permissions/PermissionHelper.kt
@@ -130,4 +130,20 @@ class PermissionHelper @Inject constructor(
 
     @RequiresApi(Build.VERSION_CODES.M)
     fun getNotificationPolicyAccessIntent(): Intent = Intent(Settings.ACTION_NOTIFICATION_POLICY_ACCESS_SETTINGS)
+
+    fun getDndAccessHint(isDismissed: Boolean, hasDevicesNeedingDnd: Boolean): PermissionHint {
+        val shouldShow = hasApiLevel(Build.VERSION_CODES.M) &&
+                hasDevicesNeedingDnd &&
+                !hasNotificationPolicyAccess() &&
+                !isDismissed
+        return if (shouldShow) {
+            @SuppressLint("NewApi")
+            val intent = getNotificationPolicyAccessIntent().apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+            PermissionHint(shouldShow = true, intent = intent)
+        } else {
+            PermissionHint(shouldShow = false)
+        }
+    }
 }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardAction.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardAction.kt
@@ -22,5 +22,7 @@ sealed interface DashboardAction {
 
     data object DismissNotificationPermissionHint : DashboardAction
 
+    data object DismissDndAccessHint : DashboardAction
+
     data class ToggleAdjustmentLock(val addr: DeviceAddr) : DashboardAction
 }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
@@ -71,6 +71,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.bluemusic.devices.core.DeviceAddr
 import eu.darken.bluemusic.devices.ui.dashboard.rows.Android10AppLaunchHintCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.BatteryOptimizationHintCard
+import eu.darken.bluemusic.devices.ui.dashboard.rows.DndAccessHintCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.EmptyDevicesCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.NotificationPermissionHintCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.device.ManagedDeviceItem
@@ -202,6 +203,15 @@ fun DevicesScreen(
                     Android10AppLaunchHintCard(
                         intent = state.android10AppLaunchIntent,
                         onDismiss = { onDeviceAction(DashboardAction.DismissAndroid10AppLaunchHint) }
+                    )
+                }
+            }
+
+            if (state.showDndAccessHint && state.dndAccessIntent != null) {
+                item {
+                    DndAccessHintCard(
+                        intent = state.dndAccessIntent,
+                        onDismiss = { onDeviceAction(DashboardAction.DismissDndAccessHint) }
                     )
                 }
             }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
@@ -88,6 +88,24 @@ class DashboardViewModel @Inject constructor(
         permissionHelper.getNotificationPermissionHint(isDismissed)
     }
 
+    private val dndAccessHintFlow = combine(
+        flow {
+            while (true) {
+                emit(System.currentTimeMillis())
+                delay(1000)
+            }
+        },
+        generalSettings.isDndAccessHintDismissed.flow,
+        devicesFlow,
+    ) { _, isDismissed, devices ->
+        val hasDevicesNeedingDnd = devices.any { device ->
+            device.getVolume(AudioStream.Type.RINGTONE) != null ||
+                device.getVolume(AudioStream.Type.NOTIFICATION) != null ||
+                device.dndMode != null
+        }
+        permissionHelper.getDndAccessHint(isDismissed, hasDevicesNeedingDnd)
+    }
+
     private val devicesWithAppsFlow = combine(
         devicesFlow,
         appRepo.apps
@@ -110,8 +128,9 @@ class DashboardViewModel @Inject constructor(
         batteryOptimizationHintFlow,
         overlayPermissionHintFlow,
         notificationPermissionHintFlow,
+        dndAccessHintFlow,
         devicesSettings.lockedDevices.flow,
-    ) { upgradeInfo, bluetoothState, devicesWithApps, batteryHint, overlayHint, notificationHint, lockedDevices ->
+    ) { upgradeInfo, bluetoothState, devicesWithApps, batteryHint, overlayHint, notificationHint, dndHint, lockedDevices ->
         State(
             isProVersion = upgradeInfo.isUpgraded,
             isBluetoothEnabled = bluetoothState.isEnabled,
@@ -123,6 +142,8 @@ class DashboardViewModel @Inject constructor(
             showAndroid10AppLaunchHint = overlayHint.shouldShow,
             android10AppLaunchIntent = overlayHint.intent,
             showNotificationPermissionHint = notificationHint.shouldShow,
+            showDndAccessHint = dndHint.shouldShow,
+            dndAccessIntent = dndHint.intent,
         )
     }.asStateFlow()
 
@@ -143,6 +164,8 @@ class DashboardViewModel @Inject constructor(
         val showAndroid10AppLaunchHint: Boolean = false,
         val android10AppLaunchIntent: Intent? = null,
         val showNotificationPermissionHint: Boolean = false,
+        val showDndAccessHint: Boolean = false,
+        val dndAccessIntent: Intent? = null,
     ) {
         // Convenience property for backwards compatibility
         val devices: List<ManagedDevice> get() = devicesWithApps.map { it.device }
@@ -182,6 +205,12 @@ class DashboardViewModel @Inject constructor(
             is DashboardAction.DismissNotificationPermissionHint -> {
                 launch {
                     generalSettings.isNotificationPermissionHintDismissed.update { true }
+                }
+            }
+
+            is DashboardAction.DismissDndAccessHint -> {
+                launch {
+                    generalSettings.isDndAccessHintDismissed.update { true }
                 }
             }
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/DndAccessHintCard.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/DndAccessHintCard.kt
@@ -1,0 +1,130 @@
+package eu.darken.bluemusic.devices.ui.dashboard.rows
+
+import android.content.Intent
+import android.provider.Settings
+import android.widget.Toast
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.DoNotDisturb
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.compose.Preview2
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+
+@Composable
+fun DndAccessHintCard(
+    intent: Intent,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .animateContentSize(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.TwoTone.DoNotDisturb,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = stringResource(R.string.dnd_access_hint_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.dnd_access_hint_message),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.action_dismiss))
+                }
+                Button(
+                    onClick = {
+                        try {
+                            context.startActivity(intent)
+                        } catch (e: Exception) {
+                            log(TAG) { "Failed to open DND access settings: $e" }
+                            try {
+                                val fallback = Intent(Settings.ACTION_SETTINGS)
+                                context.startActivity(fallback)
+                            } catch (e2: Exception) {
+                                log(TAG) { "Failed to open general settings: $e2" }
+                                Toast.makeText(
+                                    context,
+                                    R.string.general_error_no_compatible_app_found_msg,
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                            }
+                        }
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Text(stringResource(R.string.dnd_access_fix_action))
+                }
+            }
+        }
+    }
+}
+
+private val TAG = logTag("DndAccess", "HintCard")
+
+@Preview2
+@Composable
+fun DndAccessHintCardPreview() {
+    PreviewWrapper {
+        DndAccessHintCard(
+            intent = Intent(),
+            onDismiss = {}
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupData.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupData.kt
@@ -61,4 +61,5 @@ data class GeneralSettingsBackup(
     val isBatteryOptimizationHintDismissed: Boolean = false,
     val isAndroid10AppLaunchHintDismissed: Boolean = false,
     val isNotificationPermissionHintDismissed: Boolean = false,
+    val isDndAccessHintDismissed: Boolean = false,
 )

--- a/app/src/main/java/eu/darken/bluemusic/main/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/core/GeneralSettings.kt
@@ -47,6 +47,7 @@ class GeneralSettings @Inject constructor(
     val isBatteryOptimizationHintDismissed = dataStore.createValue("hints.battery.optimization.dismissed", false)
     val isAndroid10AppLaunchHintDismissed = dataStore.createValue("hints.android10.applaunch.dismissed", false)
     val isNotificationPermissionHintDismissed = dataStore.createValue("hints.notification.permission.dismissed", false)
+    val isDndAccessHintDismissed = dataStore.createValue("hints.dnd.access.dismissed", false)
 
 
     suspend fun toBackup(): GeneralSettingsBackup = GeneralSettingsBackup(
@@ -57,6 +58,7 @@ class GeneralSettings @Inject constructor(
         isBatteryOptimizationHintDismissed = isBatteryOptimizationHintDismissed.value(),
         isAndroid10AppLaunchHintDismissed = isAndroid10AppLaunchHintDismissed.value(),
         isNotificationPermissionHintDismissed = isNotificationPermissionHintDismissed.value(),
+        isDndAccessHintDismissed = isDndAccessHintDismissed.value(),
     )
 
     suspend fun applyBackup(backup: GeneralSettingsBackup) {
@@ -70,6 +72,7 @@ class GeneralSettings @Inject constructor(
                 if (backup.isBatteryOptimizationHintDismissed) isBatteryOptimizationHintDismissed.setIn(this, true)
                 if (backup.isAndroid10AppLaunchHintDismissed) isAndroid10AppLaunchHintDismissed.setIn(this, true)
                 if (backup.isNotificationPermissionHintDismissed) isNotificationPermissionHintDismissed.setIn(this, true)
+                if (backup.isDndAccessHintDismissed) isDndAccessHintDismissed.setIn(this, true)
             }.toPreferences()
         }
     }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
@@ -74,7 +74,11 @@ class VolumeTool @Inject constructor(
             delay(10)
 
             // https://stackoverflow.com/questions/6733163/notificationmanager-notify-fails-with-securityexception
-            audioManager.setStreamVolume(streamId.id, volume, flags)
+            try {
+                audioManager.setStreamVolume(streamId.id, volume, flags)
+            } catch (e: SecurityException) {
+                log(TAG, WARN) { "setStreamVolume($streamId, $volume) denied: ${e.message}" }
+            }
 
             delay(10)
         } finally {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
@@ -2,6 +2,7 @@ package eu.darken.bluemusic.monitor.core.modules.connection
 
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.devices.core.DeviceRepo
@@ -36,7 +37,7 @@ abstract class BaseVolumeModule(
     override val tag: String
         get() = logTag("Monitor", "$type", "Volume", "Module")
 
-    open suspend fun areRequirementsMet(): Boolean = true
+    open suspend fun unmetRequirement(): String? = null
 
     override suspend fun handle(event: DeviceEvent) {
         if (event !is DeviceEvent.Connected) return
@@ -46,8 +47,9 @@ abstract class BaseVolumeModule(
         log(tag) { "Desired $type volume is $volumeMode" }
         if (volumeMode == null) return
 
-        if (!areRequirementsMet()) {
-            log(tag) { "Requirements not met!" }
+        val unmet = unmetRequirement()
+        if (unmet != null) {
+            log(tag, WARN) { "Skipping volume restore — requirement not met: $unmet" }
             return
         }
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/DndModeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/DndModeModule.kt
@@ -6,6 +6,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.hasApiLevel
@@ -40,7 +41,7 @@ class DndModeModule @Inject constructor(
 
         device.dndMode?.let { mode ->
             if (!permissionHelper.hasNotificationPolicyAccess()) {
-                log(TAG) { "Skipping DND mode handling - no notification policy access" }
+                log(TAG, WARN) { "Skipping DND mode — requirement not met: ACCESS_NOTIFICATION_POLICY (DND access) is not granted" }
                 return
             }
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/NotificationVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/NotificationVolumeModule.kt
@@ -30,7 +30,11 @@ class NotificationVolumeModule @Inject constructor(
     override val type: AudioStream.Type = AudioStream.Type.NOTIFICATION
 
     @Suppress("NewApi")
-    override suspend fun areRequirementsMet(): Boolean = !hasApiLevel(23) || permissionHelper.hasNotificationPolicyAccess()
+    override suspend fun unmetRequirement(): String? = when {
+        !hasApiLevel(23) -> null
+        permissionHelper.hasNotificationPolicyAccess() -> null
+        else -> "ACCESS_NOTIFICATION_POLICY (DND access) is not granted"
+    }
 
     @Module @InstallIn(SingletonComponent::class)
     abstract class Mod {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/RingVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/RingVolumeModule.kt
@@ -36,7 +36,11 @@ class RingVolumeModule @Inject constructor(
     override val type: AudioStream.Type = AudioStream.Type.RINGTONE
 
     @Suppress("NewApi")
-    override suspend fun areRequirementsMet(): Boolean = !hasApiLevel(23) || permissionHelper.hasNotificationPolicyAccess()
+    override suspend fun unmetRequirement(): String? = when {
+        !hasApiLevel(23) -> null
+        permissionHelper.hasNotificationPolicyAccess() -> null
+        else -> "ACCESS_NOTIFICATION_POLICY (DND access) is not granted"
+    }
 
     @Module @InstallIn(SingletonComponent::class)
     abstract class Mod {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -416,6 +416,9 @@
     <string name="android10_applaunch_hint_message">Android 10 requires special permission to launch apps or show the home screen from background. Grant "Display over other apps" permission.</string>
     <string name="notification_permission_hint_title">Notification permission</string>
     <string name="notification_permission_hint_message">Grant notification permission to see status updates when adjusting volumes.</string>
+    <string name="dnd_access_hint_title">Do Not Disturb access</string>
+    <string name="dnd_access_hint_message">Without Do Not Disturb access, ringtone, notification, and DND mode settings can\'t be applied when your devices connect.</string>
+    <string name="dnd_access_fix_action">Grant access</string>
 
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Purchase cancelled</string>

--- a/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupDataTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupDataTest.kt
@@ -75,6 +75,7 @@ class BackupDataTest : BaseTest() {
             isBatteryOptimizationHintDismissed = true,
             isAndroid10AppLaunchHintDismissed = true,
             isNotificationPermissionHintDismissed = true,
+            isDndAccessHintDismissed = true,
         ),
     )
 
@@ -165,7 +166,8 @@ class BackupDataTest : BaseTest() {
                     "isOnboardingCompleted": true,
                     "isBatteryOptimizationHintDismissed": true,
                     "isAndroid10AppLaunchHintDismissed": true,
-                    "isNotificationPermissionHintDismissed": true
+                    "isNotificationPermissionHintDismissed": true,
+                    "isDndAccessHintDismissed": true
                 }
             }
         """.trimIndent()


### PR DESCRIPTION
## Summary
- When Do Not Disturb (Notification Policy) access is revoked on Android 6+, BlueMusic can't adjust ringtone/notification volume or DND mode. Previously this failed silently — some sliders just wouldn't land where the device config said they should.
- Adds a dashboard hint card that appears when any managed device has ringtone volume, notification volume, or DND mode configured AND the permission is missing, with a one-tap deep link to the system settings page.
- The hint is gated on "device actually needs this" — users with only Music/Call/Alarm configured won't see it.
- Connect-time log for the skipped write path is now WARN with the actual reason instead of a terse "Requirements not met!".
- `setStreamVolume` calls now tolerate `SecurityException` so a permission revoked during the 4s reaction delay doesn't surface as an unhandled module failure.

Refs #129

## Test plan
- [ ] On Android 6+ device: configure ringtone volume at 100% on a test device, revoke DND access, dashboard shows the hint card within ~1s
- [ ] Tap "Grant access" → opens DND settings → granting the permission hides the card within ~1s
- [ ] Dismiss button hides the card and remembers the choice across dashboard navigations (cleared by clearing app data)
- [ ] With only Music/Call/Alarm configured on all devices, card does not appear even when DND is revoked
- [ ] Connect a device with ringtone/notification configured while DND is revoked → logcat shows `WARN ... Skipping volume restore — requirement not met: ACCESS_NOTIFICATION_POLICY ...`
- [ ] Reconnect after granting access → ringtone/notification sliders land at 100%
