### PR TITLE
Fix blocked volume jumps still being saved when rate limiter is on

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
@@ -91,7 +91,20 @@ class VolumeUpdateModule @Inject constructor(
         val ringerMode = ringerTool.getCurrentRingerMode()
         val min = volumeTool.getMinVolume(id)
         val max = volumeTool.getMaxVolume(id)
-        val percentage = levelToPercentage(event.newVolume, min, max)
+
+        // If VolumeRateLimiterModule (priority 5) was eligible to act on this stream, it may have
+        // already corrected the jump this event reports, and its own write only produces a `self`
+        // event we'd ignore — so persist the live hardware level instead of the event's value.
+        // Without an eligible limiter we keep the event's snapshot: a later live read could catch
+        // an unrelated route change instead (issue #232).
+        val limiterMayHaveIntervened = allActive.any {
+            it.volumeRateLimiterEffective && it.address in ownerAddresses && it.getStreamType(id) != null
+        }
+        val effectiveVolume = if (limiterMayHaveIntervened) volumeTool.getCurrentVolume(id) else event.newVolume
+        if (effectiveVolume != event.newVolume) {
+            log(TAG, DEBUG) { "Hardware level for $id is $effectiveVolume, not event's ${event.newVolume}, persisting hardware level" }
+        }
+        val percentage = levelToPercentage(effectiveVolume, min, max)
 
         stable.forEach { dev ->
             val streamType = dev.getStreamType(id)!!
@@ -106,7 +119,7 @@ class VolumeUpdateModule @Inject constructor(
                 AudioStream.Type.NOTIFICATION -> when (ringerMode) {
                     RingerMode.NORMAL -> VolumeMode.Normal(percentage)
                     else -> {
-                        if (event.newVolume > 0) VolumeMode.Normal(percentage) else null
+                        if (effectiveVolume > 0) VolumeMode.Normal(percentage) else null
                     }
                 }
 
@@ -128,9 +141,9 @@ class VolumeUpdateModule @Inject constructor(
                     val storedMode = VolumeMode.fromFloat(storedVolume)
                     if (storedMode is VolumeMode.Normal) {
                         val storedLevel = percentageToLevel(storedMode.percentage, min, max)
-                        if (storedLevel == event.newVolume) {
+                        if (storedLevel == effectiveVolume) {
                             log(TAG, VERBOSE) {
-                                "Stored ${storedMode.percentage} already maps to level ${event.newVolume}, skipping $dev"
+                                "Stored ${storedMode.percentage} already maps to level $effectiveVolume, skipping $dev"
                             }
                             return@forEach
                         }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModuleTest.kt
@@ -79,6 +79,7 @@ class VolumeUpdateModuleTest : BaseTest() {
         alarmVolume: Float? = null,
         volumeObserving: Boolean = true,
         volumeLock: Boolean = false,
+        volumeRateLimiter: Boolean = false,
         lastConnected: Long = 0L,
     ): DeviceConfigEntity = DeviceConfigEntity(
         address = address,
@@ -89,6 +90,7 @@ class VolumeUpdateModuleTest : BaseTest() {
         alarmVolume = alarmVolume,
         volumeObserving = volumeObserving,
         volumeLock = volumeLock,
+        volumeRateLimiter = volumeRateLimiter,
         lastConnected = lastConnected,
     )
 
@@ -109,14 +111,30 @@ class VolumeUpdateModuleTest : BaseTest() {
         )
     }
 
+    /**
+     * When a rate-limiter-eligible owner exists, the module persists the live
+     * hardware level instead of the event's value. Default: hardware matches
+     * what the event reported; tests for the rate-limiter interplay pass a
+     * diverging [hardwareLevel].
+     */
+    private suspend fun handleObserved(
+        module: VolumeUpdateModule,
+        event: VolumeEvent,
+        hardwareLevel: Int = event.newVolume,
+    ) {
+        every { volumeTool.getCurrentVolume(event.streamId) } returns hardwareLevel
+        module.handle(event)
+    }
+
     private suspend fun runTransform(
         module: VolumeUpdateModule,
         event: VolumeEvent,
         seedConfig: DeviceConfigEntity,
+        hardwareLevel: Int = event.newVolume,
     ): DeviceConfigEntity {
         val slot = slot<(DeviceConfigEntity) -> DeviceConfigEntity>()
         coEvery { deviceRepo.updateDevice(address, capture(slot)) } just Runs
-        module.handle(event)
+        handleObserved(module, event, hardwareLevel)
         return slot.captured(seedConfig)
     }
 
@@ -129,8 +147,9 @@ class VolumeUpdateModuleTest : BaseTest() {
         val cfg = config(musicVolume = 0.5f)
         seedActive(managedDevice(cfg))
 
-        module.handle(
-            VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 11, self = true)
+        handleObserved(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 11, self = true),
         )
 
         coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
@@ -147,8 +166,9 @@ class VolumeUpdateModuleTest : BaseTest() {
 
         observationGate.suppress(AudioStream.Id.STREAM_MUSIC)
 
-        module.handle(
-            VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 11, self = false)
+        handleObserved(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 11, self = false),
         )
 
         coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
@@ -166,8 +186,9 @@ class VolumeUpdateModuleTest : BaseTest() {
         val token = observationGate.suppress(AudioStream.Id.STREAM_MUSIC)
         observationGate.unsuppress(token)
 
-        module.handle(
-            VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 11, self = false)
+        handleObserved(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 11, self = false),
         )
 
         coVerify(exactly = 1) { deviceRepo.updateDevice(any(), any()) }
@@ -181,8 +202,9 @@ class VolumeUpdateModuleTest : BaseTest() {
 
         observationGate.suppress(AudioStream.Id.STREAM_VOICE_CALL)
 
-        module.handle(
-            VolumeEvent(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE, oldVolume = 15, newVolume = 11, self = false)
+        handleObserved(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE, oldVolume = 15, newVolume = 11, self = false),
         )
 
         coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
@@ -268,8 +290,9 @@ class VolumeUpdateModuleTest : BaseTest() {
 
         every { ringerTool.getCurrentRingerMode() } returns RingerMode.VIBRATE
 
-        module.handle(
-            VolumeEvent(AudioStream.Id.STREAM_NOTIFICATION, 1, 0, self = false)
+        handleObserved(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_NOTIFICATION, 1, 0, self = false),
         )
 
         coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
@@ -309,8 +332,9 @@ class VolumeUpdateModuleTest : BaseTest() {
         every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
 
 
-        module.handle(
-            VolumeEvent(AudioStream.Id.STREAM_MUSIC, 11, 17, self = false)
+        handleObserved(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, 11, 17, self = false),
         )
 
         coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
@@ -328,8 +352,9 @@ class VolumeUpdateModuleTest : BaseTest() {
         every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
 
 
-        module.handle(
-            VolumeEvent(AudioStream.Id.STREAM_MUSIC, 11, 17, self = false)
+        handleObserved(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, 11, 17, self = false),
         )
 
         coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
@@ -348,8 +373,9 @@ class VolumeUpdateModuleTest : BaseTest() {
         every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
 
 
-        module.handle(
-            VolumeEvent(AudioStream.Id.STREAM_MUSIC, 11, 17, self = false)
+        handleObserved(
+            module,
+            VolumeEvent(AudioStream.Id.STREAM_MUSIC, 11, 17, self = false),
         )
 
         coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
@@ -378,7 +404,7 @@ class VolumeUpdateModuleTest : BaseTest() {
         every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
 
 
-        module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false))
+        handleObserved(module, VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false))
 
         coVerify(exactly = 1) { deviceRepo.updateDevice("AA:BB:CC:DD:EE:01", any()) }
         coVerify(exactly = 0) { deviceRepo.updateDevice("AA:BB:CC:DD:EE:02", any()) }
@@ -407,7 +433,7 @@ class VolumeUpdateModuleTest : BaseTest() {
         every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
 
 
-        module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false))
+        handleObserved(module, VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false))
 
         coVerify(exactly = 1) { deviceRepo.updateDevice("AA:BB:CC:DD:EE:01", any()) }
         coVerify(exactly = 0) { deviceRepo.updateDevice("AA:BB:CC:DD:EE:02", any()) }
@@ -449,7 +475,7 @@ class VolumeUpdateModuleTest : BaseTest() {
         every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
 
 
-        module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false))
+        handleObserved(module, VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false))
 
         coVerify(exactly = 0) { deviceRepo.updateDevice("AA:BB:CC:DD:EE:01", any()) }
         coVerify(exactly = 1) { deviceRepo.updateDevice("AA:BB:CC:DD:EE:02", any()) }
@@ -476,7 +502,7 @@ class VolumeUpdateModuleTest : BaseTest() {
         every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
 
 
-        module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false))
+        handleObserved(module, VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false))
 
         coVerify(exactly = 1) { deviceRepo.updateDevice("AA:BB:CC:DD:EE:01", any()) }
         coVerify(exactly = 1) { deviceRepo.updateDevice("AA:BB:CC:DD:EE:02", any()) }
@@ -500,7 +526,7 @@ class VolumeUpdateModuleTest : BaseTest() {
         every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
 
 
-        module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false))
+        handleObserved(module, VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false))
 
         coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
     }
@@ -519,8 +545,9 @@ class VolumeUpdateModuleTest : BaseTest() {
 
             every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
     
-            module.handle(
-                VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 6, self = false)
+            handleObserved(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 6, self = false),
             )
 
             coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
@@ -583,7 +610,7 @@ class VolumeUpdateModuleTest : BaseTest() {
 
             every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
     
-            module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 6, self = false))
+            handleObserved(module, VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 6, self = false))
 
             // dev1 skipped (equivalent), dev2 written (different level)
             coVerify(exactly = 0) { deviceRepo.updateDevice("AA:BB:CC:DD:EE:01", any()) }
