### PR TITLE
Make Google Play billing recover from Play outages and stale purchase data

### DIFF
--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.upgrade.core
 
 import android.app.Activity
+import com.android.billingclient.api.BillingClient.BillingResponseCode
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.datastore.value
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
@@ -26,6 +27,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -50,6 +52,14 @@ class UpgradeRepoGplay @Inject constructor(
 
     override val mainWebsite: String = SITE
 
+    // Counter, not a flag: overlapping already-owned recoveries (buy taps racing the UI disable)
+    // must keep the busy signal up until the LAST one finishes.
+    private val autoRestoring = MutableStateFlow(0)
+
+    // The already-owned auto-restores below run invisibly on AppScope; expose their busy state so
+    // the UI can pause entitlement actions instead of racing them with a manual restore or a buy.
+    val autoRestoreBusy: Flow<Boolean> = autoRestoring.map { it > 0 }
+
     init {
         // Grace bookkeeping is driven by *fresh* Play query results only (per-connection/manual
         // refreshes, completed purchases) — never by the replayed billingData/upgradeInfo flows.
@@ -69,6 +79,27 @@ class UpgradeRepoGplay @Inject constructor(
                 }
             }
             .setupCommonEventHandlers(TAG) { "lastProState-stamping" }
+            .launchIn(scope)
+
+        // Async variant of the launch-result ITEM_ALREADY_OWNED case: Play told us mid-flow that the
+        // user already owns it. Reconcile silently — Play shows its own UI for purchase-sheet
+        // failures, so no app-side dialog here.
+        billingManager.purchaseFailures
+            .filter { it.responseCode == BillingResponseCode.ITEM_ALREADY_OWNED }
+            .onEach {
+                log(TAG, INFO) { "Async already-owned event -> restoring purchase" }
+                autoRestoring.update { it + 1 }
+                try {
+                    withTimeoutOrNull(RESTORE_ON_OWNED_TIMEOUT_MS) { restorePurchaseNow() }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, WARN) { "Async already-owned restore failed: ${e.asLog()}" }
+                } finally {
+                    autoRestoring.update { it - 1 }
+                }
+            }
+            .setupCommonEventHandlers(TAG) { "asyncAlreadyOwned" }
             .launchIn(scope)
     }
 
