### PR TITLE
Fix app continuing to manage volumes while disabled

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
@@ -45,6 +45,10 @@ constructor(
     fun onToggleEnabled(enabled: Boolean) = launch {
         log(tag) { "onToggleEnabled($enabled)" }
         devicesSettings.setEnabled(enabled)
+        // Disabling is handled centrally: MonitorControl observes enabledState and stops the
+        // service; the orchestrator's own watcher tears down the session as a safety net.
+        // forceStart: a quick disable->enable can race the old session's teardown — a plain
+        // start would be swallowed by onStartCommand and killed by the old job's stopSelf.
         if (enabled) {
             monitorControl.startMonitor(forceStart = true)
         }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/WakeLockManager.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/WakeLockManager.kt
@@ -14,6 +14,7 @@ import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.permissions.PermissionHelper
 import eu.darken.bluemusic.monitor.core.screenwake.ScreenWakeActivity
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import javax.inject.Inject
@@ -60,6 +61,12 @@ class WakeLockManager @Inject constructor(
             }
         }
     }
+
+    /**
+     * Synchronous release for teardown paths (e.g. Service.onDestroy) where launching a
+     * coroutine could outlive the process. Release is fast (mutex + release call).
+     */
+    fun releaseBlocking() = runBlocking { setWakeLock(false) }
 
     fun wakeScreenNow() {
         // Background activity launch (BAL) restrictions only apply on API 29+ (Android 10+).

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/BluetoothEventQueue.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/BluetoothEventQueue.kt
@@ -26,6 +26,16 @@ class BluetoothEventQueue @Inject constructor() {
         _events.send(event)
     }
 
+    /**
+     * Drops all queued events. Called when monitoring shuts down due to the app being
+     * disabled, so stale pre-disable events don't fire after a later re-enable.
+     */
+    fun clear() {
+        var dropped = 0
+        while (_events.tryReceive().isSuccess) dropped++
+        if (dropped > 0) log(TAG) { "clear(): dropped $dropped stale events" }
+    }
+
     fun stampEvent(
         type: Event.Type,
         sourceDevice: SourceDevice,

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/EventDispatcher.kt
@@ -125,7 +125,12 @@ class EventDispatcher @Inject constructor(
                 return@withLock
             }
 
-            eventTypeDedupTracker.observeEnabledState(devicesSettings.currentEnabledState())
+            val enabledState = devicesSettings.currentEnabledState()
+            eventTypeDedupTracker.observeEnabledState(enabledState)
+            if (!enabledState.isEnabled) {
+                log(TAG, WARN) { "dispatch: Dropping event, app is disabled: $bluetoothEvent" }
+                return@withLock
+            }
 
             if (!eventTypeDedupTracker.shouldProcess(bluetoothEvent.sourceDevice.address, bluetoothEvent.type)) {
                 return@withLock

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorControl.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorControl.kt
@@ -10,8 +10,11 @@ import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.flow.setupCommonEventHandlers
 import eu.darken.bluemusic.common.startServiceCompat
 import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.monitor.ui.MonitorNotifications
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -24,30 +27,57 @@ class MonitorControl @Inject constructor(
     @AppScope private val appScope: CoroutineScope,
     @ApplicationContext private val context: Context,
     deviceRepo: DeviceRepo,
+    private val devicesSettings: DevicesSettings,
     @Suppress("unused") // Eagerly inits the singleton so notification channel + PendingIntent IPC
     monitorNotifications: MonitorNotifications, // run before any startForegroundService() call
 ) {
 
     init {
-        deviceRepo.devices
-            .map { devices ->
+        var lastToggleEpoch: Long? = null
+        combine(
+            deviceRepo.devices.map { devices ->
                 devices.any { device ->
-                    device.isConnected && device.requiresPersistentSession
+                    device.isActive && device.requiresPersistentSession
                 }
-            }
+            },
+            devicesSettings.enabledState,
+        ) { needsService, enabledState -> needsService to enabledState }
             .distinctUntilChanged()
             .setupCommonEventHandlers(TAG) { "Device monitor" }
-            .onEach { needsService ->
-                if (needsService) {
-                    log(TAG) { "Connected device needs persistent session, starting monitor service" }
-                    startMonitor()
+            .onEach { (needsService, enabledState) ->
+                // A toggle epoch change means any running session is tearing itself down
+                // (orchestrator's enabled watcher). A plain start in that window would be
+                // swallowed by onStartCommand and then killed by the old job's stopSelf,
+                // so re-enable starts must be replacement starts.
+                val epochChanged = lastToggleEpoch != null && lastToggleEpoch != enabledState.toggleEpoch
+                lastToggleEpoch = enabledState.toggleEpoch
+                try {
+                    when {
+                        !enabledState.isEnabled -> {
+                            log(TAG) { "App is disabled, stopping monitor service" }
+                            stopMonitor()
+                        }
+
+                        needsService -> {
+                            log(TAG) { "Active device needs persistent session, starting monitor service" }
+                            startMonitor(forceStart = epochChanged)
+                        }
+                    }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Device monitor action failed: ${e.message}" }
                 }
             }
             .launchIn(appScope)
     }
 
-    fun startMonitor(forceStart: Boolean = false) {
+    suspend fun startMonitor(forceStart: Boolean = false) {
         log(TAG, VERBOSE) { "startMonitor(forceStart=$forceStart)" }
+        if (!devicesSettings.currentEnabledState().isEnabled) {
+            log(TAG, WARN) { "startMonitor: App is disabled, ignoring start request." }
+            return
+        }
         try {
             context.startServiceCompat(MonitorService.intent(context, forceStart))
             log(TAG) { "Monitor start request sent." }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestrator.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestrator.kt
@@ -11,6 +11,7 @@ import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.flow.setupCommonEventHandlers
 import eu.darken.bluemusic.common.flow.throttleLatest
 import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.devices.core.ManagedDevice
 import eu.darken.bluemusic.devices.core.currentDevices
 import eu.darken.bluemusic.monitor.core.audio.RingerModeObserver
@@ -22,10 +23,12 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.take
 import java.time.Duration
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -34,6 +37,7 @@ import javax.inject.Singleton
 class MonitorOrchestrator @Inject constructor(
     private val bluetoothRepo: BluetoothRepo,
     private val deviceRepo: DeviceRepo,
+    private val devicesSettings: DevicesSettings,
     private val volumeObserver: VolumeObserver,
     private val ringerModeObserver: RingerModeObserver,
     private val bluetoothEventQueue: BluetoothEventQueue,
@@ -56,6 +60,13 @@ class MonitorOrchestrator @Inject constructor(
         scope: CoroutineScope,
         onActiveDevicesChanged: suspend (List<ManagedDevice>) -> Unit,
     ) {
+        val startEnabledState = devicesSettings.currentEnabledState()
+        if (!startEnabledState.isEnabled) {
+            log(TAG, WARN) { "Aborting, app is disabled: $startEnabledState" }
+            bluetoothEventQueue.clear()
+            return
+        }
+
         val bluetoothState = bluetoothRepo.currentState()
         if (!bluetoothState.isReady) {
             log(TAG, WARN) { "Aborting, Bluetooth state is not ready: $bluetoothState" }
@@ -71,6 +82,19 @@ class MonitorOrchestrator @Inject constructor(
 
         val monitorJob = Job(scope.coroutineContext[Job])
         val monitorScope = CoroutineScope(scope.coroutineContext + monitorJob)
+
+        devicesSettings.enabledState
+            .setupCommonEventHandlers(TAG) { "Enabled monitor" }
+            .filter { !it.isEnabled || it.toggleEpoch != startEnabledState.toggleEpoch }
+            .take(1)
+            .onEach { state ->
+                log(TAG, WARN) { "App was disabled or toggled ($startEnabledState -> $state), stopping monitor." }
+                eventDispatcher.cancelAllJobs()
+                bluetoothEventQueue.clear()
+                monitorJob.cancel()
+            }
+            .catch { log(TAG, WARN) { "Enabled monitor flow failed:\n${it.asLog()}" } }
+            .launchIn(monitorScope)
 
         ringerModeObserver.ringerMode
             .setupCommonEventHandlers(TAG) { "RingerMode monitor" }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorService.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorService.kt
@@ -20,6 +20,7 @@ import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.hasApiLevel
 import eu.darken.bluemusic.devices.core.ManagedDevice
 import eu.darken.bluemusic.common.ui.Service2
+import eu.darken.bluemusic.monitor.core.WakeLockManager
 import eu.darken.bluemusic.monitor.core.ownership.AudioStreamOwnerRegistry
 import eu.darken.bluemusic.monitor.ui.MonitorNotifications
 import kotlinx.coroutines.CancellationException
@@ -40,6 +41,7 @@ class MonitorService : Service2() {
     @Inject lateinit var orchestrator: MonitorOrchestrator
     @Inject lateinit var eventDispatcher: EventDispatcher
     @Inject lateinit var ownerRegistry: AudioStreamOwnerRegistry
+    @Inject lateinit var wakeLockManager: WakeLockManager
 
     private val serviceScope by lazy {
         CoroutineScope(SupervisorJob() + dispatcherProvider.IO)
@@ -138,6 +140,7 @@ class MonitorService : Service2() {
         }
         if (injectionComplete) {
             eventDispatcher.cancelAllJobs()
+            wakeLockManager.releaseBlocking()
             ownerRegistry.resetBlocking()
             serviceScope.cancel("Service destroyed")
         } else {

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/BluetoothEventQueueTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/BluetoothEventQueueTest.kt
@@ -1,0 +1,51 @@
+package eu.darken.bluemusic.monitor.core.service
+
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class BluetoothEventQueueTest : BaseTest() {
+
+    private fun event(sequence: Long) = BluetoothEventQueue.Event(
+        type = BluetoothEventQueue.Event.Type.CONNECTED,
+        sourceDevice = mockk<SourceDevice> {
+            every { address } returns "AA:BB:CC:DD:EE:FF"
+        },
+        receivedAtElapsedMs = sequence * 1000L,
+        sequence = sequence,
+    )
+
+    @Test
+    fun `clear drops all queued events`() = runTest {
+        val queue = BluetoothEventQueue()
+        queue.submit(event(0))
+        queue.submit(event(1))
+        queue.submit(event(2))
+
+        queue.clear()
+
+        val received = mutableListOf<BluetoothEventQueue.Event>()
+        val collector = launch { received.add(queue.events.first()) }
+        advanceTimeBy(5_000)
+        collector.isActive shouldBe true // nothing to receive, collector still suspended
+        received shouldBe emptyList()
+        collector.cancel()
+    }
+
+    @Test
+    fun `events submitted after clear are still delivered`() = runTest {
+        val queue = BluetoothEventQueue()
+        queue.submit(event(0))
+        queue.clear()
+        queue.submit(event(1))
+
+        queue.events.first().sequence shouldBe 1L
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/EventDispatcherTest.kt
@@ -153,6 +153,21 @@ class EventDispatcherTest : BaseTest() {
     }
 
     @Test
+    fun `event is dropped while app is disabled`() = runTest {
+        currentEnabledState = DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
+        val buds = managedDevice(budsAddress, connected = true)
+        devicesFlow.value = listOf(buds)
+        val dispatcher = createDispatcher()
+
+        dispatcher.dispatch(event(budsAddress, CONNECTED))
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { module1.handle(any()) }
+        coVerify(exactly = 0) { module2.handle(any()) }
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+    }
+
+    @Test
     fun `fresh event is dispatched to all modules`() = runTest {
         val buds = managedDevice(budsAddress, connected = true)
         devicesFlow.value = listOf(buds)

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorControlTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorControlTest.kt
@@ -4,9 +4,11 @@ import android.content.Context
 import android.content.Intent
 import eu.darken.bluemusic.common.startServiceCompat
 import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.devices.core.ManagedDevice
 import eu.darken.bluemusic.monitor.ui.MonitorNotifications
 import io.mockk.Runs
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -28,8 +30,10 @@ class MonitorControlTest : BaseTest() {
 
     private lateinit var context: Context
     private lateinit var deviceRepo: DeviceRepo
+    private lateinit var devicesSettings: DevicesSettings
     private lateinit var monitorNotifications: MonitorNotifications
     private lateinit var devicesFlow: MutableStateFlow<List<ManagedDevice>>
+    private lateinit var enabledFlow: MutableStateFlow<DevicesSettings.EnabledState>
     private lateinit var fakeIntent: Intent
 
     @BeforeEach
@@ -39,6 +43,11 @@ class MonitorControlTest : BaseTest() {
         devicesFlow = MutableStateFlow(emptyList())
         deviceRepo = mockk(relaxed = true) {
             every { devices } returns devicesFlow
+        }
+        enabledFlow = MutableStateFlow(DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 0L))
+        devicesSettings = mockk {
+            every { enabledState } returns enabledFlow
+            coEvery { currentEnabledState() } answers { enabledFlow.value }
         }
 
         fakeIntent = mockk(relaxed = true)
@@ -59,71 +68,104 @@ class MonitorControlTest : BaseTest() {
     }
 
     private fun device(
-        connected: Boolean,
+        active: Boolean,
         requiresPersistentSession: Boolean,
     ): ManagedDevice = mockk(relaxed = true) {
-        every { isConnected } returns connected
+        every { isActive } returns active
         every { this@mockk.requiresPersistentSession } returns requiresPersistentSession
     }
 
-    @Test
-    fun `connected device with requiresPersistentSession triggers service start`() = runTest(UnconfinedTestDispatcher()) {
-        MonitorControl(
-            appScope = backgroundScope,
-            context = context,
-            deviceRepo = deviceRepo,
-            monitorNotifications = monitorNotifications,
-        )
+    private fun runTestWithControl(testBody: suspend kotlinx.coroutines.test.TestScope.() -> Unit) =
+        runTest(UnconfinedTestDispatcher()) {
+            MonitorControl(
+                appScope = backgroundScope,
+                context = context,
+                deviceRepo = deviceRepo,
+                devicesSettings = devicesSettings,
+                monitorNotifications = monitorNotifications,
+            )
+            testBody()
+        }
 
-        devicesFlow.value = listOf(device(connected = true, requiresPersistentSession = true))
+    @Test
+    fun `active device with requiresPersistentSession triggers service start`() = runTestWithControl {
+        devicesFlow.value = listOf(device(active = true, requiresPersistentSession = true))
 
         verify(atLeast = 1) { context.startServiceCompat(fakeIntent) }
     }
 
     @Test
-    fun `disconnected device does NOT trigger service start`() = runTest(UnconfinedTestDispatcher()) {
-        MonitorControl(
-            appScope = backgroundScope,
-            context = context,
-            deviceRepo = deviceRepo,
-            monitorNotifications = monitorNotifications,
-        )
-
-        devicesFlow.value = listOf(device(connected = false, requiresPersistentSession = true))
+    fun `inactive device does NOT trigger service start`() = runTestWithControl {
+        devicesFlow.value = listOf(device(active = false, requiresPersistentSession = true))
 
         verify(exactly = 0) { context.startServiceCompat(any()) }
     }
 
     @Test
-    fun `connected device without requiresPersistentSession does NOT trigger service start`() = runTest(UnconfinedTestDispatcher()) {
-        MonitorControl(
-            appScope = backgroundScope,
-            context = context,
-            deviceRepo = deviceRepo,
-            monitorNotifications = monitorNotifications,
-        )
-
-        devicesFlow.value = listOf(device(connected = true, requiresPersistentSession = false))
+    fun `active device without requiresPersistentSession does NOT trigger service start`() = runTestWithControl {
+        devicesFlow.value = listOf(device(active = true, requiresPersistentSession = false))
 
         verify(exactly = 0) { context.startServiceCompat(any()) }
     }
 
     @Test
-    fun `flipping requiresPersistentSession true on connected device triggers service start`() = runTest(UnconfinedTestDispatcher()) {
-        MonitorControl(
-            appScope = backgroundScope,
-            context = context,
-            deviceRepo = deviceRepo,
-            monitorNotifications = monitorNotifications,
-        )
-
-        // First emission: connected but no persistent session
-        devicesFlow.value = listOf(device(connected = true, requiresPersistentSession = false))
+    fun `flipping requiresPersistentSession true on active device triggers service start`() = runTestWithControl {
+        // First emission: active but no persistent session
+        devicesFlow.value = listOf(device(active = true, requiresPersistentSession = false))
         verify(exactly = 0) { context.startServiceCompat(any()) }
 
         // Second emission: same connection state, now needs persistent session (e.g. user toggled keepAwake)
-        devicesFlow.value = listOf(device(connected = true, requiresPersistentSession = true))
+        devicesFlow.value = listOf(device(active = true, requiresPersistentSession = true))
 
         verify(atLeast = 1) { context.startServiceCompat(fakeIntent) }
+    }
+
+    @Test
+    fun `persistent device while app disabled does NOT trigger service start`() = runTestWithControl {
+        enabledFlow.value = DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
+
+        devicesFlow.value = listOf(device(active = true, requiresPersistentSession = true))
+
+        verify(exactly = 0) { context.startServiceCompat(any()) }
+    }
+
+    @Test
+    fun `disabling the app stops the service`() = runTestWithControl {
+        devicesFlow.value = listOf(device(active = true, requiresPersistentSession = true))
+        verify(atLeast = 1) { context.startServiceCompat(fakeIntent) }
+
+        enabledFlow.value = DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
+
+        verify(atLeast = 1) { context.stopService(fakeIntent) }
+    }
+
+    @Test
+    fun `re-enabling with persistent device connected restarts the service`() = runTestWithControl {
+        enabledFlow.value = DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
+        devicesFlow.value = listOf(device(active = true, requiresPersistentSession = true))
+        verify(exactly = 0) { context.startServiceCompat(any()) }
+
+        enabledFlow.value = DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 2L)
+
+        verify(atLeast = 1) { context.startServiceCompat(fakeIntent) }
+        // Re-enable must be a replacement start: a plain start in the teardown window of the
+        // previous session would be ignored by onStartCommand and killed by its stopSelf.
+        verify(atLeast = 1) { MonitorService.intent(any(), true) }
+    }
+
+    @Test
+    fun `startMonitor is a no-op while app is disabled`() = runTest(UnconfinedTestDispatcher()) {
+        enabledFlow.value = DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
+        val control = MonitorControl(
+            appScope = backgroundScope,
+            context = context,
+            deviceRepo = deviceRepo,
+            devicesSettings = devicesSettings,
+            monitorNotifications = monitorNotifications,
+        )
+
+        control.startMonitor(forceStart = true)
+
+        verify(exactly = 0) { context.startServiceCompat(any()) }
     }
 }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestratorTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorOrchestratorTest.kt
@@ -2,6 +2,7 @@ package eu.darken.bluemusic.monitor.core.service
 
 import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
 import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.devices.core.ManagedDevice
 import eu.darken.bluemusic.monitor.core.audio.RingerModeEvent
 import eu.darken.bluemusic.monitor.core.audio.RingerModeObserver
@@ -9,10 +10,13 @@ import eu.darken.bluemusic.monitor.core.audio.VolumeEvent
 import eu.darken.bluemusic.monitor.core.audio.VolumeObserver
 import eu.darken.bluemusic.monitor.core.ownership.AudioStreamOwnerRegistry
 import io.kotest.matchers.shouldBe
+import io.mockk.Runs
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.filter
@@ -39,8 +43,10 @@ class MonitorOrchestratorTest : BaseTest() {
     private lateinit var ownerRegistry: AudioStreamOwnerRegistry
     private lateinit var volumeEventDispatcher: VolumeEventDispatcher
 
+    private lateinit var devicesSettings: DevicesSettings
     private lateinit var devicesFlow: MutableStateFlow<List<ManagedDevice>>
     private lateinit var stateFlow: MutableStateFlow<BluetoothRepo.State>
+    private lateinit var enabledFlow: MutableStateFlow<DevicesSettings.EnabledState>
     private lateinit var idleFlow: MutableStateFlow<Boolean>
     private lateinit var workGen: AtomicLong
 
@@ -51,6 +57,12 @@ class MonitorOrchestratorTest : BaseTest() {
         )
         bluetoothRepo = mockk { every { state } returns stateFlow }
 
+        enabledFlow = MutableStateFlow(DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 0L))
+        devicesSettings = mockk {
+            every { enabledState } returns enabledFlow
+            coEvery { currentEnabledState() } answers { enabledFlow.value }
+        }
+
         devicesFlow = MutableStateFlow(emptyList())
         deviceRepo = mockk(relaxed = true) {
             every { devices } returns devicesFlow
@@ -58,7 +70,10 @@ class MonitorOrchestratorTest : BaseTest() {
 
         volumeObserver = mockk { every { volumes } returns MutableSharedFlow() }
         ringerModeObserver = mockk { every { ringerMode } returns MutableSharedFlow() }
-        bluetoothEventQueue = mockk { every { events } returns MutableSharedFlow() }
+        bluetoothEventQueue = mockk {
+            every { events } returns MutableSharedFlow()
+            every { clear() } just Runs
+        }
         idleFlow = MutableStateFlow(true)
         workGen = AtomicLong(0)
         eventDispatcher = mockk(relaxed = true) {
@@ -74,6 +89,7 @@ class MonitorOrchestratorTest : BaseTest() {
     private fun createOrchestrator() = MonitorOrchestrator(
         bluetoothRepo = bluetoothRepo,
         deviceRepo = deviceRepo,
+        devicesSettings = devicesSettings,
         volumeObserver = volumeObserver,
         ringerModeObserver = ringerModeObserver,
         bluetoothEventQueue = bluetoothEventQueue,
@@ -340,6 +356,76 @@ class MonitorOrchestratorTest : BaseTest() {
 
         // Initial callback + at least one update
         (callbackInvocations.size >= 2) shouldBe true
+
+        job.cancel()
+    }
+
+    // --- App enabled gating ---
+
+    @Test
+    fun `disabled at start - returns immediately and clears queued events`() = runTest {
+        enabledFlow.value = DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
+        val device = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresPersistentSession = true)
+        devicesFlow.value = listOf(device)
+
+        val callbackInvocations = mutableListOf<List<ManagedDevice>>()
+        val orchestrator = createOrchestrator()
+
+        orchestrator.monitor(this) { callbackInvocations.add(it) }
+        advanceUntilIdle()
+
+        callbackInvocations shouldBe emptyList()
+        coVerify(exactly = 0) { ownerRegistry.reset() }
+        verify(exactly = 1) { bluetoothEventQueue.clear() }
+    }
+
+    @Test
+    fun `disabling mid-monitoring stops even with persistent session device`() = runTest {
+        val device = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresPersistentSession = true)
+        devicesFlow.value = listOf(device)
+
+        val orchestrator = createOrchestrator()
+        var monitorReturned = false
+
+        val job = launch {
+            orchestrator.monitor(this@runTest) {}
+            monitorReturned = true
+        }
+
+        advanceTimeBy(30_000)
+        monitorReturned shouldBe false
+
+        enabledFlow.value = DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
+        advanceUntilIdle()
+
+        monitorReturned shouldBe true
+        verify(atLeast = 1) { eventDispatcher.cancelAllJobs() }
+        verify(atLeast = 1) { bluetoothEventQueue.clear() }
+
+        job.cancel()
+    }
+
+    @Test
+    fun `collapsed toggle cycle (epoch change while enabled) stops the session`() = runTest {
+        val device = managedDevice("AA:BB:CC:DD:EE:FF", active = true, requiresPersistentSession = true)
+        devicesFlow.value = listOf(device)
+
+        val orchestrator = createOrchestrator()
+        var monitorReturned = false
+
+        val job = launch {
+            orchestrator.monitor(this@runTest) {}
+            monitorReturned = true
+        }
+
+        advanceTimeBy(5_000)
+        monitorReturned shouldBe false
+
+        // e.g. backup restore flips enabled off and on; observer only sees the final true
+        enabledFlow.value = DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 2L)
+        advanceUntilIdle()
+
+        monitorReturned shouldBe true
 
         job.cancel()
     }


### PR DESCRIPTION
Disabling the app in the device settings only stopped new Bluetooth connection events from being handled — an already running monitor service kept working: volume lock kept reverting manual volume changes, volume observation kept overwriting saved device volumes, and the service would even restart itself while disabled.

- Tearing down the monitor session when the app is disabled (or the toggle flips while it runs), including in-flight actions and queued Bluetooth events
- The monitor service now only starts while the app is enabled, and stops centrally on disable; re-enabling with a connected device restarts it
- Bluetooth events that slip in while disabled are dropped before they touch any state
- The keep-awake wakelock is released when the service stops, instead of lingering for up to 4 hours
- New regression tests for the disable/enable lifecycle