@@ -604,11 +631,102 @@ class VolumeUpdateModuleTest : BaseTest() {
             every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
     
             // event newVolume=4 → same as stored level → skip
-            module.handle(
-                VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 3, newVolume = 4, self = false)
+            handleObserved(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 3, newVolume = 4, self = false),
             )
 
             coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Hardware readback: persist what's actually set, not what the event said
+    //
+    // Regression: with the rate limiter (priority 5) enabled, a Zello-style
+    // volume jump is physically clamped before this module (priority 10) runs,
+    // but the event still carries the original high value. Persisting the event
+    // value stored the blocked jump and restored it on the next connect.
+    //
+    // Readback only happens when a rate-limiter-eligible owner exists for the
+    // stream — otherwise the event's snapshot is kept, so a late live read
+    // can't pick up an unrelated route change (issue #232).
+    // ------------------------------------------------------------------------
+    @Nested
+    inner class HardwareReadback {
+        @Test
+        fun `persists hardware level when it differs from event volume`() = runTest {
+            val module = createModule()
+            // stored 0.1 → level 2; event reports jump to 15, but limiter clamped hardware to 6
+            val cfg = config(musicVolume = 0.1f, volumeRateLimiter = true)
+            seedActive(managedDevice(cfg))
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+            val result = runTransform(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 15, self = false),
+                cfg,
+                hardwareLevel = 6,
+            )
+
+            result.musicVolume shouldBe levelToPercentage(6, 0, 15)
+        }
+
+        @Test
+        fun `skips persist when hardware was reverted to the stored level`() = runTest {
+            val module = createModule()
+            // stored maps to level 5; event reports jump to 15, but limiter reverted hardware to 5
+            val cfg = config(musicVolume = levelToPercentage(5, 0, 15), volumeRateLimiter = true)
+            seedActive(managedDevice(cfg))
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+            handleObserved(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 15, self = false),
+                hardwareLevel = 5,
+            )
+
+            coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+        }
+
+        @Test
+        fun `notification zero-guard under vibrate uses hardware level`() = runTest {
+            val module = createModule()
+            // event says 5, but hardware reads 0 → ambiguous 0 under vibrate → preserve stored
+            val cfg = config(notificationVolume = 0.19f, volumeRateLimiter = true)
+            seedActive(managedDevice(cfg))
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.VIBRATE
+
+            handleObserved(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_NOTIFICATION, oldVolume = 1, newVolume = 5, self = false),
+                hardwareLevel = 0,
+            )
+
+            coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+        }
+
+        @Test
+        fun `without eligible rate limiter the event volume is persisted, not the live read`() = runTest {
+            val module = createModule()
+            // No limiter on this device → no priority-5 writer, keep the event's snapshot
+            // even when the live read disagrees (e.g. route already torn down, issue #232).
+            val cfg = config(musicVolume = 0.1f, volumeRateLimiter = false)
+            seedActive(managedDevice(cfg))
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+            val result = runTransform(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 11, self = false),
+                cfg,
+                hardwareLevel = 0,
+            )
+
+            result.musicVolume shouldBe levelToPercentage(11, 0, 15)
         }
     }
 }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/VolumeRateLimiterPersistIntegrationTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/VolumeRateLimiterPersistIntegrationTest.kt
