### PR TITLE
Port Google Play billing restore, grace and buy-flow fixes from SD Maid SE

### DIFF
--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/BillingCache.kt
@@ -21,4 +21,16 @@ class BillingCache @Inject constructor(
 
     val lastProStateAt = dataStore.createValue("gplay.cache.lastProAt", 0L)
     val lastProStateSku = dataStore.createValue("gplay.cache.lastProSku", "")
+
+    // Both values describe one fact — "when were we last Pro, and via which SKU" — so they are
+    // written in a single DataStore transaction: a process death can't leave a fresh timestamp
+    // paired with a stale SKU (which would select the wrong grace window).
+    suspend fun stampLastProState(skuId: String, at: Long) {
+        dataStore.updateData { prefs ->
+            prefs.toMutablePreferences().apply {
+                lastProStateSku.setIn(this, skuId)
+                lastProStateAt.setIn(this, at)
+            }.toPreferences()
+        }
+    }
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -90,6 +90,10 @@ class UpgradeRepoGplay @Inject constructor(
         .setupCommonEventHandlers(TAG) { "upgradeInfo2" }
         .shareIn(scope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
+    // True once we've ever confirmed a (known) Pro purchase on this install; drives the proactive
+    // restore banner. Local signal only — a fresh install or switched Google account starts false.
+    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow.map { it > 0 }
+
     suspend fun launchBillingFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
         log(TAG) { "launchBillingFlow($activity,$sku)" }
         val resultChannel = Channel<Result<Unit>>()

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -53,7 +53,7 @@ class UpgradeRepoGplay @Inject constructor(
             val now = System.currentTimeMillis()
             val lastProStateAt = billingCache.lastProStateAt.value()
             log(TAG) { "Catch: now=$now, lastProStateAt=$lastProStateAt, attempt=$attempt, error=$error" }
-            if ((now - lastProStateAt) < GRACE_PERIOD_MS) {
+            if ((now - lastProStateAt) < graceWindowMs()) {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, and just got an error, what is GPlay doing???" }
                 emit(Info(gracePeriod = true, billingData = null))
             } else {
@@ -112,7 +112,7 @@ class UpgradeRepoGplay @Inject constructor(
             // keeps us Pro via the grace period; otherwise surface the error so the caller can show
             // the proper "Play unavailable" message instead of a generic restore failure.
             val lastProStateAt = billingCache.lastProStateAt.value()
-            if ((System.currentTimeMillis() - lastProStateAt) < GRACE_PERIOD_MS) {
+            if ((System.currentTimeMillis() - lastProStateAt) < graceWindowMs()) {
                 log(TAG, VERBOSE) { "restore hit a Play error but we were Pro recently -> grace" }
                 Info(gracePeriod = true, billingData = null)
             } else {
@@ -129,18 +129,33 @@ class UpgradeRepoGplay @Inject constructor(
         log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
         return when {
             this?.purchases?.isNotEmpty() == true -> {
-                // If we are pro refresh timestamp
-                billingCache.lastProStateAt.value(now)
-                Info(billingData = this)
+                val info = Info(billingData = this)
+                // Only a *known* Pro SKU counts as "last Pro state" — an unrecognized purchase must
+                // not refresh the grace timestamp. Prefer the permanent IAP so it drives the window.
+                preferredProSku(info.upgrades)?.let { sku ->
+                    billingCache.lastProStateAt.value(now)
+                    billingCache.lastProStateSku.value(sku.id)
+                }
+                info
             }
 
-            (now - lastProStateAt) < GRACE_PERIOD_MS -> {
+            (now - lastProStateAt) < graceWindowMs() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
                 Info(gracePeriod = true, billingData = null)
             }
 
             else -> Info(billingData = this)
         }
+    }
+
+    // Grace window depends on what was last owned: a permanent one-time purchase gets a long window,
+    // a subscription (or an unknown/legacy last SKU) gets the short default.
+    private suspend fun graceWindowMs(): Long {
+        val lastSku = billingCache.lastProStateSku.value()
+        val type = OurSku.PRO_SKUS.singleOrNull { it.id == lastSku }?.type
+        val window = if (type == Sku.Type.IAP) GRACE_PERIOD_IAP_MS else GRACE_PERIOD_MS
+        log(TAG) { "graceWindowMs(): lastSku=$lastSku, type=$type -> ${window}ms" }
+        return window
     }
 
     data class Info(
@@ -178,9 +193,19 @@ class UpgradeRepoGplay @Inject constructor(
     companion object {
         private const val SITE = "https://play.google.com/store/apps/details?id=eu.darken.bluemusic"
 
-        // Keep paying users Pro through transient empty/failed Play Billing responses.
+        // Keep paying users Pro through transient empty/failed Play Billing responses. A permanent
+        // one-time purchase should almost never be dropped on a hiccup, so it gets a long window; a
+        // subscription legitimately lapses, so it keeps the short one. GRACE_PERIOD_MS is the
+        // subscription/default window (also used when the last-owned SKU is unknown/legacy).
         val GRACE_PERIOD_MS = Duration.ofDays(7).toMillis()
+        val GRACE_PERIOD_IAP_MS = Duration.ofDays(30).toMillis()
 
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
+
+        // The SKU whose grace window applies when several are owned: the permanent one-time purchase
+        // wins over a subscription (purchases are time-sorted, so firstOrNull alone isn't enough).
+        // null when no known Pro SKU is owned.
+        internal fun preferredProSku(upgrades: Collection<PurchasedSku>): Sku? =
+            upgrades.firstOrNull { it.sku.type == Sku.Type.IAP }?.sku ?: upgrades.firstOrNull()?.sku
     }
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -32,6 +32,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Duration
@@ -116,11 +117,13 @@ class UpgradeRepoGplay @Inject constructor(
     // restore banner. Local signal only — a fresh install or switched Google account starts false.
     val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow.map { it > 0 }
 
-    private val autoRestoring = MutableStateFlow(false)
+    // Counter, not a flag: overlapping already-owned recoveries (buy taps racing the UI disable)
+    // must keep the busy signal up until the LAST one finishes.
+    private val autoRestoring = MutableStateFlow(0)
 
     // The already-owned auto-restore below runs invisibly on AppScope; expose its busy state so the
     // UI can pause entitlement actions instead of racing it with a manual restore or another buy.
-    val autoRestoreBusy: Flow<Boolean> = autoRestoring
+    val autoRestoreBusy: Flow<Boolean> = autoRestoring.map { it > 0 }
 
     fun launchBillingFlow(
         activity: Activity,
@@ -144,7 +147,7 @@ class UpgradeRepoGplay @Inject constructor(
                         // Stale local state: Play says they already own it, so tapping "buy" really
                         // means "unlock what I own" — restore instead of showing an error.
                         log(TAG, INFO) { "Launch says already owned -> restoring purchase" }
-                        autoRestoring.value = true
+                        autoRestoring.update { it + 1 }
                         val restored = try {
                             withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow() }
                         } catch (re: CancellationException) {
@@ -153,7 +156,7 @@ class UpgradeRepoGplay @Inject constructor(
                             log(TAG, WARN) { "Restore after already-owned failed: ${re.asLog()}" }
                             null
                         } finally {
-                            autoRestoring.value = false
+                            autoRestoring.update { it - 1 }
                         }
                         if (restored?.isUpgraded != true) {
                             // Couldn't reconcile the entitlement (pending purchase, account mismatch,

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -23,6 +23,7 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
@@ -115,6 +116,12 @@ class UpgradeRepoGplay @Inject constructor(
     // restore banner. Local signal only — a fresh install or switched Google account starts false.
     val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow.map { it > 0 }
 
+    private val autoRestoring = MutableStateFlow(false)
+
+    // The already-owned auto-restore below runs invisibly on AppScope; expose its busy state so the
+    // UI can pause entitlement actions instead of racing it with a manual restore or another buy.
+    val autoRestoreBusy: Flow<Boolean> = autoRestoring
+
     fun launchBillingFlow(
         activity: Activity,
         sku: Sku,
@@ -137,6 +144,7 @@ class UpgradeRepoGplay @Inject constructor(
                         // Stale local state: Play says they already own it, so tapping "buy" really
                         // means "unlock what I own" — restore instead of showing an error.
                         log(TAG, INFO) { "Launch says already owned -> restoring purchase" }
+                        autoRestoring.value = true
                         val restored = try {
                             withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow() }
                         } catch (re: CancellationException) {
@@ -144,6 +152,8 @@ class UpgradeRepoGplay @Inject constructor(
                         } catch (re: Exception) {
                             log(TAG, WARN) { "Restore after already-owned failed: ${re.asLog()}" }
                             null
+                        } finally {
+                            autoRestoring.value = false
                         }
                         if (restored?.isUpgraded != true) {
                             // Couldn't reconcile the entitlement (pending purchase, account mismatch,

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -4,7 +4,9 @@ import android.app.Activity
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.datastore.value
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
 import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
@@ -12,12 +14,13 @@ import eu.darken.bluemusic.common.flow.setupCommonEventHandlers
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.upgrade.core.billing.BillingData
 import eu.darken.bluemusic.upgrade.core.billing.BillingManager
+import eu.darken.bluemusic.upgrade.core.billing.ItemAlreadyOwnedBillingException
 import eu.darken.bluemusic.upgrade.core.billing.PurchasedSku
 import eu.darken.bluemusic.upgrade.core.billing.Sku
 import eu.darken.bluemusic.upgrade.core.billing.SkuDetails
+import eu.darken.bluemusic.upgrade.core.billing.UserCanceledBillingException
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
@@ -30,6 +33,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
@@ -94,22 +98,48 @@ class UpgradeRepoGplay @Inject constructor(
     // restore banner. Local signal only — a fresh install or switched Google account starts false.
     val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow.map { it > 0 }
 
-    suspend fun launchBillingFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
+    fun launchBillingFlow(
+        activity: Activity,
+        sku: Sku,
+        offer: Sku.Subscription.Offer?,
+        onError: (Throwable) -> Unit,
+    ) {
         log(TAG) { "launchBillingFlow($activity,$sku)" }
-        val resultChannel = Channel<Result<Unit>>()
-
+        // AppScope on purpose: the purchase flow and the already-owned recovery below must survive
+        // the upgrade screen being closed; the reactive isUpgraded emission unlocks the app either way.
         scope.launch {
             try {
                 billingManager.startIapFlow(activity, sku, offer)
-                resultChannel.send(Result.success(Unit))
             } catch (e: Exception) {
-                log(TAG) { "startIapFlow failed:${e.asLog()}" }
-                resultChannel.send(Result.failure(e))
+                when {
+                    e is UserCanceledBillingException -> log(TAG) { "User canceled billing flow" }
+
+                    e is ItemAlreadyOwnedBillingException -> {
+                        // Stale local state: Play says they already own it, so tapping "buy" really
+                        // means "unlock what I own" — restore instead of showing an error.
+                        log(TAG, INFO) { "Launch says already owned -> restoring purchase" }
+                        val restored = try {
+                            withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow() }
+                        } catch (re: CancellationException) {
+                            throw re
+                        } catch (re: Exception) {
+                            log(TAG, WARN) { "Restore after already-owned failed: ${re.asLog()}" }
+                            null
+                        }
+                        if (restored?.isUpgraded != true) {
+                            // Couldn't reconcile the entitlement (pending purchase, account mismatch,
+                            // Play quirk) — fall back to the already-owned dialog with restore tips.
+                            onError(e)
+                        }
+                    }
+
+                    else -> {
+                        log(TAG) { "startIapFlow failed:${e.asLog()}" }
+                        onError(e)
+                    }
+                }
             }
         }
-
-        val result = resultChannel.receive()
-        result.getOrThrow()
     }
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = billingManager.querySkus(*skus)
@@ -221,6 +251,7 @@ class UpgradeRepoGplay @Inject constructor(
         // subscription/default window (also used when the last-owned SKU is unknown/legacy).
         val GRACE_PERIOD_MS = Duration.ofDays(7).toMillis()
         val GRACE_PERIOD_IAP_MS = Duration.ofDays(30).toMillis()
+        private const val RESTORE_ON_OWNED_TIMEOUT_MS = 15_000L
 
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
 

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -2,7 +2,6 @@ package eu.darken.bluemusic.upgrade.core
 
 import android.app.Activity
 import eu.darken.bluemusic.common.coroutine.AppScope
-import eu.darken.bluemusic.common.coroutine.DispatcherProvider
 import eu.darken.bluemusic.common.datastore.value
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
@@ -16,6 +15,7 @@ import eu.darken.bluemusic.upgrade.core.billing.BillingManager
 import eu.darken.bluemusic.upgrade.core.billing.PurchasedSku
 import eu.darken.bluemusic.upgrade.core.billing.Sku
 import eu.darken.bluemusic.upgrade.core.billing.SkuDetails
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.launch
+import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -35,7 +36,6 @@ import kotlin.math.pow
 @Singleton
 class UpgradeRepoGplay @Inject constructor(
     @param:AppScope private val scope: CoroutineScope,
-    private val dispatcherProvider: DispatcherProvider,
     private val billingManager: BillingManager,
     private val billingCache: BillingCache,
 ) : UpgradeRepo {
@@ -46,36 +46,15 @@ class UpgradeRepoGplay @Inject constructor(
         .map<BillingData, BillingData?> { it }
         .onStart { emit(null) }
         .setupCommonEventHandlers(TAG) { "upgradeInfo1" }
-        .map { data: BillingData? -> // Only relinquish pro state if we haven't had it for a while
-            val now = System.currentTimeMillis()
-            val lastProStateAt = billingCache.lastProStateAt.value()
-            log(TAG) { "Map: now=$now, lastProStateAt=$lastProStateAt, data=${data}" }
-
-            when {
-                data?.purchases?.isNotEmpty() == true -> {
-                    // If we are pro refresh timestamp
-                    billingCache.lastProStateAt.value(now)
-                    Info(billingData = data)
-                }
-
-                (now - lastProStateAt) < 7 * 24 * 60 * 1000L -> { // 7 days
-                    log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
-                    Info(gracePeriod = true, billingData = null)
-                }
-
-                else -> {
-                    Info(billingData = data)
-                }
-            }
-        }
+        .map { data: BillingData? -> data.toUpgradeInfo() }
         .distinctUntilChanged()
         .retryWhen { error, attempt ->
             // Ignore Google Play errors if the last pro state was recent
             val now = System.currentTimeMillis()
             val lastProStateAt = billingCache.lastProStateAt.value()
             log(TAG) { "Catch: now=$now, lastProStateAt=$lastProStateAt, attempt=$attempt, error=$error" }
-            if ((now - lastProStateAt) < 7 * 24 * 60 * 1000L) { // 7 days
-                log(TAG, VERBOSE) { "We are not pro, but were recently, and just and an error, what is GPlay doing???" }
+            if ((now - lastProStateAt) < GRACE_PERIOD_MS) {
+                log(TAG, VERBOSE) { "We are not pro, but were recently, and just got an error, what is GPlay doing???" }
                 emit(Info(gracePeriod = true, billingData = null))
             } else {
                 emit(Info(error = error, billingData = null))
@@ -89,7 +68,7 @@ class UpgradeRepoGplay @Inject constructor(
     suspend fun launchBillingFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
         log(TAG) { "launchBillingFlow($activity,$sku)" }
         val resultChannel = Channel<Result<Unit>>()
-        
+
         scope.launch {
             try {
                 billingManager.startIapFlow(activity, sku, offer)
@@ -108,7 +87,60 @@ class UpgradeRepoGplay @Inject constructor(
 
     override suspend fun refresh() {
         log(TAG) { "refresh()" }
-        billingManager.refresh()
+        try {
+            billingManager.refresh()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Background refresh: keep the old swallow-and-log behaviour so callers like MainViewModel
+            // aren't affected. The explicit restore path uses restorePurchaseNow(), which surfaces errors.
+            log(TAG, ERROR) { "Background refresh failed: ${e.asLog()}" }
+        }
+    }
+
+    // Explicit "Restore purchase": query Play now and evaluate Pro from the returned data in the same
+    // coroutine (real happens-before), so we never read a stale upgradeInfo replay. Billing errors
+    // propagate so the caller can distinguish "not owned" from "Play unavailable".
+    suspend fun restorePurchaseNow(): Info {
+        log(TAG) { "restorePurchaseNow()" }
+        return try {
+            billingManager.refresh().toUpgradeInfo()
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Mirror the reactive flow's retryWhen: a transient Play error while we were Pro recently
+            // keeps us Pro via the grace period; otherwise surface the error so the caller can show
+            // the proper "Play unavailable" message instead of a generic restore failure.
+            val lastProStateAt = billingCache.lastProStateAt.value()
+            if ((System.currentTimeMillis() - lastProStateAt) < GRACE_PERIOD_MS) {
+                log(TAG, VERBOSE) { "restore hit a Play error but we were Pro recently -> grace" }
+                Info(gracePeriod = true, billingData = null)
+            } else {
+                throw e
+            }
+        }
+    }
+
+    // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
+    // Only relinquishes Pro if we haven't had it for a while (grace period).
+    private suspend fun BillingData?.toUpgradeInfo(): Info {
+        val now = System.currentTimeMillis()
+        val lastProStateAt = billingCache.lastProStateAt.value()
+        log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
+        return when {
+            this?.purchases?.isNotEmpty() == true -> {
+                // If we are pro refresh timestamp
+                billingCache.lastProStateAt.value(now)
+                Info(billingData = this)
+            }
+
+            (now - lastProStateAt) < GRACE_PERIOD_MS -> {
+                log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
+                Info(gracePeriod = true, billingData = null)
+            }
+
+            else -> Info(billingData = this)
+        }
     }
 
     data class Info(
@@ -145,6 +177,10 @@ class UpgradeRepoGplay @Inject constructor(
 
     companion object {
         private const val SITE = "https://play.google.com/store/apps/details?id=eu.darken.bluemusic"
+
+        // Keep paying users Pro through transient empty/failed Play Billing responses.
+        val GRACE_PERIOD_MS = Duration.ofDays(7).toMillis()
+
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
     }
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -21,8 +21,11 @@ import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
@@ -41,6 +44,28 @@ class UpgradeRepoGplay @Inject constructor(
 ) : UpgradeRepo {
 
     override val mainWebsite: String = SITE
+
+    init {
+        // Grace bookkeeping is driven by *fresh* Play query results only (per-connection/manual
+        // refreshes, completed purchases) — never by the replayed billingData/upgradeInfo flows.
+        // Replayed data re-running the reactive mapping must not re-stamp the timestamp, otherwise a
+        // long-lived process (e.g. while the monitor service is up) could keep extending the grace
+        // window from data that is weeks old.
+        billingManager.freshBillingData
+            .onEach { stampLastProState(it) }
+            .catch { log(TAG, ERROR) { "Pro state stamping failed: ${it.asLog()}" } }
+            .setupCommonEventHandlers(TAG) { "lastProState-stamping" }
+            .launchIn(scope)
+    }
+
+    private suspend fun stampLastProState(data: BillingData) {
+        val sku = preferredProSku(Info(billingData = data).upgrades) ?: return
+        log(TAG, VERBOSE) { "Fresh Pro state confirmed by $sku, stamping." }
+        // SKU before timestamp: if we die in between, the old timestamp keeps its old window class
+        // instead of a fresh timestamp being interpreted with a stale SKU.
+        billingCache.lastProStateSku.value(sku.id)
+        billingCache.lastProStateAt.value(System.currentTimeMillis())
+    }
 
     override val upgradeInfo: Flow<Info> = billingManager.billingData
         .map<BillingData, BillingData?> { it }
@@ -122,22 +147,15 @@ class UpgradeRepoGplay @Inject constructor(
     }
 
     // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
-    // Only relinquishes Pro if we haven't had it for a while (grace period).
+    // Only relinquishes Pro if we haven't had it for a while (grace period). Pure: the grace
+    // timestamp is stamped by the freshBillingData collector above, not from mapped (possibly
+    // replayed) flow data.
     private suspend fun BillingData?.toUpgradeInfo(): Info {
         val now = System.currentTimeMillis()
         val lastProStateAt = billingCache.lastProStateAt.value()
         log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
         return when {
-            this?.purchases?.isNotEmpty() == true -> {
-                val info = Info(billingData = this)
-                // Only a *known* Pro SKU counts as "last Pro state" — an unrecognized purchase must
-                // not refresh the grace timestamp. Prefer the permanent IAP so it drives the window.
-                preferredProSku(info.upgrades)?.let { sku ->
-                    billingCache.lastProStateAt.value(now)
-                    billingCache.lastProStateSku.value(sku.id)
-                }
-                info
-            }
+            this?.purchases?.isNotEmpty() == true -> Info(billingData = this)
 
             (now - lastProStateAt) < graceWindowMs() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -24,7 +24,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
@@ -56,19 +55,37 @@ class UpgradeRepoGplay @Inject constructor(
         // long-lived process (e.g. while the monitor service is up) could keep extending the grace
         // window from data that is weeks old.
         billingManager.freshBillingData
-            .onEach { stampLastProState(it) }
-            .catch { log(TAG, ERROR) { "Pro state stamping failed: ${it.asLog()}" } }
+            .onEach { fresh ->
+                try {
+                    stampLastProState(fresh)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    // Isolate per-emission failures: one failed write must not kill this permanent
+                    // collector and stop all future grace bookkeeping.
+                    log(TAG, ERROR) { "Pro state stamping failed: ${e.asLog()}" }
+                }
+            }
             .setupCommonEventHandlers(TAG) { "lastProState-stamping" }
             .launchIn(scope)
     }
 
-    private suspend fun stampLastProState(data: BillingData) {
-        val sku = preferredProSku(Info(billingData = data).upgrades) ?: return
-        log(TAG, VERBOSE) { "Fresh Pro state confirmed by $sku, stamping." }
-        // SKU before timestamp: if we die in between, the old timestamp keeps its old window class
-        // instead of a fresh timestamp being interpreted with a stale SKU.
-        billingCache.lastProStateSku.value(sku.id)
-        billingCache.lastProStateAt.value(System.currentTimeMillis())
+    private suspend fun stampLastProState(fresh: BillingManager.FreshData) {
+        val sku = preferredProSku(Info(billingData = fresh.data).upgrades) ?: return
+        val storedSkuId = billingCache.lastProStateSku.value()
+        val storedType = OurSku.PRO_SKUS.singleOrNull { it.id == storedSkuId }?.type
+        // A purchase event is not a full ownership snapshot: a subscription-only event must not
+        // downgrade the grace class of a previously confirmed permanent IAP. Full query snapshots
+        // are authoritative and always win.
+        val effectiveSkuId = if (
+            !fresh.isFullSnapshot && storedType == Sku.Type.IAP && sku.type != Sku.Type.IAP
+        ) {
+            storedSkuId
+        } else {
+            sku.id
+        }
+        log(TAG, VERBOSE) { "Fresh Pro state confirmed by $sku, stamping $effectiveSkuId." }
+        billingCache.stampLastProState(effectiveSkuId, System.currentTimeMillis())
     }
 
     override val upgradeInfo: Flow<Info> = billingManager.billingData
@@ -110,6 +127,8 @@ class UpgradeRepoGplay @Inject constructor(
         scope.launch {
             try {
                 billingManager.startIapFlow(activity, sku, offer)
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 when {
                     e is UserCanceledBillingException -> log(TAG) { "User canceled billing flow" }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
@@ -174,11 +174,15 @@ class BillingManager @Inject constructor(
             if (this !is BillingClientException) return this
 
             return when (result.responseCode) {
+                BillingResponseCode.USER_CANCELED -> UserCanceledBillingException(this)
                 BillingResponseCode.BILLING_UNAVAILABLE,
                 BillingResponseCode.SERVICE_UNAVAILABLE,
                 BillingResponseCode.SERVICE_DISCONNECTED,
                 BillingResponseCode.SERVICE_TIMEOUT -> GplayServiceUnavailableException(this)
 
+                BillingResponseCode.ERROR -> InternalBillingException(this)
+                BillingResponseCode.NETWORK_ERROR -> NetworkBillingException(this)
+                BillingResponseCode.ITEM_ALREADY_OWNED -> ItemAlreadyOwnedBillingException(this)
                 else -> this
             }
         }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
@@ -41,18 +41,26 @@ class BillingManager @Inject constructor(
     connectionProvider: BillingConnectionProvider,
 ) {
 
+    // Fresh Play data plus its provenance: a query result covers all owned products, while a
+    // purchase event only carries the products of that transaction — consumers deciding between
+    // per-SKU behaviors (like grace windows) need to know the difference.
+    data class FreshData(
+        val data: BillingData,
+        val isFullSnapshot: Boolean,
+    )
+
     // Emits only data that was *freshly* obtained from Play: per-connection/manual query results and
     // completed purchase events. Unlike billingData below (whose shareIn replay re-serves old data to
     // late subscribers), every emission here represents an actual Play round-trip, so consumers can
     // safely use it for time-based bookkeeping like the Pro grace period.
-    private val freshData = MutableSharedFlow<BillingData>(replay = 1)
-    val freshBillingData: Flow<BillingData> = freshData
+    private val freshData = MutableSharedFlow<FreshData>(replay = 1)
+    val freshBillingData: Flow<FreshData> = freshData
 
     private val connection = connectionProvider.connection
         .onEach {
             try {
                 val fresh = it.refreshPurchases()
-                freshData.emit(BillingData(purchases = fresh))
+                freshData.emit(FreshData(BillingData(purchases = fresh), isFullSnapshot = true))
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -82,7 +90,7 @@ class BillingManager @Inject constructor(
                     ?.takeIf { (result, _) -> result.isSuccess }
                     ?.let { (_, purchases) -> purchases?.filter { it.purchaseState == PurchaseState.PURCHASED } }
             }
-            .onEach { freshData.emit(BillingData(purchases = it)) }
+            .onEach { freshData.emit(FreshData(BillingData(purchases = it), isFullSnapshot = false)) }
             .setupCommonEventHandlers(TAG) { "fresh-purchase-events" }
             .launchIn(scope)
 
@@ -166,7 +174,8 @@ class BillingManager @Inject constructor(
         // Query in the caller's context and return the result directly, so callers get the fresh
         // purchases (and any billing error) with a real happens-before instead of racing the shared
         // upgradeInfo replay cache.
-        return BillingData(purchases = useConnection { refreshPurchases() }).also { freshData.emit(it) }
+        return BillingData(purchases = useConnection { refreshPurchases() })
+            .also { freshData.emit(FreshData(it, isFullSnapshot = true)) }
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
@@ -2,6 +2,7 @@ package eu.darken.bluemusic.upgrade.core.billing
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.Purchase.PurchaseState
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
@@ -13,16 +14,19 @@ import eu.darken.bluemusic.common.flow.setupCommonEventHandlers
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingClientException
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnection
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnectionProvider
+import eu.darken.bluemusic.upgrade.core.billing.client.isSuccess
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
@@ -37,10 +41,20 @@ class BillingManager @Inject constructor(
     connectionProvider: BillingConnectionProvider,
 ) {
 
+    // Emits only data that was *freshly* obtained from Play: per-connection/manual query results and
+    // completed purchase events. Unlike billingData below (whose shareIn replay re-serves old data to
+    // late subscribers), every emission here represents an actual Play round-trip, so consumers can
+    // safely use it for time-based bookkeeping like the Pro grace period.
+    private val freshData = MutableSharedFlow<BillingData>(replay = 1)
+    val freshBillingData: Flow<BillingData> = freshData
+
     private val connection = connectionProvider.connection
         .onEach {
             try {
-                it.refreshPurchases()
+                val fresh = it.refreshPurchases()
+                freshData.emit(BillingData(purchases = fresh))
+            } catch (e: CancellationException) {
+                throw e
             } catch (e: Exception) {
                 log(TAG, ERROR) { "Initial purchase data refresh failed: ${e.asLog()}" }
             }
@@ -60,6 +74,18 @@ class BillingManager @Inject constructor(
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
     init {
+        // Completed purchases arriving via the PurchasesUpdatedListener are fresh Play data too.
+        connection
+            .flatMapLatest { it.purchaseEvents }
+            .mapNotNull { event ->
+                event
+                    ?.takeIf { (result, _) -> result.isSuccess }
+                    ?.let { (_, purchases) -> purchases?.filter { it.purchaseState == PurchaseState.PURCHASED } }
+            }
+            .onEach { freshData.emit(BillingData(purchases = it)) }
+            .setupCommonEventHandlers(TAG) { "fresh-purchase-events" }
+            .launchIn(scope)
+
         purchases
             .onEach { purchases ->
                 purchases
@@ -140,7 +166,7 @@ class BillingManager @Inject constructor(
         // Query in the caller's context and return the result directly, so callers get the fresh
         // purchases (and any billing error) with a real happens-before instead of racing the shared
         // upgradeInfo replay cache.
-        return BillingData(purchases = useConnection { refreshPurchases() })
+        return BillingData(purchases = useConnection { refreshPurchases() }).also { freshData.emit(it) }
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
@@ -28,7 +28,6 @@ import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -136,17 +135,12 @@ class BillingManager @Inject constructor(
         }
     }
 
-    suspend fun refresh() {
+    suspend fun refresh(): BillingData {
         log(TAG) { "refresh()" }
-        scope.launch {
-            useConnection {
-                try {
-                    refreshPurchases()
-                } catch (e: Exception) {
-                    log(TAG, ERROR) { "Manual purchase data refresh failed: ${e.asLog()}" }
-                }
-            }
-        }.join()
+        // Query in the caller's context and return the result directly, so callers get the fresh
+        // purchases (and any billing error) with a real happens-before instead of racing the shared
+        // upgradeInfo replay cache.
+        return BillingData(purchases = useConnection { refreshPurchases() })
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
@@ -60,7 +60,7 @@ class BillingManager @Inject constructor(
         .onEach {
             try {
                 val fresh = it.refreshPurchases()
-                freshData.emit(FreshData(BillingData(purchases = fresh), isFullSnapshot = true))
+                freshData.emit(FreshData(BillingData(purchases = fresh.purchases), isFullSnapshot = fresh.isComplete))
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
@@ -174,8 +174,9 @@ class BillingManager @Inject constructor(
         // Query in the caller's context and return the result directly, so callers get the fresh
         // purchases (and any billing error) with a real happens-before instead of racing the shared
         // upgradeInfo replay cache.
-        return BillingData(purchases = useConnection { refreshPurchases() })
-            .also { freshData.emit(FreshData(it, isFullSnapshot = true)) }
+        val fresh = useConnection { refreshPurchases() }
+        return BillingData(purchases = fresh.purchases)
+            .also { freshData.emit(FreshData(it, isFullSnapshot = fresh.isComplete)) }
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/InternalBillingException.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/InternalBillingException.kt
@@ -1,0 +1,16 @@
+package eu.darken.bluemusic.upgrade.core.billing
+
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.ca.toCaString
+import eu.darken.bluemusic.common.error.HasLocalizedError
+import eu.darken.bluemusic.common.error.LocalizedError
+
+class InternalBillingException(cause: Throwable) :
+    BillingException("An internal Google Play error occurred.", cause), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.upgrades_gplay_internal_error_title.toCaString(),
+        description = R.string.upgrades_gplay_internal_error_description.toCaString(),
+    )
+}

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/ItemAlreadyOwnedBillingException.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/ItemAlreadyOwnedBillingException.kt
@@ -1,0 +1,16 @@
+package eu.darken.bluemusic.upgrade.core.billing
+
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.ca.toCaString
+import eu.darken.bluemusic.common.error.HasLocalizedError
+import eu.darken.bluemusic.common.error.LocalizedError
+
+class ItemAlreadyOwnedBillingException(cause: Throwable) :
+    BillingException("Item is already owned.", cause), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.upgrades_gplay_already_owned_error_title.toCaString(),
+        description = R.string.upgrades_gplay_already_owned_error_description.toCaString(),
+    )
+}

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/NetworkBillingException.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/NetworkBillingException.kt
@@ -1,0 +1,16 @@
+package eu.darken.bluemusic.upgrade.core.billing
+
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.ca.toCaString
+import eu.darken.bluemusic.common.error.HasLocalizedError
+import eu.darken.bluemusic.common.error.LocalizedError
+
+class NetworkBillingException(cause: Throwable) :
+    BillingException("Unable to connect to Google Play.", cause), HasLocalizedError {
+
+    override fun getLocalizedError(): LocalizedError = LocalizedError(
+        throwable = this,
+        label = R.string.upgrades_gplay_network_error_title.toCaString(),
+        description = R.string.upgrades_gplay_network_error_description.toCaString(),
+    )
+}

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/UserCanceledBillingException.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/UserCanceledBillingException.kt
@@ -1,0 +1,8 @@
+package eu.darken.bluemusic.upgrade.core.billing
+
+/**
+ * Exception thrown when user cancels the billing flow.
+ * Does NOT implement HasLocalizedError - should be dismissed silently.
+ */
+class UserCanceledBillingException(cause: Throwable) :
+    BillingException("User canceled billing flow.", cause)

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
@@ -20,12 +20,14 @@ import eu.darken.bluemusic.upgrade.core.billing.BillingManager.Companion.tryMapU
 import eu.darken.bluemusic.upgrade.core.billing.Sku
 import eu.darken.bluemusic.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.withContext
 import kotlin.coroutines.resume
 import kotlin.coroutines.suspendCoroutine
 
@@ -187,7 +189,19 @@ data class BillingConnection(
             setProductDetailsParamsList(listOf(productDetail))
         }.build()
 
-        return client.launchBillingFlow(activity, params)
+        // launchBillingFlow must run on the main thread (documented BillingClient contract), and its
+        // RETURNED result reports whether the flow could be launched at all (DEVELOPER_ERROR,
+        // ITEM_ALREADY_OWNED, BILLING_UNAVAILABLE, ...) — failures arrive here, not as exceptions.
+        // Throw like the other client calls do, so callers can surface them instead of silence.
+        val result = withContext(Dispatchers.Main) {
+            client.launchBillingFlow(activity, params)
+        }
+        log(TAG) {
+            "launchBillingFlow(sku=$sku): code=${result.responseCode}, message=${result.debugMessage}"
+        }
+        if (!result.isSuccess) throw BillingClientException(result)
+
+        return result
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
@@ -19,8 +19,8 @@ import eu.darken.bluemusic.common.flow.setupCommonEventHandlers
 import eu.darken.bluemusic.upgrade.core.billing.BillingManager.Companion.tryMapUserFriendly
 import eu.darken.bluemusic.upgrade.core.billing.Sku
 import eu.darken.bluemusic.upgrade.core.billing.SkuDetails
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -73,27 +73,34 @@ data class BillingConnection(
         return purchaseData
     }
 
-    suspend fun refreshPurchases() = coroutineScope {
+    // Returns the freshly queried PURCHASED purchases so callers get a guaranteed happens-before
+    // relation instead of racing the shared purchases/upgradeInfo replay caches after a refresh.
+    // Tolerant of a single product-type failure: if either query finds a purchase we treat that as
+    // authoritative, and only propagate an error when nothing was found AND a query failed — so the
+    // caller can tell "not owned" apart from "couldn't verify".
+    suspend fun refreshPurchases(): Collection<Purchase> = coroutineScope {
         log(TAG) { "refreshPurchases()" }
-        val iapJob = async {
-            try {
-                val iaps = queryPurchases(BillingClient.ProductType.INAPP)
-                log(TAG) { "Refreshed IAPs: $iaps" }
-                queryCacheIaps.value = iaps.filter { it.purchaseState == PurchaseState.PURCHASED }
-            } catch (e: Exception) {
-                throw e.tryMapUserFriendly()
-            }
-        }
-        val subJob = async {
-            try {
-                val subs = queryPurchases(BillingClient.ProductType.SUBS)
-                log(TAG) { "Refreshed SUBs: $subs" }
-                queryCacheSubs.value = subs.filter { it.purchaseState == PurchaseState.PURCHASED }
-            } catch (e: Exception) {
-                throw e.tryMapUserFriendly()
-            }
-        }
-        awaitAll(iapJob, subJob)
+        val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) { queryCacheIaps.value = it } }
+        val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) { queryCacheSubs.value = it } }
+        val iap = iapJob.await()
+        val sub = subJob.await()
+        log(TAG) { "Refreshed IAPs=${iap.getOrNull()}, SUBs=${sub.getOrNull()}" }
+        combinePurchaseResults(iap, sub)
+    }
+
+    // Never throws except on cancellation, so a single failing product-type query doesn't cancel the
+    // sibling query (or the coroutineScope). The exception is already user-friendly-mapped.
+    private suspend fun queryPurchasedProducts(
+        @BillingClient.ProductType type: String,
+        cache: (Collection<Purchase>) -> Unit,
+    ): Result<Collection<Purchase>> = try {
+        val purchased = queryPurchases(type).filter { it.purchaseState == PurchaseState.PURCHASED }
+        cache(purchased)
+        Result.success(purchased)
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        Result.failure(e.tryMapUserFriendly())
     }
 
     suspend fun acknowledgePurchase(purchase: Purchase): BillingResult {
@@ -185,5 +192,25 @@ data class BillingConnection(
 
     companion object {
         val TAG: String = logTag("Upgrade", "Gplay", "Billing", "ClientConnection")
+
+        // Combines the two product-type query results: a purchase found by either type is
+        // authoritative; an error is only propagated when nothing was found, so callers can tell
+        // "not owned" apart from "couldn't verify one product type". Treating any found purchase as
+        // authoritative is safe here because every product this app sells is a Pro SKU (see
+        // OurSku.PRO_SKUS) — there are no unrelated products whose presence could mask a failed
+        // query for the type that actually carries the entitlement. Pure and unit-tested.
+        internal fun combinePurchaseResults(
+            iap: Result<Collection<Purchase>>,
+            sub: Result<Collection<Purchase>>,
+        ): Collection<Purchase> {
+            val found = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+            return when {
+                found.isNotEmpty() -> found.sortedByDescending { it.purchaseTime }
+                else -> {
+                    (iap.exceptionOrNull() ?: sub.exceptionOrNull())?.let { throw it }
+                    emptyList()
+                }
+            }
+        }
     }
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
@@ -81,14 +81,23 @@ data class BillingConnection(
     // Tolerant of a single product-type failure: if either query finds a purchase we treat that as
     // authoritative, and only propagate an error when nothing was found AND a query failed — so the
     // caller can tell "not owned" apart from "couldn't verify".
-    suspend fun refreshPurchases(): Collection<Purchase> = coroutineScope {
+    // The purchases of a refresh plus whether it covered both product types: a partial result (one
+    // query failed) is still authoritative for what it FOUND, but must not be treated as proof of
+    // absence for the type that couldn't be checked.
+    data class PurchaseRefresh(
+        val purchases: Collection<Purchase>,
+        val isComplete: Boolean,
+    )
+
+    suspend fun refreshPurchases(): PurchaseRefresh = coroutineScope {
         log(TAG) { "refreshPurchases()" }
         val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) }
         val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) }
         val iap = iapJob.await()
         val sub = subJob.await()
         log(TAG) { "Refreshed IAPs=${iap.getOrNull()}, SUBs=${sub.getOrNull()}" }
-        combinePurchaseResults(iap, sub).also { querySnapshot.value = it }
+        val combined = combinePurchaseResults(iap, sub).also { querySnapshot.value = it }
+        PurchaseRefresh(purchases = combined, isComplete = iap.isSuccess && sub.isSuccess)
     }
 
     // Never throws except on cancellation, so a single failing product-type query doesn't cancel the

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
@@ -36,18 +36,19 @@ data class BillingConnection(
     val purchaseEvents: Flow<Pair<BillingResult, Collection<Purchase>?>?>,
 ) {
 
-    private val queryCacheIaps = MutableStateFlow<Collection<Purchase>?>(null)
-    private val queryCacheSubs = MutableStateFlow<Collection<Purchase>?>(null)
+    // Last authoritative ownership snapshot: the combined result of a successful refreshPurchases().
+    // A single snapshot (instead of per-product-type caches) makes sure a partial result — one
+    // product type failed but the other found a purchase — still reaches the reactive purchases
+    // flow, matching exactly what refreshPurchases() reported to its caller.
+    private val querySnapshot = MutableStateFlow<Collection<Purchase>?>(null)
 
     val purchases: Flow<Collection<Purchase>> = combine(
         purchaseEvents,
-        queryCacheIaps.filterNotNull(),
-        queryCacheSubs.filterNotNull(),
-    ) { purchaseEvent, iapCache, subCache ->
+        querySnapshot.filterNotNull(),
+    ) { purchaseEvent, snapshot ->
         val combined = mutableSetOf<Purchase>()
 
-        combined.addAll(iapCache)
-        combined.addAll(subCache)
+        combined.addAll(snapshot)
 
         purchaseEvent
             ?.takeIf { (result, _) -> result.isSuccess }
@@ -82,23 +83,20 @@ data class BillingConnection(
     // caller can tell "not owned" apart from "couldn't verify".
     suspend fun refreshPurchases(): Collection<Purchase> = coroutineScope {
         log(TAG) { "refreshPurchases()" }
-        val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) { queryCacheIaps.value = it } }
-        val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) { queryCacheSubs.value = it } }
+        val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) }
+        val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) }
         val iap = iapJob.await()
         val sub = subJob.await()
         log(TAG) { "Refreshed IAPs=${iap.getOrNull()}, SUBs=${sub.getOrNull()}" }
-        combinePurchaseResults(iap, sub)
+        combinePurchaseResults(iap, sub).also { querySnapshot.value = it }
     }
 
     // Never throws except on cancellation, so a single failing product-type query doesn't cancel the
     // sibling query (or the coroutineScope). The exception is already user-friendly-mapped.
     private suspend fun queryPurchasedProducts(
         @BillingClient.ProductType type: String,
-        cache: (Collection<Purchase>) -> Unit,
     ): Result<Collection<Purchase>> = try {
-        val purchased = queryPurchases(type).filter { it.purchaseState == PurchaseState.PURCHASED }
-        cache(purchased)
-        Result.success(purchased)
+        Result.success(queryPurchases(type).filter { it.purchaseState == PurchaseState.PURCHASED })
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -12,8 +12,11 @@ import androidx.compose.material.icons.twotone.Palette
 import androidx.compose.material.icons.twotone.PlayCircle
 import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Tune
+import androidx.compose.foundation.layout.Column
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
@@ -120,6 +123,12 @@ private fun PricingContent(
     if (state == null) {
         CircularProgressIndicator(modifier = Modifier.padding(vertical = 12.dp))
         return
+    }
+
+    if (state.wasPreviouslyPro) {
+        RestoreBanner(onRestorePurchase = onRestorePurchase)
+
+        Spacer(modifier = Modifier.height(16.dp))
     }
 
     val hasSubscriptionOption = state.subState.available || state.trialState.available
@@ -253,6 +262,42 @@ private fun PricingContent(
     )
 }
 
+@Composable
+private fun RestoreBanner(
+    onRestorePurchase: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.tertiaryContainer,
+            contentColor = MaterialTheme.colorScheme.onTertiaryContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Text(
+                text = stringResource(R.string.upgrade_screen_restore_banner_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+
+            Spacer(modifier = Modifier.height(6.dp))
+
+            Text(
+                text = stringResource(R.string.upgrade_screen_restore_banner_body),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+
+            Spacer(modifier = Modifier.height(12.dp))
+
+            Button(
+                onClick = onRestorePurchase,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+            }
+        }
+    }
+}
+
 @Preview2
 @Composable
 fun UpgradeScreenPreview() {
@@ -281,6 +326,35 @@ fun UpgradeScreenPreview() {
     }
 }
 
+
+@Preview2
+@Composable
+fun UpgradeScreenPreviouslyProPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            state = UpgradeViewModel.State(
+                iapState = UpgradeViewModel.State.Iap(
+                    available = true,
+                    formattedPrice = "$4.99",
+                ),
+                subState = UpgradeViewModel.State.Sub(
+                    available = true,
+                    formattedPrice = "$2.99",
+                ),
+                trialState = UpgradeViewModel.State.Trial(
+                    available = false,
+                    formattedPrice = null,
+                ),
+                wasPreviouslyPro = true,
+            ),
+            onNavigateBack = {},
+            onGoIap = {},
+            onGoSubscription = {},
+            onGoSubscriptionTrial = {},
+            onRestorePurchase = {},
+        )
+    }
+}
 
 @Composable
 fun RestoreFailedDialog(

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -126,10 +126,17 @@ private fun PricingContent(
     }
 
     if (state.wasPreviouslyPro) {
-        RestoreBanner(onRestorePurchase = onRestorePurchase)
+        RestoreBanner(
+            onRestorePurchase = onRestorePurchase,
+            restoreInProgress = state.restoreInProgress,
+        )
 
         Spacer(modifier = Modifier.height(16.dp))
     }
+
+    // While a restore runs, all entitlement actions pause: a purchase flow racing a restore would
+    // just confuse both the user and Play.
+    val actionsEnabled = !state.restoreInProgress
 
     val hasSubscriptionOption = state.subState.available || state.trialState.available
     val hasIapOption = state.iapState.available
@@ -144,6 +151,7 @@ private fun PricingContent(
 
         Button(
             onClick = onPrimaryAction,
+            enabled = actionsEnabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp),
@@ -180,6 +188,7 @@ private fun PricingContent(
         if (hasSubscriptionOption) {
             FilledTonalButton(
                 onClick = onGoIap,
+                enabled = actionsEnabled,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(48.dp),
@@ -192,6 +201,7 @@ private fun PricingContent(
         } else {
             Button(
                 onClick = onGoIap,
+                enabled = actionsEnabled,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(48.dp),
@@ -224,6 +234,7 @@ private fun PricingContent(
     if (!hasSubscriptionOption && !hasIapOption) {
         Button(
             onClick = onGoIap,
+            enabled = actionsEnabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp),
@@ -244,11 +255,23 @@ private fun PricingContent(
 
     OutlinedButton(
         onClick = onRestorePurchase,
+        enabled = actionsEnabled,
         modifier = Modifier
             .fillMaxWidth()
             .height(48.dp),
     ) {
-        Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+        if (state.restoreInProgress) {
+            CircularProgressIndicator(
+                modifier = Modifier.size(18.dp),
+                strokeWidth = 2.dp,
+            )
+            Text(
+                text = stringResource(R.string.upgrade_screen_restore_purchase_action),
+                modifier = Modifier.padding(start = 8.dp),
+            )
+        } else {
+            Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+        }
     }
 
     Text(
@@ -265,6 +288,7 @@ private fun PricingContent(
 @Composable
 private fun RestoreBanner(
     onRestorePurchase: () -> Unit,
+    restoreInProgress: Boolean = false,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -290,9 +314,21 @@ private fun RestoreBanner(
 
             Button(
                 onClick = onRestorePurchase,
+                enabled = !restoreInProgress,
                 modifier = Modifier.fillMaxWidth(),
             ) {
-                Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+                if (restoreInProgress) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(18.dp),
+                        strokeWidth = 2.dp,
+                    )
+                    Text(
+                        text = stringResource(R.string.upgrade_screen_restore_purchase_action),
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                } else {
+                    Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
+                }
             }
         }
     }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -4,8 +4,8 @@ import android.app.Activity
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.bluemusic.common.coroutine.DispatcherProvider
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
-import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
+import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.flow.SingleEventFlow
@@ -15,9 +15,9 @@ import eu.darken.bluemusic.upgrade.core.OurSku
 import eu.darken.bluemusic.upgrade.core.UpgradeRepoGplay
 import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.bluemusic.upgrade.core.billing.Sku
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
@@ -141,17 +141,34 @@ class UpgradeViewModel @Inject constructor(
     fun restorePurchase() = launch {
         log(tag) { "restorePurchase()" }
 
-        log(tag, VERBOSE) { "Refreshing" }
-        upgradeRepo.refresh()
+        try {
+            val restored = withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+            when {
+                restored == null -> {
+                    // Play never answered in time; the restore-failed dialog already suggests waiting /
+                    // clearing the Play cache, which fits a timeout too.
+                    log(tag, WARN) { "Restore purchase timed out" }
+                    events.tryEmit(UpgradeEvents.RestoreFailed)
+                }
 
-        val refreshedState = upgradeRepo.upgradeInfo.first()
-        log(tag) { "Refreshed purchase state: $refreshedState" }
+                restored.isUpgraded -> log(tag, INFO) { "Restored purchase :))" }
 
-        if (refreshedState.isUpgraded) {
-            log(tag, INFO) { "Restored purchase :))" }
-        } else {
-            log(tag, WARN) { "Restore purchase failed" }
-            events.tryEmit(UpgradeEvents.RestoreFailed)
+                else -> {
+                    log(tag, WARN) { "Restore purchase failed" }
+                    events.tryEmit(UpgradeEvents.RestoreFailed)
+                }
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            // Play/billing error (e.g. service unavailable): surface the proper error dialog instead
+            // of the generic "restore failed" message, so the user can tell the two cases apart.
+            log(tag, WARN) { "Restore purchase errored: ${e.asLog()}" }
+            errorEvents.tryEmit(e)
         }
+    }
+
+    companion object {
+        private const val RESTORE_TIMEOUT_MS = 15_000L
     }
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -133,19 +133,29 @@ class UpgradeViewModel @Inject constructor(
         )
     }
 
-    fun onGoIap(activity: Activity) = launch {
+    fun onGoIap(activity: Activity) {
         log(tag) { "onGoIap($activity)" }
-        upgradeRepo.launchBillingFlow(activity, OurSku.Iap.PRO_UPGRADE, null)
+        upgradeRepo.launchBillingFlow(activity, OurSku.Iap.PRO_UPGRADE, null, onError = errorEvents::tryEmit)
     }
 
-    fun onGoSubscription(activity: Activity) = launch {
+    fun onGoSubscription(activity: Activity) {
         log(tag) { "onGoSubscription($activity)" }
-        upgradeRepo.launchBillingFlow(activity, OurSku.Sub.PRO_UPGRADE, OurSku.Sub.PRO_UPGRADE.BASE_OFFER)
+        upgradeRepo.launchBillingFlow(
+            activity,
+            OurSku.Sub.PRO_UPGRADE,
+            OurSku.Sub.PRO_UPGRADE.BASE_OFFER,
+            onError = errorEvents::tryEmit,
+        )
     }
 
-    fun onGoSubscriptionTrial(activity: Activity) = launch {
+    fun onGoSubscriptionTrial(activity: Activity) {
         log(tag) { "onGoSubscriptionTrial($activity)" }
-        upgradeRepo.launchBillingFlow(activity, OurSku.Sub.PRO_UPGRADE, OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER)
+        upgradeRepo.launchBillingFlow(
+            activity,
+            OurSku.Sub.PRO_UPGRADE,
+            OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER,
+            onError = errorEvents::tryEmit,
+        )
     }
 
     fun restorePurchase() = launch {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -36,6 +36,14 @@ class UpgradeViewModel @Inject constructor(
 
     private val restoring = MutableStateFlow(false)
 
+    // Manual restore or the repo's invisible already-owned auto-restore: either pauses the
+    // entitlement actions.
+    private val restoreBusy = combine(restoring, upgradeRepo.autoRestoreBusy) { manual, auto ->
+        manual || auto
+    }
+
+    private var hasShownUnavailableError = false
+
     init {
         upgradeRepo.upgradeInfo
             .filter { it.isUpgraded }
@@ -69,12 +77,19 @@ class UpgradeViewModel @Inject constructor(
         },
         upgradeRepo.upgradeInfo,
         upgradeRepo.wasEverPro,
-        restoring,
+        restoreBusy,
     ) { iap, sub, current, wasEverPro, isRestoring ->
         if (iap == null && sub == null) {
-            errorEvents.emit(
-                GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out."))
-            )
+            // This combine re-runs on every upstream change (e.g. restore progress toggling) —
+            // emit the unavailable error once per failure episode, not once per recombination.
+            if (!hasShownUnavailableError) {
+                hasShownUnavailableError = true
+                errorEvents.emit(
+                    GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out."))
+                )
+            }
+        } else {
+            hasShownUnavailableError = false
         }
 
         val iapOffer = iap?.singleOrNull { it.sku.id == OurSku.Iap.PRO_UPGRADE.id }?.details?.oneTimePurchaseOfferDetails

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -16,6 +16,7 @@ import eu.darken.bluemusic.upgrade.core.UpgradeRepoGplay
 import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.bluemusic.upgrade.core.billing.Sku
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
@@ -32,6 +33,8 @@ class UpgradeViewModel @Inject constructor(
 ) : ViewModel4(dispatcherProvider, logTag("Upgrade", "Screen", "VM"), navCtrl) {
 
     val events = SingleEventFlow<UpgradeEvents>()
+
+    private val restoring = MutableStateFlow(false)
 
     init {
         upgradeRepo.upgradeInfo
@@ -66,7 +69,8 @@ class UpgradeViewModel @Inject constructor(
         },
         upgradeRepo.upgradeInfo,
         upgradeRepo.wasEverPro,
-    ) { iap, sub, current, wasEverPro ->
+        restoring,
+    ) { iap, sub, current, wasEverPro, isRestoring ->
         if (iap == null && sub == null) {
             errorEvents.emit(
                 GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out."))
@@ -101,6 +105,7 @@ class UpgradeViewModel @Inject constructor(
             trialState = trialState,
             // Hidden while a grace period or an actual purchase keeps the user Pro.
             wasPreviouslyPro = wasEverPro && !current.isUpgraded,
+            restoreInProgress = isRestoring,
         )
     }.asStateFlow()
 
@@ -109,6 +114,7 @@ class UpgradeViewModel @Inject constructor(
         val subState: Sub,
         val trialState: Trial,
         val wasPreviouslyPro: Boolean = false,
+        val restoreInProgress: Boolean = false,
     ) {
 
         class Iap(
@@ -143,6 +149,14 @@ class UpgradeViewModel @Inject constructor(
     }
 
     fun restorePurchase() = launch {
+        // Single-flight: repeated taps while a restore is running (worst case bounded by
+        // RESTORE_TIMEOUT_MS) must not stack concurrent restores and duplicate result dialogs. The
+        // UI also disables the buttons, but that can lag a dispatch turn — this guard is the real
+        // protection.
+        if (!restoring.compareAndSet(expect = false, update = true)) {
+            log(tag) { "restorePurchase() ignored, already in progress" }
+            return@launch
+        }
         log(tag) { "restorePurchase()" }
 
         try {
@@ -169,6 +183,10 @@ class UpgradeViewModel @Inject constructor(
             // of the generic "restore failed" message, so the user can tell the two cases apart.
             log(tag, WARN) { "Restore purchase errored: ${e.asLog()}" }
             errorEvents.tryEmit(e)
+        } finally {
+            // Reset only after result handling, so the single-flight guard covers the whole
+            // user-visible action, including dialog emission.
+            restoring.value = false
         }
     }
 

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -65,7 +65,8 @@ class UpgradeViewModel @Inject constructor(
             emit(data)
         },
         upgradeRepo.upgradeInfo,
-    ) { iap, sub, current ->
+        upgradeRepo.wasEverPro,
+    ) { iap, sub, current, wasEverPro ->
         if (iap == null && sub == null) {
             errorEvents.emit(
                 GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out."))
@@ -98,6 +99,8 @@ class UpgradeViewModel @Inject constructor(
             iapState = iapState,
             subState = subState,
             trialState = trialState,
+            // Hidden while a grace period or an actual purchase keeps the user Pro.
+            wasPreviouslyPro = wasEverPro && !current.isUpgraded,
         )
     }.asStateFlow()
 
@@ -105,6 +108,7 @@ class UpgradeViewModel @Inject constructor(
         val iapState: Iap,
         val subState: Sub,
         val trialState: Trial,
+        val wasPreviouslyPro: Boolean = false,
     ) {
 
         class Iap(

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -23,6 +23,8 @@
     <string name="upgrade_screen_iap_action_hint">The one-time purchase costs %s.</string>
     <string name="upgrade_screen_thanks_toast">You are the best! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restore purchase</string>
+    <string name="upgrade_screen_restore_banner_title">Already bought BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">It looks like you upgraded on this device before. Restore your purchase to unlock it again.</string>
     <string name="upgrade_screen_restore_purchase_message">Your upgrade is valid across devices on the same Google account.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Troubleshooting tips for unrecognized upgrades:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store synchronization may take time. Try rebooting, clearing Google Play cache or simply wait.</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -30,6 +30,12 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store synchronization may take time. Try rebooting, clearing Google Play cache or simply wait.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Multiple accounts can confuse Google Play. Log out of other accounts or install through the Google Play website, which forces associations with a specific account.</string>
 
+    <string name="upgrades_gplay_already_owned_error_title">Already purchased</string>
+    <string name="upgrades_gplay_already_owned_error_description">Use the \"Restore purchase\" option to restore your purchase. If the issue persists, try clearing Google Play cache and restarting your device.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play error</string>
+    <string name="upgrades_gplay_internal_error_description">An internal Google Play error occurred. Please try the following:\n\n• Restart your device\n• Clear Google Play Store cache\n• Try again later</string>
+    <string name="upgrades_gplay_network_error_title">Connection error</string>
+    <string name="upgrades_gplay_network_error_description">Unable to connect to Google Play. Please check your internet connection and try again.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play is unavailable</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager can\'t connect to Google Play. Is Google Play installed and up to date? Is your Google Account logged in? Try clearing the cache of the Google Play app and rebooting your device.</string>
     <string name="upgrades_no_purchases_found_check_account">No purchases found. Are you using the right account?</string>

--- a/app/src/test/java/testhelpers/coroutine/TestExtensions.kt
+++ b/app/src/test/java/testhelpers/coroutine/TestExtensions.kt
@@ -1,0 +1,42 @@
+package testhelpers.coroutine
+
+import eu.darken.bluemusic.common.debug.logging.asLog
+import eu.darken.bluemusic.common.debug.logging.log
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.reflect.KClass
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+fun runTest2(
+    autoCancel: Boolean = false,
+    context: CoroutineContext = EmptyCoroutineContext,
+    expectedError: KClass<out Throwable>? = null,
+    timeout: Duration = 60.seconds,
+    testBody: suspend TestScope.() -> Unit
+) {
+    try {
+        val scope = TestScope(context = context)
+        try {
+            scope.runTest(
+                timeout = timeout
+            ) {
+                testBody()
+                if (autoCancel) scope.cancel("autoCancel")
+            }
+        } catch (e: Throwable) {
+            val isExpected = expectedError?.isInstance(e) ?: false
+            if (!isExpected) throw e
+        }
+    } catch (e: CancellationException) {
+        if (e.message == "autoCancel" && autoCancel) {
+            log("test") { "Test was auto-cancelled ${e.asLog()}" }
+        } else {
+            throw e
+        }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
@@ -9,10 +9,13 @@ import eu.darken.bluemusic.upgrade.core.billing.PurchasedSku
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
@@ -26,18 +29,24 @@ class UpgradeRepoGplayTest : BaseTest() {
     private val billingManager = mockk<BillingManager>()
     private val billingCache = mockk<BillingCache>()
 
+    private val lastProState = mockk<DataStoreValue<Long>>(relaxed = true)
+    private val lastProStateSku = mockk<DataStoreValue<String>>(relaxed = true)
+
     // Builds a repo whose stored last-Pro timestamp is `lastProAt`. billingData is stubbed only
     // because the upgradeInfo flow references it at construction; it is never collected here.
-    private fun repo(lastProAt: Long, lastSku: String = ""): UpgradeRepoGplay {
-        every { billingManager.billingData } returns flowOf(BillingData(emptySet()))
-        val lastPro = mockk<DataStoreValue<Long>>(relaxed = true).apply {
-            every { flow } returns flowOf(lastProAt)
-        }
-        every { billingCache.lastProStateAt } returns lastPro
-        val lastProSku = mockk<DataStoreValue<String>>(relaxed = true).apply {
-            every { flow } returns flowOf(lastSku)
-        }
-        every { billingCache.lastProStateSku } returns lastProSku
+    private fun repo(
+        lastProAt: Long,
+        lastSku: String = "",
+        billingData: BillingData = BillingData(emptySet()),
+        freshBillingData: BillingData? = null,
+    ): UpgradeRepoGplay {
+        every { billingManager.billingData } returns flowOf(billingData)
+        every { billingManager.freshBillingData } returns
+            (freshBillingData?.let { flowOf(it) } ?: emptyFlow())
+        every { lastProState.flow } returns flowOf(lastProAt)
+        every { billingCache.lastProStateAt } returns lastProState
+        every { lastProStateSku.flow } returns flowOf(lastSku)
+        every { billingCache.lastProStateSku } returns lastProStateSku
         return UpgradeRepoGplay(scope, billingManager, billingCache)
     }
 
@@ -153,5 +162,37 @@ class UpgradeRepoGplayTest : BaseTest() {
         UpgradeRepoGplay.preferredProSku(listOf(iap))?.id shouldBe OurSku.Iap.PRO_UPGRADE.id
         UpgradeRepoGplay.preferredProSku(listOf(sub))?.id shouldBe OurSku.Sub.PRO_UPGRADE.id
         UpgradeRepoGplay.preferredProSku(emptyList()) shouldBe null
+    }
+
+    @Test fun `mapped billing data does not stamp the grace timestamp`() = runTest2 {
+        // The reactive mapping can run on replayed (stale) data, e.g. when the upgrade screen is
+        // reopened in a long-lived process — that must not extend the grace window.
+        val repo = repo(lastProAt = 0L, billingData = BillingData(setOf(proPurchase())))
+
+        // upgradeInfo is seeded with a null emission; wait for the purchase-mapped one, twice, so
+        // the second collection is served from the shareIn replay cache.
+        repo.upgradeInfo.first { it.isUpgraded }.isUpgraded shouldBe true
+        repo.upgradeInfo.first { it.isUpgraded }.isUpgraded shouldBe true
+
+        coVerify(exactly = 0) { lastProState.update(any()) }
+        coVerify(exactly = 0) { lastProStateSku.update(any()) }
+    }
+
+    @Test fun `fresh billing data stamps the grace timestamp`() = runTest2 {
+        repo(lastProAt = 0L, freshBillingData = BillingData(setOf(proPurchase())))
+
+        coVerify(exactly = 1) { lastProStateSku.update(any()) }
+        coVerify(exactly = 1) { lastProState.update(any()) }
+    }
+
+    @Test fun `fresh data without a known pro SKU does not stamp`() = runTest2 {
+        val unknown = mockk<Purchase>().apply {
+            every { products } returns listOf("some.unknown.product")
+            every { purchaseTime } returns 1_000L
+        }
+        repo(lastProAt = 0L, freshBillingData = BillingData(setOf(unknown)))
+
+        coVerify(exactly = 0) { lastProState.update(any()) }
+        coVerify(exactly = 0) { lastProStateSku.update(any()) }
     }
 }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
@@ -5,6 +5,7 @@ import eu.darken.bluemusic.common.datastore.DataStoreValue
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.upgrade.core.billing.BillingData
 import eu.darken.bluemusic.upgrade.core.billing.BillingManager
+import eu.darken.bluemusic.upgrade.core.billing.PurchasedSku
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.flowOf
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
+import java.time.Duration
 import java.time.Instant
 
 class UpgradeRepoGplayTest : BaseTest() {
@@ -26,12 +28,16 @@ class UpgradeRepoGplayTest : BaseTest() {
 
     // Builds a repo whose stored last-Pro timestamp is `lastProAt`. billingData is stubbed only
     // because the upgradeInfo flow references it at construction; it is never collected here.
-    private fun repo(lastProAt: Long): UpgradeRepoGplay {
+    private fun repo(lastProAt: Long, lastSku: String = ""): UpgradeRepoGplay {
         every { billingManager.billingData } returns flowOf(BillingData(emptySet()))
         val lastPro = mockk<DataStoreValue<Long>>(relaxed = true).apply {
             every { flow } returns flowOf(lastProAt)
         }
         every { billingCache.lastProStateAt } returns lastPro
+        val lastProSku = mockk<DataStoreValue<String>>(relaxed = true).apply {
+            every { flow } returns flowOf(lastSku)
+        }
+        every { billingCache.lastProStateSku } returns lastProSku
         return UpgradeRepoGplay(scope, billingManager, billingCache)
     }
 
@@ -106,5 +112,46 @@ class UpgradeRepoGplayTest : BaseTest() {
         shouldThrow<RuntimeException> {
             repo(lastProAt = 0L).restorePurchaseNow()
         }
+    }
+
+    @Test fun `permanent IAP keeps grace well beyond the subscription window`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+        // 20 days ago: past the 7-day subscription window, but within the 30-day IAP window.
+        val twentyDaysAgo = System.currentTimeMillis() - Duration.ofDays(20).toMillis()
+
+        repo(lastProAt = twentyDaysAgo, lastSku = OurSku.Iap.PRO_UPGRADE.id)
+            .restorePurchaseNow().isUpgraded shouldBe true
+    }
+
+    @Test fun `subscription grace expires after the short window`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+        val twentyDaysAgo = System.currentTimeMillis() - Duration.ofDays(20).toMillis()
+
+        repo(lastProAt = twentyDaysAgo, lastSku = OurSku.Sub.PRO_UPGRADE.id)
+            .restorePurchaseNow().isUpgraded shouldBe false
+    }
+
+    @Test fun `legacy empty last SKU falls back to the short window`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+        val twentyDaysAgo = System.currentTimeMillis() - Duration.ofDays(20).toMillis()
+
+        // Existing installs have a timestamp but no recorded SKU: they keep the old 7-day window
+        // until the next successful query records one.
+        repo(lastProAt = twentyDaysAgo, lastSku = "").restorePurchaseNow().isUpgraded shouldBe false
+    }
+
+    @Test fun `IAP grace window is longer than the subscription window`() {
+        (UpgradeRepoGplay.GRACE_PERIOD_IAP_MS > UpgradeRepoGplay.GRACE_PERIOD_MS) shouldBe true
+        UpgradeRepoGplay.GRACE_PERIOD_IAP_MS shouldBe Duration.ofDays(30).toMillis()
+    }
+
+    @Test fun `preferredProSku prefers the permanent IAP when both are owned`() {
+        val iap = PurchasedSku(OurSku.Iap.PRO_UPGRADE, mockk<Purchase>())
+        val sub = PurchasedSku(OurSku.Sub.PRO_UPGRADE, mockk<Purchase>())
+
+        UpgradeRepoGplay.preferredProSku(listOf(sub, iap))?.id shouldBe OurSku.Iap.PRO_UPGRADE.id
+        UpgradeRepoGplay.preferredProSku(listOf(iap))?.id shouldBe OurSku.Iap.PRO_UPGRADE.id
+        UpgradeRepoGplay.preferredProSku(listOf(sub))?.id shouldBe OurSku.Sub.PRO_UPGRADE.id
+        UpgradeRepoGplay.preferredProSku(emptyList()) shouldBe null
     }
 }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
@@ -13,6 +13,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -42,7 +43,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         lastProAt: Long,
         lastSku: String = "",
         billingData: BillingData = BillingData(emptySet()),
-        freshBillingData: BillingData? = null,
+        freshBillingData: BillingManager.FreshData? = null,
     ): UpgradeRepoGplay {
         every { billingManager.billingData } returns flowOf(billingData)
         every { billingManager.freshBillingData } returns
@@ -51,6 +52,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         every { billingCache.lastProStateAt } returns lastProState
         every { lastProStateSku.flow } returns flowOf(lastSku)
         every { billingCache.lastProStateSku } returns lastProStateSku
+        coJustRun { billingCache.stampLastProState(any(), any()) }
         return UpgradeRepoGplay(scope, billingManager, billingCache)
     }
 
@@ -178,15 +180,19 @@ class UpgradeRepoGplayTest : BaseTest() {
         repo.upgradeInfo.first { it.isUpgraded }.isUpgraded shouldBe true
         repo.upgradeInfo.first { it.isUpgraded }.isUpgraded shouldBe true
 
-        coVerify(exactly = 0) { lastProState.update(any()) }
-        coVerify(exactly = 0) { lastProStateSku.update(any()) }
+        coVerify(exactly = 0) { billingCache.stampLastProState(any(), any()) }
     }
 
     @Test fun `fresh billing data stamps the grace timestamp`() = runTest2 {
-        repo(lastProAt = 0L, freshBillingData = BillingData(setOf(proPurchase())))
+        repo(
+            lastProAt = 0L,
+            freshBillingData = BillingManager.FreshData(
+                BillingData(setOf(proPurchase())),
+                isFullSnapshot = true,
+            ),
+        )
 
-        coVerify(exactly = 1) { lastProStateSku.update(any()) }
-        coVerify(exactly = 1) { lastProState.update(any()) }
+        coVerify(exactly = 1) { billingCache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, any()) }
     }
 
     @Test fun `fresh data without a known pro SKU does not stamp`() = runTest2 {
@@ -194,10 +200,41 @@ class UpgradeRepoGplayTest : BaseTest() {
             every { products } returns listOf("some.unknown.product")
             every { purchaseTime } returns 1_000L
         }
-        repo(lastProAt = 0L, freshBillingData = BillingData(setOf(unknown)))
+        repo(
+            lastProAt = 0L,
+            freshBillingData = BillingManager.FreshData(BillingData(setOf(unknown)), isFullSnapshot = true),
+        )
 
-        coVerify(exactly = 0) { lastProState.update(any()) }
-        coVerify(exactly = 0) { lastProStateSku.update(any()) }
+        coVerify(exactly = 0) { billingCache.stampLastProState(any(), any()) }
+    }
+
+    @Test fun `a subscription-only purchase event does not downgrade the IAP grace class`() = runTest2 {
+        val subOnly = mockk<Purchase>().apply {
+            every { products } returns listOf(OurSku.Sub.PRO_UPGRADE.id)
+            every { purchaseTime } returns 1_000L
+        }
+        repo(
+            lastProAt = 1_000L,
+            lastSku = OurSku.Iap.PRO_UPGRADE.id,
+            freshBillingData = BillingManager.FreshData(BillingData(setOf(subOnly)), isFullSnapshot = false),
+        )
+
+        // Timestamp refreshes, but the stored SKU keeps the permanent IAP's 30-day class.
+        coVerify(exactly = 1) { billingCache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, any()) }
+    }
+
+    @Test fun `a full snapshot with only a subscription stamps the subscription class`() = runTest2 {
+        val subOnly = mockk<Purchase>().apply {
+            every { products } returns listOf(OurSku.Sub.PRO_UPGRADE.id)
+            every { purchaseTime } returns 1_000L
+        }
+        repo(
+            lastProAt = 1_000L,
+            lastSku = OurSku.Iap.PRO_UPGRADE.id,
+            freshBillingData = BillingManager.FreshData(BillingData(setOf(subOnly)), isFullSnapshot = true),
+        )
+
+        coVerify(exactly = 1) { billingCache.stampLastProState(OurSku.Sub.PRO_UPGRADE.id, any()) }
     }
 
     @Test fun `already-owned buy attempt silently restores the purchase instead of erroring`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1,0 +1,110 @@
+package eu.darken.bluemusic.upgrade.core
+
+import com.android.billingclient.api.Purchase
+import eu.darken.bluemusic.common.datastore.DataStoreValue
+import eu.darken.bluemusic.common.upgrade.UpgradeRepo
+import eu.darken.bluemusic.upgrade.core.billing.BillingData
+import eu.darken.bluemusic.upgrade.core.billing.BillingManager
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import java.time.Instant
+
+class UpgradeRepoGplayTest : BaseTest() {
+
+    private val scope = CoroutineScope(Dispatchers.Unconfined)
+    private val billingManager = mockk<BillingManager>()
+    private val billingCache = mockk<BillingCache>()
+
+    // Builds a repo whose stored last-Pro timestamp is `lastProAt`. billingData is stubbed only
+    // because the upgradeInfo flow references it at construction; it is never collected here.
+    private fun repo(lastProAt: Long): UpgradeRepoGplay {
+        every { billingManager.billingData } returns flowOf(BillingData(emptySet()))
+        val lastPro = mockk<DataStoreValue<Long>>(relaxed = true).apply {
+            every { flow } returns flowOf(lastProAt)
+        }
+        every { billingCache.lastProStateAt } returns lastPro
+        return UpgradeRepoGplay(scope, billingManager, billingCache)
+    }
+
+    private fun proPurchase() = mockk<Purchase>().apply {
+        every { products } returns OurSku.PRO_SKUS.map { it.id }
+        every { purchaseTime } returns Instant.parse("2024-01-01T00:00:00Z").toEpochMilli()
+    }
+
+    @Test fun `test upgrade info pro status mapping`() {
+        UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = null
+        ).apply {
+            isUpgraded shouldBe false
+            type shouldBe UpgradeRepo.Type.GPLAY
+        }
+
+        UpgradeRepoGplay.Info(
+            gracePeriod = true,
+            billingData = null
+        ).isUpgraded shouldBe true
+
+        val info = UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = BillingData(
+                purchases = setOf(
+                    mockk<Purchase>().apply {
+                        every { products } returns OurSku.PRO_SKUS.map { it.id }
+                        every { purchaseTime } returns Instant.parse("2023-12-10T00:00:00Z").toEpochMilli()
+                    }
+                )
+            )
+        )
+        info.isUpgraded shouldBe true
+        info.upgradedAt shouldBe Instant.parse("2023-12-10T00:00:00Z")
+    }
+
+    @Test fun `grace period is 7 days`() {
+        // Guards against the unit error where 7 * 24 * 60 * 1000 (2.8h) was used instead of 7 days,
+        // which dropped paying users to non-Pro within hours of a transient empty/failed billing response.
+        UpgradeRepoGplay.GRACE_PERIOD_MS shouldBe 604_800_000L
+    }
+
+    @Test fun `restore returns pro when a purchase is found`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+
+        repo(lastProAt = 0L).restorePurchaseNow().isUpgraded shouldBe true
+    }
+
+    @Test fun `restore keeps pro within grace when the query comes back empty`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().isUpgraded shouldBe true
+    }
+
+    @Test fun `restore is not pro when the query is empty and grace has expired`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+
+        val expired = System.currentTimeMillis() - UpgradeRepoGplay.GRACE_PERIOD_MS - 1_000
+        repo(lastProAt = expired).restorePurchaseNow().isUpgraded shouldBe false
+    }
+
+    @Test fun `restore keeps pro within grace when the query errors`() = runTest2 {
+        coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
+
+        repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow().isUpgraded shouldBe true
+    }
+
+    @Test fun `restore rethrows the error when it happens outside grace`() = runTest2 {
+        coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
+
+        shouldThrow<RuntimeException> {
+            repo(lastProAt = 0L).restorePurchaseNow()
+        }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1,13 +1,17 @@
 package eu.darken.bluemusic.upgrade.core
 
+import android.app.Activity
 import com.android.billingclient.api.Purchase
 import eu.darken.bluemusic.common.datastore.DataStoreValue
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.upgrade.core.billing.BillingData
 import eu.darken.bluemusic.upgrade.core.billing.BillingManager
+import eu.darken.bluemusic.upgrade.core.billing.ItemAlreadyOwnedBillingException
 import eu.darken.bluemusic.upgrade.core.billing.PurchasedSku
+import eu.darken.bluemusic.upgrade.core.billing.UserCanceledBillingException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -194,5 +198,59 @@ class UpgradeRepoGplayTest : BaseTest() {
 
         coVerify(exactly = 0) { lastProState.update(any()) }
         coVerify(exactly = 0) { lastProStateSku.update(any()) }
+    }
+
+    @Test fun `already-owned buy attempt silently restores the purchase instead of erroring`() = runTest2 {
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+
+        errors shouldBe emptyList<Throwable>()
+    }
+
+    @Test fun `already-owned buy attempt falls back to the error dialog when restore finds nothing`() = runTest2 {
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        coEvery { billingManager.refresh() } returns BillingData(emptySet())
+
+        val errors = mutableListOf<Throwable>()
+        // Grace expired -> the restore can't rescue the entitlement either.
+        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+
+        errors.single().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
+    }
+
+    @Test fun `already-owned buy attempt falls back to the error dialog when restore itself errors`() = runTest2 {
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        coEvery { billingManager.refresh() } throws RuntimeException("Play unavailable")
+
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+
+        errors.single().shouldBeInstanceOf<ItemAlreadyOwnedBillingException>()
+    }
+
+    @Test fun `user cancel during the buy flow stays silent`() = runTest2 {
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            UserCanceledBillingException(RuntimeException("launch result"))
+
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+
+        errors shouldBe emptyList<Throwable>()
+    }
+
+    @Test fun `other buy flow failures reach the error callback`() = runTest2 {
+        val failure = RuntimeException("launch failed")
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws failure
+
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+
+        errors.single() shouldBe failure
     }
 }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
@@ -37,8 +37,10 @@ class BillingManagerTest : BaseTest() {
     private fun connection(
         refreshResults: List<Collection<Purchase>>,
         events: Flow<Pair<BillingResult, Collection<Purchase>?>?> = emptyFlow(),
+        refreshComplete: Boolean = true,
     ) = mockk<BillingConnection>().apply {
-        coEvery { refreshPurchases() } returnsMany refreshResults
+        coEvery { refreshPurchases() } returnsMany
+            refreshResults.map { BillingConnection.PurchaseRefresh(it, isComplete = refreshComplete) }
         every { purchases } returns emptyFlow()
         every { purchaseEvents } returns events
     }
@@ -59,6 +61,17 @@ class BillingManagerTest : BaseTest() {
 
         refreshed shouldBe BillingData(listOf(owned))
         manager.freshBillingData.first() shouldBe BillingManager.FreshData(refreshed, isFullSnapshot = true)
+    }
+
+    @Test fun `a partial refresh is not labeled a full snapshot`() = runTest2 {
+        val owned = purchase()
+        val manager = manager(
+            connection(refreshResults = listOf(emptyList(), listOf(owned)), refreshComplete = false)
+        )
+
+        manager.refresh()
+
+        manager.freshBillingData.first().isFullSnapshot shouldBe false
     }
 
     @Test fun `completed purchase events emit fresh billing data`() = runTest2 {
@@ -94,7 +107,8 @@ class BillingManagerTest : BaseTest() {
     // the path Play uses for immediate "buy" failures (returned result, not an exception).
     private fun launchFailingManager(code: Int): BillingManager {
         val connection = mockk<BillingConnection>().apply {
-            coEvery { refreshPurchases() } returns emptyList()
+            coEvery { refreshPurchases() } returns
+                BillingConnection.PurchaseRefresh(emptyList(), isComplete = true)
             every { purchases } returns emptyFlow()
             every { purchaseEvents } returns emptyFlow()
             coEvery { launchBillingFlow(any(), any(), null) } throws

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
@@ -58,7 +58,7 @@ class BillingManagerTest : BaseTest() {
         val refreshed = manager.refresh()
 
         refreshed shouldBe BillingData(listOf(owned))
-        manager.freshBillingData.first() shouldBe refreshed
+        manager.freshBillingData.first() shouldBe BillingManager.FreshData(refreshed, isFullSnapshot = true)
     }
 
     @Test fun `completed purchase events emit fresh billing data`() = runTest2 {
@@ -71,7 +71,8 @@ class BillingManagerTest : BaseTest() {
             )
         )
 
-        manager.freshBillingData.first() shouldBe BillingData(listOf(owned))
+        manager.freshBillingData.first() shouldBe
+            BillingManager.FreshData(BillingData(listOf(owned)), isFullSnapshot = false)
     }
 
     @Test fun `failed purchase events do not emit fresh billing data`() = runTest2 {
@@ -85,7 +86,8 @@ class BillingManagerTest : BaseTest() {
         )
 
         // Only the initial refresh result may arrive, never the failed event's payload.
-        manager.freshBillingData.first() shouldBe BillingData(listOf(owned))
+        manager.freshBillingData.first() shouldBe
+            BillingManager.FreshData(BillingData(listOf(owned)), isFullSnapshot = true)
     }
 
     // A manager whose connection fails launchBillingFlow with the given launch-result code —

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
@@ -1,11 +1,15 @@
 package eu.darken.bluemusic.upgrade.core.billing
 
+import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.Purchase.PurchaseState
+import eu.darken.bluemusic.upgrade.core.OurSku
+import eu.darken.bluemusic.upgrade.core.billing.client.BillingClientException
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnection
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnectionProvider
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
@@ -82,5 +86,53 @@ class BillingManagerTest : BaseTest() {
 
         // Only the initial refresh result may arrive, never the failed event's payload.
         manager.freshBillingData.first() shouldBe BillingData(listOf(owned))
+    }
+
+    // A manager whose connection fails launchBillingFlow with the given launch-result code —
+    // the path Play uses for immediate "buy" failures (returned result, not an exception).
+    private fun launchFailingManager(code: Int): BillingManager {
+        val connection = mockk<BillingConnection>().apply {
+            coEvery { refreshPurchases() } returns emptyList()
+            every { purchases } returns emptyFlow()
+            every { purchaseEvents } returns emptyFlow()
+            coEvery { launchBillingFlow(any(), any(), null) } throws
+                BillingClientException(BillingResult.newBuilder().setResponseCode(code).build())
+        }
+        return manager(connection)
+    }
+
+    @Test fun `already-owned launch failure maps to ItemAlreadyOwnedBillingException`() = runTest2 {
+        shouldThrow<ItemAlreadyOwnedBillingException> {
+            launchFailingManager(BillingResponseCode.ITEM_ALREADY_OWNED)
+                .startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
+        }
+    }
+
+    @Test fun `user cancel from the launch result maps to UserCanceledBillingException`() = runTest2 {
+        shouldThrow<UserCanceledBillingException> {
+            launchFailingManager(BillingResponseCode.USER_CANCELED)
+                .startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
+        }
+    }
+
+    @Test fun `billing-unavailable launch failure maps to the service error`() = runTest2 {
+        shouldThrow<GplayServiceUnavailableException> {
+            launchFailingManager(BillingResponseCode.BILLING_UNAVAILABLE)
+                .startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
+        }
+    }
+
+    @Test fun `network launch failure maps to NetworkBillingException`() = runTest2 {
+        shouldThrow<NetworkBillingException> {
+            launchFailingManager(BillingResponseCode.NETWORK_ERROR)
+                .startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
+        }
+    }
+
+    @Test fun `developer errors are rethrown unmapped`() = runTest2 {
+        shouldThrow<BillingClientException> {
+            launchFailingManager(BillingResponseCode.DEVELOPER_ERROR)
+                .startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
+        }
     }
 }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
@@ -1,0 +1,86 @@
+package eu.darken.bluemusic.upgrade.core.billing
+
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.Purchase.PurchaseState
+import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnection
+import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnectionProvider
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+
+class BillingManagerTest : BaseTest() {
+
+    private val scope = CoroutineScope(Dispatchers.Unconfined)
+
+    private fun purchase() = mockk<Purchase>().apply {
+        every { purchaseState } returns PurchaseState.PURCHASED
+        every { purchaseTime } returns 1_000L
+        every { isAcknowledged } returns true
+    }
+
+    private fun connection(
+        refreshResults: List<Collection<Purchase>>,
+        events: Flow<Pair<BillingResult, Collection<Purchase>?>?> = emptyFlow(),
+    ) = mockk<BillingConnection>().apply {
+        coEvery { refreshPurchases() } returnsMany refreshResults
+        every { purchases } returns emptyFlow()
+        every { purchaseEvents } returns events
+    }
+
+    private fun manager(connection: BillingConnection): BillingManager {
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flowOf(connection)
+        }
+        return BillingManager(scope, provider)
+    }
+
+    @Test fun `manual refresh returns and emits fresh billing data`() = runTest2 {
+        val owned = purchase()
+        // First result feeds the initial per-connection refresh, second the manual one.
+        val manager = manager(connection(refreshResults = listOf(emptyList(), listOf(owned))))
+
+        val refreshed = manager.refresh()
+
+        refreshed shouldBe BillingData(listOf(owned))
+        manager.freshBillingData.first() shouldBe refreshed
+    }
+
+    @Test fun `completed purchase events emit fresh billing data`() = runTest2 {
+        val owned = purchase()
+        val ok = BillingResult.newBuilder().setResponseCode(BillingResponseCode.OK).build()
+        val manager = manager(
+            connection(
+                refreshResults = listOf(emptyList()),
+                events = flowOf(ok to listOf(owned)),
+            )
+        )
+
+        manager.freshBillingData.first() shouldBe BillingData(listOf(owned))
+    }
+
+    @Test fun `failed purchase events do not emit fresh billing data`() = runTest2 {
+        val owned = purchase()
+        val error = BillingResult.newBuilder().setResponseCode(BillingResponseCode.ERROR).build()
+        val manager = manager(
+            connection(
+                refreshResults = listOf(listOf(owned)),
+                events = flowOf(error to listOf(purchase())),
+            )
+        )
+
+        // Only the initial refresh result may arrive, never the failed event's payload.
+        manager.freshBillingData.first() shouldBe BillingData(listOf(owned))
+    }
+}

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -94,7 +94,9 @@ class BillingConnectionTest : BaseTest() {
             )
             val connection = BillingConnection(client, MutableStateFlow(null))
 
-            connection.refreshPurchases() shouldBe listOf(owned)
+            val refresh = connection.refreshPurchases()
+            refresh.purchases shouldBe listOf(owned)
+            refresh.isComplete shouldBe false
             connection.purchases.first() shouldBe listOf(owned)
         } finally {
             unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -1,0 +1,54 @@
+package eu.darken.bluemusic.upgrade.core.billing.client
+
+import com.android.billingclient.api.Purchase
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class BillingConnectionTest : BaseTest() {
+
+    private fun purchase(time: Long) = mockk<Purchase>().apply { every { purchaseTime } returns time }
+
+    @Test fun `combines both product types, newest first`() {
+        val older = purchase(1_000)
+        val newer = purchase(2_000)
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(older)),
+            sub = Result.success(listOf(newer)),
+        ) shouldBe listOf(newer, older)
+    }
+
+    @Test fun `a single product-type failure does not mask a purchase found by the other`() {
+        val owned = purchase(1_000)
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(owned)),
+            sub = Result.failure(RuntimeException("SUBS query failed")),
+        ) shouldBe listOf(owned)
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.failure(RuntimeException("IAP query failed")),
+            sub = Result.success(listOf(owned)),
+        ) shouldBe listOf(owned)
+    }
+
+    @Test fun `both product types empty returns empty`() {
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(emptyList()),
+            sub = Result.success(emptyList()),
+        ) shouldBe emptyList()
+    }
+
+    @Test fun `nothing found but a query failed rethrows the error`() {
+        shouldThrow<RuntimeException> {
+            BillingConnection.combinePurchaseResults(
+                iap = Result.success(emptyList()),
+                sub = Result.failure(RuntimeException("SUBS query failed")),
+            )
+        }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -1,16 +1,40 @@
 package eu.darken.bluemusic.upgrade.core.billing.client
 
+import android.text.TextUtils
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
+import com.android.billingclient.api.Purchase.PurchaseState
+import com.android.billingclient.api.PurchasesResult
+import com.android.billingclient.api.QueryPurchasesParams
+import com.android.billingclient.api.queryPurchasesAsync
+import eu.darken.bluemusic.upgrade.core.OurSku
+import eu.darken.bluemusic.upgrade.core.billing.SkuDetails
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.spyk
+import io.mockk.unmockkStatic
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
 
 class BillingConnectionTest : BaseTest() {
 
     private fun purchase(time: Long) = mockk<Purchase>().apply { every { purchaseTime } returns time }
+
+    private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
 
     @Test fun `combines both product types, newest first`() {
         val older = purchase(1_000)
@@ -49,6 +73,86 @@ class BillingConnectionTest : BaseTest() {
                 iap = Result.success(emptyList()),
                 sub = Result.failure(RuntimeException("SUBS query failed")),
             )
+        }
+    }
+
+    @Test fun `a partial-failure refresh still reaches the reactive purchases flow`() = runTest2 {
+        // A purchase found by one product type while the other query fails must not leave the
+        // reactive purchases/upgradeInfo chain starved — otherwise a successful restore would never
+        // actually unlock the app.
+        mockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        try {
+            val owned = mockk<Purchase>().apply {
+                every { purchaseState } returns PurchaseState.PURCHASED
+                every { purchaseTime } returns 1_000L
+            }
+            val client = mockk<BillingClient>()
+            // Single-threaded test dispatcher: first query is INAPP, second is SUBS.
+            coEvery { client.queryPurchasesAsync(any<QueryPurchasesParams>()) } returnsMany listOf(
+                PurchasesResult(result(BillingResponseCode.OK), listOf(owned)),
+                PurchasesResult(result(BillingResponseCode.ERROR), emptyList()),
+            )
+            val connection = BillingConnection(client, MutableStateFlow(null))
+
+            connection.refreshPurchases() shouldBe listOf(owned)
+            connection.purchases.first() shouldBe listOf(owned)
+        } finally {
+            unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+
+    // The BillingFlowParams builder calls TextUtils.isEmpty, which is an unmocked Android stub in
+    // plain JVM tests — give it its real behavior.
+    private fun mockTextUtils() {
+        mockkStatic(TextUtils::class)
+        every { TextUtils.isEmpty(anyNullable()) } answers { firstArg<CharSequence?>().isNullOrEmpty() }
+    }
+
+    @Test fun `launch billing flow throws on a non-OK launch result`() = runTest2 {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        mockTextUtils()
+        try {
+            val client = mockk<BillingClient>()
+            val connection = spyk(BillingConnection(client, MutableStateFlow(null)))
+            val details = mockk<ProductDetails>(relaxed = true).apply {
+                every { productId } returns OurSku.Iap.PRO_UPGRADE.id
+                every { subscriptionOfferDetails } returns null
+            }
+            coEvery { connection.querySkus(*anyVararg()) } returns
+                listOf(SkuDetails(sku = OurSku.Iap.PRO_UPGRADE, details = details))
+            every { client.launchBillingFlow(any(), any()) } returns
+                result(BillingResponseCode.ITEM_ALREADY_OWNED)
+
+            val ex = shouldThrow<BillingClientException> {
+                connection.launchBillingFlow(mockk(), OurSku.Iap.PRO_UPGRADE, null)
+            }
+            ex.result.responseCode shouldBe BillingResponseCode.ITEM_ALREADY_OWNED
+        } finally {
+            unmockkStatic(TextUtils::class)
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test fun `launch billing flow returns the result when the launch succeeds`() = runTest2 {
+        Dispatchers.setMain(UnconfinedTestDispatcher())
+        mockTextUtils()
+        try {
+            val client = mockk<BillingClient>()
+            val connection = spyk(BillingConnection(client, MutableStateFlow(null)))
+            val details = mockk<ProductDetails>(relaxed = true).apply {
+                every { productId } returns OurSku.Iap.PRO_UPGRADE.id
+                every { subscriptionOfferDetails } returns null
+            }
+            coEvery { connection.querySkus(*anyVararg()) } returns
+                listOf(SkuDetails(sku = OurSku.Iap.PRO_UPGRADE, details = details))
+            every { client.launchBillingFlow(any(), any()) } returns result(BillingResponseCode.OK)
+
+            val launchResult = connection.launchBillingFlow(mockk(), OurSku.Iap.PRO_UPGRADE, null)
+
+            launchResult.responseCode shouldBe BillingResponseCode.OK
+        } finally {
+            unmockkStatic(TextUtils::class)
+            Dispatchers.resetMain()
         }
     }
 }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
@@ -2,6 +2,7 @@ package eu.darken.bluemusic.upgrade.ui
 
 import eu.darken.bluemusic.common.navigation.NavigationController
 import eu.darken.bluemusic.upgrade.core.UpgradeRepoGplay
+import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -43,6 +44,7 @@ class UpgradeViewModelTest : BaseTest() {
     private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
         every { wasEverPro } returns MutableStateFlow(false)
+        every { autoRestoreBusy } returns MutableStateFlow(false)
         coEvery { querySkus(*anyVararg()) } returns emptyList()
     }
 
@@ -160,6 +162,49 @@ class UpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test fun `auto-restore busy state pauses the ui like a manual restore`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        every { repo.autoRestoreBusy } returns MutableStateFlow(true)
+        val vm = buildVm(repo)
+
+        val state = async { vm.state.filterNotNull().first() }
+        advanceUntilIdle()
+
+        state.await().restoreInProgress shouldBe true
+    }
+
+    @Test fun `play-unavailable error is emitted once despite state recombinations`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        // Both SKU queries exceed the 5s query timeout -> "Play unavailable" episode.
+        coEvery { repo.querySkus(*anyVararg()) } coAnswers {
+            delay(6_000)
+            emptyList()
+        }
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(1_000)
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        }
+        val vm = buildVm(repo)
+
+        val errors = mutableListOf<Throwable>()
+        val errorCollector = launch { vm.errorEvents.collect { errors.add(it) } }
+        val stateCollector = launch { vm.state.collect {} }
+        advanceUntilIdle()
+
+        // Restore progress toggling recombines the state twice more.
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        errors.filterIsInstance<GplayServiceUnavailableException>().size shouldBe 1
+
+        errorCollector.cancel()
+        stateCollector.cancel()
     }
 
     @Test fun `restore errors surface via errorEvents not RestoreFailed`() = runTest2(

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
@@ -1,0 +1,183 @@
+package eu.darken.bluemusic.upgrade.ui
+
+import eu.darken.bluemusic.common.navigation.NavigationController
+import eu.darken.bluemusic.upgrade.core.UpgradeRepoGplay
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import testhelpers.coroutine.runTest2
+
+class UpgradeViewModelTest : BaseTest() {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @BeforeEach
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterEach
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun mockRepo(): UpgradeRepoGplay = mockk<UpgradeRepoGplay>(relaxed = true).apply {
+        every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
+        every { wasEverPro } returns MutableStateFlow(false)
+        coEvery { querySkus(*anyVararg()) } returns emptyList()
+    }
+
+    private fun buildVm(repo: UpgradeRepoGplay) = UpgradeViewModel(
+        dispatcherProvider = TestDispatcherProvider(testDispatcher),
+        navCtrl = mockk<NavigationController>(relaxed = true),
+        upgradeRepo = repo,
+    )
+
+    @Test fun `previously pro without current entitlement raises the banner flag`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        every { repo.wasEverPro } returns MutableStateFlow(true)
+        val vm = buildVm(repo)
+
+        val state = async { vm.state.filterNotNull().first() }
+        advanceUntilIdle()
+
+        state.await().wasPreviouslyPro shouldBe true
+    }
+
+    @Test fun `grace period keeps the banner flag off`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        every { repo.wasEverPro } returns MutableStateFlow(true)
+        every { repo.upgradeInfo } returns
+            MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
+        val vm = buildVm(repo)
+
+        val state = async { vm.state.filterNotNull().first() }
+        advanceUntilIdle()
+
+        state.await().wasPreviouslyPro shouldBe false
+    }
+
+    @Test fun `restore is single flight`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(1_000)
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        }
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.restorePurchaseNow() }
+    }
+
+    @Test fun `restore guard re-arms after completion`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        val vm = buildVm(repo)
+
+        vm.restorePurchase()
+        advanceUntilIdle()
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        coVerify(exactly = 2) { repo.restorePurchaseNow() }
+    }
+
+    @Test fun `restore that times out emits RestoreFailed and re-enables the UI`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(30_000) // longer than the 15s restore timeout
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        }
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreFailed
+
+        // The single-flight guard must have re-armed after the timeout.
+        vm.restorePurchase()
+        advanceUntilIdle()
+        coVerify(exactly = 2) { repo.restorePurchaseNow() }
+    }
+
+    @Test fun `restore progress folds into the ui state`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(10_000)
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        }
+        val vm = buildVm(repo)
+
+        val states = mutableListOf<UpgradeViewModel.State>()
+        val collector = launch { vm.state.filterNotNull().collect { states.add(it) } }
+
+        vm.restorePurchase()
+        advanceTimeBy(5_000)
+        states.last().restoreInProgress shouldBe true
+
+        advanceUntilIdle()
+        states.last().restoreInProgress shouldBe false
+
+        collector.cancel()
+    }
+
+    @Test fun `restore with no purchase emits RestoreFailed`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(false, null, null)
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test fun `restore errors surface via errorEvents not RestoreFailed`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } throws RuntimeException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val error = async { vm.errorEvents.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        error.await().message shouldBe "Play unavailable"
+
+        // The single-flight guard must have re-armed after the error.
+        vm.restorePurchase()
+        advanceUntilIdle()
+        coVerify(exactly = 2) { repo.restorePurchaseNow() }
+    }
+}


### PR DESCRIPTION
## What changed

Ports the SD Maid SE billing fix series (d4rken-org/sdmaid-se#2554, #2555, #2556, #2558, #2559) — BlueMusic's gplay billing stack shares the same code lineage and had every one of those bugs — plus five BlueMusic-first hardening fixes found during the port's review.

- **Restore purchase** no longer races the shared flow replay cache: Pro is evaluated from freshly queried purchases in the same coroutine, bounded by a 15s timeout, and billing errors show the proper "Play unavailable" dialog instead of the generic restore-failed one. A single failed product-type query no longer masks a purchase found by the other, and a partial result now still reaches the reactive purchases flow (a gap that also exists upstream).
- **Grace period**: one-time Pro buyers stay Pro through up to 30 days of Play hiccups, subscriptions keep 7 days. Also fixes the grace math bug — `7 * 24 * 60 * 1000` ms is ~2.8 hours, not 7 days. Grace is stamped only from fresh-provenance Play data (never replayed flow data), atomically (SKU + timestamp in one DataStore transaction), and a subscription-only purchase event can't downgrade a permanent IAP's window.
- **Restore banner** for returning Pro buyers ("Already bought BVM Pro?"), driven by a local wasEverPro signal.
- **Restore progress**: spinner + single-flight guard; buy buttons pause during restores (manual or the invisible already-owned auto-restore) so entitlement operations can't race each other.
- **Buy-flow failures are no longer silent**: `launchBillingFlow`'s returned result now throws (and runs on the main thread per the BillingClient contract); ITEM_ALREADY_OWNED auto-restores silently, other failures show localized error dialogs (already-owned / internal / network / user-canceled-silent).

## Technical Context

- Commit-per-upstream-PR structure; the five BlueMusic-original commits are candidates for upstreaming to SD Maid SE (replay grace re-stamping, partial-result starvation of the purchases combine, partial-snapshot grace downgrade, auto-restore busy state, Play-unavailable dialog dedup).
- New `app/src/testGplay` unit test source set (~50 tests: repo grace/restore matrix, connection combine/launch seams, manager mapping/fresh-data, ViewModel single-flight/timeout/banner) + `runTest2` helper in shared test helpers.
- New base-English strings (restore banner + billing error dialogs) go through the usual Crowdin round-trip; full `lintGplayDebug` was already red on main (pre-existing NewApi/MissingTranslation errors), all CI-gated `lintVital*` variants pass.
- Design decisions and per-finding review notes came out of a Codex-assisted review; deliberate SD Maid parity kept for the AppScope buy-flow shape and `Collection<Purchase>` refresh shape.