### PR TITLE
Fix connect-pipeline timing and volume HUD regressions

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
@@ -151,36 +151,34 @@ class VolumeTool @Inject constructor(
         log(TAG, VERBOSE) { "changeVolume(streamId=$streamId, level=$targetLevel, visible=$visible, delay=$delay)" }
 
         val max = getMaxVolume(streamId)
-        if (targetLevel > max) {
-            log(TAG, WARN) { "Target volume of $targetLevel exceeds max of $max." }
-            return false
+        val min = getMinVolume(streamId)
+        val clampedTarget = targetLevel.coerceIn(min, max)
+        if (clampedTarget != targetLevel) {
+            log(TAG, WARN) { "Target level $targetLevel clamped to $clampedTarget (min=$min, max=$max)." }
         }
 
         val currentLevel = getCurrentVolume(streamId)
-        if (currentLevel == targetLevel) {
-            writeTracker.rememberCurrentTarget(streamId, targetLevel)
-            log(TAG, VERBOSE) { "Target volume of $targetLevel already set." }
+        if (currentLevel == clampedTarget) {
+            writeTracker.rememberCurrentTarget(streamId, clampedTarget)
+            log(TAG, VERBOSE) { "Target volume of $clampedTarget already set." }
             return false
         }
 
         log(TAG, DEBUG) {
-            "Adjusting volume (streamId=$streamId, targetLevel=$targetLevel, current=$currentLevel, max=$max, visible=$visible, delay=$delay)."
+            "Adjusting volume (streamId=$streamId, targetLevel=$clampedTarget, current=$currentLevel, max=$max, visible=$visible, delay=$delay)."
         }
+        val flag = if (visible) AudioManager.FLAG_SHOW_UI else 0
         if (delay == Duration.ZERO) {
-            setVolume(streamId, targetLevel, if (visible) AudioManager.FLAG_SHOW_UI else 0)
+            setVolume(streamId, clampedTarget, flag)
         } else {
-            if (currentLevel < targetLevel) {
-                for (volumeStep in currentLevel..targetLevel) {
-                    setVolume(streamId, volumeStep, if (visible) AudioManager.FLAG_SHOW_UI else 0)
-
-                    delay(delay)
-                }
+            val range: IntProgression = if (currentLevel < clampedTarget) {
+                (currentLevel + 1)..clampedTarget
             } else {
-                for (volumeStep in currentLevel downTo targetLevel) {
-                    setVolume(streamId, volumeStep, if (visible) AudioManager.FLAG_SHOW_UI else 0)
-
-                    delay(delay)
-                }
+                (currentLevel - 1) downTo clampedTarget
+            }
+            for (step in range) {
+                setVolume(streamId, step, flag)
+                if (step != range.last) delay(delay)
             }
         }
         return true

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
@@ -152,6 +152,10 @@ class VolumeTool @Inject constructor(
 
         val max = getMaxVolume(streamId)
         val min = getMinVolume(streamId)
+        if (min > max) {
+            log(TAG, WARN) { "Invalid stream bounds: min=$min > max=$max for $streamId; aborting changeVolume." }
+            return false
+        }
         val clampedTarget = targetLevel.coerceIn(min, max)
         if (clampedTarget != targetLevel) {
             log(TAG, WARN) { "Target level $targetLevel clamped to $clampedTarget (min=$min, max=$max)." }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/AutoplayModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/AutoplayModule.kt
@@ -27,7 +27,7 @@ class AutoplayModule @Inject constructor(
     override val tag: String
         get() = TAG
 
-    override val priority: Int = 20
+    override val priority: Int = 8
 
     override suspend fun handle(event: DeviceEvent) {
         if (event !is DeviceEvent.Connected) return

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModule.kt
@@ -106,14 +106,15 @@ abstract class BaseVolumeModule(
             val currentVolume = volumeTool.getCurrentVolume(device.getStreamId(type))
 
             log(tag, VERBOSE) { "Current volume is $currentVolume and we will lower then raise it." }
-            if (volumeTool.lowerByOne(device.getStreamId(type), true)) {
+            val visible = device.visibleAdjustments
+            if (volumeTool.lowerByOne(device.getStreamId(type), visible)) {
                 log(tag, VERBOSE) { "Volume was nudged lower, now nudging higher, to previous value." }
                 delay(500)
-                volumeTool.increaseByOne(device.getStreamId(type), true)
-            } else if (volumeTool.increaseByOne(device.getStreamId(type), true)) {
+                volumeTool.increaseByOne(device.getStreamId(type), visible)
+            } else if (volumeTool.increaseByOne(device.getStreamId(type), visible)) {
                 log(tag, VERBOSE) { "Volume was nudged higher, now nudging lower, to previous value." }
                 delay(500)
-                volumeTool.lowerByOne(device.getStreamId(type), true)
+                volumeTool.lowerByOne(device.getStreamId(type), visible)
             }
         }
     }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicLong
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -68,16 +69,32 @@ class EventDispatcher @Inject constructor(
     private val _isIdle = MutableStateFlow(true)
     val isIdle: StateFlow<Boolean> = _isIdle.asStateFlow()
 
+    // Monotonic counter incremented on every job tracked. Allows the orchestrator's
+    // cooldown to detect "work happened during grace" deterministically, without
+    // depending on StateFlow conflation behaviour for short-lived work.
+    private val workGeneration = AtomicLong(0)
+    fun currentWorkGeneration(): Long = workGeneration.get()
+
+    // Lock that serializes the (set mutation + _isIdle write) pair so completion
+    // callbacks for old jobs can't overwrite an `_isIdle = false` set by a fresh
+    // trackJob — see EventDispatcherTest.`isIdle stays consistent under concurrent track and complete`.
+    private val trackingLock = Any()
+
     suspend fun awaitIdle() {
         isIdle.filter { it }.first()
     }
 
     private fun trackJob(job: Job) {
-        trackedJobs.add(job)
-        _isIdle.value = false
+        workGeneration.incrementAndGet()
+        synchronized(trackingLock) {
+            trackedJobs.add(job)
+            _isIdle.value = false
+        }
         job.invokeOnCompletion {
-            trackedJobs.remove(job)
-            if (trackedJobs.isEmpty()) _isIdle.value = true
+            synchronized(trackingLock) {
+                trackedJobs.remove(job)
+                if (trackedJobs.isEmpty()) _isIdle.value = true
+            }
         }
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
@@ -23,6 +23,11 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -56,8 +61,25 @@ class EventDispatcher @Inject constructor(
 
     private val activeJobs = ConcurrentHashMap<DeviceAddr, Job>()
     private val nonCancellableJobs: MutableSet<Job> = ConcurrentHashMap.newKeySet()
+    private val trackedJobs: MutableSet<Job> = ConcurrentHashMap.newKeySet()
     private val shutdown = AtomicBoolean(false)
     private val dispatchMutex = Mutex()
+
+    private val _isIdle = MutableStateFlow(true)
+    val isIdle: StateFlow<Boolean> = _isIdle.asStateFlow()
+
+    suspend fun awaitIdle() {
+        isIdle.filter { it }.first()
+    }
+
+    private fun trackJob(job: Job) {
+        trackedJobs.add(job)
+        _isIdle.value = false
+        job.invokeOnCompletion {
+            trackedJobs.remove(job)
+            if (trackedJobs.isEmpty()) _isIdle.value = true
+        }
+    }
 
     suspend fun dispatch(bluetoothEvent: BluetoothEventQueue.Event) {
         dispatchMutex.withLock {
@@ -169,13 +191,17 @@ class EventDispatcher @Inject constructor(
                 }.also { job ->
                     nonCancellableJobs.add(job)
                     job.invokeOnCompletion { nonCancellableJobs.remove(job) }
+                    trackJob(job)
                 }
             }
 
             // Cancellable modules are tracked and cancelled when a superseding event arrives.
             activeJobs[address] = appScope.launch(dispatcherProvider.IO) {
                 executeModules(deviceEvent, cancellableModules)
-            }.also { job -> job.invokeOnCompletion { activeJobs.remove(address, job) } }
+            }.also { job ->
+                job.invokeOnCompletion { activeJobs.remove(address, job) }
+                trackJob(job)
+            }
         }
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestrator.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestrator.kt
@@ -22,13 +22,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Duration
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -121,16 +118,15 @@ class MonitorOrchestrator @Inject constructor(
                         log(TAG) { "Active devices present; waiting for dispatcher idle then 15s grace before stopping." }
                         while (true) {
                             eventDispatcher.awaitIdle()
-                            val wentBusy = withTimeoutOrNull(Duration.ofSeconds(15).toMillis()) {
-                                eventDispatcher.isIdle.filter { !it }.first()
-                                true
+                            val genAtStart = eventDispatcher.currentWorkGeneration()
+                            delay(Duration.ofSeconds(15).toMillis())
+                            if (eventDispatcher.currentWorkGeneration() != genAtStart) {
+                                log(TAG) { "Dispatcher had new work during grace; restarting cooldown." }
+                                continue
                             }
-                            if (wentBusy == null) {
-                                log(TAG) { "Dispatcher idle for 15s; stopping." }
-                                monitorJob.cancel()
-                                return@flow
-                            }
-                            log(TAG) { "Dispatcher went busy during grace; restarting cooldown." }
+                            log(TAG) { "Dispatcher idle for 15s; stopping." }
+                            monitorJob.cancel()
+                            return@flow
                         }
                     }
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestrator.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestrator.kt
@@ -22,10 +22,13 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Duration
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -115,13 +118,20 @@ class MonitorOrchestrator @Inject constructor(
                     }
 
                     activeDevices.isNotEmpty() -> flow {
-                        log(TAG) { "There are active devices but we don't need to stay active for them." }
-                        val maxMonitoringDuration = activeDevices.maxOf { it.monitoringDuration }
-                        log(TAG) { "Maximum monitoring duration: $maxMonitoringDuration" }
-                        val toDelay = Duration.ofSeconds(15) + maxMonitoringDuration
-                        delay(toDelay.toMillis())
-                        log(TAG) { "Stopping now, nothing changed." }
-                        monitorJob.cancel()
+                        log(TAG) { "Active devices present; waiting for dispatcher idle then 15s grace before stopping." }
+                        while (true) {
+                            eventDispatcher.awaitIdle()
+                            val wentBusy = withTimeoutOrNull(Duration.ofSeconds(15).toMillis()) {
+                                eventDispatcher.isIdle.filter { !it }.first()
+                                true
+                            }
+                            if (wentBusy == null) {
+                                log(TAG) { "Dispatcher idle for 15s; stopping." }
+                                monitorJob.cancel()
+                                return@flow
+                            }
+                            log(TAG) { "Dispatcher went busy during grace; restarting cooldown." }
+                        }
                     }
 
                     else -> flow<Unit> {

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
@@ -143,6 +143,31 @@ class VolumeToolTest : BaseTest() {
     }
 
     @Test
+    fun `min greater than max returns false without writing or recording target`() = runTest {
+        // Defensive guard: if the platform reports degenerate stream bounds (min > max),
+        // VolumeTool aborts before calling coerceIn (which would throw IllegalArgumentException).
+        every { audioManager.getStreamMaxVolume(any()) } returns -1
+        // getMinVolume returns 0 in unit tests (Build.VERSION.SDK_INT==0 path), so 0 > -1.
+        audioLevels[AudioStream.Id.STREAM_MUSIC] = 0
+        val writes = mutableListOf<Int>()
+        every { audioManager.setStreamVolume(AudioStream.Id.STREAM_MUSIC.id, any(), any()) } answers {
+            val level = secondArg<Int>()
+            audioLevels[AudioStream.Id.STREAM_MUSIC] = level
+            writes += level
+        }
+
+        val result = volumeTool.changeVolume(
+            streamId = AudioStream.Id.STREAM_MUSIC,
+            targetLevel = 5,
+            delay = Duration.ofMillis(1),
+        )
+
+        result shouldBe false
+        writes shouldBe emptyList()
+        volumeTool.hasRecentTarget(AudioStream.Id.STREAM_MUSIC, 5) shouldBe false
+    }
+
+    @Test
     fun `target level below min is clamped to min`() = runTest {
         // In unit tests Build.VERSION.SDK_INT is 0 (no Robolectric), so getMinVolume returns 0.
         audioLevels[AudioStream.Id.STREAM_MUSIC] = 3

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
@@ -5,11 +5,15 @@ import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import java.time.Duration
+
+@OptIn(ExperimentalCoroutinesApi::class)
 
 class VolumeToolTest : BaseTest() {
 
@@ -71,13 +75,13 @@ class VolumeToolTest : BaseTest() {
     }
 
     @Test
-    fun `delayed stepped writes classify intermediate levels as self and retain final recent target`() = runTest {
+    fun `delayed stepped writes skip no-op start step and retain final recent target`() = runTest {
         audioLevels[AudioStream.Id.STREAM_MUSIC] = 2
-        val selfClassifications = mutableListOf<Pair<Int, Boolean>>()
+        val writes = mutableListOf<Int>()
         every { audioManager.setStreamVolume(AudioStream.Id.STREAM_MUSIC.id, any(), any()) } answers {
             val level = secondArg<Int>()
             audioLevels[AudioStream.Id.STREAM_MUSIC] = level
-            selfClassifications += level to volumeTool.wasUs(AudioStream.Id.STREAM_MUSIC, level)
+            writes += level
         }
 
         volumeTool.changeVolume(
@@ -86,12 +90,124 @@ class VolumeToolTest : BaseTest() {
             delay = Duration.ofMillis(1),
         )
 
-        selfClassifications shouldBe listOf(
-            2 to true,
-            3 to true,
-            4 to true,
-        )
+        // Old behavior wrote 2,3,4 (no-op start). New behavior writes only 3,4.
+        writes shouldBe listOf(3, 4)
         volumeTool.hasRecentTarget(AudioStream.Id.STREAM_MUSIC, 4) shouldBe true
+    }
+
+    @Test
+    fun `ramp from 9 to 20 writes exactly 11 levels with no trailing delay`() = runTest {
+        every { audioManager.getStreamMaxVolume(any()) } returns 25
+        audioLevels[AudioStream.Id.STREAM_MUSIC] = 9
+        val writes = mutableListOf<Int>()
+        every { audioManager.setStreamVolume(AudioStream.Id.STREAM_MUSIC.id, any(), any()) } answers {
+            val level = secondArg<Int>()
+            audioLevels[AudioStream.Id.STREAM_MUSIC] = level
+            writes += level
+        }
+
+        val started = currentTime
+        volumeTool.changeVolume(
+            streamId = AudioStream.Id.STREAM_MUSIC,
+            targetLevel = 20,
+            delay = Duration.ofMillis(500),
+        )
+        val elapsed = currentTime - started
+
+        writes shouldBe (10..20).toList()
+        // Per setVolume(): each call adds 10ms before + 10ms after = 20ms.
+        // 11 writes with 10 inter-write delays of 500ms (no trailing delay):
+        // 11 * 20 (write overhead) + 10 * 500 (inter-write delays) = 220 + 5000 = 5220
+        elapsed shouldBe 5220L
+    }
+
+    @Test
+    fun `ramp downwards to target writes step-by-step skipping current level`() = runTest {
+        audioLevels[AudioStream.Id.STREAM_MUSIC] = 10
+        val writes = mutableListOf<Int>()
+        every { audioManager.setStreamVolume(AudioStream.Id.STREAM_MUSIC.id, any(), any()) } answers {
+            val level = secondArg<Int>()
+            audioLevels[AudioStream.Id.STREAM_MUSIC] = level
+            writes += level
+        }
+
+        volumeTool.changeVolume(
+            streamId = AudioStream.Id.STREAM_MUSIC,
+            targetLevel = 7,
+            delay = Duration.ofMillis(1),
+        )
+
+        // 10 → 7 should write 9, 8, 7 (skip 10)
+        writes shouldBe listOf(9, 8, 7)
+        volumeTool.hasRecentTarget(AudioStream.Id.STREAM_MUSIC, 7) shouldBe true
+    }
+
+    @Test
+    fun `target level below min is clamped to min`() = runTest {
+        // In unit tests Build.VERSION.SDK_INT is 0 (no Robolectric), so getMinVolume returns 0.
+        audioLevels[AudioStream.Id.STREAM_MUSIC] = 3
+        val writes = mutableListOf<Int>()
+        every { audioManager.setStreamVolume(AudioStream.Id.STREAM_MUSIC.id, any(), any()) } answers {
+            val level = secondArg<Int>()
+            audioLevels[AudioStream.Id.STREAM_MUSIC] = level
+            writes += level
+        }
+
+        volumeTool.changeVolume(
+            streamId = AudioStream.Id.STREAM_MUSIC,
+            targetLevel = -2,
+            delay = Duration.ofMillis(1),
+        )
+
+        // Clamped to min=0. Should ramp down 3 → 2 → 1 → 0.
+        writes shouldBe listOf(2, 1, 0)
+        volumeTool.hasRecentTarget(AudioStream.Id.STREAM_MUSIC, 0) shouldBe true
+    }
+
+    @Test
+    fun `ramp with visible=false uses flag 0 for every write`() = runTest {
+        audioLevels[AudioStream.Id.STREAM_MUSIC] = 2
+        val flags = mutableListOf<Int>()
+        every { audioManager.setStreamVolume(AudioStream.Id.STREAM_MUSIC.id, any(), any()) } answers {
+            val level = secondArg<Int>()
+            val flag = thirdArg<Int>()
+            audioLevels[AudioStream.Id.STREAM_MUSIC] = level
+            flags += flag
+        }
+
+        volumeTool.changeVolume(
+            streamId = AudioStream.Id.STREAM_MUSIC,
+            targetLevel = 5,
+            visible = false,
+            delay = Duration.ofMillis(1),
+        )
+
+        flags shouldBe listOf(0, 0, 0)
+    }
+
+    @Test
+    fun `ramp with visible=true uses FLAG_SHOW_UI for every write`() = runTest {
+        audioLevels[AudioStream.Id.STREAM_MUSIC] = 2
+        val flags = mutableListOf<Int>()
+        every { audioManager.setStreamVolume(AudioStream.Id.STREAM_MUSIC.id, any(), any()) } answers {
+            val level = secondArg<Int>()
+            val flag = thirdArg<Int>()
+            audioLevels[AudioStream.Id.STREAM_MUSIC] = level
+            flags += flag
+        }
+
+        volumeTool.changeVolume(
+            streamId = AudioStream.Id.STREAM_MUSIC,
+            targetLevel = 5,
+            visible = true,
+            delay = Duration.ofMillis(1),
+        )
+
+        flags shouldBe listOf(
+            android.media.AudioManager.FLAG_SHOW_UI,
+            android.media.AudioManager.FLAG_SHOW_UI,
+            android.media.AudioManager.FLAG_SHOW_UI,
+        )
     }
 
     private fun toStreamId(id: Int): AudioStream.Id {

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/connection/BaseVolumeModuleTest.kt
@@ -522,4 +522,105 @@ class BaseVolumeModuleTest : BaseTest() {
             coVerify(atLeast = 1) { volumeTool.changeVolume(streamId, 0.44f) }
         }
     }
+
+    @Nested
+    inner class NudgeVisibility {
+        // Device with nudgeVolume=true and visibleAdjustments configurable; setInitial finds
+        // current=target so it falls into the nudge path.
+
+        private fun deviceWithNudge(visibleAdjustments: Boolean): ManagedDevice = ManagedDevice(
+            isConnected = true,
+            device = testSourceDevice,
+            config = DeviceConfigEntity(
+                address = testAddress,
+                musicVolume = 0.44f,
+                actionDelay = 0L,
+                monitoringDuration = 0L,
+                isEnabled = true,
+                nudgeVolume = true,
+                visibleAdjustments = visibleAdjustments,
+            ),
+        )
+
+        @Test
+        fun `nudge with visibleAdjustments=false passes visible=false to volume tool`() = runTest(UnconfinedTestDispatcher()) {
+            val devicesFlow = MutableStateFlow<List<ManagedDevice>>(emptyList())
+            val registry = AudioStreamOwnerRegistry()
+            val (mod, _) = createModuleWithDeps(registry, devicesFlow)
+
+            val dev = deviceWithNudge(visibleAdjustments = false)
+            devicesFlow.value = listOf(dev)
+            registry.onDeviceConnected(testAddress, "TestDevice", SourceDevice.Type.HEADPHONES, 1000L, 0L)
+
+            every { volumeTool.getMaxVolume(streamId) } returns maxLevel
+            every { volumeTool.getCurrentVolume(streamId) } returns targetLevel
+            // changeVolume returns false (already at target) → enters nudge branch
+            coEvery { volumeTool.changeVolume(streamId, any<Float>(), any(), any()) } returns false
+            coEvery { volumeTool.lowerByOne(streamId, false) } returns true
+            coEvery { volumeTool.increaseByOne(streamId, false) } returns true
+
+            val job = launch { mod.handle(DeviceEvent.Connected(dev)) }
+            advanceTimeBy(1_000) // past the inter-nudge delay(500)
+            job.join()
+
+            coVerify(exactly = 1) { volumeTool.lowerByOne(streamId, false) }
+            coVerify(exactly = 1) { volumeTool.increaseByOne(streamId, false) }
+            coVerify(exactly = 0) { volumeTool.lowerByOne(streamId, true) }
+            coVerify(exactly = 0) { volumeTool.increaseByOne(streamId, true) }
+        }
+
+        @Test
+        fun `nudge with visibleAdjustments=true passes visible=true to volume tool`() = runTest(UnconfinedTestDispatcher()) {
+            val devicesFlow = MutableStateFlow<List<ManagedDevice>>(emptyList())
+            val registry = AudioStreamOwnerRegistry()
+            val (mod, _) = createModuleWithDeps(registry, devicesFlow)
+
+            val dev = deviceWithNudge(visibleAdjustments = true)
+            devicesFlow.value = listOf(dev)
+            registry.onDeviceConnected(testAddress, "TestDevice", SourceDevice.Type.HEADPHONES, 1000L, 0L)
+
+            every { volumeTool.getMaxVolume(streamId) } returns maxLevel
+            every { volumeTool.getCurrentVolume(streamId) } returns targetLevel
+            coEvery { volumeTool.changeVolume(streamId, any<Float>(), any(), any()) } returns false
+            coEvery { volumeTool.lowerByOne(streamId, true) } returns true
+            coEvery { volumeTool.increaseByOne(streamId, true) } returns true
+
+            val job = launch { mod.handle(DeviceEvent.Connected(dev)) }
+            advanceTimeBy(1_000)
+            job.join()
+
+            coVerify(exactly = 1) { volumeTool.lowerByOne(streamId, true) }
+            coVerify(exactly = 1) { volumeTool.increaseByOne(streamId, true) }
+            coVerify(exactly = 0) { volumeTool.lowerByOne(streamId, false) }
+            coVerify(exactly = 0) { volumeTool.increaseByOne(streamId, false) }
+        }
+
+        @Test
+        fun `nudge increase-then-lower path also respects visibleAdjustments=false`() = runTest(UnconfinedTestDispatcher()) {
+            // First lowerByOne returns false (e.g. already at min) → falls into the increase-then-lower branch.
+            val devicesFlow = MutableStateFlow<List<ManagedDevice>>(emptyList())
+            val registry = AudioStreamOwnerRegistry()
+            val (mod, _) = createModuleWithDeps(registry, devicesFlow)
+
+            val dev = deviceWithNudge(visibleAdjustments = false)
+            devicesFlow.value = listOf(dev)
+            registry.onDeviceConnected(testAddress, "TestDevice", SourceDevice.Type.HEADPHONES, 1000L, 0L)
+
+            every { volumeTool.getMaxVolume(streamId) } returns maxLevel
+            every { volumeTool.getCurrentVolume(streamId) } returns targetLevel
+            coEvery { volumeTool.changeVolume(streamId, any<Float>(), any(), any()) } returns false
+            coEvery { volumeTool.lowerByOne(streamId, false) } returns false
+            coEvery { volumeTool.increaseByOne(streamId, false) } returns true
+
+            val job = launch { mod.handle(DeviceEvent.Connected(dev)) }
+            advanceTimeBy(1_000)
+            job.join()
+
+            // path 1 lowerByOne returns false → enters else-if branch → increaseByOne, then recovery lowerByOne
+            coVerify(exactly = 2) { volumeTool.lowerByOne(streamId, false) }
+            coVerify(exactly = 1) { volumeTool.increaseByOne(streamId, false) }
+            coVerify(exactly = 0) { volumeTool.lowerByOne(streamId, true) }
+            coVerify(exactly = 0) { volumeTool.increaseByOne(streamId, true) }
+        }
+    }
 }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
@@ -738,4 +738,235 @@ class EventDispatcherTest : BaseTest() {
 
         coVerify(exactly = 1) { deviceRepo.updateDevice(budsAddress, any()) }
     }
+
+    @Test
+    fun `isIdle starts true before any dispatch`() = runTest {
+        val dispatcher = createDispatcher()
+        dispatcher.isIdle.value shouldBe true
+    }
+
+    @Test
+    fun `isIdle flips false on dispatch and back to true after cancellable job completes`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        val running = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        coEvery { module1.handle(any()) } coAnswers {
+            running.complete(Unit)
+            release.await()
+        }
+
+        val dispatcher = createDispatcher()
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+
+        running.await()
+        dispatcher.isIdle.value shouldBe false
+
+        release.complete(Unit)
+        advanceUntilIdle()
+
+        dispatcher.isIdle.value shouldBe true
+    }
+
+    @Test
+    fun `isIdle flips false on dispatch and back to true after non-cancellable job completes`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        val running = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        val nonCancellable = mockk<ConnectionModule>(relaxed = true) {
+            every { priority } returns 1
+            every { tag } returns "NonCancellable"
+            every { cancellable } returns false
+        }
+        coEvery { nonCancellable.handle(any()) } coAnswers {
+            running.complete(Unit)
+            release.await()
+        }
+
+        val dispatcher = EventDispatcher(
+            appScope = this,
+            dispatcherProvider = asDispatcherProvider(),
+            deviceRepo = deviceRepo,
+            devicesSettings = devicesSettings,
+            connectionModuleMap = setOf(nonCancellable),
+            eventTypeDedupTracker = tracker,
+            ownerRegistry = AudioStreamOwnerRegistry(),
+        )
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+
+        running.await()
+        dispatcher.isIdle.value shouldBe false
+
+        release.complete(Unit)
+        advanceUntilIdle()
+
+        dispatcher.isIdle.value shouldBe true
+    }
+
+    @Test
+    fun `isIdle stays false until both cancellable and non-cancellable jobs complete`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        val cancellableRunning = CompletableDeferred<Unit>()
+        val cancellableRelease = CompletableDeferred<Unit>()
+        val nonCancellableRunning = CompletableDeferred<Unit>()
+        val nonCancellableRelease = CompletableDeferred<Unit>()
+
+        val cancellableMod = mockk<ConnectionModule>(relaxed = true) {
+            every { priority } returns 10
+            every { tag } returns "Cancellable"
+            every { cancellable } returns true
+        }
+        coEvery { cancellableMod.handle(any()) } coAnswers {
+            cancellableRunning.complete(Unit)
+            cancellableRelease.await()
+        }
+        val nonCancellableMod = mockk<ConnectionModule>(relaxed = true) {
+            every { priority } returns 1
+            every { tag } returns "NonCancellable"
+            every { cancellable } returns false
+        }
+        coEvery { nonCancellableMod.handle(any()) } coAnswers {
+            nonCancellableRunning.complete(Unit)
+            nonCancellableRelease.await()
+        }
+
+        val dispatcher = EventDispatcher(
+            appScope = this,
+            dispatcherProvider = asDispatcherProvider(),
+            deviceRepo = deviceRepo,
+            devicesSettings = devicesSettings,
+            connectionModuleMap = setOf(cancellableMod, nonCancellableMod),
+            eventTypeDedupTracker = tracker,
+            ownerRegistry = AudioStreamOwnerRegistry(),
+        )
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+
+        cancellableRunning.await()
+        nonCancellableRunning.await()
+        dispatcher.isIdle.value shouldBe false
+
+        // Release only the cancellable; non-cancellable still in flight
+        cancellableRelease.complete(Unit)
+        advanceUntilIdle()
+        dispatcher.isIdle.value shouldBe false
+
+        // Release the non-cancellable too
+        nonCancellableRelease.complete(Unit)
+        advanceUntilIdle()
+        dispatcher.isIdle.value shouldBe true
+    }
+
+    @Test
+    fun `awaitIdle returns immediately when already idle`() = runTest {
+        val dispatcher = createDispatcher()
+        dispatcher.awaitIdle()
+        dispatcher.isIdle.value shouldBe true
+    }
+
+    @Test
+    fun `awaitIdle suspends until in-flight jobs complete`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        val running = CompletableDeferred<Unit>()
+        val release = CompletableDeferred<Unit>()
+        coEvery { module1.handle(any()) } coAnswers {
+            running.complete(Unit)
+            release.await()
+        }
+
+        val dispatcher = createDispatcher()
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        running.await()
+
+        var awaitIdleReturned = false
+        val waiter = launch {
+            dispatcher.awaitIdle()
+            awaitIdleReturned = true
+        }
+
+        advanceUntilIdle()
+        awaitIdleReturned shouldBe false
+
+        release.complete(Unit)
+        advanceUntilIdle()
+        waiter.join()
+        awaitIdleReturned shouldBe true
+    }
+
+    @Test
+    fun `superseded job still counts as in-flight until invokeOnCompletion runs`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        val firstRunning = CompletableDeferred<Unit>()
+        val secondRunning = CompletableDeferred<Unit>()
+        val secondRelease = CompletableDeferred<Unit>()
+        var callCount = 0
+        coEvery { module1.handle(any()) } coAnswers {
+            val n = ++callCount
+            if (n == 1) {
+                firstRunning.complete(Unit)
+                kotlinx.coroutines.delay(60_000)
+            } else {
+                secondRunning.complete(Unit)
+                secondRelease.await()
+            }
+        }
+
+        val dispatcher = createDispatcher()
+
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        firstRunning.await()
+        dispatcher.isIdle.value shouldBe false
+
+        // Supersede with a disconnect — this cancels the first job, but its
+        // invokeOnCompletion runs eventually and untracks it.
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+        secondRunning.await()
+        dispatcher.isIdle.value shouldBe false
+
+        secondRelease.complete(Unit)
+        advanceUntilIdle()
+        dispatcher.isIdle.value shouldBe true
+    }
+
+    @Test
+    fun `cancelAllJobs followed by resetForNewSession does not strand awaitIdle`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        val release = CompletableDeferred<Unit>()
+        coEvery { module1.handle(any()) } coAnswers { release.await() }
+
+        val dispatcher = createDispatcher()
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        advanceUntilIdle()
+
+        dispatcher.isIdle.value shouldBe false
+
+        dispatcher.cancelAllJobs()
+        advanceUntilIdle()
+
+        dispatcher.isIdle.value shouldBe true
+
+        dispatcher.resetForNewSession()
+
+        var awaitIdleReturned = false
+        val waiter = launch {
+            dispatcher.awaitIdle()
+            awaitIdleReturned = true
+        }
+        advanceUntilIdle()
+        waiter.join()
+        awaitIdleReturned shouldBe true
+
+        // Release the deferred so the cancelled coroutine can finish unwinding cleanly.
+        release.complete(Unit)
+    }
 }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
@@ -969,4 +969,74 @@ class EventDispatcherTest : BaseTest() {
         // Release the deferred so the cancelled coroutine can finish unwinding cleanly.
         release.complete(Unit)
     }
+
+    @Test
+    fun `currentWorkGeneration starts at 0 and increments on dispatch`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        val release = CompletableDeferred<Unit>()
+        coEvery { module1.handle(any()) } coAnswers { release.await() }
+
+        val dispatcher = createDispatcher()
+        dispatcher.currentWorkGeneration() shouldBe 0L
+
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        advanceUntilIdle()
+
+        // At least one trackJob ran (the cancellable launch).
+        (dispatcher.currentWorkGeneration() > 0L) shouldBe true
+
+        release.complete(Unit)
+    }
+
+    @Test
+    fun `currentWorkGeneration keeps increasing across multiple dispatches`() = runTest {
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        val firstRelease = CompletableDeferred<Unit>()
+        val secondRelease = CompletableDeferred<Unit>()
+        var callCount = 0
+        coEvery { module1.handle(any()) } coAnswers {
+            val n = ++callCount
+            if (n == 1) firstRelease.await() else secondRelease.await()
+        }
+
+        val dispatcher = createDispatcher()
+
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        advanceUntilIdle()
+        val genAfterFirst = dispatcher.currentWorkGeneration()
+        (genAfterFirst > 0L) shouldBe true
+
+        dispatcher.dispatch(event(budsAddress, DISCONNECTED))
+        advanceUntilIdle()
+        val genAfterSecond = dispatcher.currentWorkGeneration()
+        (genAfterSecond > genAfterFirst) shouldBe true
+
+        firstRelease.complete(Unit)
+        secondRelease.complete(Unit)
+    }
+
+    @Test
+    fun `currentWorkGeneration increments even when a fast dispatch finishes before isIdle is observed`() = runTest {
+        // Verifies that the orchestrator's "did anything happen during grace?" check
+        // remains accurate even for blink-and-you-miss-it dispatches whose isIdle=false
+        // gets conflated by StateFlow before any collector observes it.
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+
+        // Module returns immediately — total in-flight time is microseconds.
+        coEvery { module1.handle(any()) } returns Unit
+
+        val dispatcher = createDispatcher()
+        val genBefore = dispatcher.currentWorkGeneration()
+
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        advanceUntilIdle()
+
+        dispatcher.isIdle.value shouldBe true
+        (dispatcher.currentWorkGeneration() > genBefore) shouldBe true
+    }
 }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestratorTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestratorTest.kt
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import java.time.Duration
+import java.util.concurrent.atomic.AtomicLong
 
 class MonitorOrchestratorTest : BaseTest() {
 
@@ -41,6 +42,7 @@ class MonitorOrchestratorTest : BaseTest() {
     private lateinit var devicesFlow: MutableStateFlow<List<ManagedDevice>>
     private lateinit var stateFlow: MutableStateFlow<BluetoothRepo.State>
     private lateinit var idleFlow: MutableStateFlow<Boolean>
+    private lateinit var workGen: AtomicLong
 
     @BeforeEach
     fun setup() {
@@ -58,9 +60,11 @@ class MonitorOrchestratorTest : BaseTest() {
         ringerModeObserver = mockk { every { ringerMode } returns MutableSharedFlow() }
         bluetoothEventQueue = mockk { every { events } returns MutableSharedFlow() }
         idleFlow = MutableStateFlow(true)
+        workGen = AtomicLong(0)
         eventDispatcher = mockk(relaxed = true) {
             every { isIdle } returns idleFlow
             coEvery { awaitIdle() } coAnswers { idleFlow.filter { it }.first() }
+            every { currentWorkGeneration() } answers { workGen.get() }
         }
         ringerModeTransitionHandler = mockk(relaxed = true)
         ownerRegistry = mockk(relaxed = true)
@@ -224,17 +228,65 @@ class MonitorOrchestratorTest : BaseTest() {
             monitorReturned = true
         }
 
-        // Idle from start; advance 10s into grace window
+        // Idle from start; advance 10s into the first grace window.
         advanceTimeBy(10_000)
         monitorReturned shouldBe false
 
-        // Mid-grace, dispatcher goes busy → resets cooldown
+        // Mid-grace: dispatcher gets new work — bump generation AND flip idle to false
+        // to simulate what trackJob() does in production. The cooldown checks generation
+        // (not isIdle) at the end of the 15s delay, so this *will* be detected.
+        workGen.incrementAndGet()
         idleFlow.value = false
+
+        // Finish out the original 15s delay — orchestrator sees generation changed, restarts.
+        advanceTimeBy(5_001)
+        monitorReturned shouldBe false
+
+        // Restart loop calls awaitIdle() which suspends because dispatcher is busy.
         advanceTimeBy(20_000)
         monitorReturned shouldBe false
 
-        // Dispatcher becomes idle again
+        // Dispatcher becomes idle again — awaitIdle() returns, new 15s grace begins.
         idleFlow.value = true
+        advanceTimeBy(14_000)
+        monitorReturned shouldBe false
+
+        advanceTimeBy(2_000)
+        advanceUntilIdle()
+        monitorReturned shouldBe true
+
+        job.cancel()
+    }
+
+    @Test
+    fun `work bump alone during grace restarts cooldown even without idle flip`() = runTest {
+        // Edge case: a fast dispatch that completes within the 15s grace window —
+        // its trackJob bumps the generation but isIdle may already be true again
+        // by the time the cooldown's delay completes. Generation-based check still detects it.
+        val device = managedDevice(
+            "AA:BB:CC:DD:EE:FF",
+            active = true,
+            requiresMonitor = false,
+        )
+        devicesFlow.value = listOf(device)
+
+        val orchestrator = createOrchestrator()
+        var monitorReturned = false
+
+        val job = launch {
+            orchestrator.monitor(this@runTest) {}
+            monitorReturned = true
+        }
+
+        // Mid-grace, simulate a brief dispatch that bumps generation but leaves idle=true.
+        advanceTimeBy(10_000)
+        workGen.incrementAndGet()
+
+        // Finish out the original 15s delay — generation differs → restart.
+        advanceTimeBy(5_001)
+        monitorReturned shouldBe false
+
+        // Second grace window with no further work.
         advanceTimeBy(14_000)
         monitorReturned shouldBe false
 

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestratorTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestratorTest.kt
@@ -13,9 +13,11 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
-import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -38,6 +40,7 @@ class MonitorOrchestratorTest : BaseTest() {
 
     private lateinit var devicesFlow: MutableStateFlow<List<ManagedDevice>>
     private lateinit var stateFlow: MutableStateFlow<BluetoothRepo.State>
+    private lateinit var idleFlow: MutableStateFlow<Boolean>
 
     @BeforeEach
     fun setup() {
@@ -54,7 +57,11 @@ class MonitorOrchestratorTest : BaseTest() {
         volumeObserver = mockk { every { volumes } returns MutableSharedFlow() }
         ringerModeObserver = mockk { every { ringerMode } returns MutableSharedFlow() }
         bluetoothEventQueue = mockk { every { events } returns MutableSharedFlow() }
-        eventDispatcher = mockk(relaxed = true)
+        idleFlow = MutableStateFlow(true)
+        eventDispatcher = mockk(relaxed = true) {
+            every { isIdle } returns idleFlow
+            coEvery { awaitIdle() } coAnswers { idleFlow.filter { it }.first() }
+        }
         ringerModeTransitionHandler = mockk(relaxed = true)
         ownerRegistry = mockk(relaxed = true)
         volumeEventDispatcher = mockk(relaxed = true)
@@ -139,13 +146,11 @@ class MonitorOrchestratorTest : BaseTest() {
     }
 
     @Test
-    fun `active devices without requiresMonitor - stops after grace period`() = runTest {
-        val monitoringDuration = Duration.ofSeconds(5)
+    fun `active devices without requiresMonitor - stops after idle grace period`() = runTest {
         val device = managedDevice(
             "AA:BB:CC:DD:EE:FF",
             active = true,
             requiresMonitor = false,
-            monitoringDuration = monitoringDuration,
         )
         devicesFlow.value = listOf(device)
 
@@ -157,8 +162,80 @@ class MonitorOrchestratorTest : BaseTest() {
             monitorReturned = true
         }
 
-        // 15s grace + 5s monitoring = 20s (throttleLatest emits first value immediately)
-        advanceTimeBy(19_000)
+        // Dispatcher is idle from the start. 15s grace before stopping.
+        advanceTimeBy(14_000)
+        monitorReturned shouldBe false
+
+        advanceTimeBy(2_000)
+        advanceUntilIdle()
+        monitorReturned shouldBe true
+
+        job.cancel()
+    }
+
+    @Test
+    fun `slow handler in flight - kill timer does not fire until awaitIdle resolves`() = runTest {
+        idleFlow.value = false // Dispatcher busy from start
+        val device = managedDevice(
+            "AA:BB:CC:DD:EE:FF",
+            active = true,
+            requiresMonitor = false,
+        )
+        devicesFlow.value = listOf(device)
+
+        val orchestrator = createOrchestrator()
+        var monitorReturned = false
+
+        val job = launch {
+            orchestrator.monitor(this@runTest) {}
+            monitorReturned = true
+        }
+
+        // 30s in, dispatcher still busy → must not return
+        advanceTimeBy(30_000)
+        monitorReturned shouldBe false
+
+        // Dispatcher becomes idle
+        idleFlow.value = true
+        advanceTimeBy(14_000)
+        monitorReturned shouldBe false
+
+        advanceTimeBy(2_000)
+        advanceUntilIdle()
+        monitorReturned shouldBe true
+
+        job.cancel()
+    }
+
+    @Test
+    fun `dispatcher going busy during 15s grace restarts cooldown`() = runTest {
+        val device = managedDevice(
+            "AA:BB:CC:DD:EE:FF",
+            active = true,
+            requiresMonitor = false,
+        )
+        devicesFlow.value = listOf(device)
+
+        val orchestrator = createOrchestrator()
+        var monitorReturned = false
+
+        val job = launch {
+            orchestrator.monitor(this@runTest) {}
+            monitorReturned = true
+        }
+
+        // Idle from start; advance 10s into grace window
+        advanceTimeBy(10_000)
+        monitorReturned shouldBe false
+
+        // Mid-grace, dispatcher goes busy → resets cooldown
+        idleFlow.value = false
+        advanceTimeBy(20_000)
+        monitorReturned shouldBe false
+
+        // Dispatcher becomes idle again
+        idleFlow.value = true
+        advanceTimeBy(14_000)
         monitorReturned shouldBe false
 
         advanceTimeBy(2_000)


### PR DESCRIPTION
Fixes three regressions reported on Android 16 (Pixel 9) where the connect-handling service was being killed before its work finished:

- Music volume restore was being interrupted mid-ramp, leaving the volume at a wrong level.
- Autoplay's "play" key event frequently failed to fire on connect (was a victim of the same early-stop bug).
- Volume nudge respects the per-profile "show volume UI" toggle (was always showing the HUD when nudge was enabled).
- Volume ramp wasted one step at the start and one delay at the end.

Root cause was `MonitorOrchestrator`'s fixed kill budget (`15s + monitoringDuration`) being shorter than the actual sequential per-priority handler runtime. Replaced with continuous-idleness cooldown gated on `EventDispatcher.awaitIdle()`.

A separate fix for "screen does not turn on at connect with KeepAwake" is in a follow-up PR.
