### PR TITLE
Make billing reconnect on user demand and tolerate slow Play stores

### DIFF
--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
@@ -26,12 +26,18 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.updateAndGet
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.withTimeoutOrNull
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -56,8 +62,29 @@ class BillingManager @Inject constructor(
     private val freshData = MutableSharedFlow<FreshData>(replay = 1)
     val freshBillingData: Flow<FreshData> = freshData
 
+    // Bumped whenever someone actively wants billing NOW (see useConnection): a pending reconnect
+    // backoff is cut short instead of making the user wait out the timer. A generation counter
+    // (compared against the value captured at attempt start) instead of an event flow, so demand
+    // arriving while a connection attempt is still in flight isn't lost, while demand that was
+    // already satisfied by a healthy connection can't skip a future backoff.
+    private val connectionDemand = MutableStateFlow(0)
+
+    // Highest demand generation actually served by a healthy connection (see useConnection):
+    // demand that was already satisfied must not skip a backoff after a later disconnect.
+    private val servedDemand = MutableStateFlow(0)
+
+    // Consecutive failed connection attempts since the last successful one. retryWhen's `attempt`
+    // counter never resets within a collection, so a long-lived process with earlier (healed)
+    // failures would otherwise start every new failure episode at the maximum backoff.
+    private var connectionFailStreak = 0
+
+    // Only touched from the sharing collector (onStart/onEach/retryWhen run sequentially there).
+    private var demandAtAttemptStart = 0
+
     private val connection = connectionProvider.connection
+        .onStart { demandAtAttemptStart = connectionDemand.value }
         .onEach {
+            connectionFailStreak = 0
             try {
                 val fresh = it.refreshPurchases()
                 freshData.emit(FreshData(BillingData(purchases = fresh.purchases), isFullSnapshot = fresh.isComplete))
@@ -67,7 +94,7 @@ class BillingManager @Inject constructor(
                 log(TAG, ERROR) { "Initial purchase data refresh failed: ${e.asLog()}" }
             }
         }
-        .retryWhen { cause, attempt ->
+        .retryWhen { cause, _ ->
             // Never give up terminally: the ack collector pins this shareIn forever, so WhileSubscribed
             // can't restart a completed upstream — a swallowed terminal failure (e.g. one transient
             // BILLING_UNAVAILABLE while Play updates itself at boot) would leave billing dead until
@@ -75,8 +102,20 @@ class BillingManager @Inject constructor(
             if (cause is CancellationException) {
                 false
             } else {
-                log(TAG, WARN) { "Billing connection failed (attempt=$attempt), will retry: ${cause.asLog()}" }
-                delay((30_000L * (attempt + 1)).coerceAtMost(300_000L))
+                connectionFailStreak++
+                val backoffMs = (30_000L * connectionFailStreak).coerceAtMost(300_000L)
+                log(TAG, WARN) {
+                    "Billing connection failed (streak=$connectionFailStreak), retrying in ${backoffMs}ms: ${cause.asLog()}"
+                }
+                // Wait out the backoff, but let active billing demand short-circuit it: a user who
+                // just fixed their Play situation (signed in, updated the store) shouldn't wait for
+                // the timer when they tap restore/buy or reopen the upgrade screen. Only demand that
+                // is newer than the failed attempt AND not yet served counts — the former limits a
+                // still-waiting caller to one skip per attempt (no tight retry loop), the latter
+                // keeps demand already satisfied by a healthy connection from skipping this backoff.
+                withTimeoutOrNull(backoffMs) {
+                    connectionDemand.first { it != demandAtAttemptStart && it > servedDemand.value }
+                }
                 true
             }
         }
@@ -162,10 +201,21 @@ class BillingManager @Inject constructor(
             .launchIn(scope)
     }
 
-    private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T = connection
-        .map { action(it) }
-        .take(1)
-        .single()
+    private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T {
+        // Every caller here is active demand (opening the upgrade screen, restore/buy taps, purchase
+        // acks) — cut a pending reconnect backoff short. A no-op while the connection is healthy.
+        val demandGen = connectionDemand.updateAndGet { it + 1 }
+        try {
+            return connection
+                .map { action(it) }
+                .take(1)
+                .single()
+        } finally {
+            // Settled on ANY termination — success, error, or the caller's own timeout/cancel: a
+            // call that is over is no longer pending demand and must not skip a much later backoff.
+            servedDemand.update { served -> maxOf(served, demandGen) }
+        }
+    }
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = useConnection {
         log(TAG) { "querySkus(): $skus..." }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
@@ -169,6 +169,17 @@ data class BillingConnection(
             throw IllegalStateException("No details available for ${skus.joinToString { "${it.type}-${it.id}" }}")
         }
 
+        // Concise offer overview: makes "Play withheld an offer (e.g. trial eligibility)" vs "app
+        // failed to match it" diagnosable from debug logs without wading through the full JSON.
+        log(TAG) {
+            val offers = details.joinToString { detail ->
+                val subOffers = detail.subscriptionOfferDetails
+                    ?.joinToString { "${it.basePlanId}/${it.offerId ?: "base"}" }
+                "${detail.productId} -> [${subOffers ?: "one-time"}]"
+            }
+            "querySkus() offers: $offers"
+        }
+
         return details
             .groupBy { it.productId }
             .mapNotNull { (key, details) ->

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -54,7 +54,7 @@ class UpgradeViewModel @Inject constructor(
 
     val state = combine(
         flow {
-            val data = withTimeoutOrNull(5000) {
+            val data = withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) {
                 try {
                     upgradeRepo.querySkus(*OurSku.PRO_SKUS.filterIsInstance<Sku.Iap>().toTypedArray())
                 } catch (e: Exception) {
@@ -65,7 +65,7 @@ class UpgradeViewModel @Inject constructor(
             emit(data)
         },
         flow {
-            val data = withTimeoutOrNull(5000) {
+            val data = withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) {
                 try {
                     upgradeRepo.querySkus(*OurSku.PRO_SKUS.filterIsInstance<Sku.Subscription>().toTypedArray())
                 } catch (e: Exception) {
@@ -217,5 +217,9 @@ class UpgradeViewModel @Inject constructor(
 
     companion object {
         private const val RESTORE_TIMEOUT_MS = 15_000L
+
+        // The very first billing query after Play sign-in can take >8s (measured) while Play warms
+        // up — 5s produced false "Play unavailable" dialogs on slow-but-healthy stores.
+        private const val SKU_QUERY_TIMEOUT_MS = 15_000L
     }
 }

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Opgradeer na BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager het geen advertensies nie en verkoop nie gebruikersdata nie. My werk word deur jou gefinansier ❤️.</string>
     <string name="upgrade_screen_why_title">Voordele</string>
-    <string name="upgrade_screen_why_body">• \'n Gemotiveerde ontwikkelaar 🧙
-• Onbeperkte toestelle ➡️➡️
-• Ekstra aksies ⚙️
-en meer…</string>
-    <string name="upgrade_screen_how_title">Opsies</string>
-    <string name="upgrade_screen_how_body">Jy kan kies tussen \'n eenmalige aankoop en \'n goedkoper jaarlikse inskrywing.\nDie inskrywing begin met \'n gratis 14-dag proeftydperk, waarna jy een keer per jaar gehef sal word. Proef en inskrywing kan te eniger tyd gekanselleer word.\nDieselfde funksies, net verskillende prysmodelle.</string>
     <string name="upgrade_screen_subscription_trial_action">Begin gratis 14-dag proef</string>
     <string name="upgrade_screen_subscription_action">Teken in</string>
     <string name="upgrade_screen_subscription_action_hint">Die inskrywing kos %s per jaar.</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">ወደ BVM Pro ክበቱ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ምንም እዋዀት ይረጋል፣ የተገባይ ውሂብንነም አይሸጥም። የ።ቡቡ፡ በ።ቡቡ፠ ዘርድ የካዘለኂው ❤️።</string>
     <string name="upgrade_screen_why_title">ጥቅሞች</string>
-    <string name="upgrade_screen_why_body">• የተጠቀየ ማድርግዬ 🧙
-• ምንም አይኖን መሣሪያዎች ➡️➡️
-• ✏✏✏✏ ✏✏✏ ⚙️
-እና ይጀምሮ...</string>
-    <string name="upgrade_screen_how_title">አማራጮች</string>
-    <string name="upgrade_screen_how_body">በአንድ ጊዜ ግዢ እና በርካሽ የዓመታዊ ደንበኝነት መካከል መምረጥ ይችላሉ።\nደንበኝነቱ በነፃ የ14 ቀን ሙከራ ይጀምራል፣ ከዚያ በኋላ በዓመት አንድ ጊዜ ይከፈላሉ። ሙከራ እና ደንበኝነት በማንኛውም ጊዜ ሊሰረዝ ይችላል።\nተመሳሳይ ባህሪያት፣ የተለያዩ የዋጋ አሰጣጥ ሞዴሎች ብቻ።</string>
     <string name="upgrade_screen_subscription_trial_action">ነፃ የ14 ቀን ሙከራ ይጀምሩ</string>
     <string name="upgrade_screen_subscription_action">ይመዝገቡ</string>
     <string name="upgrade_screen_subscription_action_hint">ደንበኝነቱ በዓመት %s ያስከፍላል።</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">الترقية إلى BVM Pro</string>
     <string name="upgrade_screen_preamble">لا يعرض Bluetooth Volume Manager أية إعلانات ولا يبيع بيانات المستخدم. يتم تمويل عملي من قِبَلكم ❤️.</string>
     <string name="upgrade_screen_why_title">المميزات</string>
-    <string name="upgrade_screen_why_body">• مطوّر متحمس 🧙
-• أجهزة غير محدودة ➡️➡️
-• إجراءات إضافية ⚙️
-والمزيد…</string>
-    <string name="upgrade_screen_how_title">الخيارات</string>
-    <string name="upgrade_screen_how_body">يمكنك الاختيار بين شراء مرّة واحدة واشتراك سنوي أرخص.\nيبدأ الاشتراك بالتجربة المجانية لمدة 14 يوما، وبعد ذلك ستتقاضى رسوما مرة واحدة في السنة. يمكن إلغاء التجربة والاشتراك في أي وقت.\nنفس الميزات لكن بنماذج تسعير مختلفة.</string>
     <string name="upgrade_screen_subscription_trial_action">بدء التجربة المجانية لمدة 14 يوماً</string>
     <string name="upgrade_screen_subscription_action">اشتراك</string>
     <string name="upgrade_screen_subscription_action_hint">الاشتراك يكلف %s لكل سنة.</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro-ya yüksəldin</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-də reklam yoxdur və istifadəçi məlumatlarını satmır. Mənim işim sizin tərəfindən maliyyələşdirilir ❤️.</string>
     <string name="upgrade_screen_why_title">Üstünlüklər</string>
-    <string name="upgrade_screen_why_body">• Həvəsli bir tərtibatçı 🧙
-• Limitsiz cihazlar ➡️➡️
-• Əlave əməliyyatlar ⚙️
-və daha çox…</string>
-    <string name="upgrade_screen_how_title">Seçimlər</string>
-    <string name="upgrade_screen_how_body">Siz birdəfəlik alış və daha ucuz illik abunə arasında seçim edə bilərsiniz.\nAbunə pulsuz 14 günlük sınaq ilə başlayır, bundan sonra ildə bir dəfə ödəniş edəcəksiniz. Sınaq və abunə istənilən vaxt ləğv edilə bilər.\nEyni xüsusiyyətlər, sadəcə fərqli qiymət modelləri.</string>
     <string name="upgrade_screen_subscription_trial_action">Pulsuz 14 günlük sınağa başlayın</string>
     <string name="upgrade_screen_subscription_action">Abunə olun</string>
     <string name="upgrade_screen_subscription_action_hint">Abunə ildə %s başa gəlir.</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Перайсці на BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не мае рэкламы і не прадае дадзеныя карыстальнікаў. Мая праца фінансуецца вамі ❤️.</string>
     <string name="upgrade_screen_why_title">Перавагі</string>
-    <string name="upgrade_screen_why_body">• Матываваны разработнік 🧙
-• Неабмежаваная колькасць прылад ➡️➡️
-• Дадатковыя дзеянні ⚙️
-і ншш…</string>
-    <string name="upgrade_screen_how_title">Варыянты</string>
-    <string name="upgrade_screen_how_body">Вы можаце выбраць паміж аднаразовай пакупкай і больш таннай гадавой падпіскай.\nПадпіска пачынаецца з бясплатнай 14-дзённай пробнай версіі, пасля якой плата будзе спаганяцца раз у год. Пробны перыяд і падпіску можна скасаваць у любы час.\nТыя ж функцыі, толькі розныя спосабы аплаты.</string>
     <string name="upgrade_screen_subscription_trial_action">Пачаць бясплатны пробны 14-дзённы перыяд</string>
     <string name="upgrade_screen_subscription_action">Падпісацца</string>
     <string name="upgrade_screen_subscription_action_hint">Падпіска каштуе %s у год.</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Надграждане до BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager няма реклами и не продава потребителски данни. Работата ми се финансира от вас ❤️.</string>
     <string name="upgrade_screen_why_title">Предимства</string>
-    <string name="upgrade_screen_why_body">• Мотивиран разработчик 🧙
-• Неограничени устройства ➡️➡️
-• Допълнителни действия ⚙️
-и още…</string>
-    <string name="upgrade_screen_how_title">Опции</string>
-    <string name="upgrade_screen_how_body">Можете да избирате между еднократна покупка и по-евтин годишен абонамент.\nАбонаментът започва с безплатен 14-дневен пробен период, след което ще бъдете таксувани веднъж годишно. Пробният период и абонаментът могат да бъдат анулирани по всяко време.\nСъщи функции, просто различни ценови модели.</string>
     <string name="upgrade_screen_subscription_trial_action">Започнете безплатен 14-дневен пробен период</string>
     <string name="upgrade_screen_subscription_action">Абонирайте се</string>
     <string name="upgrade_screen_subscription_action_hint">Абонаментът струва %s годишно.</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro-তে আপগ্রেড করুন</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-এ কোনো বিজ্ঞাপন নেই এবং ব্যবহারকারীর তথ্য বিক্রি করে না। আমার কাজ আপনার দ্বারা পরিচালিত ❤️।</string>
     <string name="upgrade_screen_why_title">সুবিধাসমূহ</string>
-    <string name="upgrade_screen_why_body">• একজন উৎসাহী ডেভেলপার 🧙\n• অসীমিত ডিভাইস ➡️➡️\n• অতিরিক্ত অ্যাকশন ⚙️\nআরও অনেক কিছু…</string>
-    <string name="upgrade_screen_how_title">বিকল্পসমূহ</string>
-    <string name="upgrade_screen_how_body">আপনি এককালীন ক্রয় এবং একটি সস্তা বার্ষিক সদস্যতার মধ্যে বেছে নিতে পারেন৷\nসাবস্ক্রিপশন বিনামূল্যে 14-দিনের ট্রায়াল দিয়ে শুরু করতে পারেন, তারপরে আপনাকে প্রতি বছরে একবার চার্জ করা হবে। ট্রায়াল এবং সাবস্ক্রিপশন যে কোন সময় বাতিলযোগ্য।\nএকই বৈশিষ্ট্য, শুধু ভিন্ন মূল্যের মডেল।</string>
     <string name="upgrade_screen_subscription_trial_action">বিনামূল্যে ১৪-দিনের ট্রায়াল শুরু করুন</string>
     <string name="upgrade_screen_subscription_action">সাবস্ক্রাইব করুন</string>
     <string name="upgrade_screen_subscription_action_hint">সাবস্ক্রিপশনে প্রতি এক বছরে %s খরচ হয়।</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Millora a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no té anuncis i no ven les dades d’usuari. El meu treball està finiançat per vosaltres ❤️.</string>
     <string name="upgrade_screen_why_title">Avantatges</string>
-    <string name="upgrade_screen_why_body">• Un desenvolupador motivat 🧙\n• Dispositius il·limitats ➡️➡️\n• Accions addicionals ⚙️\ni més…</string>
-    <string name="upgrade_screen_how_title">Opcions</string>
-    <string name="upgrade_screen_how_body">Podeu triar entre una compra única i una subscripció anual més barata.\nLa subscripció comença amb una prova gratuïta de 14 dies, després de la qual se us cobrarà un cop l\'any. La prova i la subscripció es poden cancel·lar en qualsevol moment.\nLes mateixes funcions, només models de preus diferents.</string>
     <string name="upgrade_screen_subscription_trial_action">Comença la prova gratuïta de 14 dies</string>
     <string name="upgrade_screen_subscription_action">Subscripció</string>
     <string name="upgrade_screen_subscription_action_hint">El preu de la subscripció és de %s anuals.</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Upgradovat na BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neobsahuje žádné reklamy a neprodává data uživatelů. Moje práce je financována vámi ❤️.</string>
     <string name="upgrade_screen_why_title">Výhody</string>
-    <string name="upgrade_screen_why_body">• Motivovaný vývojář 🧙\n• Neomezený počet zařízení ➡️➡️\n• Další akce ⚙️\na více…</string>
-    <string name="upgrade_screen_how_title">Možnosti</string>
-    <string name="upgrade_screen_how_body">Můžete si vybrat mezi jednorázovým nákupem a levnějším ročním předplatným.\nPředplatné začíná 14denní bezplatnou zkušební dobou, po které budete jednou ročně účtováni. Zkušební dobu a předplatné je možné kdykoliv zrušit.\nStejné funkce, jen různé cenové modely.</string>
     <string name="upgrade_screen_subscription_trial_action">Zahájit bezplatnou 14denní zkušební dobu</string>
     <string name="upgrade_screen_subscription_action">Předplatit</string>
     <string name="upgrade_screen_subscription_action_hint">Předplatné stojí %s ročně.</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Opgrader til BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen reklamer og sælger ikke brugerdata. Mit arbejde er finansieret af dig ❤️.</string>
     <string name="upgrade_screen_why_title">Fordele</string>
-    <string name="upgrade_screen_why_body">• En motiveret udvikler 🧙
-• Ubegrænset antal enheder ➡️➡️
-• Ekstra handlinger ⚙️
-og mere…</string>
-    <string name="upgrade_screen_how_title">Muligheder</string>
-    <string name="upgrade_screen_how_body">Du kan vælge mellem et engangskøb eller et billigere årsabonnement.\nAbonnementet starter med en gratis prøveperiode på 14 dage, hvorefter du opkræves én gang om året. Prøveperiode og abonnement kan opsiges når som helst.\nSamme funktioner, bare forskellige prismodeller.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis 14-dages prøveperiode</string>
     <string name="upgrade_screen_subscription_action">Abonner</string>
     <string name="upgrade_screen_subscription_action_hint">Abonnementet koster %s pr. år.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Auf BVM Pro upgraden</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager enthält keine Werbung und verkauft keine Nutzerdaten. Meine Arbeit wird von dir finanziert ❤️.</string>
     <string name="upgrade_screen_why_title">Vorteile</string>
-    <string name="upgrade_screen_why_body">• Ein motivierter Entwickler 🧙
-• Unbegrenzte Geräte ➡️➡️
-• Extra-Aktionen ⚙️
-und mehr…</string>
-    <string name="upgrade_screen_how_title">Optionen</string>
-    <string name="upgrade_screen_how_body">Du kannst zwischen einem einmaligen Kauf und einem günstigeren Jahresabonnement wählen.\nDas Abonnement beginnt mit einer kostenlosen 14-tägigen Testversion; danach wird Dir einmal jährlich eine Gebühr berechnet. Testversion und Abonnement sind jederzeit kündbar.\nGleiche Funktionen, nur unterschiedliche Preismodelle.</string>
     <string name="upgrade_screen_subscription_trial_action">Kostenlose 14-tägige Testversion starten</string>
     <string name="upgrade_screen_subscription_action">Abonnieren</string>
     <string name="upgrade_screen_subscription_action_hint">Das Abonnement kostet %s pro Jahr.</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Αναβαθμίστε στο BVM Pro</string>
     <string name="upgrade_screen_preamble">Το Bluetooth Volume Manager δεν έχει διαφημίσεις και δεν πωλεί δεδομένα χρηστών. Η δουλειά μου χρηματοδοτείται από εσάς ❤️.</string>
     <string name="upgrade_screen_why_title">Πλεονεκτήματα</string>
-    <string name="upgrade_screen_why_body">• Ένας παρακινημένος προγραμματιστής 🧙
-• Απεριόριστες συσκευές ➡️➡️
-• Επιπλέον ενέργειες ⚙️
-και άλλα…</string>
-    <string name="upgrade_screen_how_title">Επιλογές</string>
-    <string name="upgrade_screen_how_body">Μπορείτε να επιλέξετε μεταξύ μιας εφάπαξ αγοράς και μιας φθηνότερης ετήσιας συνδρομής.\nΗ συνδρομή ξεκινά με μια δωρεάν δοκιμή 14 ημερών, μετά την οποία θα χρεώνεστε ετησίως. Η δοκιμή και η συνδρομή ακυρώνονται ανά πάσα στιγμή.\nΊδια χαρακτηριστικά, απλά διαφορετικά μοντέλα τιμολόγησης.</string>
     <string name="upgrade_screen_subscription_trial_action">Έναρξη δωρεάν δοκιμής 14 ημερών</string>
     <string name="upgrade_screen_subscription_action">Εγγραφή</string>
     <string name="upgrade_screen_subscription_action_hint">Η συνδρομή κοστίζει %s ετησίως.</string>

--- a/app/src/gplay/res/values-eo-rUY/strings.xml
+++ b/app/src/gplay/res/values-eo-rUY/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Plibonigi al BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ne havas reklamojn kaj ne vendas uzantoajn datumojn. Mia laboro estas financata de vi ❤️.</string>
     <string name="upgrade_screen_why_title">Avantaĝoj</string>
-    <string name="upgrade_screen_why_body">• Motivita programisto 🧙\n• Senlimaj aparatoj ➡️➡️\n• Ekstra agoj ⚙️\nkas pli…</string>
-    <string name="upgrade_screen_how_title">Opcioj</string>
-    <string name="upgrade_screen_how_body">Vi povas elekti inter unufoja aĉeto kaj pli malmultekosta jara abono.\nLa abono komenciĝas per senpaga 14-taga provo, post kiu vi estos ŝargita unufoje jare. La provo kaj abono estas nuligeblaj en iu ajn momento.\nSamaj funkcioj, nur malsamaj prezaj modeloj.</string>
     <string name="upgrade_screen_subscription_trial_action">Komenci senpagan 14-tagan provon</string>
     <string name="upgrade_screen_subscription_action">Aboni</string>
     <string name="upgrade_screen_subscription_action_hint">La abono kostas %s jare.</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Actualizar a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende datos de usuario. Mi trabajo es financiado por vos ❤️.</string>
     <string name="upgrade_screen_why_title">Ventajas</string>
-    <string name="upgrade_screen_why_body">• Un desarrollador motivado 🧙\n• Dispositivos ilimitados ➡️➡️\n• Acciones extra ⚙️\ny más…</string>
-    <string name="upgrade_screen_how_title">Opciones</string>
-    <string name="upgrade_screen_how_body">Puedes elegir entre una compra única o una suscripción anual más barata.\nLa suscripción comienza con una prueba gratuita de 14 días, tras la cual se te cobrará una vez al año. Tanto la prueba como la suscripción se pueden cancelar en cualquier momento.\nLas mismas funciones, pero diferentes modalidades de precios.</string>
     <string name="upgrade_screen_subscription_trial_action">Empezá la prueba gratuita de 14 días</string>
     <string name="upgrade_screen_subscription_action">Suscríbete</string>
     <string name="upgrade_screen_subscription_action_hint">La suscripción cuesta %s al año.</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Actualizar a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene publicidad y no vende datos de usuarios. Mi trabajo es financiado por ti ❤️.</string>
     <string name="upgrade_screen_why_title">Ventajas</string>
-    <string name="upgrade_screen_why_body">• Un desarrollador motivado 🧙\n• Dispositivos ilimitados ➡️➡️\n• Acciones extra ⚙️\ny más…</string>
-    <string name="upgrade_screen_how_title">Opciones</string>
-    <string name="upgrade_screen_how_body">Puedes elegir entre una compra única y una suscripción anual más barata.\nLa suscripción comienza con una prueba gratuita de 14 días, después de la cual se te cobrará una vez al año. La prueba y suscripción se pueden cancelar en cualquier momento.\nMismas funciones, solo modelos de precios diferentes.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar prueba gratuita de 14 días</string>
     <string name="upgrade_screen_subscription_action">Suscribirse</string>
     <string name="upgrade_screen_subscription_action_hint">La suscripción cuesta %s por año.</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Actualizar a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende los datos de los usuarios. Mi trabajo está financiado por ti ❤️.</string>
     <string name="upgrade_screen_why_title">Ventajas</string>
-    <string name="upgrade_screen_why_body">• Un desarrollador motivado 🧙\n• Dispositivos ilimitados ➡️➡️\n• Acciones adicionales ⚙️\ny más…</string>
-    <string name="upgrade_screen_how_title">Opciones</string>
-    <string name="upgrade_screen_how_body">Puedes elegir entre una compra única o una suscripción anual más barata.\nLa suscripción comienza con una prueba gratuita de 14 días, tras la cual se te cobrará una vez al año. Tanto la prueba como la suscripción se pueden cancelar en cualquier momento.\nLas mismas funciones, pero diferentes modalidades de precios.</string>
     <string name="upgrade_screen_subscription_trial_action">Empieza la prueba gratuita de 14 días</string>
     <string name="upgrade_screen_subscription_action">Suscríbete</string>
     <string name="upgrade_screen_subscription_action_hint">La suscripción cuesta %s al año.</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Uuenda BVM Pro-ks</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manageris pole reklaame ja see ei müü kasutajaandmeid. Minu tööd toetate teie ❤️.</string>
     <string name="upgrade_screen_why_title">Eelised</string>
-    <string name="upgrade_screen_why_body">• Motiveeritud arendaja 🧙
-• Piiramatu arv seadmeid ➡️➡️
-• Lisategevused ⚙️
-ja veel…</string>
-    <string name="upgrade_screen_how_title">Valikud</string>
-    <string name="upgrade_screen_how_body">Saate valida ühekordse ostu ja odavama aastatellimuse vahel.\nTellimus algab 14 päevase prooviperioodiga, pärast seda võetakse raha korra aastas. Prooviperioodi ja tellimust saab tühistada igal ajal.\nSamad võimalused, erineb vaid hinnastamismudel.</string>
     <string name="upgrade_screen_subscription_trial_action">Alustage tasuta 14 päevast prooviperioodi</string>
     <string name="upgrade_screen_subscription_action">Telli</string>
     <string name="upgrade_screen_subscription_action_hint">Tellimus maksab %s aastas.</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Berritu BVM Pro-ra</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ek ez du iragarkirik eta ez du erabiltzailearen daturik saltzen. Nire lana zuk finantzatzen duzu ❤️.</string>
     <string name="upgrade_screen_why_title">Abantailak</string>
-    <string name="upgrade_screen_why_body">• Garatzaile motibatu bat 🧙\n• Mugagabeko gailuak ➡️➡️\n• Ekintza gehigarriak ⚙️\neta gehiago…</string>
-    <string name="upgrade_screen_how_title">Ezarpenak</string>
-    <string name="upgrade_screen_how_body">Aukera dezakezu erosketa bakarra eta urteko harpidetza merkeagoa.\nHarpidetza 14 eguneko doako epaiketa batekin hasten da. Ondoren, urtean behin kobratuko duzu. Epaiketa eta harpidetza edozein unetan ezeztatu daitezke.\nEzaugarri berdinak, prezio eredu desberdinak.</string>
     <string name="upgrade_screen_subscription_trial_action">14 eguneko proba doan hasi</string>
     <string name="upgrade_screen_subscription_action">Harpidetu</string>
     <string name="upgrade_screen_subscription_action_hint">Harpidetza urtero %s-ko prezioa du.</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">ارتقاء به BVM Pro</string>
     <string name="upgrade_screen_preamble">مدیر صدای بلوتوث تبلیغات ندارد و داده‌های کاربر را نمی‌فروشد. کار من توسط شما تأمین می‌شود ❤️.</string>
     <string name="upgrade_screen_why_title">مزایا</string>
-    <string name="upgrade_screen_why_body">• یک دولوپر انگیزه‌مند 🧙\n• دستگاه‌های نامحدود ➡️➡️\n• اقدامات اضافی ⚙️\nو بیشتر…</string>
-    <string name="upgrade_screen_how_title">گزینه‌ها</string>
-    <string name="upgrade_screen_how_body">می‌توانید بین یک خرید یک‌باره و یک اشتراک سالیانه ارزان‌تر انتخاب کنید.\nاشتراک با یک دوره آزمایشی ۱۴ روزه رایگان شروع می‌شود و پس از آن به صورت سالیانه هزینه می‌شود. دوره آزمایشی و اشتراک در هر زمان قابل لغو هستند.\nهمان ویژگی‌ها، فقط مدل‌های قیمتی متفاوت.</string>
     <string name="upgrade_screen_subscription_trial_action">شروع دوره آزمایشی ۱۴ روزه رایگان</string>
     <string name="upgrade_screen_subscription_action">اشتراک</string>
     <string name="upgrade_screen_subscription_action_hint">هزینه اشتراک سالیانه %s است.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Päivitä BVM Pro:hon</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerissa ei ole mainoksia eikä se myy käyttäjätietoja. Työni rahoitetaan sinun toimestasi ❤️.</string>
     <string name="upgrade_screen_why_title">Edut</string>
-    <string name="upgrade_screen_why_body">• Motivoitunut kehittäjä 🧙
-• Rajattomat laitteet ➡️➡️
-• Lisätoimintoja ⚙️
-ja paljon muuta…</string>
-    <string name="upgrade_screen_how_title">Vaihtoehdot</string>
-    <string name="upgrade_screen_how_body">Voit valita kertaostoksen ja halvemman vuositilauksen välillä.\nTilaus alkaa ilmaisella 14 päivän kokeilujaksolla, jonka jälkeen sinua veloitetaan kerran vuodessa. Kokeilu ja tilaus voidaan peruuttaa milloin tahansa.\nSamat ominaisuudet, vain eri hinnoittelumallit.</string>
     <string name="upgrade_screen_subscription_trial_action">Aloita ilmainen 14 päivän kokeilu</string>
     <string name="upgrade_screen_subscription_action">Tilaa</string>
     <string name="upgrade_screen_subscription_action_hint">Tilaus maksaa %s vuodessa.</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">I-upgrade sa BVM Pro</string>
     <string name="upgrade_screen_preamble">Ang Bluetooth Volume Manager ay walang mga ad at hindi nagbebenta ng data ng user. Ang aking trabaho ay pinopondohan mo ❤️.</string>
     <string name="upgrade_screen_why_title">Mga Benepisyo</string>
-    <string name="upgrade_screen_why_body">• Isang motivated na developer 🧙
-• Walang limitasyong mga device ➡️➡️
-• Mga karagdagang aksyon ⚙️
-at marami pa…</string>
-    <string name="upgrade_screen_how_title">Mga Opsyon</string>
-    <string name="upgrade_screen_how_body">Maaari kang pumili sa pagitan ng isang one-time na pagbili at isang mas murang taunang subscription.\nAng subscription ay nagsisimula sa libreng 14-araw na pagsubok, pagkatapos nito ay sisingilin ka ng isang beses bawat taon. Ang pagsubok at subscription ay maaaring kanselahin anumang oras.\nPareho ang mga feature, iba lang ang mga modelo ng pagpepresyo.</string>
     <string name="upgrade_screen_subscription_trial_action">Simulan ang libreng 14-day trial</string>
     <string name="upgrade_screen_subscription_action">Mag-subscribe</string>
     <string name="upgrade_screen_subscription_action_hint">Ang subscription ay nagkakahalaga ng %s bawat taon.</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Passer à BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n’affiche pas de publicités et ne vend pas les données des utilisateurs. Mon travail est financé par vous ❤️.</string>
     <string name="upgrade_screen_why_title">Avantages</string>
-    <string name="upgrade_screen_why_body">• Un développeur motivé 🧙
-• Appareils illimités ➡️➡️
-• Actions supplémentaires ⚙️
-et plus…</string>
-    <string name="upgrade_screen_how_title">Options</string>
-    <string name="upgrade_screen_how_body">Vous pouvez soit choisir un achat unique soit un abonnement annuel moins coûteux.\nL\'abonnement commence par un essai gratuit de 14 jours suivi d’une facture annuelle. L’essai et l’abonnement peuvent être annulés n’importe quand.\nMême fonctions, juste différents modes tarifaires.</string>
     <string name="upgrade_screen_subscription_trial_action">Commencer l’essai gratuit de 14 jours</string>
     <string name="upgrade_screen_subscription_action">M’abonner</string>
     <string name="upgrade_screen_subscription_action_hint">L’abonnement coûte %s par an.</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Actualizar a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non ten anuncios e non vende datos de usuario. O meu traballo está financiado por ti ❤️.</string>
     <string name="upgrade_screen_why_title">Vantaxes</string>
-    <string name="upgrade_screen_why_body">• Un desenvolvedor motivado 🧙
-• Dispositivos ilimitados ➡️➡️
-• Accións extras ⚙️
-e moito máis…</string>
-    <string name="upgrade_screen_how_title">Opcións</string>
-    <string name="upgrade_screen_how_body">Podes escoller entre unha compra única e unha subscrición anual máis barata.\nA subscrición comeza cunha proba gratuíta de 14 días, despois da cal se che cobrará unha vez ao ano. A proba e subscrición poden cancelarse en calquera momento.\nAs mesmas características, só diferentes modelos de prezos.</string>
     <string name="upgrade_screen_subscription_trial_action">Comezar proba gratuíta de 14 días</string>
     <string name="upgrade_screen_subscription_action">Subscribirse</string>
     <string name="upgrade_screen_subscription_action_hint">A subscrición custa %s ao ano.</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro में अपग्रेड करें</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager में कोई विज्ञापन नहीं है और वह उपयोगकर्ता डेटा नहीं बेचता। मेरा काम आपके द्वारा वित्तपोषित है ❤️।</string>
     <string name="upgrade_screen_why_title">लाभ</string>
-    <string name="upgrade_screen_why_body">• एक प्रेरित डेवलपर 🧙
-• असीमित डिवाइस ➡️➡️
-• अतिरिक्त क्रियाएं ⚙️
-और भी बहुत कुछ…</string>
-    <string name="upgrade_screen_how_title">विकल्प</string>
-    <string name="upgrade_screen_how_body">आप एक बार की खरीद और एक सस्ती वार्षिक सदस्यता के बीच चयन कर सकते हैं।\nसदस्यता 14 दिनों के निःशुल्क परीक्षण के साथ शुरू होती है, जिसके बाद आपसे प्रति वर्ष एक बार शुल्क लिया जाएगा। परीक्षण और सदस्यता किसी भी समय रद्द की जा सकती है।\n सुविधाएं वही हैं, बस मूल्य निर्धारण मॉडल अलग हैं।</string>
     <string name="upgrade_screen_subscription_trial_action">14 दिन का निःशुल्क परीक्षण प्रारंभ करें</string>
     <string name="upgrade_screen_subscription_action">सदस्यता लें</string>
     <string name="upgrade_screen_subscription_action_hint">सदस्यता का मूल्य %s प्रति वर्ष है।</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Nadogradite na BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nema oglasa i ne prodaje korisničke podatke. Moj rad financirate vi ❤️.</string>
     <string name="upgrade_screen_why_title">Prednosti</string>
-    <string name="upgrade_screen_why_body">• Motivirani developer 🧙
-• Neograničeni uređaji ➡️➡️
-• Dodatne radnje ⚙️
-i još mnogo toga…</string>
-    <string name="upgrade_screen_how_title">Mogućnosti</string>
-    <string name="upgrade_screen_how_body">Možete birati između jednokratne kupnje i jeftinije godišnje pretplate.\nPretplata počinje besplatnim probnim razdobljem od 14 dana, nakon čega će vam se naplaćivati ​​jednom godišnje. Probno razdoblje i pretplata mogu se otkazati u bilo kojem trenutku.\nIste značajke, samo različiti modeli cijena.</string>
     <string name="upgrade_screen_subscription_trial_action">Započnite besplatno probno razdoblje od 14 dana</string>
     <string name="upgrade_screen_subscription_action">Pretplatite se</string>
     <string name="upgrade_screen_subscription_action_hint">Pretplata košta %s godišnje.</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Frissítés BVM Pro-ra</string>
     <string name="upgrade_screen_preamble">A Bluetooth Volume Manager nem tartalmaz hirdetéseket, és nem értékesít felhasználói adatokat. A munkámat te finanszírozód ❤️.</string>
     <string name="upgrade_screen_why_title">Előnyök</string>
-    <string name="upgrade_screen_why_body">• Egy motivált fejlesztő 🧙
-• Korlátlan eszközök ➡️➡️
-• Extra műveletek ⚙️
-és még sok más…</string>
-    <string name="upgrade_screen_how_title">Lehetőségek</string>
-    <string name="upgrade_screen_how_body">Választhat az egyszeri vásárlás és az olcsóbb éves előfizetés között.\nAz előfizetés egy 14 napos ingyenes próbaverzióval kezdődik, amely után évente egyszer kerül felszámításra. A próbaidőszak és az előfizetés bármikor lemondható.\nAzonos funkciók, csak különböző árképzési modellek.</string>
     <string name="upgrade_screen_subscription_trial_action">Ingyenes 14 napos próbaidőszak indítása</string>
     <string name="upgrade_screen_subscription_action">Iratkozz fel</string>
     <string name="upgrade_screen_subscription_action_hint">Az előfizetés évi %s.</string>

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Անցնել BVM Pro-ին</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ում գովազդներ չկան և ուժղատության տվյալներ չի վարարկում։ Մեր աշխատանքե ժղարգարվում ե դզեր կողմից։</string>
     <string name="upgrade_screen_why_title">Առավելություններ</string>
-    <string name="upgrade_screen_why_body">• Մոտիվացված մշակուշ 🧙
-• Անսահման սարքեր ➡️➡️
-• Դոդական գործություններ ⚙️
-և այլն ավելին։։։</string>
-    <string name="upgrade_screen_how_title">Ընտրանքներ</string>
-    <string name="upgrade_screen_how_body">Կարող եք ընտրել միանգամյա գնման և ավելի էժան տարեկան բաժանորդագրության միջև:\nԲաժանորդագրությունը սկսվում է անվճար 14 օրվա փորձարկման շրջանով, որից հետո ձեզնից կգանձվի տարին մեկ անգամ: Փորձարկումը և բաժանորդագրությունը կարելի է չեղարկել ցանկացած ժամանակ:\nՆույն գործառույթները, միայն տարբեր գնային մոդելներ:</string>
     <string name="upgrade_screen_subscription_trial_action">Սկսել անվճար 14 օրվա փորձարկումը</string>
     <string name="upgrade_screen_subscription_action">Բաժանորդագրվել</string>
     <string name="upgrade_screen_subscription_action_hint">Բաժանորդագրությունը արժե %s տարեկան:</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Upgrade ke BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tidak menampilkan iklan dan tidak menjual data pengguna. Pekerjaan saya dibiayai oleh Anda ❤️.</string>
     <string name="upgrade_screen_why_title">Kelebihan</string>
-    <string name="upgrade_screen_why_body">• Developer yang bersemangat 🧙\n• Perangkat tak terbatas ➡️➡️\n• Aksi tambahan ⚙️\ndan lainnya…</string>
-    <string name="upgrade_screen_how_title">Pilihan</string>
-    <string name="upgrade_screen_how_body">Anda bisa memilih antara pembelian satu kali dan langganan tahunan yang lebih murah.\nLangganannya dimulai dengan coba gratis 14 hari. Setelah itu, Anda akan dicas tiap tahun. Masa percobaan dan langganan bisa dibatalkan kapan saja.\nFitur-fiturnya sama, hanya model biayanya saja yang berbeda.</string>
     <string name="upgrade_screen_subscription_trial_action">Mulai coba gratis 14 hari</string>
     <string name="upgrade_screen_subscription_action">Berlangganan</string>
     <string name="upgrade_screen_subscription_action_hint">Langganan harganya %s per tahun.</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Uppfæra í BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager birtir engar auglýsingar og selur ekki notendagögn. Verk mitt er fjármagnaö af þér ❤️.</string>
     <string name="upgrade_screen_why_title">Kostir</string>
-    <string name="upgrade_screen_why_body">• Áhugasamur forritari 🧙\n• Ótakmörkuð tæki ➡️➡️\n• Auka aðgerðir ⚙️\nog fleira…</string>
-    <string name="upgrade_screen_how_title">Valkostir</string>
-    <string name="upgrade_screen_how_body">Þú getur valið á milli einskiptiskaupa og ódýrari árlegrar áskriftar.\nÁskriftin byrjar með ókeypis 14 daga prufu, eftir það verður þér rukkað einu sinni á ári. Prufan og áskrift er hægt að hætta við hvenær sem er.\nSömu eiginleikar, bara mismunandi verðlagslíkön.</string>
     <string name="upgrade_screen_subscription_trial_action">Byrja ókeypis 14 daga prufu</string>
     <string name="upgrade_screen_subscription_action">Gerast áskrifandi</string>
     <string name="upgrade_screen_subscription_action_hint">Áskriftin kostar %s á ári.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Aggiorna a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non contiene pubblicità e non vende i dati degli utenti. Il mio lavoro è finanziato da te ❤️.</string>
     <string name="upgrade_screen_why_title">Vantaggi</string>
-    <string name="upgrade_screen_why_body">• Uno sviluppatore motivato 🧙
-• Dispositivi illimitati ➡️➡️
-• Azioni extra ⚙️
-e altro ancora…</string>
-    <string name="upgrade_screen_how_title">Opzioni</string>
-    <string name="upgrade_screen_how_body">È possibile scegliere tra un acquisto una tantum e un abbonamento annuale più economico.\nL\'abbonamento inizia con una prova gratuita di 14 giorni, dopo di che ti verrà addebitato il costo una volta all\'anno. La prova e l\'abbonamento sono cancellabili in qualsiasi momento.\nStesse funzionalità sbloccate, solo diversi modelli di prezzo.</string>
     <string name="upgrade_screen_subscription_trial_action">Inizia la prova gratuita di 14 giorni</string>
     <string name="upgrade_screen_subscription_action">Abbonati</string>
     <string name="upgrade_screen_subscription_action_hint">L\'abbonamento costa %s all\'anno.</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">שדרג ל-BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ללא מודעות ואינה מוכרת נתוני משתמשים. העבודה שלי ממומנת על ידך ❤️.</string>
     <string name="upgrade_screen_why_title">יתרונות</string>
-    <string name="upgrade_screen_why_body">• מפתח מוטיבציה גבוהה 🧙
-• מכשירים ללא הגבלה ➡️➡️
-• פעולות נוספות ⚙️
-ועוד…</string>
-    <string name="upgrade_screen_how_title">הגדרות</string>
-    <string name="upgrade_screen_how_body">אתה יכול לבחור בין רכישה חד פעמית לבין מנוי שנתי זול יותר.\nהמינוי מתחיל בניסיון חינם של 14 יום, ולאחר מכן תחויב פעם בשנה. גרסת ניסיון ומנוי ניתנים לביטול בכל עת.\nאותן תכונות, רק דגמי תמחור שונים.</string>
     <string name="upgrade_screen_subscription_trial_action">התחילו 14 ימי ניסיון</string>
     <string name="upgrade_screen_subscription_action">הירשם כמנוי</string>
     <string name="upgrade_screen_subscription_action_hint">המנוי עולה %s לשנה.</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro にアップグレード</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerは広告がなく、ユーザーデータを販売しません。私の作業はあなたによって支えられています ❤️。</string>
     <string name="upgrade_screen_why_title">メリット</string>
-    <string name="upgrade_screen_why_body">• やる気のある開発者 🧙
-• 無制限のデバイス ➡️➡️
-• 追加アクション ⚙️
-その他…</string>
-    <string name="upgrade_screen_how_title">オプション</string>
-    <string name="upgrade_screen_how_body">定期購入は14日間の無料トライアルから開始します。\n無料トライアルの終了後から1年に1回の課金がされます。\n無料トライアルと定期購入はいつでもキャンセル可能です。</string>
     <string name="upgrade_screen_subscription_trial_action">14日間の無料トライアルを開始</string>
     <string name="upgrade_screen_subscription_action">登録</string>
     <string name="upgrade_screen_subscription_action_hint">定期購入は、年/%sのお支払いです。</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">გადაიდგეს BVM Pro-ზე</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager რეკლამაგარეშია და მომხმარეთა მონაცემებს არ ყიდის. ჩემს სამუშაოს დაფინანსება თქვენია გვიერ გენიათ ❤️.</string>
     <string name="upgrade_screen_why_title">უპირატესობები</string>
-    <string name="upgrade_screen_why_body">• მოტივირებული დამპროგრამებელი 🧙\n• ულიმიტო მოწყობილობები ➡️➡️\n• დამატებითი მოქმედები ⚙️\nდა მეტი მრავალი…</string>
-    <string name="upgrade_screen_how_title">ვარიანტები</string>
-    <string name="upgrade_screen_how_body">თქვენ შეგიძლიათ აირჩიოთ ერთჯერად შეძენასა და უფრო იაფ წლიურ გამოწერას შორის.\nგამოწერა იწყება უფასო 14-დღიანი საცდელი პერიოდით, რის შემდეგაც წელიწადში ერთხელ დაგეკისრებათ გადახდა. საცდელი და გამოწერა ნებისმიერ დროს შეიძლება გაუქმდეს.\nიგივე ფუნქციები, უბრალოდ განსხვავებული ფასების მოდელები.</string>
     <string name="upgrade_screen_subscription_trial_action">დაიწყეთ უფასო 14-დღიანი საცდელი</string>
     <string name="upgrade_screen_subscription_action">გამოწერა</string>
     <string name="upgrade_screen_subscription_action_hint">გამოწერა ღირს %s წელიწადში.</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">អ័ពគថ83 ត្រឹមត្រូវ BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager មិនមានព្សនា ។។។ ហើយមិនលក់លាយត្រម្វន្តិយរបស់ប្រើបស័រី។ ការការរបស់សម្រាប់របស់ត្រងប្រើទីអ្នក ❤️។</string>
     <string name="upgrade_screen_why_title">អត្ថប្រយោជន៍</string>
-    <string name="upgrade_screen_why_body">• អ្នកអភិវឌ្ឍន៍ដែលមានការលើកទឹកចិត្ត 🧙
-• ឧបករណ៍គ្មានដែន ➡️➡️
-• សកម្មភាពបន្ថែម ⚙️
-និងច្រើនទៀត…</string>
-    <string name="upgrade_screen_how_title">ជម្រើស</string>
-    <string name="upgrade_screen_how_body">អ្នកអាចជ្រើសរើសរវាងការទិញម្តង និងការជាវប្រចាំឆ្នាំដែលថោកជាង។\nការជាវចាប់ផ្តើមជាមួយការសាកល្បង 14 ថ្ងៃដោយឥតគិតថ្លៃ បន្ទាប់ពីនោះអ្នកនឹងត្រូវគិតថ្លៃម្តងក្នុងមួយឆ្នាំ។ ការសាកល្បង និងការជាវអាចលុបចោលបានគ្រប់ពេល។\nមុខងារដូចគ្នា គ្រាន់តែម៉ូដែលតម្លៃខុសគ្នា។</string>
     <string name="upgrade_screen_subscription_trial_action">ចាប់ផ្តើមការសាកល្បង 14 ថ្ងៃដោយឥតគិតថ្លៃ</string>
     <string name="upgrade_screen_subscription_action">ជាវ</string>
     <string name="upgrade_screen_subscription_action_hint">ការជាវមានតម្លៃ %s ក្នុងមួយឆ្នាំ។</string>

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -10,14 +10,6 @@
     <string name="upgrade_screen_title">Biçe BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklamê nake û daneya bikarhêner nafroşe. Xebata min ji aliyê we ve tê fînanskirinê ❤️.</string>
     <string name="upgrade_screen_why_title">Avantaj</string>
-    <string name="upgrade_screen_why_body">• Geşedêrekî dilxwaz 🧙
-• Cêhazên bê-sînor ➡️➡️
-• Kiryarên zêde ⚙️
-û zêdetir…</string>
-    <string name="upgrade_screen_how_title">Vebijark</string>
-    <string name="upgrade_screen_how_body">Hûn dikarin di navbera kirîna yekcar û aboneyeke salarê ya erzantir de hilbijêrîn.
-Aboneyê bi ceribandîneke 14 rojî ya belaş dest pê dike, piştî wê salê carekê tê deynkirinê. Ceribandîn û aboneyê her dem tên îpta lkirinê.
-Heman taybetmendî, tenê modelên bihayê cuda.</string>
     <string name="upgrade_screen_subscription_trial_action">Ceribandîna 14-rojî ya belaş dest pê bike</string>
     <string name="upgrade_screen_subscription_action">Abone bibe</string>
     <string name="upgrade_screen_subscription_action_hint">Aboneyê salê %s lêdixe.</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro ಗೆ ದರ್ಜೆಯೇರಿ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ಜಾಹೀರಾತುಗಳಿಲ್ಲ ಮತ್ತು ಬಳಕೆದಾರರ ಡೇಟಾ ಮಾರಾಟುವುದಿಲ್ಲ. ನನ್ನ ಕೆಲಸ ನಿಮ್ಮಿಂದ ಹಗಲಾಗುತ್ತದೆ ❤️.</string>
     <string name="upgrade_screen_why_title">ಪ್ರಯೋಜನಗಳು</string>
-    <string name="upgrade_screen_why_body">• ಪ್ರೇರಿತ ಅಭಿವರ್ಧಕ 🧙
-• ಸಿಮಿತವಿಲ್ಲದ ಸಾಧನಗಳು ➡️➡️
-• ಹೆಚ್ಚಿನ ಕಾರ್ಯಗಳು ⚙️
-ಮತ್ತು ಇನ್ನಂತಃ…</string>
-    <string name="upgrade_screen_how_title">ಆಯ್ಕೆಗಳು</string>
-    <string name="upgrade_screen_how_body">ನೀವು ಒಂದು ಬಾರಿನ ಖರೀದು ಮತ್ತು ವಾರ್ಷಿಕ ಚಂದಾಸಮ್ಮತಿ ನಡುವೆ ಆಯ್ಕೆಮಾಡಬಹುದು.</string>
     <string name="upgrade_screen_subscription_trial_action">ಉಚಿತ 14-ದಿನಗಳ ಪರೀಕ್ಷೆ ಪ್ರಾರಂಭಿಸಿ</string>
     <string name="upgrade_screen_subscription_action">ಚಂದಾಸಮ್ಮತಿ ಪಡೆಯಿ</string>
     <string name="upgrade_screen_subscription_action_hint">ಚಂದಾಸಮ್ಮತಿಗೆ ಪ್ರತಿ ವರ್ಷ %s ಖರ್ಚಾಗುತ್ತದೆ.</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro로 업그레이드</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager는 광고가 없고 유저 데이터를 팔지 않습니다. 제 작업은 여러분의 지원으로 이루어집니다 ❤️.</string>
     <string name="upgrade_screen_why_title">장점</string>
-    <string name="upgrade_screen_why_body">• 열정적인 개발자 🧙
-• 무제한 기기 ➡️➡️
-• 추가 액션 ⚙️
-그리고 더...</string>
-    <string name="upgrade_screen_how_title">옵션</string>
-    <string name="upgrade_screen_how_body">연간 구독형과 영구 구매 중 선택할 수 있습니다.\n구독 시 14일 무료 평가판 이후 매년 요금이 청구됩니다. 평가판 및 구독 모두 언제든 취소할 수 있습니다.\n영구 구매와 구독형 사이 기능의 차이는 없습니다.</string>
     <string name="upgrade_screen_subscription_trial_action">14일 무료 평가판 시작</string>
     <string name="upgrade_screen_subscription_action">구독하기</string>
     <string name="upgrade_screen_subscription_action_hint">구독은 매년 %s 가 청구됩니다.</string>

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro га өтүү</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager жарнамаларсыз жана пайдалануучулардын мәлиматын сатпайт. Менин жумушум сиздин қаржыланат ❤️.</string>
     <string name="upgrade_screen_why_title">Артыкчылыктары</string>
-    <string name="upgrade_screen_why_body">• Мотивацияланган ишкери девелопчу 🧙\n• Чексиз түзмөктөр ➡️➡️\n• Кошумча акциялар ⚙️\nжана көбүрөк…</string>
-    <string name="upgrade_screen_how_title">Мүмкүнчүлүктөр</string>
-    <string name="upgrade_screen_how_body">Бир жолку сатып алуу немесе арзан жылдык жазылык арасында тандашыңыз.\nЖазылык 14 күндүк бепло сынамадан башталат, андан кейин жылына бир жолу акы төлөнет.Сынама жана жазылыкъты каалаган учурда бекер кылууга болот.\nБирдей функциялар, тек эргежтүүлүү моделдери айырма.</string>
     <string name="upgrade_screen_subscription_trial_action">14 күндүк бепло сынаманы баштоо</string>
     <string name="upgrade_screen_subscription_action">Жазылуу</string>
     <string name="upgrade_screen_subscription_action_hint">Жазылык жылына %s түрүн.</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">ອັບເກຣດເປັນ BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ບ່ມີໂຆສນາເກ໭ນແລະບ່ຂາຍຂ້ອມູນຜູ້ໃຊ້. ງານຂອງຂ້ອນສະຫນັບສນຸນໂດຍທ່ານ ❤️.</string>
     <string name="upgrade_screen_why_title">ຂໍ້ດີ</string>
-    <string name="upgrade_screen_why_body">• ນ଱ກພັດທນາທີ່ມີແຣງຈູງໃຈ ༉
-• ອຸປກອນໄດ້ໄມ່ຈຳກັດ ➡️➡️
-• ການກຳໄວ້ເພິ່ມເຕີມ ⚙️
-ແລະอື່ນຢົ່ວ…</string>
-    <string name="upgrade_screen_how_title">ຕົວເລືອກ</string>
-    <string name="upgrade_screen_how_body">ທ່ານສາມາດເລືອກລະຫວ່າງການຊື້ຄັ້ງດຽວ ແລະການສະໝັກສະມາຊິກປະຈຳປີທີ່ຖືກກວ່າ.\nການສະໝັກສະມາຊິກເລີ່ມຕົ້ນດ້ວຍການທົດລອງຟຣີ 14 ວັນ, ຫຼັງຈາກນັ້ນທ່ານຈະຖືກຮຽກເກັບເງິນປີລະຄັ້ງ. ການທົດລອງ ແລະການສະໝັກສະມາຊິກສາມາດຍົກເລີກໄດ້ທຸກເວລາ.\nຄຸນສົມບັດດຽວກັນ, ພຽງແຕ່ຮູບແບບລາຄາທີ່ແຕກຕ່າງກັນ.</string>
     <string name="upgrade_screen_subscription_trial_action">ເລີ່ມທົດລອງຟຣີ 14 ວັນ</string>
     <string name="upgrade_screen_subscription_action">ສະໝັກສະມາຊິກ</string>
     <string name="upgrade_screen_subscription_action_hint">ການສະໝັກສະມາຊິກລາຄາ %s ຕໍ່ປີ.</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Atnaujinti į BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neturi reklamų ir neparduoda naudotojų duomenų. Mano darbas finansuojamas jūsų ❤️.</string>
     <string name="upgrade_screen_why_title">Privalumai</string>
-    <string name="upgrade_screen_why_body">• Motyvuotas kūrėjas 🧙
-• Neriboti įrenginiai ➡️➡️
-• Papildomi veiksmai ⚙️
-ir daugiau…</string>
-    <string name="upgrade_screen_how_title">Parinktys</string>
-    <string name="upgrade_screen_how_body">Galite rinktis tarp vienkartinio pirkimo ir pigesnės metinės prenumeratos.\nPrenumerata prasideda nemokamuoju 14 dienų bandomuoju laikotarpiu, po kurio jums bus imamas mokestis kartą per metus. Bandomasis laikotarpis ir prenumerata gali būti atšaukti bet kada.\nTos pačios funkcijos, tik skirtingi kainų modeliai.</string>
     <string name="upgrade_screen_subscription_trial_action">Pradėti nemokamą 14 dienų bandomąjį laikotarpį</string>
     <string name="upgrade_screen_subscription_action">Prenumeruoti</string>
     <string name="upgrade_screen_subscription_action_hint">Prenumerata kainuoja %s per metus.</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Jaunināt uz BSP Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth skaļuma pārvaldniekam nav reklāmu un tas nepardod lietotāju datus. Manu darbu finansiē jūs.</string>
     <string name="upgrade_screen_why_title">Priekšrocības</string>
-    <string name="upgrade_screen_why_body">* Motivēts izstrādātājs\n* Neierobežotas ierīces\n* Papildu darbības\nun vairāk...</string>
-    <string name="upgrade_screen_how_title">Opcijas</string>
-    <string name="upgrade_screen_how_body">Varat izvēlēties starp vienreizēju pirkumu un lētāku gada abonementu.\nAbonements sākas ar bezmaksas 14 dienu izmēģinājuma periodu, pēc kura jums tiks iekasēta maksa reizi gadā. Izmēģinājumu un abonementu var atcelt jebkurā laikā.\nTas pašas funkcijas, tikai dažādi cenu modeļi.</string>
     <string name="upgrade_screen_subscription_trial_action">Sāciet bezmaksas 14 dienu izmēģinājumu</string>
     <string name="upgrade_screen_subscription_action">Abonēt</string>
     <string name="upgrade_screen_subscription_action_hint">Abonements maksā %s gadā.</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Надгради на BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклами и не продава кориснички податоци. Мојата работа е финансирана од вас ❤️.</string>
     <string name="upgrade_screen_why_title">Предности</string>
-    <string name="upgrade_screen_why_body">• Мотивиран програмер 🧙
-• Неограничен број уреди ➡️➡️
-• Дополнителни акции ⚙️
-и уште многу…</string>
-    <string name="upgrade_screen_how_title">Опции</string>
-    <string name="upgrade_screen_how_body">Можете да избирате помеѓу еднократна купувачка и поевтина годишна претплата.\nПретплатата започнува со бесплатен пробен период од 14 дена, по што ќе ви се наплаќа еднаш годишно. Пробниот период и претплатата можат да се откажат во секое време.\nИсти функции, само различни модели на цени.</string>
     <string name="upgrade_screen_subscription_trial_action">Започнете бесплатен пробен период од 14 дена</string>
     <string name="upgrade_screen_subscription_action">Претплатете се</string>
     <string name="upgrade_screen_subscription_action_hint">Претплатата чини %s годишно.</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager പ്രജ്ഞാപനങ്ങൾ ഇല്ല, ഉപയോക്തൃ ഡേറ്റ വിൽക്കുന്നില്ല. എന്റെ ജോലി നിങ്ങൾ വഴി ധനസഹായം കിട്ടുന്നു ❤️.</string>
     <string name="upgrade_screen_why_title">പ്രയോജനങ്ങൾ</string>
-    <string name="upgrade_screen_why_body">• ഒരു പ്രേരണപ്പെട്ട ഡെവലപ്പർ 🧙\n• അപരിമിത ഉപകരണങ്ങൾ ➡️➡️\n• അധിക ആക്ഷനുകൾ ⚙️\nകൂടുതൽ...</string>
-    <string name="upgrade_screen_how_title">ഓപ്ഷനുകൾ</string>
-    <string name="upgrade_screen_how_body">നിങ്ങൾക്ക് ഒറ്റത്തവണ വാങ്ങലിനും വിലകുറഞ്ഞ വാർഷിക സബ്‌സ്‌ക്രിപ്‌ഷനുമിടയിൽ തിരഞ്ഞെടുക്കാം.\nസബ്‌സ്‌ക്രിപ്‌ഷൻ സൗജന്യ 14-ദിവസ ട്രയലിൽ ആരംഭിക്കുന്നു, അതിനുശേഷം നിങ്ങളിൽ നിന്ന് വർഷത്തിലൊരിക്കൽ നിരക്ക് ഈടാക്കും. ട്രയലും സബ്‌സ്‌ക്രിപ്‌ഷനും എപ്പോൾ വേണമെങ്കിലും റദ്ദാക്കാവുന്നതാണ്.\nഅതേ സവിശേഷതകൾ, വ്യത്യസ്ത വിലനിർണ്ണയ മോഡലുകൾ മാത്രം.</string>
     <string name="upgrade_screen_subscription_trial_action">സൗജന്യ 14-ദിവസ ട്രയൽ ആരംഭിക്കുക</string>
     <string name="upgrade_screen_subscription_action">സബ്‌സ്ക്രൈബ്</string>
     <string name="upgrade_screen_subscription_action_hint">സബ്‌സ്‌ക്രിപ്‌ഷന്റെ വില പ്രതിവർഷം %s ആണ്.</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro рүү шилжээх</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager сурталчилгаагүй бөгөөд хэрэглэгчийн өгөгдлийг зардаггүй. Миний ажиллыг та нараар санхүүжнэ ❤️.</string>
     <string name="upgrade_screen_why_title">Давуу талууд</string>
-    <string name="upgrade_screen_why_body">• Урамшуулсан хөгжлөлөөр 🧙\n• Хязгаагүй төхөөрөмжүүд ➡️➡️\n• Нэмэлт үйлдлүүд ⚙️\nба дараа…</string>
-    <string name="upgrade_screen_how_title">Сонголтууд</string>
-    <string name="upgrade_screen_how_body">Та нэг удаагийн худалдан авалт болон хямд жилийн захиалгын хооронд сонгох боломжтой.\nЗахиалга нь 14 хоногийн үнэ төлбөргүй туршилтаар эхэлдэг бөгөөд үүний дараа танаас жилд нэг удаа төлбөр авна. Туршилт болон захиалгыг хүссэн үедээ цуцалж болно.\nИжил боломжууд, зөвхөн өөр үнийн загварууд.</string>
     <string name="upgrade_screen_subscription_trial_action">14 хоногийн үнэ төлбөргүй туршилт эхлүүлэх</string>
     <string name="upgrade_screen_subscription_action">Захиалах</string>
     <string name="upgrade_screen_subscription_action_hint">Захиалга жилд %s өртөгтэй.</string>

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -10,14 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro वर अपग्रेड करा</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ला कोणतीही अॅड नाही आणि वापरकर्त्यांचा डेटा विकत नाही. माझे काम तुम्ही उचलवून अर्थपुरवठा केलेली आहे ❤️.</string>
     <string name="upgrade_screen_why_title">फायदे</string>
-    <string name="upgrade_screen_why_body">• एक प्रेरित विकसक 🧙
-• अमर्यादित डिव्हाइसेस ➡️➡️
-• अतिरिक्त क्रिया ⚙️
-आणि बरेच काही…</string>
-    <string name="upgrade_screen_how_title">पर्याय</string>
-    <string name="upgrade_screen_how_body">तुम्ही एकवेळ खरेदी आणि स्वस्त वार्षिक सदस्यत्व यांपैकी निवड करू शकता.
-सदस्यत्व मोफत 14-दिवसांच्या चाचणी सह सुरू होते, त्यानंतर तुम्हाला वर्षातून एकदा शुल्क आकारले जाईल. चाचणी आणि सदस्यत्व केव्हाही रद्द करता येते.
-समान वैशिष्ट्ये, फक्त वेगळे मूल्यनिर्धारण मॉडेल्स.</string>
     <string name="upgrade_screen_subscription_trial_action">मोफत 14-दिवसांची चाचणी सुरू करा</string>
     <string name="upgrade_screen_subscription_action">सदस्यत्व घ्या</string>
     <string name="upgrade_screen_subscription_action_hint">सदस्यत्वाची किंमत वर्षाला %s आहे.</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Naik taraf ke BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tiada iklan dan tidak menjual data pengguna. Kerja saya dibiayai oleh anda ❤️.</string>
     <string name="upgrade_screen_why_title">Kelebihan</string>
-    <string name="upgrade_screen_why_body">• Pembangun yang bermotivasi 🧙
-• Peranti tanpa had ➡️➡️
-• Tindakan tambahan ⚙️
-dan banyak lagi…</string>
-    <string name="upgrade_screen_how_title">Pilihan</string>
-    <string name="upgrade_screen_how_body">Anda boleh memilih antara pembelian sekali dan langganan tahunan yang lebih murah.\nLangganan bermula dengan percubaan 14 hari percuma, selepas itu anda akan dicaj sekali setahun. Percubaan dan langganan boleh dibatalkan pada bila-bila masa.\nCiri yang sama, cuma model harga yang berbeza.</string>
     <string name="upgrade_screen_subscription_trial_action">Mulakan percubaan 14 hari percuma</string>
     <string name="upgrade_screen_subscription_action">Langgan</string>
     <string name="upgrade_screen_subscription_action_hint">Kos langganan %s setahun.</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro သို့ အဆင့်မြှင့်ပါ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager တွင် ကြော်ငြာများမရှိပါ၊ အသုံးပြုသူဒေတာများကိုလည်း မရောင်းချပါ။ ကျွန်ုပ်၏အလုပ်ကို သင်မှ ငွေကြေးထောက်ပံ့ထားပါသည် ❤️။</string>
     <string name="upgrade_screen_why_title">အကျိုးကျေးဇူးများ</string>
-    <string name="upgrade_screen_why_body">• လှုံ့ဆော်မှုရှိသော developer တစ်ဦး 🧙
-• ကန့်သတ်မှုမရှိသော ကိရိယာများ ➡️➡️
-• အပိုလုပ်ဆောင်ချက်များ ⚙️
-နှင့် အခြားများ…</string>
-    <string name="upgrade_screen_how_title">ရွေးချယ်စရာများ</string>
-    <string name="upgrade_screen_how_body">သင်သည် တစ်ကြိမ်တည်းဝယ်ယူမှုနှင့် ပိုမိုစျေးသက်သာသော နှစ်စဉ် subscription အကြား ရွေးချယ်နိုင်ပါသည်။\nSubscription သည် ၁၄ ရက် အခမဲ့အစမ်းသုံးခြင်းဖြင့် စတင်ပြီး၊ ထို့နောက် နှစ်စဉ်တစ်ကြိမ် ငွေကောက်ခံမည်။ အစမ်းသုံးခြင်းနှင့် subscription ကို အချိန်မရွေး ပယ်ဖျက်နိုင်ပါသည်။\nတူညီသော အင်္ဂါရပ်များ၊ စျေးနှုန်းပုံစံများသာ ကွဲပြားပါသည်။</string>
     <string name="upgrade_screen_subscription_trial_action">၁၄ ရက် အခမဲ့အစမ်းသုံးခြင်း စတင်မည်</string>
     <string name="upgrade_screen_subscription_action">Subscribe လုပ်မည်</string>
     <string name="upgrade_screen_subscription_action_hint">Subscription သည် နှစ်စဉ် %s ကျသင့်သည်။</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro मा अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager मा कुनै विज्ञापन छैन र यसले प्रयोगकर्ताको डेटा बাंड्दैन। मेरो काम तपाईंले गर्नुभएको आर्थिक सहयोगबाट चलिरहेको छ ❤️।</string>
     <string name="upgrade_screen_why_title">फाइदाहरू</string>
-    <string name="upgrade_screen_why_body">• एक प्रेरित डेभलपर 🧙\n• असीमित यन्त्रहरू ➡️➡️\n• थप क्रियाहरू ⚙️\nर थप…</string>
-    <string name="upgrade_screen_how_title">विकल्पहरू</string>
-    <string name="upgrade_screen_how_body">तपाईं एक-पटक खरिद र सस्तो वार्षिक सदस्यता बीच छनौट गर्न सक्नुहुन्छ।\nसदस्यता 14-दिनको निःशुल्क परीक्षणको साथ सुरु हुन्छ, जसपछि तपाईंलाई वर्षमा एक पटक शुल्क लगाइनेछ। परीक्षण र सदस्यता कुनै पनि समयमा रद्द गर्न सकिन्छ।\nउस्तै सुविधाहरू, केवल फरक मूल्य निर्धारण मोडेलहरू।</string>
     <string name="upgrade_screen_subscription_trial_action">14-दिनको निःशुल्क परीक्षण सुरु गर्नुहोस्</string>
     <string name="upgrade_screen_subscription_action">सदस्यता लिनुहोस्</string>
     <string name="upgrade_screen_subscription_action_hint">सदस्यता प्रति वर्ष %s लाग्छ।</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Upgrade naar BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager bevat geen advertenties en verkoopt geen gebruikersgegevens. Mijn werk wordt door jou gefinancierd ❤️.</string>
     <string name="upgrade_screen_why_title">Voordelen</string>
-    <string name="upgrade_screen_why_body">• Een gemotiveerde ontwikkelaar 🧙
-• Onbeperkte apparaten ➡️➡️
-• Extra acties ⚙️
-en meer…</string>
-    <string name="upgrade_screen_how_title">Opties</string>
-    <string name="upgrade_screen_how_body">Je kunt kiezen tussen een eenmalige aankoop en een goedkoper jaarabonnement.\nHet abonnement begint met een gratis proefperiode van 14 dagen, waarna u eenmaal per jaar in rekening wordt gebracht. Proef en abonnement zijn op elk moment opzegbaar.\nDezelfde functies, alleen verschillende prijsmodellen.</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis proefperiode van 14 dagen</string>
     <string name="upgrade_screen_subscription_action">Abonneren</string>
     <string name="upgrade_screen_subscription_action_hint">Het abonnement kost %s per jaar.</string>

--- a/app/src/gplay/res/values-no/strings.xml
+++ b/app/src/gplay/res/values-no/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Oppgrader til BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen annonser og selger ikke brukerdata. Arbeidet mitt er finansiert av deg ❤️.</string>
     <string name="upgrade_screen_why_title">Fordeler</string>
-    <string name="upgrade_screen_why_body">• En motivert utvikler 🧞
-• Ubegrenset antall enheter ➡️➡️
-• Ekstra handlinger ⚙️
-og mer…</string>
-    <string name="upgrade_screen_how_title">Alternativer</string>
-    <string name="upgrade_screen_how_body">Du kan velge mellom et engangskjøp og et billigere årlig abonnement.\nAbonnementet starter med en gratis 14-dagers prøveperiode, etterfulgt av en årlig belastning. Prøveperioden og abonnementet kan kanselleres når som helst.\nSamme funksjoner, bare forskjellige prismodeller.</string>
     <string name="upgrade_screen_subscription_trial_action">Start 14-dagers gratis prøveperiode</string>
     <string name="upgrade_screen_subscription_action">Abonner</string>
     <string name="upgrade_screen_subscription_action_hint">Abonnementet koster %s per år.</string>

--- a/app/src/gplay/res/values-pcm-rNG/strings.xml
+++ b/app/src/gplay/res/values-pcm-rNG/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Upgrade to BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no get ads and no dey sell user data. My work dey financed by you.</string>
     <string name="upgrade_screen_why_title">Advantages</string>
-    <string name="upgrade_screen_why_body">- Motivated developer\n- Unlimited devices\n- Extra actions\nand more...</string>
-    <string name="upgrade_screen_how_title">Options</string>
-    <string name="upgrade_screen_how_body">You fit choose between one-time purchase and cheaper yearly subscription.\nDi subscription start with free 14-day trial, afta dat dem go charge you once per year. Trial and subscription fit cancel anytime.\nSame features, just different pricing models.</string>
     <string name="upgrade_screen_subscription_trial_action">Start free 14-day trial</string>
     <string name="upgrade_screen_subscription_action">Subscribe</string>
     <string name="upgrade_screen_subscription_action_hint">Di subscription cost %s per year.</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Uaktualnij do BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nie zawiera reklam i nie sprzedaje danych użytkowników. Moja praca jest finansowana przez ciebie ❤️.</string>
     <string name="upgrade_screen_why_title">Zalety</string>
-    <string name="upgrade_screen_why_body">• Zmotywowany deweloper 🧙
-• Nieograniczona liczba urządzeń ➡️➡️
-• Dodatkowe akcje ⚙️
-i więcej…</string>
-    <string name="upgrade_screen_how_title">Opcje</string>
-    <string name="upgrade_screen_how_body">Możesz wybrać pomiędzy jednorazowym zakupem a tańszą roczną subskrypcją.\nSubskrypcja zaczyna się od 14-dniowego bezpłatnego okresu próbnego, po którym opłata jest pobierana raz w roku. Okres próbny oraz subskrypcja mogą zostać anulowane w każdej chwili.\nTe same funkcje, tylko inne modele cenowe.</string>
     <string name="upgrade_screen_subscription_trial_action">Rozpocznij bezpłatny 14-dniowy okres próbny</string>
     <string name="upgrade_screen_subscription_action">Subskrybuj</string>
     <string name="upgrade_screen_subscription_action_hint">Subskrypcja kosztuje %s rocznie.</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Atualizar para BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados do usuário. Meu trabalho é financiado por você ❤️.</string>
     <string name="upgrade_screen_why_title">Vantagens</string>
-    <string name="upgrade_screen_why_body">• Um desenvolvedor motivado 🧙
-• Dispositivos ilimitados ➡️➡️
-• Ações extras ⚙️
-e muito mais…</string>
-    <string name="upgrade_screen_how_title">Opções</string>
-    <string name="upgrade_screen_how_body">Você pode escolher entre uma compra única ou uma assinatura anual mais barata.\nA assinatura começa com um teste gratuito de 14 dias, após o qual você será cobrado uma vez por ano. Teste e assinatura são canceláveis a qualquer momento.\nAs mesmas funcionalidades, apenas diferentes modelos de preços.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito de 14 dias</string>
     <string name="upgrade_screen_subscription_action">Se inscrever</string>
     <string name="upgrade_screen_subscription_action_hint">A assinatura custa %s por ano.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Atualizar para BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados dos utilizadores. O meu trabalho é financiado por si ❤️.</string>
     <string name="upgrade_screen_why_title">Vantagens</string>
-    <string name="upgrade_screen_why_body">• Um programador motivado 🧙
-• Dispositivos ilimitados ➡️➡️
-• Ações extra ⚙️
-e mais…</string>
-    <string name="upgrade_screen_how_title">Opções</string>
-    <string name="upgrade_screen_how_body">Pode escolher entre uma compra única ou uma assinatura anual mais barata.\nA assinatura começa com um teste gratuito por 14 dias, após o qual será cobrada uma vez por ano. O período de testes e a assinatura podem ser canceladas em qualquer momento.\nAs mesmas funcionalidades, apenas diferentes modelos de preços.</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito de 14 dias</string>
     <string name="upgrade_screen_subscription_action">Subscrever</string>
     <string name="upgrade_screen_subscription_action_hint">A assinatura custa %s por ano.</string>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Upgradar a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n\'ha nagins annunzis e na venda betg las datas dals utilisaders. Mia lavur vegn finanziada da tai ❤️.</string>
     <string name="upgrade_screen_why_title">Avantatgs</string>
-    <string name="upgrade_screen_why_body">• In sviluppader motivà 🧙\n• Apparats senza limita ➡️➡️\n• Acziuns supplementaras ⚙️\ne dapli…</string>
-    <string name="upgrade_screen_how_title">Opziuns</string>
-    <string name="upgrade_screen_how_body">Ti pos tscherner tranter ina cumprenda singula e in abunament annual pli bunmartgà.\nL\'abunament cumenza cun ina prova gratuita da 14 dis, suenter la quala vegns ti fatturà in\'ura a l\'onn. La prova ed il subscripziun èn revocabels en mintga mument.\nMemsmas caratteristicas, mo models da pretsch differents.</string>
     <string name="upgrade_screen_subscription_trial_action">Cumenzar prova gratuita da 14 dis</string>
     <string name="upgrade_screen_subscription_action">Abunament</string>
     <string name="upgrade_screen_subscription_action_hint">L\'abunament custa %s per onn.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Actualizează la BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nu are reclame şi nu vinde datele utilizatorilor. Munca mea este finanțată de tine ❤️.</string>
     <string name="upgrade_screen_why_title">Avantaje</string>
-    <string name="upgrade_screen_why_body">• Un developer motivat 🧙
-• Dispozitive nelimitate ➡️➡️
-• Acțiuni extra ⚙️
-şi mai mult…</string>
-    <string name="upgrade_screen_how_title">Opțiuni</string>
-    <string name="upgrade_screen_how_body">Poți alege între o achiziție unică și un abonament anual mai ieftin.\nAbonamentul începe cu o probă gratuită de 14 zile, după care vei fi taxat o dată pe an. Încercarea şi abonamentul pot fi anulate în orice moment.\nAceleaşi caracteristici, doar modele de preţuri diferite.</string>
     <string name="upgrade_screen_subscription_trial_action">Începeți trial-ul gratuit 14 zile</string>
     <string name="upgrade_screen_subscription_action">Abonează-te</string>
     <string name="upgrade_screen_subscription_action_hint">Abonamentul costă %s pe an.</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Обновить до BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не содержит рекламы и не продаёт данные пользователей. Моя работа финансируется вами ❤️.</string>
     <string name="upgrade_screen_why_title">Преимущества</string>
-    <string name="upgrade_screen_why_body">• Мотивированный разработчик 🧙
-• Неограниченное количество устройств ➡️➡️
-• Дополнительные действия ⚙️
-и многое другое…</string>
-    <string name="upgrade_screen_how_title">Варианты</string>
-    <string name="upgrade_screen_how_body">Вы можете выбрать между разовой покупкой или более выгодной годовой подпиской.\nПодписка начинается с бесплатного 14-дневного пробного периода, после чего списание происходит раз в год. Пробный период и подписку можно отменить в любой момент.\nТе же функции, просто разные модели оплаты.</string>
     <string name="upgrade_screen_subscription_trial_action">Начать 14-дневный бесплатный период</string>
     <string name="upgrade_screen_subscription_action">Подписаться</string>
     <string name="upgrade_screen_subscription_action_hint">Подписка стоит %s в год.</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Addobba a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non tenet publitzidade e non bendet datos de sos utentes. Su traballu meu est finantziadu dae bois ❤️.</string>
     <string name="upgrade_screen_why_title">Vantàgios</string>
-    <string name="upgrade_screen_why_body">• Unu programadore motivadu 🧙
-• Dispositivus illimitados ➡️➡️
-• Atziones extras ⚙️
-e àteru…</string>
-    <string name="upgrade_screen_how_title">Optziones</string>
-    <string name="upgrade_screen_how_body">Podes seberare intre unu cùmperu de una borta ebbia e un\'abbonamentu annuale prus baràtu.\nS\'abbonamentu cumintza cun una proa de badas de 14 dies, a pustis de custu ti diant cobràre una borta a s\'annu. Sa proa e s\'abbonamentu podent èssere cantzellados in cale si siat momentu.\nSas matèssias caraterìsticas, modelos de prètziu diferentes ebbia.</string>
     <string name="upgrade_screen_subscription_trial_action">Cumintza sa proa de badas de 14 dies</string>
     <string name="upgrade_screen_subscription_action">Abbòna·ti</string>
     <string name="upgrade_screen_subscription_action_hint">S\'abbonamentu costat %s a s\'annu.</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro වෙත උත්‍යෝජනය කරන්න</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager හි දැන්වීම් නොමැති අතර පරිශීලක දත්ත විකුණන්නේ නැත. මගේ වැඩ ඔබ විසින් මූල්‍යාධාර සපයයි ❤️.</string>
     <string name="upgrade_screen_why_title">වාසි</string>
-    <string name="upgrade_screen_why_body">• උනන්දු සංවර්ධකයෙකු 🧙
-• අසීමිත උපකරණ ➡️➡️
-• අමතර ක්‍රියා ⚙️
-සහ තවත්…</string>
-    <string name="upgrade_screen_how_title">විකල්ප</string>
-    <string name="upgrade_screen_how_body">ඔබට එක් වරක් මිලදී ගැනීමක් සහ මිල අඩු වාර්ෂික දායකත්වයක් අතර තෝරා ගත හැක.\nදායකත්වය දින 14ක නොමිලේ අත්හදා බැලීමක් සමඟ ආරම්භ වන අතර, ඉන්පසු ඔබට වසරකට වරක් අය කෙරේ. අත්හදා බැලීම සහ දායකත්වය ඕනෑම වේලාවක අවලංගු කළ හැක.\nඑකම විශේෂාංග, මිල ගණන් ආකෘති පමණක් වෙනස්.</string>
     <string name="upgrade_screen_subscription_trial_action">දින 14ක නොමිලේ අත්හදා බැලීම ආරම්භ කරන්න</string>
     <string name="upgrade_screen_subscription_action">දායක වන්න</string>
     <string name="upgrade_screen_subscription_action_hint">දායකත්වය වසරකට %s වැය වේ.</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Prejsť na BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nemá žiadne reklamy a nepredáva používateľské údaje. Moja práca je financovaná vami ❤️.</string>
     <string name="upgrade_screen_why_title">Výhody</string>
-    <string name="upgrade_screen_why_body">• Motivovaný vývojár 🧙
-• Neobmedzené zariadenia ➡️➡️
-• Extra akcie ⚙️
-a viac…</string>
-    <string name="upgrade_screen_how_title">Možnosti</string>
-    <string name="upgrade_screen_how_body">Môžete si vybrať medzi jednorazovým nákupom a lacnejším ročným odberom.\nPredplatné sa začína bezplatnou 14-dňovou skúšobnou verziou, po ktorej vám bude raz ročne účtovaný poplatok. Skúšobnú verziu a predplatné je možné kedykoľvek zrušiť.\nRovnaké funkcie, len iné cenové modely.</string>
     <string name="upgrade_screen_subscription_trial_action">Spustite bezplatnú 14-dňovú skúšobnú verziu</string>
     <string name="upgrade_screen_subscription_action">Predplatiť</string>
     <string name="upgrade_screen_subscription_action_hint">Predplatné stojí %s ročne.</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Nadgradite na BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nima oglasov in ne prodaja uporabniških podatkov. Moje delo financirate vi ❤️.</string>
     <string name="upgrade_screen_why_title">Prednosti</string>
-    <string name="upgrade_screen_why_body">• Motiviran razvijalec 🧙\n• Neomejene naprave ➡️➡️\n• Dodatna dejanja ⚙️\nin več…</string>
-    <string name="upgrade_screen_how_title">Možnosti</string>
-    <string name="upgrade_screen_how_body">Izbirate lahko med enkratnim nakupom in cenejšo letno naročnino.\nNaročnina se začne z brezplačnim 14-dnevnim preizkusom, nakar vam zaračunam enkrat na leto.  Preizkus in naročnino lahko kadarkoli prekličete.\nIste funkcije, samo različni načini plačevanja.</string>
     <string name="upgrade_screen_subscription_trial_action">Začni 14-dnevni preizkus</string>
     <string name="upgrade_screen_subscription_action">Naroči se</string>
     <string name="upgrade_screen_subscription_action_hint">Naročnina stane %s na leto.</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Përmirëso në BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nuk ka reklama dhe nuk shet të dhënat e përdoruesit. Puna ime financohet nga ju ❤️.</string>
     <string name="upgrade_screen_why_title">Avantazhet</string>
-    <string name="upgrade_screen_why_body">• Një zhvillues i motivuar 🧙
-• Pajisje të pakufizuara ➡️➡️
-• Veprime shtesë ⚙️
-dhe më shumë…</string>
-    <string name="upgrade_screen_how_title">Opsione</string>
-    <string name="upgrade_screen_how_body">Mund të zgjedhësh midis një blerjeje të një herëshme dhe një abonimi vjetor më të lirë.\nAbonimi fillon me një provë falas 14-ditore, pas së cilës do të tarifohesh një herë në vit. Prova dhe abonimi janë të anulueshme në çdo kohë.\nTë njëjtat veçori, vetëm modele të ndryshme çmimesh.</string>
     <string name="upgrade_screen_subscription_trial_action">Filloni provën falas 14-ditore</string>
     <string name="upgrade_screen_subscription_action">Abonohu</string>
     <string name="upgrade_screen_subscription_action_hint">Abonimi kushton %s në vit.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Надогради на BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклама и не продаје корисничке податке. Мој рад финансираш ти ❤️.</string>
     <string name="upgrade_screen_why_title">Предности</string>
-    <string name="upgrade_screen_why_body">• Мотивисан програмер 🧙\n• Неограничен број уређаја ➡️➡️\n• Додатне акције ⚙️\nи још много…</string>
-    <string name="upgrade_screen_how_title">Опције</string>
-    <string name="upgrade_screen_how_body">Можете бирати између једнократне куповине и јефтиније годишње претплате.\nПретплата почиње са бесплатним 14-дневним пробним периодом, након чега ће вам бити наплаћено једном годишње. Пробни период и претплата се могу отказати у било које време.\nИсте функције, само различити модели цена.</string>
     <string name="upgrade_screen_subscription_trial_action">Започни бесплатни 14-дневни пробни период</string>
     <string name="upgrade_screen_subscription_action">Претплати се</string>
     <string name="upgrade_screen_subscription_action_hint">Претплата кошта %s годишње.</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Uppgradera till BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har inga annonser och säljer inte användardata. Mitt arbete finansieras av dig ❤️.</string>
     <string name="upgrade_screen_why_title">Fördelar</string>
-    <string name="upgrade_screen_why_body">• En motiverad utvecklare 🧙
-• Obegränsade enheter ➡️➡️
-• Extra åtgärder ⚙️
-och mer…</string>
-    <string name="upgrade_screen_how_title">Alternativ</string>
-    <string name="upgrade_screen_how_body">Du kan välja mellan ett engångsköp och en billigare årlig prenumeration.\nPrenumerationen börjar med en gratis 14-dagars testperiod, varefter du debiteras en gång per år. Test och prenumeration kan avbrytas när som helst.\nSamma funktioner, bara olika prismodeller.</string>
     <string name="upgrade_screen_subscription_trial_action">Starta gratis 14-dagars test</string>
     <string name="upgrade_screen_subscription_action">Prenumerera</string>
     <string name="upgrade_screen_subscription_action_hint">Prenumerationen kostar %s per år.</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Boresha hadi BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager haina matangazo na haiuzi data ya mtumiaji. Kazi yangu inafadhiliwa na wewe ❤️.</string>
     <string name="upgrade_screen_why_title">Faida</string>
-    <string name="upgrade_screen_why_body">• Msanidi aliyehamasika 🧙\n• Vifaa visivyo na kikomo ➡️➡️\n• Vitendo vya ziada ⚙️\nna zaidi…</string>
-    <string name="upgrade_screen_how_title">Chaguo</string>
-    <string name="upgrade_screen_how_body">Unaweza kuchagua kati ya ununuzi wa mara moja na usajili wa kila mwaka ulio rahisi zaidi.\nUsajili unaanza na majaribio ya bure ya siku 14, baada ya hapo utalipishwa mara moja kwa mwaka. Majaribio na usajili vinaweza kufutwa wakati wowote.\nVipengele sawa, tu mifano tofauti ya bei.</string>
     <string name="upgrade_screen_subscription_trial_action">Anza majaribio ya bure ya siku 14</string>
     <string name="upgrade_screen_subscription_action">Jisajili</string>
     <string name="upgrade_screen_subscription_action_hint">Usajili ungharimu %s kwa mwaka.</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">BVM Proக்கு மேம்படுத்து</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager விளம்பரங்கள் இல்லாதது மற்றும் பயனர் தரவுகளை விற்கவிற்கை இல்லை. என் பணியின் நிதியம் உங்களால் வழங்கப்படுகிறது.</string>
     <string name="upgrade_screen_why_title">நன்மைகள்</string>
-    <string name="upgrade_screen_why_body">• ஒரு உறுதியான உருவாக்கி
-• இம்மியான சாதனங்கள்
-• கூடுதல் செயல்கள்
-மற்றும் பலவற்றுடன்...</string>
-    <string name="upgrade_screen_how_title">விருப்பங்கள்</string>
-    <string name="upgrade_screen_how_body">நீங்கள் ஒரு முறை வாங்குதல் மற்றும் மலிவான வருடாந்திர சந்தா இடையே தேர்வு செய்யலாம்.\nசந்தா இலவச 14-நாள் சோதனையுடன் தொடங்குகிறது, அதன் பிறகு வருடத்திற்கு ஒருமுறை கட்டணம் வசூலிக்கப்படும். சோதனை மற்றும் சந்தா எப்போது வேண்டுமானாலும் ரத்து செய்யப்படலாம்.\nஅதே அம்சங்கள், வெவ்வேறு விலை மாதிரிகள் மட்டும்.</string>
     <string name="upgrade_screen_subscription_trial_action">இலவச 14-நாள் சோதனையைத் தொடங்கு</string>
     <string name="upgrade_screen_subscription_action">சந்தா</string>
     <string name="upgrade_screen_subscription_action_hint">சந்தா வருடத்திற்கு %s செலவாகும்.</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro కి అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager కి ప్రకటనలు లేవు మరియు వినియోగదారు డేటాను విక్రయించదు. నా పని మీరు ఆర్థిక సహాయం చేస్తున్నారు ❤️.</string>
     <string name="upgrade_screen_why_title">ప్రయోజనాలు</string>
-    <string name="upgrade_screen_why_body">• ఒక ప్రేరణ పొందిన డెవలపర్ 🧙\n• అపరిమిత పరికరాలు ➡️➡️\n• అదనపు చర్యలు ⚙️\nమరియు మరిన్ని…</string>
-    <string name="upgrade_screen_how_title">ఎంపికలు</string>
-    <string name="upgrade_screen_how_body">మీరు ఒక్కసారి కొనుగోలు మరియు చౌకైన వార్షిక సబ్‌స్క్రిప్షన్ మధ్య ఎంచుకోవచ్చు.\nసబ్‌స్క్రిప్షన్ ఉచిత 14-రోజుల ట్రయల్‌తో ప్రారంభమవుతుంది, ఆ తర్వాత సంవత్సరానికి ఒకసారి మీకు ఛార్జ్ చేయబడుతుంది. ట్రయల్ మరియు సబ్‌స్క్రిప్షన్ ఎప్పుడైనా రద్దు చేయవచ్చు.\nఅదే ఫీచర్లు, కేవలం వేర్వేరు ధర నమూనాలు.</string>
     <string name="upgrade_screen_subscription_trial_action">ఉచిత 14-రోజుల ట్రయల్ ప్రారంభించండి</string>
     <string name="upgrade_screen_subscription_action">చందాదారులవండి</string>
     <string name="upgrade_screen_subscription_action_hint">ఏడాదికి చందా %s అవుతుంది.</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">อัปเกรดเป็น BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ไม่มีโฆษณาและไม่ขายข้อมูลผู้ใช้ งานของฉันได้รับการสนับสนุนทางการเงินจากคุณ ❤️</string>
     <string name="upgrade_screen_why_title">ข้อดี</string>
-    <string name="upgrade_screen_why_body">• นักพัฒนาที่มีแรงจูงใจ 🧙\n• อุปกรณ์ไม่จำกัด ➡️➡️\n• อาการเพิ่มเติม ⚙️\nและอีกมากมา…</string>
-    <string name="upgrade_screen_how_title">ตัวเลือก</string>
-    <string name="upgrade_screen_how_body">คุณสามารถเลือกระหว่างการซื้อครั้งเดียวและการสมัครสมาชิกรายปีที่ถูกกว่า\nการสมัครสมาชิกเริ่มต้นด้วยการทดลองใช้ฟรี 14 วัน หลังจากนั้นคุณจะถูกเรียกเก็บเงินปีละครั้ง การทดลองและการสมัครสมาชิกสามารถยกเลิกได้ตลอดเวลา\nฟีเจอร์เดียวกัน เพียงแต่โมเดลราคาที่แตกต่างกัน</string>
     <string name="upgrade_screen_subscription_trial_action">เริ่มทดลองใช้ฟรี 14 วัน</string>
     <string name="upgrade_screen_subscription_action">สมัครสมาชิก</string>
     <string name="upgrade_screen_subscription_action_hint">การสมัครสมาชิกค่าใช้จ่าย %s ต่อปี</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro\'ya Yükselt</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklam içermez ve kullanıcı verilerini satmaz. Çalışmalarım sizler tarafından finanse edilmektedir ❤️.</string>
     <string name="upgrade_screen_why_title">Avantajlar</string>
-    <string name="upgrade_screen_why_body">• Motive bir geliştirici 🧙
-• Sınırsız cihaz ➡️➡️
-• Ekstra eylemler ⚙️
-ve daha fazlası…</string>
-    <string name="upgrade_screen_how_title">Şeçenekler</string>
-    <string name="upgrade_screen_how_body">Tek seferlik satın alma ile daha ucuz olan yıllık abonelik arasında seçim yapabilirsiniz.\nAbonelik 14 günlük ücretsiz deneme ile başlar ve sonrasında yılda bir kez ücretlendirilirsiniz. Deneme sürümü ve abonelik istenildiği zaman iptal edilebilir.\nAynı özellikler, sadece farklı fiyatlandırma modelleri.</string>
     <string name="upgrade_screen_subscription_trial_action">14 günlük ücretsiz denemeyi başlatın</string>
     <string name="upgrade_screen_subscription_action">Abone ol</string>
     <string name="upgrade_screen_subscription_action_hint">Abonelik ücreti yıllık %s\'dir.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Оновити до BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не має реклами та не продає дані користувачів. Моя робота фінансується вами ❤️.</string>
     <string name="upgrade_screen_why_title">Переваги</string>
-    <string name="upgrade_screen_why_body">• Мотивований розробник 🧙
-• Необмежена кількість пристроїв ➡️➡️
-• Додаткові дії ⚙️
-та більше…</string>
-    <string name="upgrade_screen_how_title">Параметри</string>
-    <string name="upgrade_screen_how_body">Ви можете вибрати між одноразовою покупкою та дешевшою річною підпискою.\nПідписка починається з безкоштовної 14-денної пробної версії, після чого з вас стягуватиметься плата раз на рік. Пробну версію та підписку можна скасувати в будь-який час.\nОдні й ті ж функції, тільки різні моделі ціноутворення.</string>
     <string name="upgrade_screen_subscription_trial_action">Розпочати безкоштовний 14-денний пробний період</string>
     <string name="upgrade_screen_subscription_action">Підписатися</string>
     <string name="upgrade_screen_subscription_action_hint">Вартість підписки становить %s на рік.</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro میں اپ گریڈ کریں</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager میں کوئی اشتہار نہیں ہے اور یہ صارف کا ڈیٹا فروخت نہیں کرتا۔ میرا کام آپ کی وجہ سے فنڈ ہوتا ہے ❤️۔</string>
     <string name="upgrade_screen_why_title">فوائد</string>
-    <string name="upgrade_screen_why_body">• ایک حوصلہ مند ڈیولپر 🧙\n• لامحدود ڈیوائسیز ➡️➡️\n• اضافی ایکشنز ⚙️\nاور بھی بہت کچھ…</string>
-    <string name="upgrade_screen_how_title">اختیارات</string>
-    <string name="upgrade_screen_how_body">آپ ایک بار کی خریداری اور سستی سالانہ سبسکرپشن کے درمیان انتخاب کر سکتے ہیں۔\nسبسکرپشن 14 دن کی مفت آزمائش کے ساتھ شروع ہوتی ہے، جس کے بعد آپ سے سال میں ایک بار چارج کیا جائے گا۔ آزمائش اور سبسکرپشن کسی بھی وقت منسوخ کی جا سکتی ہے۔\nیکساں فیچرز، صرف مختلف قیمتوں کے ماڈل۔</string>
     <string name="upgrade_screen_subscription_trial_action">14 دن کی مفت آزمائش شروع کریں</string>
     <string name="upgrade_screen_subscription_action">سبسکرائب کریں</string>
     <string name="upgrade_screen_subscription_action_hint">سبسکرپشن کی قیمت %s سالانہ ہے۔</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">BVM Pro ga o\'tish</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklamasiz va foydalanuvchi ma\'lumotlarini sotmaydi. Mening ishim siz tomonidan moliyalashtiriladi ❤️.</string>
     <string name="upgrade_screen_why_title">Afzalliklar</string>
-    <string name="upgrade_screen_why_body">• Motivatsiyali dasturchi 🧙
-• Cheksiz qurilmalar ➡️➡️
-• Qo\'shimcha amallar ⚙️
-va boshqalar…</string>
-    <string name="upgrade_screen_how_title">Variantlar</string>
-    <string name="upgrade_screen_how_body">Siz bir martalik xarid va arzonroq yillik obuna o\'rtasida tanlov qilishingiz mumkin.\nObuna bepul 14 kunlik sinov davri bilan boshlanadi, shundan so\'ng sizdan yiliga bir marta to\'lov olinadi. Sinov va obunani istalgan vaqtda bekor qilish mumkin.\nXuddi shu xususiyatlar, faqat turli narx modellari.</string>
     <string name="upgrade_screen_subscription_trial_action">Bepul 14 kunlik sinovni boshlang</string>
     <string name="upgrade_screen_subscription_action">Obuna bo\'ling</string>
     <string name="upgrade_screen_subscription_action_hint">Obuna yiliga %s turadi.</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">Nâng cấp lên BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager không có quảng cáo và không bán dữ liệu người dùng. Công việc của tôi được tài trợ bởi bạn ❤️.</string>
     <string name="upgrade_screen_why_title">Lợi thế</string>
-    <string name="upgrade_screen_why_body">• Nhà phát triển tâm huyết 🧙
-• Thiết bị không giới hạn ➡️➡️
-• Hành động bổ sung ⚙️
-và nhiều hơn nữa…</string>
-    <string name="upgrade_screen_how_title">Tùy chọn</string>
-    <string name="upgrade_screen_how_body">Bạn có thể chọn giữa mua một lần và đăng ký hàng năm rẻ hơn.\nĐăng ký bắt đầu bằng bản dùng thử miễn phí 14 ngày, sau đó bạn sẽ bị tính phí một lần mỗi năm. Bản dùng thử và đăng ký có thể bị hủy bất kỳ lúc nào.\nTính năng giống nhau, chỉ khác mô hình định giá.</string>
     <string name="upgrade_screen_subscription_trial_action">Bắt đầu dùng thử 14 ngày miễn phí</string>
     <string name="upgrade_screen_subscription_action">Đăng ký</string>
     <string name="upgrade_screen_subscription_action_hint">Chi phí đăng ký %s mỗi năm.</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">升级至 BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 没有广告，也不出售用户数据。我的工作由您资助 ❤️。</string>
     <string name="upgrade_screen_why_title">优点</string>
-    <string name="upgrade_screen_why_body">• 一位充满动力的开发者 🧙
-• 无限设备 ➡️➡️
-• 额外操作 ⚙️
-以及更多…</string>
-    <string name="upgrade_screen_how_title">选项</string>
-    <string name="upgrade_screen_how_body">您可以选择一次性付费，也可以选更便宜的年费订阅\n订阅以 14 天的免费试用期开始，之后将按年计费。试用和订阅期间可随时取消\n两种套餐功能相同，仅定价模式不同</string>
     <string name="upgrade_screen_subscription_trial_action">开始 14 天免费试用</string>
     <string name="upgrade_screen_subscription_action">订阅</string>
     <string name="upgrade_screen_subscription_action_hint">每年的订阅费用为 %s。</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">升級到 BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不出售用戶數據。我的工作由你支持 ❤️。</string>
     <string name="upgrade_screen_why_title">優點</string>
-    <string name="upgrade_screen_why_body">• 有動力的開發者 🧙\n• 無限裝置 ➡️➡️\n• 額外動作 ⚙️\n更多…</string>
-    <string name="upgrade_screen_how_title">選項</string>
-    <string name="upgrade_screen_how_body">您可以選擇單次購買，也可以選擇更便宜的每年訂閱。\n訂閱開始時有 14 天的免費試用，之後每年計費。試用和訂閱可隨時取消。\n功能相同，僅有定價模式不同。</string>
     <string name="upgrade_screen_subscription_trial_action">開始 14 天免費試用</string>
     <string name="upgrade_screen_subscription_action">訂閱</string>
     <string name="upgrade_screen_subscription_action_hint">訂閱費用為 %s 每年。</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -10,12 +10,6 @@
     <string name="upgrade_screen_title">升級至 BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不會出售使用者資料。我的工作由你贊助 ❤️。</string>
     <string name="upgrade_screen_why_title">優點</string>
-    <string name="upgrade_screen_why_body">• 充滿動力的開發者 🧙
-• 無限裝置 ➡️➡️
-• 額外動作 ⚙️
-以及更多…</string>
-    <string name="upgrade_screen_how_title">選項</string>
-    <string name="upgrade_screen_how_body">您可以選擇單次購買，也可以選擇更便宜的每年訂閱。\n訂閱開始時有 14 天的免費試用，之後每年計費。試用和訂閱可隨時取消。\n功能相同，僅有定價模式不同。</string>
     <string name="upgrade_screen_subscription_trial_action">開始 14 天免費試用</string>
     <string name="upgrade_screen_subscription_action">訂閱</string>
     <string name="upgrade_screen_subscription_action_hint">訂閱費用為 %s 每年。</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -10,9 +10,6 @@
     <string name="upgrade_screen_title">Buyekeza kuya ku-BVM Pro</string>
     <string name="upgrade_screen_preamble">I-Bluetooth Volume Manager ayinazo izikhangiso futhi ayithengisi idatha yabasebenzisi. Umsebenzi wami uxhaswa nguwe ❤️.</string>
     <string name="upgrade_screen_why_title">Izinzuzo</string>
-    <string name="upgrade_screen_why_body">• Umthuthuki okhuthazekile 🧟\n• Amadivayisi angenamkhawulo ➡️➡️\n• Izenzo ezengeziwe ⚙️\nnakunye...</string>
-    <string name="upgrade_screen_how_title">Izinketho</string>
-    <string name="upgrade_screen_how_body">Ungakhetha phakathi kokuthenga kube kanye kanye nesikhathi sokubhalisela sonyaka esishibhile.\nUkubhalisela kuqala ngesikhathi sokuhlola sezinsuku eziyi-14 samahhala, ngemva kwalokho uzokhokhiswa kanye ngonyaka. Ukuhlola nokubhalisela kungacishwa nganoma yisiphi isikhathi.\nIzici ezifanayo, kuphela amamodeli ezintengo ahlukene.</string>
     <string name="upgrade_screen_subscription_trial_action">Qala ukuhlola kwamahhala kwezinsuku eziyi-14</string>
     <string name="upgrade_screen_subscription_action">Bhalisela</string>
     <string name="upgrade_screen_subscription_action_hint">Ukubhalisela kubiza %s ngonyaka.</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -13,9 +13,6 @@
     <string name="upgrade_screen_title">Upgrade to BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager has no ads and doesn\'t sell user data. My work is financed by you ❤️.</string>
     <string name="upgrade_screen_why_title">Advantages</string>
-    <string name="upgrade_screen_why_body">• A motivated developer 🧙\n• Unlimited devices ➡️➡️\n• Extra actions ⚙️\nand more…</string>
-    <string name="upgrade_screen_how_title">Options</string>
-    <string name="upgrade_screen_how_body">You can choose between a one-time purchase and a cheaper yearly subscription.\nThe subscription starts with a free 14-day trial, after which you\'ll be charged once per year. Trial and subscription are cancellable at any time.\nSame features, just different pricing models.</string>
     <string name="upgrade_screen_subscription_trial_action">Start free 14-day trial</string>
     <string name="upgrade_screen_subscription_action">Subscribe</string>
     <string name="upgrade_screen_subscription_action_hint">The subscription costs %s per year.</string>

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
@@ -10,13 +10,16 @@ import eu.darken.bluemusic.upgrade.core.billing.client.BillingClientException
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnection
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnectionProvider
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
@@ -24,6 +27,8 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.currentTime
+import kotlinx.coroutines.test.runCurrent
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import testhelpers.coroutine.runTest2
@@ -194,5 +199,121 @@ class BillingManagerTest : BaseTest() {
 
         refreshed.await() shouldBe BillingData(listOf(owned))
         attempts shouldBe 2
+    }
+
+    @Test fun `active demand cuts the reconnect backoff short`() = runTest2 {
+        val owned = purchase()
+        var attempts = 0
+        val connection = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                if (attempts == 1) throw BillingException("Play is updating itself")
+                emit(connection)
+            }
+        }
+        val manager = BillingManager(backgroundScope, provider)
+        runCurrent() // first connection attempt fails, the 30s backoff starts
+
+        // A user tapping restore/buy right after fixing their Play situation must not wait out the
+        // backoff timer — the demand signal reconnects immediately.
+        val refreshed = async { manager.refresh() }
+        runCurrent()
+
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
+        currentTime shouldBeLessThan 30_000L
+    }
+
+    @Test fun `demand during a failing connection attempt is not lost`() = runTest2 {
+        val owned = purchase()
+        var attempts = 0
+        val connection = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                if (attempts == 1) {
+                    delay(1_000) // demand arrives while this attempt is still in flight
+                    throw BillingException("Play is updating itself")
+                }
+                emit(connection)
+            }
+        }
+        val manager = BillingManager(backgroundScope, provider)
+        runCurrent() // attempt 1 in flight, suspended
+
+        val refreshed = async { manager.refresh() } // demand lands mid-attempt
+        runCurrent()
+        advanceTimeBy(1_001) // attempt 1 fails; the pending demand must skip the backoff
+        runCurrent()
+
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
+        currentTime shouldBeLessThan 30_000L
+    }
+
+    @Test fun `demand served by a healthy connection does not skip a later backoff`() = runTest2 {
+        var attempts = 0
+        val die = CompletableDeferred<Unit>()
+        val connection = connection(refreshResults = List(4) { emptyList<Purchase>() })
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                when (attempts++) {
+                    0 -> {
+                        emit(connection)
+                        die.await()
+                        throw BillingException("connection died")
+                    }
+
+                    else -> emit(connection)
+                }
+            }
+        }
+        val manager = BillingManager(backgroundScope, provider)
+        runCurrent()
+
+        val refreshed = async { manager.refresh() } // demand is served by the healthy connection
+        runCurrent()
+        refreshed.await()
+
+        die.complete(Unit) // now the connection dies
+        runCurrent()
+
+        // The long-served demand must not short-circuit this backoff.
+        advanceTimeBy(29_000)
+        runCurrent()
+        attempts shouldBe 1
+
+        advanceTimeBy(2_000)
+        runCurrent()
+        attempts shouldBe 2
+    }
+
+    @Test fun `backoff streak resets after a successful connection`() = runTest2 {
+        var attempts = 0
+        val connection = connection(refreshResults = List(4) { emptyList<Purchase>() })
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                when (attempts++) {
+                    0 -> throw BillingException("fail 1") // streak 1 -> 30s backoff
+                    1 -> {
+                        emit(connection) // success resets the streak...
+                        throw BillingException("fail 2") // ...so this must back off 30s, not 60s
+                    }
+
+                    else -> emit(connection)
+                }
+            }
+        }
+        BillingManager(backgroundScope, provider)
+
+        advanceTimeBy(30_001)
+        runCurrent()
+        advanceTimeBy(30_001)
+        runCurrent()
+
+        // With a lifetime attempt counter the second backoff would be 60s and the third attempt
+        // wouldn't have run yet.
+        attempts shouldBe 3
     }
 }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
@@ -181,9 +181,9 @@ class UpgradeViewModelTest : BaseTest() {
         context = testDispatcher,
     ) {
         val repo = mockRepo()
-        // Both SKU queries exceed the 5s query timeout -> "Play unavailable" episode.
+        // Both SKU queries exceed the 15s query timeout -> "Play unavailable" episode.
         coEvery { repo.querySkus(*anyVararg()) } coAnswers {
-            delay(6_000)
+            delay(16_000)
             emptyList()
         }
         coEvery { repo.restorePurchaseNow() } coAnswers {


### PR DESCRIPTION
## What changed

Follow-ups from the billing smoke test session and the cross-app review (sibling projects hit a related same-process recovery gap):

- **Billing reconnects immediately on user demand.** The reconnect backoff after a failed connection was purely timer-based (up to 5 min): a user who just fixed their Play situation — signed in, updated the store — and tapped restore/buy or reopened the upgrade screen still waited out the timer. Any active billing use now cuts a pending backoff short.
- **Backoff starts fresh per failure episode.** The retry delay is computed from a failure streak that resets on successful connection, instead of `retryWhen`'s lifetime attempt counter (which never resets, so a long-lived process with earlier healed failures started every new episode at the 5-minute cap).
- **Cold Play stores no longer trigger false "unavailable" dialogs.** The first billing query after Play sign-in measured 8.5s on-device; the 5s SKU-query timeout produced a "Google Play unavailable" dialog on a slow-but-healthy store. Now 15s.
- **Offer diagnosis + copy hygiene**: debug logs now include a concise per-product offer overview (basePlanId/offerId), so "Play withheld the trial offer (eligibility)" vs "app failed to match it" is diagnosable; three unused upgrade-screen strings were deleted from all 78 gplay locale files, including one promising a 14-day trial the UI can't guarantee.

## Technical Context

- Demand tracking is a generation counter (`connectionDemand` StateFlow) captured at each connection-attempt start; the backoff waits `withTimeoutOrNull(backoff) { demand.first { it != atAttemptStart && it > servedDemand.value } }`. The two conditions were shaped by three Codex review rounds: demand arriving *mid-attempt* isn't lost (no bufferless-SharedFlow race), a still-waiting caller gets at most one skip per attempt (no tight `startConnection` loop), and demand already settled — served, failed, or cancelled (`finally`) — can't skip a much later backoff.
- New regression tests for each property: demand-cuts-backoff, mid-attempt demand, served-demand-holds-backoff, streak reset (an attempt-based counter fails it). 58 billing unit tests green; both flavors assemble; `lintVital` green.
- Upstream-relevant for SD Maid SE (same connection retry design landed there in #2561).