### PR TITLE
Fix DND "Off" switching Do Not Disturb on instead of off on Android 15+

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
@@ -308,7 +308,12 @@ fun DeviceConfigScreenHost(
 private fun getDndModeDescription(mode: DndMode?): String {
     return when (mode) {
         null -> stringResource(R.string.dnd_mode_dont_change)
-        DndMode.OFF -> stringResource(R.string.dnd_mode_off)
+        // A stale OFF can't turn DND off on API 35+ (discussion #230); present it as "Don't change".
+        DndMode.OFF -> if (DndMode.canTurnDndOff()) {
+            stringResource(R.string.dnd_mode_off)
+        } else {
+            stringResource(R.string.dnd_mode_dont_change)
+        }
         DndMode.PRIORITY_ONLY -> stringResource(R.string.dnd_mode_priority_only)
         DndMode.ALARMS_ONLY -> stringResource(R.string.dnd_mode_alarms_only)
         DndMode.TOTAL_SILENCE -> stringResource(R.string.dnd_mode_total_silence)

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/dialogs/DndModeDialog.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/dialogs/DndModeDialog.kt
@@ -30,15 +30,20 @@ fun DndModeDialog(
     onConfirm: (DndMode?) -> Unit,
     onDismiss: () -> Unit
 ) {
-    val dndModes = listOf(
-        null to stringResource(R.string.dnd_mode_dont_change),
-        DndMode.OFF to stringResource(R.string.dnd_mode_off),
-        DndMode.PRIORITY_ONLY to stringResource(R.string.dnd_mode_priority_only),
-        DndMode.ALARMS_ONLY to stringResource(R.string.dnd_mode_alarms_only),
-        DndMode.TOTAL_SILENCE to stringResource(R.string.dnd_mode_total_silence)
-    )
+    // On Android 15+ apps can't turn DND off (see DndMode.canTurnDndOff / discussion #230), so
+    // hide the "Off" option and treat any stale saved OFF as "Don't change" — re-saving then
+    // self-heals the obsolete config.
+    val canTurnOff = DndMode.canTurnDndOff()
+    val effectiveCurrent = if (currentMode == DndMode.OFF && !canTurnOff) null else currentMode
+    val dndModes = buildList {
+        add(null to stringResource(R.string.dnd_mode_dont_change))
+        if (canTurnOff) add(DndMode.OFF to stringResource(R.string.dnd_mode_off))
+        add(DndMode.PRIORITY_ONLY to stringResource(R.string.dnd_mode_priority_only))
+        add(DndMode.ALARMS_ONLY to stringResource(R.string.dnd_mode_alarms_only))
+        add(DndMode.TOTAL_SILENCE to stringResource(R.string.dnd_mode_total_silence))
+    }
 
-    var selectedMode by remember { mutableStateOf(currentMode) }
+    var selectedMode by remember { mutableStateOf(effectiveCurrent) }
 
     AlertDialog(
         onDismissRequest = onDismiss,

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/DndMode.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/DndMode.kt
@@ -3,6 +3,7 @@ package eu.darken.bluemusic.monitor.core.audio
 import android.app.NotificationManager
 import android.os.Build
 import androidx.annotation.RequiresApi
+import eu.darken.bluemusic.common.hasApiLevel
 
 enum class DndMode(val key: String) {
     OFF("off"),
@@ -36,5 +37,16 @@ enum class DndMode(val key: String) {
             "total_silence" -> TOTAL_SILENCE
             else -> null
         }
+
+        /**
+         * Apps targeting Android 15+ (API 35) can no longer turn DND off via
+         * [NotificationManager.setInterruptionFilter]. Legacy calls now toggle an app-owned
+         * implicit AutomaticZenRule instead of clearing global DND, so requesting [OFF] can't
+         * reliably turn DND off and may even surface as DND turning on. See discussion #230.
+         *
+         * Gated on the runtime SDK because devices below API 35 keep the legacy behavior
+         * regardless of the app's target.
+         */
+        fun canTurnDndOff(): Boolean = !hasApiLevel(Build.VERSION_CODES.VANILLA_ICE_CREAM)
     }
 }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/DndTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/DndTool.kt
@@ -17,13 +17,6 @@ class DndTool @Inject constructor(
     private val notificationManager: NotificationManager,
 ) {
     @SuppressLint("NewApi")
-    fun getCurrentDndMode(): DndMode = if (hasApiLevel(Build.VERSION_CODES.M)) {
-        DndMode.fromInterruptionFilter(notificationManager.currentInterruptionFilter)
-    } else {
-        DndMode.OFF
-    }
-
-    @SuppressLint("NewApi")
     fun setDndMode(mode: DndMode): Boolean {
         if (!hasApiLevel(Build.VERSION_CODES.M)) {
             log(TAG, WARN) { "DND mode requires API 23+" }
@@ -35,17 +28,23 @@ class DndTool @Inject constructor(
             return false
         }
 
-        log(TAG, VERBOSE) { "setDndMode(mode=$mode)" }
+        val rawFilter = notificationManager.currentInterruptionFilter
+        val currentMode = DndMode.fromInterruptionFilter(rawFilter)
+        log(TAG, VERBOSE) { "setDndMode(mode=$mode, currentMode=$currentMode, rawFilter=$rawFilter, sdk=${Build.VERSION.SDK_INT})" }
 
-        val currentMode = getCurrentDndMode()
+        if (mode == DndMode.OFF && !DndMode.canTurnDndOff()) {
+            log(TAG, WARN) { "Ignoring DndMode.OFF: apps can't turn DND off on API ${Build.VERSION.SDK_INT} (discussion #230). currentMode=$currentMode rawFilter=$rawFilter" }
+            return false
+        }
+
         if (currentMode == mode) {
-            log(TAG, VERBOSE) { "DND mode already set to $mode" }
+            log(TAG, VERBOSE) { "DND mode already set to $mode (rawFilter=$rawFilter)" }
             return false
         }
 
         return try {
             notificationManager.setInterruptionFilter(mode.toInterruptionFilter())
-            log(TAG, DEBUG) { "Changed DND mode from $currentMode to $mode" }
+            log(TAG, DEBUG) { "Changed DND mode from $currentMode to $mode (rawFilter was $rawFilter)" }
             true
         } catch (e: Exception) {
             log(TAG, WARN) { "Failed to set DND mode: ${e.message}" }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/DndModeModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/DndModeModule.kt
@@ -10,6 +10,7 @@ import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.hasApiLevel
 import eu.darken.bluemusic.common.permissions.PermissionHelper
+import eu.darken.bluemusic.monitor.core.audio.DndMode
 import eu.darken.bluemusic.monitor.core.audio.DndTool
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
 import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
@@ -31,6 +32,9 @@ class DndModeModule @Inject constructor(
         event is DeviceEvent.Connected
             && hasApiLevel(Build.VERSION_CODES.M)
             && event.device.dndMode != null
+            // OFF can't turn DND off on API 35+ (discussion #230); skip it here so a stale
+            // OFF config doesn't make the dispatcher pay the settle barrier for a no-op.
+            && !(event.device.dndMode == DndMode.OFF && !DndMode.canTurnDndOff())
             // Include the DND-permission check so the dispatcher doesn't pay the settle
             // barrier for users with dndMode configured but the permission revoked. The
             // check is a sync Android NotificationManager query — safe in appliesTo.

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/DndModeTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/DndModeTest.kt
@@ -1,10 +1,40 @@
 package eu.darken.bluemusic.monitor.core.audio
 
+import eu.darken.bluemusic.common.BuildWrap
 import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
 class DndModeTest : BaseTest() {
+
+    @AfterEach
+    fun teardown() {
+        unmockkObject(BuildWrap.VERSION)
+    }
+
+    private fun fakeSdk(level: Int) {
+        mockkObject(BuildWrap.VERSION)
+        every { BuildWrap.VERSION.SDK_INT } returns level
+        every { BuildWrap.VERSION.CODENAME } returns "REL"
+    }
+
+    @Test
+    fun `canTurnDndOff is true below API 35`() {
+        fakeSdk(34)
+        DndMode.canTurnDndOff() shouldBe true
+    }
+
+    @Test
+    fun `canTurnDndOff is false on API 35+`() {
+        fakeSdk(35)
+        DndMode.canTurnDndOff() shouldBe false
+        fakeSdk(36)
+        DndMode.canTurnDndOff() shouldBe false
+    }
 
     @Test
     fun `fromKey returns correct mode for each key`() {

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/DndToolTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/DndToolTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.bluemusic.monitor.core.audio
+
+import android.app.NotificationManager
+import eu.darken.bluemusic.common.BuildWrap
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class DndToolTest : BaseTest() {
+
+    private lateinit var notificationManager: NotificationManager
+
+    @BeforeEach
+    fun setup() {
+        notificationManager = mockk(relaxed = true)
+        every { notificationManager.isNotificationPolicyAccessGranted } returns true
+        // DND is currently off (all interruptions allowed).
+        every { notificationManager.currentInterruptionFilter } returns NotificationManager.INTERRUPTION_FILTER_ALL
+        mockkObject(BuildWrap.VERSION)
+        every { BuildWrap.VERSION.CODENAME } returns "REL"
+    }
+
+    @AfterEach
+    fun teardown() {
+        unmockkObject(BuildWrap.VERSION)
+    }
+
+    private fun tool() = DndTool(notificationManager)
+
+    @Test
+    fun `setDndMode OFF on API 35+ is a no-op`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 35
+        // Pretend DND is currently on so only the OFF-guard could suppress the call.
+        every { notificationManager.currentInterruptionFilter } returns NotificationManager.INTERRUPTION_FILTER_PRIORITY
+
+        tool().setDndMode(DndMode.OFF) shouldBe false
+        verify(exactly = 0) { notificationManager.setInterruptionFilter(any()) }
+    }
+
+    @Test
+    fun `setDndMode OFF below API 35 turns DND off`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 30
+        every { notificationManager.currentInterruptionFilter } returns NotificationManager.INTERRUPTION_FILTER_PRIORITY
+
+        tool().setDndMode(DndMode.OFF) shouldBe true
+        verify(exactly = 1) { notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL) }
+    }
+
+    @Test
+    fun `setDndMode PRIORITY on API 35+ still applies`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 35
+
+        tool().setDndMode(DndMode.PRIORITY_ONLY) shouldBe true
+        verify(exactly = 1) { notificationManager.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_PRIORITY) }
+    }
+
+    @Test
+    fun `setDndMode skips when already in desired mode`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 35
+        every { notificationManager.currentInterruptionFilter } returns NotificationManager.INTERRUPTION_FILTER_PRIORITY
+
+        tool().setDndMode(DndMode.PRIORITY_ONLY) shouldBe false
+        verify(exactly = 0) { notificationManager.setInterruptionFilter(any()) }
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/connection/DndModeModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/connection/DndModeModuleTest.kt
@@ -91,6 +91,27 @@ class DndModeModuleTest : BaseTest() {
     }
 
     @Test
+    fun `appliesTo OFF below API 35 is true`() {
+        // OFF still works via the legacy setInterruptionFilter path before Android 15.
+        every { BuildWrap.VERSION.SDK_INT } returns 30
+        module().appliesTo(DeviceEvent.Connected(device(dndMode = DndMode.OFF))) shouldBe true
+    }
+
+    @Test
+    fun `appliesTo OFF on API 35+ is false`() {
+        // Apps can't turn DND off on Android 15+ (discussion #230); a stale OFF config must
+        // not drag the dispatcher through the settle barrier for a guaranteed no-op.
+        every { BuildWrap.VERSION.SDK_INT } returns 35
+        module().appliesTo(DeviceEvent.Connected(device(dndMode = DndMode.OFF))) shouldBe false
+    }
+
+    @Test
+    fun `appliesTo non-OFF mode on API 35+ is still true`() {
+        every { BuildWrap.VERSION.SDK_INT } returns 35
+        module().appliesTo(DeviceEvent.Connected(device(dndMode = DndMode.PRIORITY_ONLY))) shouldBe true
+    }
+
+    @Test
     fun `handle sets DND mode when applicable`() = runTest(UnconfinedTestDispatcher()) {
         every { permissionHelper.hasNotificationPolicyAccess() } returns true
         module().handle(DeviceEvent.Connected(device(dndMode = DndMode.PRIORITY_ONLY)))


### PR DESCRIPTION
On Android 15+ apps can no longer turn Do Not Disturb off — the system API BlueMusic used now creates an app-owned "mode" instead of clearing DND, so a device profile's **DND → Off** option ended up switching DND *on*.

- Make "Off" a no-op on Android 15+ (it can't work there) and hide it from the DND picker
- Treat and display any existing "Off" config as "Don't change"; re-saving cleans up the old value
- Keep "Don't change" and the "turn DND on" modes (Priority / Alarms / Total silence) working
- Read the interruption filter once and log it (raw filter + mode + SDK) for future diagnosis

Reported in discussion #230.
