### PR TITLE
Improve autoplay setup with previews and repeatable commands

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/common/compose/UpgradeBadge.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/compose/UpgradeBadge.kt
@@ -37,3 +37,11 @@ fun UpgradeBadge(modifier: Modifier = Modifier) {
         )
     }
 }
+
+@Preview2
+@Composable
+private fun UpgradeBadgePreview() {
+    PreviewWrapper {
+        UpgradeBadge()
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/AutoplayKeycode.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/AutoplayKeycode.kt
@@ -1,0 +1,99 @@
+package eu.darken.bluemusic.devices.ui
+
+import android.view.KeyEvent
+import androidx.annotation.StringRes
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.twotone.HelpOutline
+import androidx.compose.material.icons.twotone.FastForward
+import androidx.compose.material.icons.twotone.FastRewind
+import androidx.compose.material.icons.twotone.PlayArrow
+import androidx.compose.material.icons.twotone.PlayCircle
+import androidx.compose.material.icons.twotone.SkipNext
+import androidx.compose.material.icons.twotone.SkipPrevious
+import androidx.compose.material.icons.twotone.Stop
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import eu.darken.bluemusic.R
+
+sealed interface AutoplayKeycodeOption {
+    val keycode: Int
+    val icon: ImageVector
+
+    @Composable
+    fun label(): String
+
+    data class Known(
+        override val keycode: Int,
+        @StringRes val labelRes: Int,
+        @StringRes val descriptionRes: Int,
+        override val icon: ImageVector,
+    ) : AutoplayKeycodeOption {
+        @Composable
+        override fun label(): String = stringResource(labelRes)
+
+        @Composable
+        fun description(): String = stringResource(descriptionRes)
+    }
+
+    data class Unknown(
+        override val keycode: Int,
+    ) : AutoplayKeycodeOption {
+        override val icon: ImageVector = Icons.AutoMirrored.TwoTone.HelpOutline
+
+        @Composable
+        override fun label(): String = stringResource(R.string.devices_autoplay_keycode_unknown_label, keycode)
+    }
+}
+
+object AutoplayKeycodes {
+    val knownCodes: List<AutoplayKeycodeOption.Known> = listOf(
+        AutoplayKeycodeOption.Known(
+            keycode = KeyEvent.KEYCODE_MEDIA_PLAY,
+            labelRes = R.string.devices_autoplay_keycode_play_label,
+            descriptionRes = R.string.devices_autoplay_keycode_play_desc,
+            icon = Icons.TwoTone.PlayArrow,
+        ),
+        AutoplayKeycodeOption.Known(
+            keycode = KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
+            labelRes = R.string.devices_autoplay_keycode_play_pause_label,
+            descriptionRes = R.string.devices_autoplay_keycode_play_pause_desc,
+            icon = Icons.TwoTone.PlayCircle,
+        ),
+        AutoplayKeycodeOption.Known(
+            keycode = KeyEvent.KEYCODE_MEDIA_NEXT,
+            labelRes = R.string.devices_autoplay_keycode_next_label,
+            descriptionRes = R.string.devices_autoplay_keycode_next_desc,
+            icon = Icons.TwoTone.SkipNext,
+        ),
+        AutoplayKeycodeOption.Known(
+            keycode = KeyEvent.KEYCODE_MEDIA_PREVIOUS,
+            labelRes = R.string.devices_autoplay_keycode_previous_label,
+            descriptionRes = R.string.devices_autoplay_keycode_previous_desc,
+            icon = Icons.TwoTone.SkipPrevious,
+        ),
+        AutoplayKeycodeOption.Known(
+            keycode = KeyEvent.KEYCODE_MEDIA_STOP,
+            labelRes = R.string.devices_autoplay_keycode_stop_label,
+            descriptionRes = R.string.devices_autoplay_keycode_stop_desc,
+            icon = Icons.TwoTone.Stop,
+        ),
+        AutoplayKeycodeOption.Known(
+            keycode = KeyEvent.KEYCODE_MEDIA_REWIND,
+            labelRes = R.string.devices_autoplay_keycode_rewind_label,
+            descriptionRes = R.string.devices_autoplay_keycode_rewind_desc,
+            icon = Icons.TwoTone.FastRewind,
+        ),
+        AutoplayKeycodeOption.Known(
+            keycode = KeyEvent.KEYCODE_MEDIA_FAST_FORWARD,
+            labelRes = R.string.devices_autoplay_keycode_fast_forward_label,
+            descriptionRes = R.string.devices_autoplay_keycode_fast_forward_desc,
+            icon = Icons.TwoTone.FastForward,
+        ),
+    )
+
+    private val byKeycode: Map<Int, AutoplayKeycodeOption.Known> = knownCodes.associateBy { it.keycode }
+
+    fun resolve(keycode: Int): AutoplayKeycodeOption =
+        byKeycode[keycode] ?: AutoplayKeycodeOption.Unknown(keycode)
+}

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -607,12 +608,17 @@ fun DeviceConfigScreen(
                         )
 
                         if (device.autoplay) {
+                            val codes = device.autoplayKeycodes
                             ClickablePreference(
                                 title = stringResource(R.string.devices_device_config_autoplay_keycodes_label),
-                                description = if (device.autoplayKeycodes.isEmpty()) {
-                                    stringResource(R.string.devices_device_config_autoplay_keycodes_none_set)
-                                } else {
-                                    device.autoplayKeycodes
+                                description = when {
+                                    codes.isEmpty() -> stringResource(R.string.devices_device_config_autoplay_keycodes_none_set)
+                                    codes.size > 3 -> pluralStringResource(
+                                        R.plurals.devices_indicator_auto_count,
+                                        codes.size,
+                                        codes.size,
+                                    )
+                                    else -> codes
                                         .map { AutoplayKeycodes.resolve(it).label() }
                                         .joinToString(", ")
                                 },

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
@@ -82,6 +82,7 @@ import eu.darken.bluemusic.devices.ui.config.dialogs.DeleteDeviceDialog
 import eu.darken.bluemusic.devices.ui.config.dialogs.DndModeDialog
 import eu.darken.bluemusic.devices.ui.config.dialogs.RenameDialog
 import eu.darken.bluemusic.devices.ui.config.dialogs.TimingDialog
+import eu.darken.bluemusic.devices.ui.AutoplayKeycodes
 import eu.darken.bluemusic.devices.ui.icon
 import eu.darken.bluemusic.devices.ui.settings.dialogs.AutoplayKeycodesDialog
 import eu.darken.bluemusic.monitor.core.alert.AlertType
@@ -611,19 +612,9 @@ fun DeviceConfigScreen(
                                 description = if (device.autoplayKeycodes.isEmpty()) {
                                     stringResource(R.string.devices_device_config_autoplay_keycodes_none_set)
                                 } else {
-                                    val keycodeNames = device.autoplayKeycodes.mapNotNull { keycode ->
-                                        when (keycode) {
-                                            android.view.KeyEvent.KEYCODE_MEDIA_PLAY -> "Play"
-                                            android.view.KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE -> "Play/Pause"
-                                            android.view.KeyEvent.KEYCODE_MEDIA_NEXT -> "Next"
-                                            android.view.KeyEvent.KEYCODE_MEDIA_PREVIOUS -> "Previous"
-                                            android.view.KeyEvent.KEYCODE_MEDIA_STOP -> "Stop"
-                                            android.view.KeyEvent.KEYCODE_MEDIA_REWIND -> "Rewind"
-                                            android.view.KeyEvent.KEYCODE_MEDIA_FAST_FORWARD -> "Fast Forward"
-                                            else -> null
-                                        }
-                                    }
-                                    keycodeNames.joinToString(", ")
+                                    device.autoplayKeycodes
+                                        .map { AutoplayKeycodes.resolve(it).label() }
+                                        .joinToString(", ")
                                 },
                                 icon = Icons.TwoTone.Tune,
                                 onClick = { onAction(ConfigAction.OnEditAutoplayKeycodesClicked) },

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigViewModel.kt
@@ -195,7 +195,7 @@ class DeviceConfigViewModel @AssistedInject constructor(
 
             is ConfigAction.OnEditAutoplayKeycodes -> {
                 deviceRepo.updateDevice(deviceAddress) { oldConfig ->
-                    oldConfig.copy(autoplayKeycodes = action.keycodes)
+                    oldConfig.copy(autoplayKeycodes = action.keycodes.distinct())
                 }
             }
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigViewModel.kt
@@ -195,7 +195,7 @@ class DeviceConfigViewModel @AssistedInject constructor(
 
             is ConfigAction.OnEditAutoplayKeycodes -> {
                 deviceRepo.updateDevice(deviceAddress) { oldConfig ->
-                    oldConfig.copy(autoplayKeycodes = action.keycodes.distinct())
+                    oldConfig.copy(autoplayKeycodes = action.keycodes)
                 }
             }
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/device/OptionIndicators.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/device/OptionIndicators.kt
@@ -1,7 +1,9 @@
 package eu.darken.bluemusic.devices.ui.dashboard.rows.device
 
+import android.view.KeyEvent
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
@@ -11,15 +13,15 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.Launch
+import androidx.compose.material.icons.automirrored.twotone.QueueMusic
 import androidx.compose.material.icons.twotone.BatteryFull
 import androidx.compose.material.icons.twotone.DoNotDisturb
 import androidx.compose.material.icons.twotone.GraphicEq
 import androidx.compose.material.icons.twotone.Home
 import androidx.compose.material.icons.twotone.Lock
-import androidx.compose.material.icons.twotone.PlayArrow
+import androidx.compose.material.icons.twotone.NotificationsActive
 import androidx.compose.material.icons.twotone.PowerOff
 import androidx.compose.material.icons.twotone.Speed
-import androidx.compose.material.icons.twotone.NotificationsActive
 import androidx.compose.material.icons.twotone.Visibility
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -27,6 +29,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.pluralStringResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import eu.darken.bluemusic.R
@@ -35,6 +39,8 @@ import eu.darken.bluemusic.common.apps.AppInfo
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
 import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.ui.AutoplayKeycodeOption
+import eu.darken.bluemusic.devices.ui.AutoplayKeycodes
 import eu.darken.bluemusic.monitor.core.alert.AlertType
 
 @OptIn(ExperimentalLayoutApi::class)
@@ -44,17 +50,17 @@ fun OptionIndicators(
     launchApps: List<AppInfo> = emptyList(),
     modifier: Modifier = Modifier,
 ) {
-    val indicators = buildList {
-        if (device.volumeLock) add(Icons.TwoTone.Lock to stringResource(R.string.devices_device_config_volume_lock_label))
-        if (device.keepAwake) add(Icons.TwoTone.BatteryFull to stringResource(R.string.devices_device_config_keep_awake_label))
-        if (device.nudgeVolume) add(Icons.TwoTone.GraphicEq to stringResource(R.string.devices_device_config_nudge_volume_label))
-        if (device.volumeObservingEffective) add(Icons.TwoTone.Visibility to stringResource(R.string.devices_device_config_volume_observe_label))
-        if (device.volumeSaveOnDisconnect) add(Icons.TwoTone.PowerOff to stringResource(R.string.devices_device_config_volume_save_on_disconnect_label))
-        if (device.volumeRateLimiterEffective) add(Icons.TwoTone.Speed to stringResource(R.string.devices_device_config_volume_rate_limiter_label))
-        if (device.autoplay) add(Icons.TwoTone.PlayArrow to stringResource(R.string.devices_device_config_autoplay_label))
-        if (device.showHomeScreen) add(Icons.TwoTone.Home to stringResource(R.string.devices_device_config_show_home_screen_label))
-        if (device.dndMode != null) add(Icons.TwoTone.DoNotDisturb to stringResource(R.string.devices_device_config_dnd_on_connect_label))
-        if (device.connectionAlertType != AlertType.NONE) add(Icons.TwoTone.NotificationsActive to stringResource(R.string.devices_device_config_connection_alert_label))
+    val indicators: List<Pair<ImageVector, String>> = buildList {
+        if (device.volumeLock) add(Icons.TwoTone.Lock to stringResource(R.string.devices_indicator_lock))
+        if (device.keepAwake) add(Icons.TwoTone.BatteryFull to stringResource(R.string.devices_indicator_awake))
+        if (device.nudgeVolume) add(Icons.TwoTone.GraphicEq to stringResource(R.string.devices_indicator_nudge))
+        if (device.volumeObservingEffective) add(Icons.TwoTone.Visibility to stringResource(R.string.devices_indicator_observe))
+        if (device.volumeSaveOnDisconnect) add(Icons.TwoTone.PowerOff to stringResource(R.string.devices_indicator_disconnect))
+        if (device.volumeRateLimiterEffective) add(Icons.TwoTone.Speed to stringResource(R.string.devices_indicator_limit))
+        autoplayChip(device)?.let { add(it) }
+        if (device.showHomeScreen) add(Icons.TwoTone.Home to stringResource(R.string.devices_indicator_home))
+        if (device.dndMode != null) add(Icons.TwoTone.DoNotDisturb to stringResource(R.string.devices_indicator_dnd))
+        if (device.connectionAlertType != AlertType.NONE) add(Icons.TwoTone.NotificationsActive to stringResource(R.string.devices_indicator_alert))
     }
 
     val hasLaunchApps = launchApps.isNotEmpty()
@@ -89,7 +95,7 @@ fun OptionIndicators(
                     )
                 }
             }
-            indicators.forEach { (icon, _) ->
+            indicators.forEach { (icon, label) ->
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                     modifier = Modifier
@@ -107,26 +113,30 @@ fun OptionIndicators(
                     )
                     Spacer(modifier = Modifier.width(3.dp))
                     Text(
-                        text = when (icon) {
-                            Icons.TwoTone.Lock -> stringResource(R.string.devices_indicator_lock)
-                            Icons.TwoTone.BatteryFull -> stringResource(R.string.devices_indicator_awake)
-                            Icons.TwoTone.GraphicEq -> stringResource(R.string.devices_indicator_nudge)
-                            Icons.TwoTone.Visibility -> stringResource(R.string.devices_indicator_observe)
-                            Icons.TwoTone.PowerOff -> stringResource(R.string.devices_indicator_disconnect)
-                            Icons.TwoTone.Speed -> stringResource(R.string.devices_indicator_limit)
-                            Icons.AutoMirrored.TwoTone.Launch -> stringResource(R.string.devices_indicator_launch)
-                            Icons.TwoTone.PlayArrow -> stringResource(R.string.devices_indicator_auto)
-                            Icons.TwoTone.Home -> stringResource(R.string.devices_indicator_home)
-                            Icons.TwoTone.DoNotDisturb -> stringResource(R.string.devices_indicator_dnd)
-                            Icons.TwoTone.NotificationsActive -> stringResource(R.string.devices_indicator_alert)
-                            else -> ""
-                        },
+                        text = label,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onPrimaryContainer
                     )
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun autoplayChip(device: ManagedDevice): Pair<ImageVector, String>? {
+    if (!device.autoplay) return null
+    val codes = device.autoplayKeycodes
+    if (codes.isEmpty()) return null
+
+    val singleKnown = codes.singleOrNull()?.let {
+        AutoplayKeycodes.resolve(it) as? AutoplayKeycodeOption.Known
+    }
+    return if (singleKnown != null) {
+        singleKnown.icon to singleKnown.label()
+    } else {
+        // Multiple codes OR a single unknown code → fall back to count form so we never invent a label.
+        Icons.AutoMirrored.TwoTone.QueueMusic to pluralStringResource(R.plurals.devices_indicator_auto_count, codes.size, codes.size)
     }
 }
 
@@ -160,5 +170,31 @@ private fun OptionIndicatorsPreview() {
             launchApps = mockApps,
             modifier = Modifier.padding(16.dp)
         )
+    }
+}
+
+@Preview2
+@Composable
+private fun OptionIndicatorsAutoplayVariantsPreview() {
+    PreviewWrapper {
+        val base = MockDevice().toManagedDevice()
+        val singlePlay = base.copy(config = base.config.copy(autoplay = true, autoplayKeycodes = listOf(KeyEvent.KEYCODE_MEDIA_PLAY)))
+        val singleNext = base.copy(config = base.config.copy(autoplay = true, autoplayKeycodes = listOf(KeyEvent.KEYCODE_MEDIA_NEXT)))
+        val singleFastForward = base.copy(config = base.config.copy(autoplay = true, autoplayKeycodes = listOf(KeyEvent.KEYCODE_MEDIA_FAST_FORWARD)))
+        val multi = base.copy(config = base.config.copy(autoplay = true, autoplayKeycodes = listOf(KeyEvent.KEYCODE_MEDIA_PLAY, KeyEvent.KEYCODE_MEDIA_NEXT, KeyEvent.KEYCODE_MEDIA_PREVIOUS)))
+        val empty = base.copy(config = base.config.copy(autoplay = true, autoplayKeycodes = emptyList()))
+        val unknown = base.copy(config = base.config.copy(autoplay = true, autoplayKeycodes = listOf(9999)))
+
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            OptionIndicators(device = singlePlay)
+            OptionIndicators(device = singleNext)
+            OptionIndicators(device = singleFastForward)
+            OptionIndicators(device = multi)
+            OptionIndicators(device = empty)
+            OptionIndicators(device = unknown)
+        }
     }
 }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/dialogs/AutoplayKeycodesDialog.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/dialogs/AutoplayKeycodesDialog.kt
@@ -1,22 +1,27 @@
 package eu.darken.bluemusic.devices.ui.settings.dialogs
 
 import android.view.KeyEvent
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.ArrowDownward
 import androidx.compose.material.icons.filled.ArrowUpward
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.Checkbox
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -35,7 +40,10 @@ import androidx.compose.ui.unit.dp
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.devices.ui.AutoplayKeycodeOption
 import eu.darken.bluemusic.devices.ui.AutoplayKeycodes
+
+private const val MAX_AUTOPLAY_KEYCODES = 10
 
 @Composable
 fun AutoplayKeycodesDialog(
@@ -43,152 +51,213 @@ fun AutoplayKeycodesDialog(
     onConfirm: (List<Int>) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val availableKeycodes = remember { AutoplayKeycodes.knownCodes }
-
-    var selectedKeycodes by remember { mutableStateOf(currentKeycodes.distinct()) }
+    var selectedKeycodes by remember { mutableStateOf(currentKeycodes) }
+    var showPicker by remember { mutableStateOf(false) }
+    val atCap = selectedKeycodes.size >= MAX_AUTOPLAY_KEYCODES
 
     AlertDialog(
         onDismissRequest = onDismiss,
         title = { Text(stringResource(R.string.devices_device_config_autoplay_keycodes_title)) },
         text = {
             Column(
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp)
             ) {
-                // Available keycodes section
                 Text(
-                    text = stringResource(R.string.devices_device_config_autoplay_keycodes_available),
+                    text = stringResource(R.string.devices_device_config_autoplay_keycodes_order),
                     fontWeight = FontWeight.Medium
                 )
-                LazyColumn(
-                    modifier = Modifier.weight(1f, false),
-                    verticalArrangement = Arrangement.spacedBy(4.dp)
-                ) {
-                    items(availableKeycodes) { keycodeOption ->
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            Checkbox(
-                                checked = selectedKeycodes.contains(keycodeOption.keycode),
-                                onCheckedChange = { checked ->
-                                    selectedKeycodes = if (checked) {
-                                        (selectedKeycodes + keycodeOption.keycode).distinct()
-                                    } else {
-                                        selectedKeycodes - keycodeOption.keycode
+
+                if (selectedKeycodes.isEmpty()) {
+                    Text(
+                        text = stringResource(R.string.devices_device_config_autoplay_keycodes_empty),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                } else {
+                    LazyColumn(
+                        modifier = Modifier.heightIn(max = 320.dp),
+                        verticalArrangement = Arrangement.spacedBy(4.dp)
+                    ) {
+                        itemsIndexed(selectedKeycodes) { index, keycode ->
+                            SelectedKeycodeRow(
+                                position = index + 1,
+                                option = AutoplayKeycodes.resolve(keycode),
+                                canMoveUp = index > 0,
+                                canMoveDown = index < selectedKeycodes.size - 1,
+                                onMoveUp = {
+                                    selectedKeycodes = selectedKeycodes.toMutableList().apply {
+                                        removeAt(index)
+                                        add(index - 1, keycode)
+                                    }
+                                },
+                                onMoveDown = {
+                                    selectedKeycodes = selectedKeycodes.toMutableList().apply {
+                                        removeAt(index)
+                                        add(index + 1, keycode)
+                                    }
+                                },
+                                onRemove = {
+                                    selectedKeycodes = selectedKeycodes.toMutableList().apply {
+                                        removeAt(index)
                                     }
                                 }
                             )
-                            Column(
-                                modifier = Modifier.weight(1f)
-                            ) {
-                                Text(
-                                    text = keycodeOption.label(),
-                                    style = MaterialTheme.typography.bodyLarge
-                                )
-                                Text(
-                                    text = keycodeOption.description(),
-                                    style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
-                                )
-                            }
                         }
                     }
                 }
 
-                if (selectedKeycodes.isNotEmpty()) {
-                    HorizontalDivider()
-
-                    // Selected keycodes order section
-                    Text(
-                        text = stringResource(R.string.devices_device_config_autoplay_keycodes_order),
-                        fontWeight = FontWeight.Medium
+                TextButton(
+                    onClick = { showPicker = true },
+                    enabled = !atCap,
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.Add,
+                        contentDescription = null,
+                        modifier = Modifier.size(18.dp)
                     )
-                    LazyColumn(
-                        modifier = Modifier.weight(1f, false),
-                        verticalArrangement = Arrangement.spacedBy(4.dp)
-                    ) {
-                        items(selectedKeycodes) { keycode ->
-                            val keycodeOption = availableKeycodes.find { it.keycode == keycode }
-                            if (keycodeOption != null) {
-                                val index = selectedKeycodes.indexOf(keycode)
-                                Card(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    colors = CardDefaults.cardColors(
-                                        containerColor = MaterialTheme.colorScheme.surfaceVariant
-                                    )
-                                ) {
-                                    Row(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(horizontal = 8.dp, vertical = 4.dp),
-                                        verticalAlignment = Alignment.CenterVertically
-                                    ) {
-                                        Text(
-                                            text = keycodeOption.label(),
-                                            modifier = Modifier.weight(1f)
-                                        )
-                                        Row {
-                                            IconButton(
-                                                onClick = {
-                                                    if (index > 0) {
-                                                        selectedKeycodes = selectedKeycodes.toMutableList().apply {
-                                                            removeAt(index)
-                                                            add(index - 1, keycode)
-                                                        }
-                                                    }
-                                                },
-                                                enabled = index > 0
-                                            ) {
-                                                Icon(
-                                                    Icons.Default.ArrowUpward,
-                                                    contentDescription = stringResource(R.string.cd_autoplay_keycode_move_up)
-                                                )
-                                            }
-                                            IconButton(
-                                                onClick = {
-                                                    if (index < selectedKeycodes.size - 1) {
-                                                        selectedKeycodes = selectedKeycodes.toMutableList().apply {
-                                                            removeAt(index)
-                                                            add(index + 1, keycode)
-                                                        }
-                                                    }
-                                                },
-                                                enabled = index < selectedKeycodes.size - 1
-                                            ) {
-                                                Icon(
-                                                    Icons.Default.ArrowDownward,
-                                                    contentDescription = stringResource(R.string.cd_autoplay_keycode_move_down)
-                                                )
-                                            }
-                                            IconButton(
-                                                onClick = {
-                                                    selectedKeycodes = selectedKeycodes - keycode
-                                                }
-                                            ) {
-                                                Icon(
-                                                    Icons.Default.Delete,
-                                                    contentDescription = stringResource(R.string.cd_autoplay_keycode_remove)
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(stringResource(R.string.devices_device_config_autoplay_keycodes_add_action))
+                }
+                if (atCap) {
+                    Text(
+                        text = stringResource(R.string.devices_device_config_autoplay_keycodes_max_reached, MAX_AUTOPLAY_KEYCODES),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
                 }
             }
         },
         confirmButton = {
-            TextButton(
-                onClick = {
-                    onConfirm(selectedKeycodes)
-                    onDismiss()
-                }
-            ) {
+            TextButton(onClick = {
+                onConfirm(selectedKeycodes)
+                onDismiss()
+            }) {
                 Text(stringResource(R.string.action_set))
             }
         },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.action_cancel))
+            }
+        }
+    )
+
+    if (showPicker) {
+        AutoplayKeycodePickerDialog(
+            onPick = { keycode ->
+                if (selectedKeycodes.size < MAX_AUTOPLAY_KEYCODES) {
+                    selectedKeycodes = selectedKeycodes + keycode
+                }
+                showPicker = false
+            },
+            onDismiss = { showPicker = false }
+        )
+    }
+}
+
+@Composable
+private fun SelectedKeycodeRow(
+    position: Int,
+    option: AutoplayKeycodeOption,
+    canMoveUp: Boolean,
+    canMoveDown: Boolean,
+    onMoveUp: () -> Unit,
+    onMoveDown: () -> Unit,
+    onRemove: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceVariant
+        )
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "$position.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.padding(end = 8.dp)
+            )
+            Icon(
+                imageVector = option.icon,
+                contentDescription = null,
+                modifier = Modifier.size(20.dp)
+            )
+            Spacer(modifier = Modifier.width(8.dp))
+            Text(
+                text = option.label(),
+                modifier = Modifier.weight(1f)
+            )
+            IconButton(onClick = onMoveUp, enabled = canMoveUp) {
+                Icon(
+                    Icons.Default.ArrowUpward,
+                    contentDescription = stringResource(R.string.cd_autoplay_keycode_move_up)
+                )
+            }
+            IconButton(onClick = onMoveDown, enabled = canMoveDown) {
+                Icon(
+                    Icons.Default.ArrowDownward,
+                    contentDescription = stringResource(R.string.cd_autoplay_keycode_move_down)
+                )
+            }
+            IconButton(onClick = onRemove) {
+                Icon(
+                    Icons.Default.Delete,
+                    contentDescription = stringResource(R.string.cd_autoplay_keycode_remove)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AutoplayKeycodePickerDialog(
+    onPick: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.devices_device_config_autoplay_keycodes_add_action)) },
+        text = {
+            LazyColumn(
+                modifier = Modifier.heightIn(max = 400.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                items(AutoplayKeycodes.knownCodes) { option ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onPick(option.keycode) }
+                            .padding(horizontal = 4.dp, vertical = 8.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(
+                            imageVector = option.icon,
+                            contentDescription = null,
+                            modifier = Modifier.size(24.dp)
+                        )
+                        Spacer(modifier = Modifier.width(16.dp))
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                text = option.label(),
+                                style = MaterialTheme.typography.bodyLarge
+                            )
+                            Text(
+                                text = option.description(),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant
+                            )
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {},
         dismissButton = {
             TextButton(onClick = onDismiss) {
                 Text(stringResource(R.string.action_cancel))
@@ -202,8 +271,36 @@ fun AutoplayKeycodesDialog(
 private fun AutoplayKeycodesDialogPreview() {
     PreviewWrapper {
         AutoplayKeycodesDialog(
-            currentKeycodes = listOf(KeyEvent.KEYCODE_MEDIA_PLAY, KeyEvent.KEYCODE_MEDIA_NEXT),
+            currentKeycodes = listOf(
+                KeyEvent.KEYCODE_MEDIA_PLAY,
+                KeyEvent.KEYCODE_MEDIA_NEXT,
+                KeyEvent.KEYCODE_MEDIA_NEXT,
+                KeyEvent.KEYCODE_MEDIA_NEXT,
+            ),
             onConfirm = {},
+            onDismiss = {}
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun AutoplayKeycodesDialogEmptyPreview() {
+    PreviewWrapper {
+        AutoplayKeycodesDialog(
+            currentKeycodes = emptyList(),
+            onConfirm = {},
+            onDismiss = {}
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun AutoplayKeycodePickerDialogPreview() {
+    PreviewWrapper {
+        AutoplayKeycodePickerDialog(
+            onPick = {},
             onDismiss = {}
         )
     }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/dialogs/AutoplayKeycodesDialog.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/dialogs/AutoplayKeycodesDialog.kt
@@ -31,16 +31,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
-
-data class KeycodeOption(
-    val keycode: Int,
-    val name: String,
-    val description: String
-)
+import eu.darken.bluemusic.devices.ui.AutoplayKeycodes
 
 @Composable
 fun AutoplayKeycodesDialog(
@@ -48,47 +43,9 @@ fun AutoplayKeycodesDialog(
     onConfirm: (List<Int>) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val availableKeycodes = remember {
-        listOf(
-            KeycodeOption(
-                KeyEvent.KEYCODE_MEDIA_PLAY,
-                "Play",
-                "Sends play command only"
-            ),
-            KeycodeOption(
-                KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE,
-                "Play/Pause",
-                "Toggles between play and pause"
-            ),
-            KeycodeOption(
-                KeyEvent.KEYCODE_MEDIA_NEXT,
-                "Next",
-                "Skip to next track"
-            ),
-            KeycodeOption(
-                KeyEvent.KEYCODE_MEDIA_PREVIOUS,
-                "Previous",
-                "Go to previous track"
-            ),
-            KeycodeOption(
-                KeyEvent.KEYCODE_MEDIA_STOP,
-                "Stop",
-                "Stop playback"
-            ),
-            KeycodeOption(
-                KeyEvent.KEYCODE_MEDIA_REWIND,
-                "Rewind",
-                "Rewind current track"
-            ),
-            KeycodeOption(
-                KeyEvent.KEYCODE_MEDIA_FAST_FORWARD,
-                "Fast Forward",
-                "Fast forward current track"
-            )
-        )
-    }
+    val availableKeycodes = remember { AutoplayKeycodes.knownCodes }
 
-    var selectedKeycodes by remember { mutableStateOf(currentKeycodes) }
+    var selectedKeycodes by remember { mutableStateOf(currentKeycodes.distinct()) }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -115,7 +72,7 @@ fun AutoplayKeycodesDialog(
                                 checked = selectedKeycodes.contains(keycodeOption.keycode),
                                 onCheckedChange = { checked ->
                                     selectedKeycodes = if (checked) {
-                                        selectedKeycodes + keycodeOption.keycode
+                                        (selectedKeycodes + keycodeOption.keycode).distinct()
                                     } else {
                                         selectedKeycodes - keycodeOption.keycode
                                     }
@@ -125,11 +82,11 @@ fun AutoplayKeycodesDialog(
                                 modifier = Modifier.weight(1f)
                             ) {
                                 Text(
-                                    text = keycodeOption.name,
+                                    text = keycodeOption.label(),
                                     style = MaterialTheme.typography.bodyLarge
                                 )
                                 Text(
-                                    text = keycodeOption.description,
+                                    text = keycodeOption.description(),
                                     style = MaterialTheme.typography.bodySmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant
                                 )
@@ -153,6 +110,7 @@ fun AutoplayKeycodesDialog(
                         items(selectedKeycodes) { keycode ->
                             val keycodeOption = availableKeycodes.find { it.keycode == keycode }
                             if (keycodeOption != null) {
+                                val index = selectedKeycodes.indexOf(keycode)
                                 Card(
                                     modifier = Modifier.fillMaxWidth(),
                                     colors = CardDefaults.cardColors(
@@ -166,13 +124,12 @@ fun AutoplayKeycodesDialog(
                                         verticalAlignment = Alignment.CenterVertically
                                     ) {
                                         Text(
-                                            text = keycodeOption.name,
+                                            text = keycodeOption.label(),
                                             modifier = Modifier.weight(1f)
                                         )
                                         Row {
                                             IconButton(
                                                 onClick = {
-                                                    val index = selectedKeycodes.indexOf(keycode)
                                                     if (index > 0) {
                                                         selectedKeycodes = selectedKeycodes.toMutableList().apply {
                                                             removeAt(index)
@@ -180,16 +137,15 @@ fun AutoplayKeycodesDialog(
                                                         }
                                                     }
                                                 },
-                                                enabled = selectedKeycodes.indexOf(keycode) > 0
+                                                enabled = index > 0
                                             ) {
                                                 Icon(
                                                     Icons.Default.ArrowUpward,
-                                                    contentDescription = "Move up"
+                                                    contentDescription = stringResource(R.string.cd_autoplay_keycode_move_up)
                                                 )
                                             }
                                             IconButton(
                                                 onClick = {
-                                                    val index = selectedKeycodes.indexOf(keycode)
                                                     if (index < selectedKeycodes.size - 1) {
                                                         selectedKeycodes = selectedKeycodes.toMutableList().apply {
                                                             removeAt(index)
@@ -197,11 +153,11 @@ fun AutoplayKeycodesDialog(
                                                         }
                                                     }
                                                 },
-                                                enabled = selectedKeycodes.indexOf(keycode) < selectedKeycodes.size - 1
+                                                enabled = index < selectedKeycodes.size - 1
                                             ) {
                                                 Icon(
                                                     Icons.Default.ArrowDownward,
-                                                    contentDescription = "Move down"
+                                                    contentDescription = stringResource(R.string.cd_autoplay_keycode_move_down)
                                                 )
                                             }
                                             IconButton(
@@ -211,7 +167,7 @@ fun AutoplayKeycodesDialog(
                                             ) {
                                                 Icon(
                                                     Icons.Default.Delete,
-                                                    contentDescription = "Remove"
+                                                    contentDescription = stringResource(R.string.cd_autoplay_keycode_remove)
                                                 )
                                             }
                                         }
@@ -241,7 +197,7 @@ fun AutoplayKeycodesDialog(
     )
 }
 
-@Preview
+@Preview2
 @Composable
 private fun AutoplayKeycodesDialogPreview() {
     PreviewWrapper {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -79,13 +79,35 @@
     <string name="devices_device_config_volume_rate_limit_decrease_duration_label">Volume decrease delay</string>
     <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimum time between volume decreases: %d ms</string>
     <string name="devices_device_config_autoplay_label">Autoplay</string>
-    <string name="devices_device_config_autoplay_desc">Simulate pressing play on a Bluetooth remote when this device connects.</string>
+    <string name="devices_device_config_autoplay_desc">Send the configured media key commands when this device connects.</string>
     <string name="devices_device_config_autoplay_keycodes_title">Autoplay Key Types</string>
     <string name="devices_device_config_autoplay_keycodes_available">Available key types</string>
     <string name="devices_device_config_autoplay_keycodes_order">Selected keys (in order)</string>
     <string name="devices_device_config_autoplay_keycodes_label">Key types</string>
     <string name="devices_device_config_autoplay_keycodes_desc">Configure which keys to send and in what order</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">No keys configured</string>
+    <string name="devices_autoplay_keycode_play_label">Play</string>
+    <string name="devices_autoplay_keycode_play_pause_label">Play/Pause</string>
+    <string name="devices_autoplay_keycode_next_label">Next</string>
+    <string name="devices_autoplay_keycode_previous_label">Previous</string>
+    <string name="devices_autoplay_keycode_stop_label">Stop</string>
+    <string name="devices_autoplay_keycode_rewind_label">Rewind</string>
+    <string name="devices_autoplay_keycode_fast_forward_label">Fast Forward</string>
+    <string name="devices_autoplay_keycode_play_desc">Sends play command only</string>
+    <string name="devices_autoplay_keycode_play_pause_desc">Toggles between play and pause</string>
+    <string name="devices_autoplay_keycode_next_desc">Skip to next track</string>
+    <string name="devices_autoplay_keycode_previous_desc">Go to previous track</string>
+    <string name="devices_autoplay_keycode_stop_desc">Stop playback</string>
+    <string name="devices_autoplay_keycode_rewind_desc">Rewind current track</string>
+    <string name="devices_autoplay_keycode_fast_forward_desc">Fast forward current track</string>
+    <string name="devices_autoplay_keycode_unknown_label">Unknown (%1$d)</string>
+    <plurals name="devices_indicator_auto_count">
+        <item quantity="one">%d key</item>
+        <item quantity="other">%d keys</item>
+    </plurals>
+    <string name="cd_autoplay_keycode_move_up">Move up</string>
+    <string name="cd_autoplay_keycode_move_down">Move down</string>
+    <string name="cd_autoplay_keycode_remove">Remove</string>
 
     <string name="devices_device_config_section_volumes_label">Volumes</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
@@ -448,7 +470,6 @@
     <string name="devices_indicator_disconnect">Disconnect</string>
     <string name="devices_indicator_limit">Limit</string>
     <string name="devices_indicator_launch">Launch</string>
-    <string name="devices_indicator_auto">Auto</string>
     <string name="devices_indicator_home">Home</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Alert</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -80,12 +80,14 @@
     <string name="devices_device_config_volume_rate_limit_decrease_duration_desc">Minimum time between volume decreases: %d ms</string>
     <string name="devices_device_config_autoplay_label">Autoplay</string>
     <string name="devices_device_config_autoplay_desc">Send the configured media key commands when this device connects.</string>
-    <string name="devices_device_config_autoplay_keycodes_title">Autoplay Key Types</string>
-    <string name="devices_device_config_autoplay_keycodes_available">Available key types</string>
-    <string name="devices_device_config_autoplay_keycodes_order">Selected keys (in order)</string>
-    <string name="devices_device_config_autoplay_keycodes_label">Key types</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configure which keys to send and in what order</string>
-    <string name="devices_device_config_autoplay_keycodes_none_set">No keys configured</string>
+    <string name="devices_device_config_autoplay_keycodes_title">Autoplay commands</string>
+    <string name="devices_device_config_autoplay_keycodes_order">Command sequence</string>
+    <string name="devices_device_config_autoplay_keycodes_label">Commands</string>
+    <string name="devices_device_config_autoplay_keycodes_desc">Configure which commands to send and in what order</string>
+    <string name="devices_device_config_autoplay_keycodes_none_set">No commands configured</string>
+    <string name="devices_device_config_autoplay_keycodes_add_action">Add command</string>
+    <string name="devices_device_config_autoplay_keycodes_max_reached">Maximum %1$d commands</string>
+    <string name="devices_device_config_autoplay_keycodes_empty">No commands yet. Tap \"Add command\" to start.</string>
     <string name="devices_autoplay_keycode_play_label">Play</string>
     <string name="devices_autoplay_keycode_play_pause_label">Play/Pause</string>
     <string name="devices_autoplay_keycode_next_label">Next</string>
@@ -102,8 +104,8 @@
     <string name="devices_autoplay_keycode_fast_forward_desc">Fast forward current track</string>
     <string name="devices_autoplay_keycode_unknown_label">Unknown (%1$d)</string>
     <plurals name="devices_indicator_auto_count">
-        <item quantity="one">%d key</item>
-        <item quantity="other">%d keys</item>
+        <item quantity="one">%d command</item>
+        <item quantity="other">%d commands</item>
     </plurals>
     <string name="cd_autoplay_keycode_move_up">Move up</string>
     <string name="cd_autoplay_keycode_move_down">Move down</string>


### PR DESCRIPTION
## Summary
- Device card autoplay chip now reflects the configured command(s): a single command shows its specific icon + label (e.g. Skip Next + "Next"), multiple commands collapse to a count like "3 commands".
- The command picker now allows the same command to be added multiple times and reordered individually, enabling sequences like Play + Next + Next + Next (start playback then skip 3 tracks).
- Terminology shifted from "key types" to "commands" for consistency. The ordered list shows 1-based position numbers and has a soft cap of 10 commands.
- Added string resources for all 7 keycodes so the chip, settings summary, and picker share one localized source instead of hard-coded English literals.

## Test plan
- Built: `./gradlew assembleFossDebug` — clean.
- Unit tests: `./gradlew testFossDebugUnitTest` — 526 passed.
- Smoke-tested on Pixel 8:
  - Single-key configs show action-specific chip (e.g. `[⏭ Next]`, `[⏩ Fast Forward]`).
  - Multi-key configs show queue-music icon + count form.
  - Autoplay off / empty keycode list hides the chip.
  - Dialog: `Play → Next → Previous → Next`, moving last `Next` up yields `Play, Next, Next, Previous` (index-based reorder, duplicates preserved).
  - Dialog cap: fills to 10, `Add command` disables, `Maximum 10 commands` caption appears.
