### PR TITLE
Drop default action delay back to 4 seconds

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDevice.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDevice.kt
@@ -103,10 +103,7 @@ data class ManagedDevice(
         return null
     }
 
-    // 6s is the global settle barrier window for devices without a user-configured override.
-    // Post per-module-delay collapse this is the only "wait for BT route to stabilize"
-    // window most pipelines pay; previously each module independently waited 4s of its own.
-    private val defaultActionDelay: Duration = Duration.ofSeconds(6)
+    private val defaultActionDelay: Duration = Duration.ofSeconds(4)
     private val defaultMonitoringDuration: Duration = Duration.ofSeconds(4)
     private val defaultAdjustmentDelay: Duration = Duration.ofMillis(250)
 

--- a/app/src/test/java/eu/darken/bluemusic/devices/core/ManagedDeviceTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/core/ManagedDeviceTest.kt
@@ -266,8 +266,8 @@ class ManagedDeviceTest : BaseTest() {
     }
 
     @Test
-    fun `actionDelay defaults to 6s when null`() {
-        create().actionDelay shouldBe Duration.ofSeconds(6)
+    fun `actionDelay defaults to 4s when null`() {
+        create().actionDelay shouldBe Duration.ofSeconds(4)
     }
 
     @Test


### PR DESCRIPTION
PR #226 had bumped the default `actionDelay` from 4s to 6s as a defensive hedge against a hypothetical "Android shuffles BT stream volume late during route setup" scenario. On-device verification with AirPods Pro 2 on a Pixel 8 shows the BT route stabilizes well before 4s elapse — volume changes land at the intended target and stay there, no shuffle. The 6s margin was load-bearing for no observable problem.

Reverting to 4s saves ~2s of the user-perceived connect time for everyone on the default. Users on slower routes who need longer can still customize per-device in advanced settings.

## Test plan

- [x] `./gradlew testFossDebugUnitTest` (594 pass)
- [x] `./gradlew testGplayDebugUnitTest` (594 pass)
- [x] Manual on-device test on Pixel 8 + AirPods Pro 2 with `volumeObserving + autoplay + musicVolume=100%`: connect pipeline completes cleanly at the user's target volume, music starts after volume settled.