@@ -115,15 +146,9 @@ class UpgradeRepoGplay @Inject constructor(
 
     // True once we've ever confirmed a (known) Pro purchase on this install; drives the proactive
     // restore banner. Local signal only — a fresh install or switched Google account starts false.
-    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow.map { it > 0 }
-
-    // Counter, not a flag: overlapping already-owned recoveries (buy taps racing the UI disable)
-    // must keep the busy signal up until the LAST one finishes.
-    private val autoRestoring = MutableStateFlow(0)
-
-    // The already-owned auto-restore below runs invisibly on AppScope; expose its busy state so the
-    // UI can pause entitlement actions instead of racing it with a manual restore or another buy.
-    val autoRestoreBusy: Flow<Boolean> = autoRestoring.map { it > 0 }
+    val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow
+        .map { it > 0 }
+        .distinctUntilChanged()
 
     fun launchBillingFlow(
         activity: Activity,
@@ -179,7 +204,9 @@ class UpgradeRepoGplay @Inject constructor(
     override suspend fun refresh() {
         log(TAG) { "refresh()" }
         try {
-            billingManager.refresh()
+            // Bounded: with unbounded connection retry, an unavailable Play would otherwise keep
+            // background callers (MainViewModel) suspended indefinitely.
+            withTimeoutOrNull(REFRESH_TIMEOUT_MS) { billingManager.refresh() }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -284,6 +311,7 @@ class UpgradeRepoGplay @Inject constructor(
         val GRACE_PERIOD_MS = Duration.ofDays(7).toMillis()
         val GRACE_PERIOD_IAP_MS = Duration.ofDays(30).toMillis()
         private const val RESTORE_ON_OWNED_TIMEOUT_MS = 15_000L
+        private const val REFRESH_TIMEOUT_MS = 30_000L
 
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
 

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
@@ -2,6 +2,7 @@ package eu.darken.bluemusic.upgrade.core.billing
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase.PurchaseState
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
@@ -21,7 +22,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted.Companion.WhileSubscribed
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
@@ -67,7 +67,19 @@ class BillingManager @Inject constructor(
                 log(TAG, ERROR) { "Initial purchase data refresh failed: ${e.asLog()}" }
             }
         }
-        .catch { log(TAG, ERROR) { "Unable to provide client connection:\n${it.asLog()}" } }
+        .retryWhen { cause, attempt ->
+            // Never give up terminally: the ack collector pins this shareIn forever, so WhileSubscribed
+            // can't restart a completed upstream — a swallowed terminal failure (e.g. one transient
+            // BILLING_UNAVAILABLE while Play updates itself at boot) would leave billing dead until
+            // process restart. Retry with capped backoff instead; Play recovering makes this heal.
+            if (cause is CancellationException) {
+                false
+            } else {
+                log(TAG, WARN) { "Billing connection failed (attempt=$attempt), will retry: ${cause.asLog()}" }
+                delay((30_000L * (attempt + 1)).coerceAtMost(300_000L))
+                true
+            }
+        }
         .setupCommonEventHandlers(TAG) { "connection" }
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
@@ -80,6 +92,10 @@ class BillingManager @Inject constructor(
     val billingData: Flow<BillingData> = purchases
         .map { BillingData(purchases = it) }
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
+
+    val purchaseFailures: Flow<BillingResult> = connection
+        .flatMapLatest { it.purchaseFailures }
+        .setupCommonEventHandlers(TAG) { "purchaseFailures" }
 
     init {
         // Completed purchases arriving via the PurchasesUpdatedListener are fresh Play data too.

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
@@ -34,6 +34,7 @@ import kotlin.coroutines.suspendCoroutine
 data class BillingConnection(
     private val client: BillingClient,
     val purchaseEvents: Flow<Pair<BillingResult, Collection<Purchase>?>?>,
+    private val failureEvents: Flow<BillingResult?> = MutableStateFlow(null),
 ) {
 
     // Last authoritative ownership snapshot: the combined result of a successful refreshPurchases().
@@ -57,6 +58,10 @@ data class BillingConnection(
 
         combined.sortedByDescending { it.purchaseTime }
     }.setupCommonEventHandlers(TAG) { "purchases" }
+
+    // Non-OK results from onPurchasesUpdated (e.g. async ITEM_ALREADY_OWNED after the Play sheet
+    // opened). Consumed by a single persistent collector in UpgradeRepoGplay — not an event bus.
+    val purchaseFailures: Flow<BillingResult> = failureEvents.filterNotNull()
 
     private suspend fun queryPurchases(@BillingClient.ProductType type: String): Collection<Purchase> {
         val params = QueryPurchasesParams.newBuilder().apply {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionProvider.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionProvider.kt
@@ -33,6 +33,7 @@ class BillingConnectionProvider @Inject constructor(
 
     private val provider: Flow<BillingConnection> = callbackFlow {
         val purchaseEvents = MutableStateFlow<Pair<BillingResult, Collection<Purchase>?>?>(null)
+        val failureEvents = MutableStateFlow<BillingResult?>(null)
 
         val client = newBuilder(context).apply {
             enablePendingPurchases(
@@ -50,6 +51,11 @@ class BillingConnectionProvider @Inject constructor(
                     log(TAG, WARN) {
                         "error: onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, purchases=$purchases)"
                     }
+                    // Failures are stored separately: async ITEM_ALREADY_OWNED drives the auto-restore
+                    // in UpgradeRepoGplay. A failure must not overwrite the last successful event —
+                    // the purchases combine would otherwise lose a fresh entitlement the query
+                    // snapshot doesn't contain yet.
+                    failureEvents.value = result
                 }
             }
         }.build()
@@ -63,7 +69,7 @@ class BillingConnectionProvider @Inject constructor(
 
                 when (result.responseCode) {
                     BillingResponseCode.OK -> {
-                        val connection = BillingConnection(client, purchaseEvents)
+                        val connection = BillingConnection(client, purchaseEvents, failureEvents)
                         trySendBlocking(connection)
                     }
 

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
@@ -1,6 +1,8 @@
 package eu.darken.bluemusic.upgrade.core
 
 import android.app.Activity
+import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
 import eu.darken.bluemusic.common.datastore.DataStoreValue
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
@@ -19,6 +21,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
@@ -44,10 +47,12 @@ class UpgradeRepoGplayTest : BaseTest() {
         lastSku: String = "",
         billingData: BillingData = BillingData(emptySet()),
         freshBillingData: BillingManager.FreshData? = null,
+        purchaseFailures: Flow<BillingResult> = emptyFlow(),
     ): UpgradeRepoGplay {
         every { billingManager.billingData } returns flowOf(billingData)
         every { billingManager.freshBillingData } returns
             (freshBillingData?.let { flowOf(it) } ?: emptyFlow())
+        every { billingManager.purchaseFailures } returns purchaseFailures
         every { lastProState.flow } returns flowOf(lastProAt)
         every { billingCache.lastProStateAt } returns lastProState
         every { lastProStateSku.flow } returns flowOf(lastSku)
@@ -289,5 +294,26 @@ class UpgradeRepoGplayTest : BaseTest() {
         repo(lastProAt = 0L).launchBillingFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
 
         errors.single() shouldBe failure
+    }
+
+    @Test fun `async already-owned purchase failure silently restores`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(setOf(proPurchase()))
+        val alreadyOwned = BillingResult.newBuilder()
+            .setResponseCode(BillingResponseCode.ITEM_ALREADY_OWNED)
+            .build()
+
+        repo(lastProAt = 0L, purchaseFailures = flowOf(alreadyOwned))
+
+        coVerify(exactly = 1) { billingManager.refresh() }
+    }
+
+    @Test fun `other async purchase failures are ignored`() = runTest2 {
+        val canceled = BillingResult.newBuilder()
+            .setResponseCode(BillingResponseCode.USER_CANCELED)
+            .build()
+
+        repo(lastProAt = 0L, purchaseFailures = flowOf(canceled))
+
+        coVerify(exactly = 0) { billingManager.refresh() }
     }
 }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
@@ -16,10 +16,14 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -38,11 +42,13 @@ class BillingManagerTest : BaseTest() {
         refreshResults: List<Collection<Purchase>>,
         events: Flow<Pair<BillingResult, Collection<Purchase>?>?> = emptyFlow(),
         refreshComplete: Boolean = true,
+        failures: Flow<BillingResult> = emptyFlow(),
     ) = mockk<BillingConnection>().apply {
         coEvery { refreshPurchases() } returnsMany
             refreshResults.map { BillingConnection.PurchaseRefresh(it, isComplete = refreshComplete) }
         every { purchases } returns emptyFlow()
         every { purchaseEvents } returns events
+        every { purchaseFailures } returns failures
     }
 
     private fun manager(connection: BillingConnection): BillingManager {
@@ -150,5 +156,43 @@ class BillingManagerTest : BaseTest() {
             launchFailingManager(BillingResponseCode.DEVELOPER_ERROR)
                 .startIapFlow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null)
         }
+    }
+
+    @Test fun `non-OK purchase events are exposed as purchase failures`() = runTest2 {
+        val alreadyOwned = BillingResult.newBuilder()
+            .setResponseCode(BillingResponseCode.ITEM_ALREADY_OWNED)
+            .build()
+        val manager = manager(
+            connection(
+                refreshResults = listOf(emptyList()),
+                failures = flowOf(alreadyOwned),
+            )
+        )
+
+        manager.purchaseFailures.first() shouldBe alreadyOwned
+    }
+
+    @Test fun `connection failures retry instead of killing billing`() = runTest2 {
+        // The old catch{log} swallowed terminal connection failures; with the ack collector pinning
+        // the shareIn subscription forever, billing stayed dead until process restart.
+        val owned = purchase()
+        var attempts = 0
+        // First refresh result feeds the initial per-connection refresh, second the manual one.
+        val connection = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                if (attempts == 1) throw BillingException("Play is updating itself")
+                emit(connection)
+            }
+        }
+        val manager = BillingManager(backgroundScope, provider)
+
+        val refreshed = async { manager.refresh() }
+        advanceTimeBy(31_000) // past the first 30s retry backoff
+        advanceUntilIdle()
+
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
     }
 }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -110,6 +110,42 @@ class BillingConnectionTest : BaseTest() {
         every { TextUtils.isEmpty(anyNullable()) } answers { firstArg<CharSequence?>().isNullOrEmpty() }
     }
 
+    @Test fun `purchase failures carry only non-OK listener results`() = runTest2 {
+        val failures = MutableStateFlow<BillingResult?>(null)
+        val connection = BillingConnection(mockk(), MutableStateFlow(null), failures)
+
+        failures.value = result(BillingResponseCode.ITEM_ALREADY_OWNED)
+
+        connection.purchaseFailures.first().responseCode shouldBe BillingResponseCode.ITEM_ALREADY_OWNED
+    }
+
+    @Test fun `a later failure event does not remove a fresh purchase from the purchases flow`() = runTest2 {
+        // Success and failure events live in separate flows: a USER_CANCELED arriving after a
+        // successful purchase event must not overwrite it — the purchase may not be in the query
+        // snapshot yet and would otherwise vanish from raw billing data until the next query.
+        mockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        try {
+            val client = mockk<BillingClient>()
+            coEvery { client.queryPurchasesAsync(any<QueryPurchasesParams>()) } returns
+                PurchasesResult(result(BillingResponseCode.OK), emptyList())
+            val events = MutableStateFlow<Pair<BillingResult, Collection<Purchase>?>?>(null)
+            val failures = MutableStateFlow<BillingResult?>(null)
+            val connection = BillingConnection(client, events, failures)
+            connection.refreshPurchases() // empty snapshot, predates the purchase
+
+            val owned = mockk<Purchase>().apply {
+                every { purchaseState } returns PurchaseState.PURCHASED
+                every { purchaseTime } returns 1_000L
+            }
+            events.value = result(BillingResponseCode.OK) to listOf(owned)
+            failures.value = result(BillingResponseCode.USER_CANCELED)
+
+            connection.purchases.first() shouldBe listOf(owned)
+        } finally {
+            unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+
     @Test fun `launch billing flow throws on a non-OK launch result`() = runTest2 {
         Dispatchers.setMain(UnconfinedTestDispatcher())
         mockTextUtils()


### PR DESCRIPTION
## What changed

Ports SD Maid SE's follow-up hardening PR (d4rken-org/sdmaid-se#2561). Stacked on #234.

- If Google Play is briefly unavailable when the app first checks billing (e.g. the Play Store updating itself at boot), billing now recovers on its own — previously one transient failure could leave billing dead until the process restarted, because the swallowed terminal error plus the process-lifetime ack subscriber meant the shared connection flow could never restart.
- If Play reports mid-purchase that the upgrade is already owned, it now restores automatically — the async listener variant of the launch-result case that #234 handles.

## Technical Context

- Connection: unbounded `retryWhen` with capped 5-minute backoff (cancellation passthrough) replaces `catch{log}`; background `refresh()` is bounded at 30s so an unavailable Play can't keep background callers suspended now that connection retry never gives up.
- Async ITEM_ALREADY_OWNED: listener failures are stored and exposed as `purchaseFailures`; a persistent repo collector silently runs the existing bounded restore, integrated with the `autoRestoreBusy` counter so the UI pauses entitlement actions. No app-side dialogs — Play shows its own UI for purchase-sheet failures.
- **Deviation from upstream #2561**: failure events live in a separate flow from success events. Upstream stores both in one `MutableStateFlow`, where a later failure (e.g. USER_CANCELED) overwrites the last success event and can drop a fresh purchase from the purchases combine until the next query — found in review here, to be flagged upstream. Regression test included.
- Upstream's third fix (grace stamping provenance) is already covered by #234's `freshBillingData` design and is not re-ported.
- `wasEverPro` gains `distinctUntilChanged`.