@@ -1,0 +1,231 @@
+package eu.darken.bluemusic.monitor.core.service
+
+import android.media.AudioManager
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import eu.darken.bluemusic.monitor.core.audio.RingerMode
+import eu.darken.bluemusic.monitor.core.audio.RingerTool
+import eu.darken.bluemusic.monitor.core.audio.VolumeEvent
+import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import eu.darken.bluemusic.monitor.core.audio.levelToPercentage
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeObservationGate
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeRateLimiterModule
+import eu.darken.bluemusic.monitor.core.modules.volume.VolumeUpdateModule
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.time.FakeMonotonicClock
+
+/**
+ * Regression coverage for the rate-limiter/observe-changes interplay:
+ * the limiter (priority 5) physically corrects a volume jump before
+ * VolumeUpdateModule (priority 10) runs, but the dispatched event still
+ * carries the original high value. VolumeUpdateModule must persist the
+ * live hardware level, not the event's value — otherwise a blocked jump
+ * (e.g. Zello Auto-Volume) gets stored and restored on the next connect.
+ */
+class VolumeRateLimiterPersistIntegrationTest : BaseTest() {
+
+    @Test
+    fun `rate-limited jump persists the clamped level, not the event's value`() = runTest {
+        // stored maps to level 5, hardware at 5, no prior limiter state
+        val fixture = Fixture.create(this, initialMusicVolume = levelToPercentage(5, 0, 15))
+
+        // Zello-style jump: an external app sets hardware 5 → 15
+        fixture.setHardware(15)
+        fixture.dispatch(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 15, self = false))
+
+        // Limiter clamped hardware to one step above the reference
+        fixture.hardware() shouldBe 6
+        // Persisted value matches the clamp, not the original jump
+        fixture.storedMusicVolume() shouldBe levelToPercentage(6, 0, 15)
+        fixture.totalWriteCount() shouldBe 1
+
+        // The limiter's corrective write surfaces as a self event → no further persist
+        fixture.dispatch(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 15, newVolume = 6, self = true))
+        fixture.storedMusicVolume() shouldBe levelToPercentage(6, 0, 15)
+        fixture.totalWriteCount() shouldBe 1
+    }
+
+    @Test
+    fun `jump within rate window is reverted and never persisted`() = runTest {
+        val fixture = Fixture.create(this, initialMusicVolume = levelToPercentage(6, 0, 15))
+
+        // Establish limiter reference state with an allowed single step 5 → 6
+        fixture.setHardware(6)
+        fixture.dispatch(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 6, self = false))
+        fixture.totalWriteCount() shouldBe 0 // stored already maps to level 6
+
+        // Jump within the rate window (clock unchanged)
+        fixture.setHardware(15)
+        fixture.dispatch(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 6, newVolume = 15, self = false))
+
+        fixture.hardware() shouldBe 6
+        fixture.storedMusicVolume() shouldBe levelToPercentage(6, 0, 15)
+        fixture.totalWriteCount() shouldBe 0
+    }
+
+    @Test
+    fun `handsfree call stream jump is clamped and persisted at the clamped level`() = runTest {
+        val fixture = Fixture.create(
+            this,
+            initialMusicVolume = levelToPercentage(5, 0, 15),
+            initialCallVolume = levelToPercentage(5, 0, 15),
+        )
+
+        fixture.setHardware(15, AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE)
+        fixture.dispatch(VolumeEvent(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE, oldVolume = 5, newVolume = 15, self = false))
+
+        fixture.hardware(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE) shouldBe 6
+        fixture.storedCallVolume() shouldBe levelToPercentage(6, 0, 15)
+        fixture.totalWriteCount() shouldBe 1
+
+        fixture.dispatch(VolumeEvent(AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE, oldVolume = 15, newVolume = 6, self = true))
+        fixture.totalWriteCount() shouldBe 1
+    }
+
+    private class Fixture(
+        scope: TestScope,
+        initialMusicVolume: Float,
+        initialCallVolume: Float? = null,
+    ) {
+        private val address = "AA:BB:CC:DD:EE:FF"
+
+        private val audioLevels = mutableMapOf(
+            AudioStream.Id.STREAM_MUSIC to 5,
+            AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE to 5,
+        )
+        private val writeLog = mutableListOf<Pair<DeviceConfigEntity, DeviceConfigEntity>>()
+
+        private val audioManager = mockk<AudioManager>(relaxed = true)
+        private val ringerTool = mockk<RingerTool>()
+        private val deviceRepo = mockk<DeviceRepo>()
+        private val clock = FakeMonotonicClock(now = 10_000L)
+        private val observationGate = VolumeObservationGate()
+        private val ownerRegistry = eu.darken.bluemusic.monitor.core.ownership.AudioStreamOwnerRegistry()
+
+        private val sourceDevice = mockk<SourceDevice> {
+            every { this@mockk.address } returns this@Fixture.address
+            every { label } returns "Test Device"
+            every { deviceType } returns SourceDevice.Type.HEADPHONES
+            every { getStreamId(AudioStream.Type.MUSIC) } returns AudioStream.Id.STREAM_MUSIC
+            // Headset-realistic: CALL maps to the handsfree stream
+            every { getStreamId(AudioStream.Type.CALL) } returns AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE
+            every { getStreamId(AudioStream.Type.RINGTONE) } returns AudioStream.Id.STREAM_RINGTONE
+            every { getStreamId(AudioStream.Type.NOTIFICATION) } returns AudioStream.Id.STREAM_NOTIFICATION
+            every { getStreamId(AudioStream.Type.ALARM) } returns AudioStream.Id.STREAM_ALARM
+        }
+
+        private val devicesFlow = MutableStateFlow(
+            listOf(
+                ManagedDevice(
+                    isConnected = true,
+                    device = sourceDevice,
+                    config = DeviceConfigEntity(
+                        address = address,
+                        musicVolume = initialMusicVolume,
+                        callVolume = initialCallVolume,
+                        volumeObserving = true,
+                        volumeRateLimiter = true,
+                        isEnabled = true,
+                        lastConnected = 0L, // long past → device counts as stable
+                    ),
+                )
+            )
+        )
+
+        private val volumeTool = VolumeTool(audioManager).apply {
+            clock = { scope.testScheduler.currentTime }
+        }
+
+        private val dispatcher = VolumeEventDispatcher(
+            setOf(
+                VolumeRateLimiterModule(
+                    volumeTool = volumeTool,
+                    deviceRepo = deviceRepo,
+                    ownerRegistry = ownerRegistry,
+                    clock = clock,
+                ),
+                VolumeUpdateModule(
+                    volumeTool = volumeTool,
+                    ringerTool = ringerTool,
+                    deviceRepo = deviceRepo,
+                    observationGate = observationGate,
+                    ownerRegistry = ownerRegistry,
+                ),
+            )
+        )
+
+        init {
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+            every { deviceRepo.devices } returns devicesFlow
+
+            every { audioManager.getStreamMaxVolume(any()) } returns 15
+            every { audioManager.getStreamVolume(any()) } answers {
+                audioLevels[toStreamId(firstArg())] ?: 0
+            }
+            every { audioManager.setStreamVolume(any(), any(), any()) } answers {
+                audioLevels[toStreamId(firstArg())] = secondArg()
+            }
+
+            coEvery { deviceRepo.updateDevice(any(), any()) } coAnswers {
+                val addr = firstArg<String>()
+                val transform = secondArg<(DeviceConfigEntity) -> DeviceConfigEntity>()
+                val devices = devicesFlow.value.toMutableList()
+                val index = devices.indexOfFirst { it.address == addr }
+                check(index >= 0) { "Unknown device update: $addr" }
+
+                val current = devices[index]
+                val updatedConfig = transform(current.config)
+                writeLog += current.config to updatedConfig
+                devices[index] = current.copy(config = updatedConfig)
+                devicesFlow.value = devices
+            }
+        }
+
+        private suspend fun registerOwner() {
+            ownerRegistry.onDeviceConnected(
+                address = address,
+                label = "Test Device",
+                deviceType = SourceDevice.Type.HEADPHONES,
+                receivedAtElapsedMs = 1000L,
+                sequence = 0L,
+            )
+        }
+
+        suspend fun dispatch(event: VolumeEvent) = dispatcher.dispatch(event)
+
+        fun setHardware(level: Int, stream: AudioStream.Id = AudioStream.Id.STREAM_MUSIC) {
+            audioLevels[stream] = level
+        }
+
+        fun hardware(stream: AudioStream.Id = AudioStream.Id.STREAM_MUSIC): Int = audioLevels.getValue(stream)
+
+        fun storedMusicVolume(): Float? = devicesFlow.value.first { it.address == address }.config.musicVolume
+
+        fun storedCallVolume(): Float? = devicesFlow.value.first { it.address == address }.config.callVolume
+
+        /** Every updateDevice call, including no-op writes — pins "no second persist attempt". */
+        fun totalWriteCount(): Int = writeLog.size
+
+        private fun toStreamId(rawStreamId: Int): AudioStream.Id =
+            AudioStream.Id.entries.first { it.id == rawStreamId }
+
+        companion object {
+            suspend fun create(
+                scope: TestScope,
+                initialMusicVolume: Float,
+                initialCallVolume: Float? = null,
+            ): Fixture = Fixture(scope, initialMusicVolume, initialCallVolume).apply { registerOwner() }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- With both "Observe volume changes" and the volume rate limiter enabled on a device, a sudden volume jump (e.g. an app like Zello force-raising media volume) was physically blocked by the rate limiter — but the original un-clamped volume still got saved to the device profile, and restored on the next connect, defeating the limiter.
- Volume observation now persists the actual hardware level after the rate limiter has acted, instead of the value carried by the change event.
- The live hardware read only happens when a rate-limiter-eligible device owns the stream; all other devices keep the event's snapshot, so a late read can't pick up an unrelated route change (keeps exposure to the #232 timing race unchanged).

## Tests

- New unit tests for the hardware-readback behavior, including the guard that non-rate-limited devices persist the event value.
- New end-to-end pipeline test (real dispatcher + rate limiter + volume observation over a stateful fake AudioManager) covering the clamped jump, the rate-window revert, the handsfree call stream, and the follow-up self event.
- All new regression tests were verified to fail against the previous code with the exact bug signature (persisting 100% instead of the clamped level).
- Full FOSS debug unit suite passes (626 tests).
