### PR TITLE
Fix keep-awake releasing the wakelock shortly after connect

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDevice.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDevice.kt
@@ -73,8 +73,18 @@ data class ManagedDevice(
         get() = config.connectionAlertType
     val connectionAlertSoundUri: String?
         get() = config.connectionAlertSoundUri
-    val requiresMonitor: Boolean
-        get() = volumeLock || volumeObserving || volumeRateLimiter
+    /**
+     * True when this device requires the foreground service to keep running for ongoing work.
+     *
+     * - Volume monitoring (lock / observing / rate-limiter) needs continuous re-enforcement.
+     * - Keep-awake needs the partial CPU wakelock held until disconnect.
+     *
+     * One-shot features (autoplay, app launch, connection alert, show home screen) are NOT
+     * included — they fire once during the connect dispatch and the service is free to stop
+     * after the post-dispatch idle grace.
+     */
+    val requiresPersistentSession: Boolean
+        get() = volumeLock || volumeObserving || volumeRateLimiter || keepAwake
 
     fun getVolume(type: AudioStream.Type): Float? = when (type) {
         AudioStream.Type.MUSIC -> config.musicVolume

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorControl.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorControl.kt
@@ -32,14 +32,14 @@ class MonitorControl @Inject constructor(
         deviceRepo.devices
             .map { devices ->
                 devices.any { device ->
-                    device.isConnected && device.requiresMonitor
+                    device.isConnected && device.requiresPersistentSession
                 }
             }
             .distinctUntilChanged()
             .setupCommonEventHandlers(TAG) { "Device monitor" }
-            .onEach { requiresMonitor ->
-                if (requiresMonitor) {
-                    log(TAG) { "Connected device requires monitor, starting monitor service" }
+            .onEach { needsService ->
+                if (needsService) {
+                    log(TAG) { "Connected device needs persistent session, starting monitor service" }
                     startMonitor()
                 }
             }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestrator.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestrator.kt
@@ -106,7 +106,7 @@ class MonitorOrchestrator @Inject constructor(
                 log(TAG) { "monitor: Currently active devices: ${activeDevices.map { "${it.address}/${it.label}" }}" }
                 onActiveDevicesChanged(activeDevices)
 
-                val stayActive = activeDevices.any { it.requiresMonitor }
+                val stayActive = activeDevices.any { it.requiresPersistentSession }
 
                 when {
                     activeDevices.isNotEmpty() && stayActive -> {

--- a/app/src/test/java/eu/darken/bluemusic/devices/core/ManagedDeviceTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/core/ManagedDeviceTest.kt
@@ -66,29 +66,45 @@ class ManagedDeviceTest : BaseTest() {
 
     // endregion
 
-    // region requiresMonitor
+    // region requiresPersistentSession
 
     @Test
-    fun `requiresMonitor - all false`() {
-        create().requiresMonitor shouldBe false
+    fun `requiresPersistentSession - all false`() {
+        create().requiresPersistentSession shouldBe false
     }
 
     @Test
-    fun `requiresMonitor - volumeLock true`() {
+    fun `requiresPersistentSession - volumeLock true`() {
         create(config = DeviceConfigEntity(address = "AA:BB:CC:DD:EE:FF", volumeLock = true))
-            .requiresMonitor shouldBe true
+            .requiresPersistentSession shouldBe true
     }
 
     @Test
-    fun `requiresMonitor - volumeObserving true`() {
+    fun `requiresPersistentSession - volumeObserving true`() {
         create(config = DeviceConfigEntity(address = "AA:BB:CC:DD:EE:FF", volumeObserving = true))
-            .requiresMonitor shouldBe true
+            .requiresPersistentSession shouldBe true
     }
 
     @Test
-    fun `requiresMonitor - volumeRateLimiter true`() {
+    fun `requiresPersistentSession - volumeRateLimiter true`() {
         create(config = DeviceConfigEntity(address = "AA:BB:CC:DD:EE:FF", volumeRateLimiter = true))
-            .requiresMonitor shouldBe true
+            .requiresPersistentSession shouldBe true
+    }
+
+    @Test
+    fun `requiresPersistentSession - keepAwake true`() {
+        create(config = DeviceConfigEntity(address = "AA:BB:CC:DD:EE:FF", keepAwake = true))
+            .requiresPersistentSession shouldBe true
+    }
+
+    @Test
+    fun `requiresPersistentSession - one-shot features alone do NOT flip true`() {
+        create(config = DeviceConfigEntity(address = "AA:BB:CC:DD:EE:FF", autoplay = true))
+            .requiresPersistentSession shouldBe false
+        create(config = DeviceConfigEntity(address = "AA:BB:CC:DD:EE:FF", launchPkgs = listOf("com.example")))
+            .requiresPersistentSession shouldBe false
+        create(config = DeviceConfigEntity(address = "AA:BB:CC:DD:EE:FF", showHomeScreen = true))
+            .requiresPersistentSession shouldBe false
     }
 
     @Test

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorControlTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorControlTest.kt
@@ -1,0 +1,129 @@
+package eu.darken.bluemusic.monitor.core.service
+
+import android.content.Context
+import android.content.Intent
+import eu.darken.bluemusic.common.startServiceCompat
+import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.monitor.ui.MonitorNotifications
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MonitorControlTest : BaseTest() {
+
+    private lateinit var context: Context
+    private lateinit var deviceRepo: DeviceRepo
+    private lateinit var monitorNotifications: MonitorNotifications
+    private lateinit var devicesFlow: MutableStateFlow<List<ManagedDevice>>
+    private lateinit var fakeIntent: Intent
+
+    @BeforeEach
+    fun setup() {
+        context = mockk(relaxed = true)
+        monitorNotifications = mockk(relaxed = true)
+        devicesFlow = MutableStateFlow(emptyList())
+        deviceRepo = mockk(relaxed = true) {
+            every { devices } returns devicesFlow
+        }
+
+        fakeIntent = mockk(relaxed = true)
+
+        // startServiceCompat is a top-level extension function — mockkStatic the file class.
+        mockkStatic("eu.darken.bluemusic.common.ContextExtensionsKt")
+        every { context.startServiceCompat(any()) } just Runs
+
+        // MonitorService.intent() uses real android.content.Intent which is a stub in unit tests.
+        // Mock the companion to return a fake intent.
+        mockkObject(MonitorService.Companion)
+        every { MonitorService.intent(any(), any()) } returns fakeIntent
+    }
+
+    @AfterEach
+    fun tearDown() {
+        unmockkAll()
+    }
+
+    private fun device(
+        connected: Boolean,
+        requiresPersistentSession: Boolean,
+    ): ManagedDevice = mockk(relaxed = true) {
+        every { isConnected } returns connected
+        every { this@mockk.requiresPersistentSession } returns requiresPersistentSession
+    }
+
+    @Test
+    fun `connected device with requiresPersistentSession triggers service start`() = runTest(UnconfinedTestDispatcher()) {
+        MonitorControl(
+            appScope = backgroundScope,
+            context = context,
+            deviceRepo = deviceRepo,
+            monitorNotifications = monitorNotifications,
+        )
+
+        devicesFlow.value = listOf(device(connected = true, requiresPersistentSession = true))
+
+        verify(atLeast = 1) { context.startServiceCompat(fakeIntent) }
+    }
+
+    @Test
+    fun `disconnected device does NOT trigger service start`() = runTest(UnconfinedTestDispatcher()) {
+        MonitorControl(
+            appScope = backgroundScope,
+            context = context,
+            deviceRepo = deviceRepo,
+            monitorNotifications = monitorNotifications,
+        )
+
+        devicesFlow.value = listOf(device(connected = false, requiresPersistentSession = true))
+
+        verify(exactly = 0) { context.startServiceCompat(any()) }
+    }
+
+    @Test
+    fun `connected device without requiresPersistentSession does NOT trigger service start`() = runTest(UnconfinedTestDispatcher()) {
+        MonitorControl(
+            appScope = backgroundScope,
+            context = context,
+            deviceRepo = deviceRepo,
+            monitorNotifications = monitorNotifications,
+        )
+
+        devicesFlow.value = listOf(device(connected = true, requiresPersistentSession = false))
+
+        verify(exactly = 0) { context.startServiceCompat(any()) }
+    }
+
+    @Test
+    fun `flipping requiresPersistentSession true on connected device triggers service start`() = runTest(UnconfinedTestDispatcher()) {
+        MonitorControl(
+            appScope = backgroundScope,
+            context = context,
+            deviceRepo = deviceRepo,
+            monitorNotifications = monitorNotifications,
+        )
+
+        // First emission: connected but no persistent session
+        devicesFlow.value = listOf(device(connected = true, requiresPersistentSession = false))
+        verify(exactly = 0) { context.startServiceCompat(any()) }
+
+        // Second emission: same connection state, now needs persistent session (e.g. user toggled keepAwake)
+        devicesFlow.value = listOf(device(connected = true, requiresPersistentSession = true))
+
+        verify(atLeast = 1) { context.startServiceCompat(fakeIntent) }
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestratorTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestratorTest.kt
@@ -86,12 +86,12 @@ class MonitorOrchestratorTest : BaseTest() {
     private fun managedDevice(
         address: String,
         active: Boolean = true,
-        requiresMonitor: Boolean = false,
+        requiresPersistentSession: Boolean = false,
         monitoringDuration: Duration = Duration.ZERO,
     ): ManagedDevice = mockk(relaxed = true) {
         every { this@mockk.address } returns address
         every { isActive } returns active
-        every { this@mockk.requiresMonitor } returns requiresMonitor
+        every { this@mockk.requiresPersistentSession } returns requiresPersistentSession
         every { this@mockk.monitoringDuration } returns monitoringDuration
         every { label } returns address
     }
@@ -131,8 +131,8 @@ class MonitorOrchestratorTest : BaseTest() {
     // --- Shutdown heuristics ---
 
     @Test
-    fun `requiresMonitor devices keep monitoring alive`() = runTest {
-        val device = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresMonitor = true)
+    fun `requiresPersistentSession devices keep monitoring alive`() = runTest {
+        val device = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresPersistentSession = true)
         devicesFlow.value = listOf(device)
 
         val orchestrator = createOrchestrator()
@@ -150,11 +150,11 @@ class MonitorOrchestratorTest : BaseTest() {
     }
 
     @Test
-    fun `active devices without requiresMonitor - stops after idle grace period`() = runTest {
+    fun `active devices without requiresPersistentSession - stops after idle grace period`() = runTest {
         val device = managedDevice(
             "AA:BB:CC:DD:EE:FF",
             active = true,
-            requiresMonitor = false,
+            requiresPersistentSession = false,
         )
         devicesFlow.value = listOf(device)
 
@@ -183,7 +183,7 @@ class MonitorOrchestratorTest : BaseTest() {
         val device = managedDevice(
             "AA:BB:CC:DD:EE:FF",
             active = true,
-            requiresMonitor = false,
+            requiresPersistentSession = false,
         )
         devicesFlow.value = listOf(device)
 
@@ -216,7 +216,7 @@ class MonitorOrchestratorTest : BaseTest() {
         val device = managedDevice(
             "AA:BB:CC:DD:EE:FF",
             active = true,
-            requiresMonitor = false,
+            requiresPersistentSession = false,
         )
         devicesFlow.value = listOf(device)
 
@@ -266,7 +266,7 @@ class MonitorOrchestratorTest : BaseTest() {
         val device = managedDevice(
             "AA:BB:CC:DD:EE:FF",
             active = true,
-            requiresMonitor = false,
+            requiresPersistentSession = false,
         )
         devicesFlow.value = listOf(device)
 
@@ -322,7 +322,7 @@ class MonitorOrchestratorTest : BaseTest() {
 
     @Test
     fun `device list changes mid-monitoring fires callback with updated list`() = runTest {
-        val device1 = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresMonitor = true)
+        val device1 = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresPersistentSession = true)
         devicesFlow.value = listOf(device1)
 
         val callbackInvocations = mutableListOf<List<ManagedDevice>>()
@@ -334,7 +334,7 @@ class MonitorOrchestratorTest : BaseTest() {
 
         advanceTimeBy(5_000)
 
-        val device2 = managedDevice("11:22:33:44:55:66", active = true, requiresMonitor = true)
+        val device2 = managedDevice("11:22:33:44:55:66", active = true, requiresPersistentSession = true)
         devicesFlow.value = listOf(device1, device2)
         advanceTimeBy(5_000)
 
@@ -353,7 +353,7 @@ class MonitorOrchestratorTest : BaseTest() {
 
         coEvery { ringerModeTransitionHandler.handle(any()) } throws RuntimeException("boom")
 
-        val device = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresMonitor = true)
+        val device = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresPersistentSession = true)
         devicesFlow.value = listOf(device)
 
         val callbackInvocations = mutableListOf<List<ManagedDevice>>()
@@ -380,7 +380,7 @@ class MonitorOrchestratorTest : BaseTest() {
 
         coEvery { volumeEventDispatcher.dispatch(any()) } throws RuntimeException("boom")
 
-        val device = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresMonitor = true)
+        val device = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresPersistentSession = true)
         devicesFlow.value = listOf(device)
 
         val callbackInvocations = mutableListOf<List<ManagedDevice>>()
@@ -406,7 +406,7 @@ class MonitorOrchestratorTest : BaseTest() {
 
         coEvery { eventDispatcher.dispatch(any()) } throws RuntimeException("boom")
 
-        val device = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresMonitor = true)
+        val device = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresPersistentSession = true)
         devicesFlow.value = listOf(device)
 
         val callbackInvocations = mutableListOf<List<ManagedDevice>>()


### PR DESCRIPTION
The keep-awake setting wasn't actually keeping the device awake. On Bluetooth connect, the partial CPU wakelock was acquired correctly, but ~15 seconds later the monitor service would stop (when the post-connect dispatcher fell idle) and release the wakelock again — leaving the user with the original problem the toggle was meant to solve.

Root cause: the `requiresMonitor` predicate on `ManagedDevice` excluded `keepAwake` and only flipped true for the three volume-monitoring features. So a profile with only KeepAwake enabled fell through to the "stop after idle + 15s grace" path instead of the "stay alive" path. The same predicate was used by `MonitorControl` for reactive auto-start, so toggling KeepAwake on an already-connected device also did nothing.

Renamed the property to `requiresPersistentSession` and added `keepAwake` to the predicate.

Behavior changes:
- Connecting a keep-awake-enabled device now keeps the monitor service alive (and the CPU wakelock held) for the duration of the connection, not just 15 seconds.
- Toggling keep-awake on an already-connected device auto-starts the service the same way toggling volume-lock or volume-observing already did.

Companion to the recent Bluetooth-connect timing PRs.

## Test plan

- [x] `./gradlew assembleFossDebug`
- [x] `./gradlew testFossDebugUnitTest` (566 pass)
- [x] `./gradlew testGplayDebugUnitTest` (566 pass)
