### PR TITLE
Fix rate limiter inconsistency with paired earbuds

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeRateLimiterModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeRateLimiterModule.kt
@@ -82,39 +82,45 @@ internal class VolumeRateLimiterModule @Inject constructor(
                 lastSeenGeneration = currentGeneration
             }
 
-            eligibleDevices.forEach { device ->
-                processVolumeChange(device, id, oldVolume, newVolume, currentTime)
-            }
+            processVolumeChange(eligibleDevices, id, oldVolume, newVolume, currentTime)
         }
     }
 
+    /**
+     * One decision per stream and event: at most one hardware call and at most one state update.
+     * Iterating the group instead would mutate the shared per-stream state once per device,
+     * making the outcome depend on repository iteration order (and letting a 0ms member
+     * step past a sibling's window).
+     */
     private suspend fun processVolumeChange(
-        device: ManagedDevice,
+        devices: Collection<ManagedDevice>,
         streamId: AudioStream.Id,
         oldVolume: Int,
         newVolume: Int,
         currentTime: Long
     ) {
-        val streamType = device.getStreamType(streamId) ?: return
-
         val currentState = volumeStates[streamId]
 
         // Determine the reference volume (last allowed or old volume for initial state)
         val referenceVolume = currentState?.lastAllowedVolume ?: oldVolume.takeIf { it != -1 } ?: newVolume
 
-        // Determine direction and select appropriate rate limit
+        // Determine direction, then let the most restrictive (longest) window in the owner group
+        // govern the whole group. Owner groups are usually paired earbuds, but same-name devices
+        // connecting within the grouping window (or bootstrap entries) can group too — they are
+        // already treated as one owner everywhere else.
         val volumeDiff = newVolume - referenceVolume
         val rateLimitMs = if (volumeDiff > 0) {
-            device.volumeRateLimitIncreaseMs
+            devices.maxOf { it.volumeRateLimitIncreaseMs }
         } else {
-            device.volumeRateLimitDecreaseMs
+            devices.maxOf { it.volumeRateLimitDecreaseMs }
         }
+        val members = devices.map { "${it.address}/${it.label}" }.sorted()
 
         // Check rate limiting
         if (currentState != null && (currentTime - currentState.lastChangeTimestamp) < rateLimitMs) {
-            log(TAG) { "Volume changed too quickly for $streamType, reverting from $newVolume to $referenceVolume" }
+            log(TAG) { "Volume changed too quickly for $streamId $members, reverting from $newVolume to $referenceVolume" }
             if (volumeTool.changeVolume(streamId = streamId, targetLevel = referenceVolume)) {
-                log(TAG) { "Reverted volume for $streamType to $referenceVolume due to rate limiting" }
+                log(TAG) { "Reverted volume for $streamId to $referenceVolume due to rate limiting" }
             }
             // Update timestamp to reset the timer
             volumeStates[streamId] = VolumeState(referenceVolume, currentTime)
@@ -129,15 +135,15 @@ internal class VolumeRateLimiterModule @Inject constructor(
         }
 
         if (clampedVolume != newVolume) {
-            log(TAG) { "Volume change limited for $streamType: requested=$newVolume, reference=$referenceVolume, limited to=$clampedVolume" }
+            log(TAG) { "Volume change limited for $streamId $members: requested=$newVolume, reference=$referenceVolume, limited to=$clampedVolume" }
             if (volumeTool.changeVolume(streamId = streamId, targetLevel = clampedVolume)) {
-                log(TAG) { "Applied rate-limited volume for $streamType to $clampedVolume" }
+                log(TAG) { "Applied rate-limited volume for $streamId to $clampedVolume" }
                 volumeStates[streamId] = VolumeState(clampedVolume, currentTime)
             }
         } else {
             // Volume change is within allowed range - accept it
             volumeStates[streamId] = VolumeState(newVolume, currentTime)
-            log(TAG, VERBOSE) { "Allowed volume change for $streamType to $newVolume" }
+            log(TAG, VERBOSE) { "Allowed volume change for $streamId to $newVolume" }
         }
     }
 

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeRateLimiterModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeRateLimiterModuleTest.kt
@@ -95,6 +95,51 @@ class VolumeRateLimiterModuleTest : BaseTest() {
         )
     }
 
+    private fun groupedSource(addr: String, name: String): SourceDevice = mockk {
+        every { this@mockk.address } returns addr
+        every { label } returns name
+        every { deviceType } returns SourceDevice.Type.HEADPHONES
+        every { getStreamId(AudioStream.Type.MUSIC) } returns AudioStream.Id.STREAM_MUSIC
+        every { getStreamId(AudioStream.Type.CALL) } returns AudioStream.Id.STREAM_VOICE_CALL
+        every { getStreamId(AudioStream.Type.RINGTONE) } returns AudioStream.Id.STREAM_RINGTONE
+        every { getStreamId(AudioStream.Type.NOTIFICATION) } returns AudioStream.Id.STREAM_NOTIFICATION
+        every { getStreamId(AudioStream.Type.ALARM) } returns AudioStream.Id.STREAM_ALARM
+    }
+
+    private fun groupedDevice(
+        addr: String,
+        increaseMs: Long? = null,
+        decreaseMs: Long? = null,
+        rateLimiter: Boolean = true,
+        volumeLock: Boolean = false,
+    ): ManagedDevice = ManagedDevice(
+        isConnected = true,
+        device = groupedSource(addr, "Buds3 Pro"),
+        config = DeviceConfigEntity(
+            address = addr,
+            volumeRateLimiter = rateLimiter,
+            volumeLock = volumeLock,
+            isEnabled = true,
+            musicVolume = 0.5f,
+            volumeRateLimitIncreaseMs = increaseMs,
+            volumeRateLimitDecreaseMs = decreaseMs,
+        ),
+    )
+
+    /** Same label + type, connects 2ms apart → one owner group (grouped earbuds). */
+    private suspend fun seedGroup(devices: List<ManagedDevice>) {
+        devicesFlow.value = devices
+        devices.forEachIndexed { index, device ->
+            ownerRegistry.onDeviceConnected(
+                address = device.address,
+                label = device.label,
+                deviceType = device.type,
+                receivedAtElapsedMs = 1000L + index * 2,
+                sequence = index.toLong(),
+            )
+        }
+    }
+
     @Test
     fun `volume change within rate window is reverted`() = runTest {
         val module = createModule()
@@ -334,6 +379,110 @@ class VolumeRateLimiterModuleTest : BaseTest() {
         module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 10, self = false))
 
         coVerify(exactly = 0) { volumeTool.changeVolume(streamId = any(), targetLevel = any()) }
+    }
+
+    // ------------------------------------------------------------------------
+    // Owner-group decisions: one decision per stream/event, most restrictive
+    // window wins, independent of repository iteration order.
+    // ------------------------------------------------------------------------
+
+    @Test
+    fun `grouped 0ms member cannot double-step past sibling window - either order`() = runTest {
+        for (zeroFirst in listOf(true, false)) {
+            setup()
+            val zero = groupedDevice("AA:BB:CC:DD:EE:01", increaseMs = 0L)
+            val slow = groupedDevice("AA:BB:CC:DD:EE:02", increaseMs = 1000L)
+            seedGroup(if (zeroFirst) listOf(zero, slow) else listOf(slow, zero))
+
+            coEvery { volumeTool.changeVolume(streamId = any(), targetLevel = any()) } returns true
+
+            val module = createModule()
+            module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 15, self = false))
+
+            // Exactly one correction to reference+1 — no second pass stepping to 7
+            coVerify(exactly = 1) { volumeTool.changeVolume(streamId = any(), targetLevel = any()) }
+            coVerify(exactly = 1) { volumeTool.changeVolume(streamId = AudioStream.Id.STREAM_MUSIC, targetLevel = 6) }
+        }
+    }
+
+    @Test
+    fun `grouped devices - longest window governs regardless of order`() = runTest {
+        for (fastFirst in listOf(true, false)) {
+            setup()
+            val fast = groupedDevice("AA:BB:CC:DD:EE:01", increaseMs = 500L)
+            val slow = groupedDevice("AA:BB:CC:DD:EE:02", increaseMs = 1000L)
+            seedGroup(if (fastFirst) listOf(fast, slow) else listOf(slow, fast))
+
+            coEvery { volumeTool.changeVolume(streamId = any(), targetLevel = any()) } returns true
+
+            val module = createModule()
+            // Allowed single step establishes state at t=1000
+            module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 6, self = false))
+
+            // 700ms later: past fast's 500ms window, within slow's 1000ms window
+            clock.now = 1700L
+            module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 6, newVolume = 15, self = false))
+
+            // Most restrictive window applies → single revert to 6, never a step to 7
+            coVerify(exactly = 1) { volumeTool.changeVolume(streamId = AudioStream.Id.STREAM_MUSIC, targetLevel = 6) }
+            coVerify(exactly = 0) { volumeTool.changeVolume(streamId = AudioStream.Id.STREAM_MUSIC, targetLevel = 7) }
+        }
+    }
+
+    @Test
+    fun `ineligible group member does not influence the group window`() = runTest {
+        val zero = groupedDevice("AA:BB:CC:DD:EE:01", increaseMs = 0L)
+        // Locked sibling has a long window, but volumeLock makes it rate-limiter-ineligible
+        val locked = groupedDevice("AA:BB:CC:DD:EE:02", increaseMs = 1000L, volumeLock = true)
+        seedGroup(listOf(zero, locked))
+
+        coEvery { volumeTool.changeVolume(streamId = any(), targetLevel = any()) } returns true
+
+        val module = createModule()
+        module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 6, self = false))
+        // Same clock time: with a 0ms window the jump step-clamps instead of reverting
+        module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 6, newVolume = 15, self = false))
+
+        coVerify(exactly = 1) { volumeTool.changeVolume(streamId = AudioStream.Id.STREAM_MUSIC, targetLevel = 7) }
+    }
+
+    @Test
+    fun `all-zero group acts as pure step limiter - one step per event`() = runTest {
+        val a = groupedDevice("AA:BB:CC:DD:EE:01", increaseMs = 0L)
+        val b = groupedDevice("AA:BB:CC:DD:EE:02", increaseMs = 0L)
+        seedGroup(listOf(a, b))
+
+        coEvery { volumeTool.changeVolume(streamId = any(), targetLevel = any()) } returns true
+
+        val module = createModule()
+        module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 15, self = false))
+        module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 6, newVolume = 15, self = false))
+
+        coVerify(exactly = 1) { volumeTool.changeVolume(streamId = AudioStream.Id.STREAM_MUSIC, targetLevel = 6) }
+        coVerify(exactly = 1) { volumeTool.changeVolume(streamId = AudioStream.Id.STREAM_MUSIC, targetLevel = 7) }
+        coVerify(exactly = 2) { volumeTool.changeVolume(streamId = any(), targetLevel = any()) }
+    }
+
+    @Test
+    fun `decrease direction aggregates decrease windows not increase windows`() = runTest {
+        // Tiny increase windows would (wrongly) let the drop through if the
+        // aggregation picked the wrong property for a decrease
+        val a = groupedDevice("AA:BB:CC:DD:EE:01", increaseMs = 50L, decreaseMs = 500L)
+        val b = groupedDevice("AA:BB:CC:DD:EE:02", increaseMs = 50L, decreaseMs = 1000L)
+        seedGroup(listOf(a, b))
+
+        coEvery { volumeTool.changeVolume(streamId = any(), targetLevel = any()) } returns true
+
+        val module = createModule()
+        // Allowed single-step decrease establishes state at t=1000
+        module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 10, newVolume = 9, self = false))
+
+        // 700ms later: past both increase windows and a's decrease window, within b's 1000ms decrease window
+        clock.now = 1700L
+        module.handle(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 9, newVolume = 0, self = false))
+
+        coVerify(exactly = 1) { volumeTool.changeVolume(streamId = AudioStream.Id.STREAM_MUSIC, targetLevel = 9) }
+        coVerify(exactly = 0) { volumeTool.changeVolume(streamId = AudioStream.Id.STREAM_MUSIC, targetLevel = 8) }
     }
 
     @Test

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/VolumeRateLimiterPersistIntegrationTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/VolumeRateLimiterPersistIntegrationTest.kt
@@ -93,18 +93,61 @@ class VolumeRateLimiterPersistIntegrationTest : BaseTest() {
         fixture.totalWriteCount() shouldBe 1
     }
 
+    @Test
+    fun `grouped earbuds - one hardware correction, both configs persist the clamped level`() = runTest {
+        // Order matters for the regression: the per-device fold would let the
+        // 0ms member (processed second) step past the sibling's clamp to 7.
+        val fixture = Fixture.createGroup(
+            this,
+            listOf(
+                Fixture.DeviceSpec(
+                    address = "AA:BB:CC:DD:EE:01",
+                    label = "Buds3 Pro",
+                    musicVolume = levelToPercentage(5, 0, 15),
+                    rateLimitIncreaseMs = 1000L,
+                ),
+                Fixture.DeviceSpec(
+                    address = "AA:BB:CC:DD:EE:02",
+                    label = "Buds3 Pro",
+                    musicVolume = levelToPercentage(5, 0, 15),
+                    rateLimitIncreaseMs = 0L,
+                ),
+            ),
+        )
+
+        fixture.setHardware(15)
+        fixture.dispatch(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 5, newVolume = 15, self = false))
+
+        fixture.hardware() shouldBe 6
+        fixture.hardwareWriteCount(AudioStream.Id.STREAM_MUSIC) shouldBe 1
+        fixture.storedMusicVolume("AA:BB:CC:DD:EE:01") shouldBe levelToPercentage(6, 0, 15)
+        fixture.storedMusicVolume("AA:BB:CC:DD:EE:02") shouldBe levelToPercentage(6, 0, 15)
+        fixture.totalWriteCount() shouldBe 2
+
+        // Self follow-up from the limiter's correction adds neither persists nor hardware writes
+        fixture.dispatch(VolumeEvent(AudioStream.Id.STREAM_MUSIC, oldVolume = 15, newVolume = 6, self = true))
+        fixture.totalWriteCount() shouldBe 2
+        fixture.hardwareWriteCount(AudioStream.Id.STREAM_MUSIC) shouldBe 1
+    }
+
     private class Fixture(
         scope: TestScope,
-        initialMusicVolume: Float,
-        initialCallVolume: Float? = null,
+        private val specs: List<DeviceSpec>,
     ) {
-        private val address = "AA:BB:CC:DD:EE:FF"
+        data class DeviceSpec(
+            val address: String,
+            val label: String = "Test Device",
+            val musicVolume: Float? = null,
+            val callVolume: Float? = null,
+            val rateLimitIncreaseMs: Long? = null,
+        )
 
         private val audioLevels = mutableMapOf(
             AudioStream.Id.STREAM_MUSIC to 5,
             AudioStream.Id.STREAM_BLUETOOTH_HANDSFREE to 5,
         )
         private val writeLog = mutableListOf<Pair<DeviceConfigEntity, DeviceConfigEntity>>()
+        private val hardwareWrites = mutableListOf<Pair<AudioStream.Id, Int>>()
 
         private val audioManager = mockk<AudioManager>(relaxed = true)
         private val ringerTool = mockk<RingerTool>()
@@ -113,9 +156,9 @@ class VolumeRateLimiterPersistIntegrationTest : BaseTest() {
         private val observationGate = VolumeObservationGate()
         private val ownerRegistry = eu.darken.bluemusic.monitor.core.ownership.AudioStreamOwnerRegistry()
 
-        private val sourceDevice = mockk<SourceDevice> {
-            every { this@mockk.address } returns this@Fixture.address
-            every { label } returns "Test Device"
+        private fun sourceDevice(spec: DeviceSpec) = mockk<SourceDevice> {
+            every { this@mockk.address } returns spec.address
+            every { label } returns spec.label
             every { deviceType } returns SourceDevice.Type.HEADPHONES
             every { getStreamId(AudioStream.Type.MUSIC) } returns AudioStream.Id.STREAM_MUSIC
             // Headset-realistic: CALL maps to the handsfree stream
@@ -126,21 +169,22 @@ class VolumeRateLimiterPersistIntegrationTest : BaseTest() {
         }
 
         private val devicesFlow = MutableStateFlow(
-            listOf(
+            specs.map { spec ->
                 ManagedDevice(
                     isConnected = true,
-                    device = sourceDevice,
+                    device = sourceDevice(spec),
                     config = DeviceConfigEntity(
-                        address = address,
-                        musicVolume = initialMusicVolume,
-                        callVolume = initialCallVolume,
+                        address = spec.address,
+                        musicVolume = spec.musicVolume,
+                        callVolume = spec.callVolume,
                         volumeObserving = true,
                         volumeRateLimiter = true,
+                        volumeRateLimitIncreaseMs = spec.rateLimitIncreaseMs,
                         isEnabled = true,
                         lastConnected = 0L, // long past → device counts as stable
                     ),
                 )
-            )
+            }
         )
 
         private val volumeTool = VolumeTool(audioManager).apply {
@@ -174,7 +218,9 @@ class VolumeRateLimiterPersistIntegrationTest : BaseTest() {
                 audioLevels[toStreamId(firstArg())] ?: 0
             }
             every { audioManager.setStreamVolume(any(), any(), any()) } answers {
-                audioLevels[toStreamId(firstArg())] = secondArg()
+                val stream = toStreamId(firstArg())
+                audioLevels[stream] = secondArg()
+                hardwareWrites += stream to secondArg()
             }
 
             coEvery { deviceRepo.updateDevice(any(), any()) } coAnswers {
@@ -193,13 +239,15 @@ class VolumeRateLimiterPersistIntegrationTest : BaseTest() {
         }
 
         private suspend fun registerOwner() {
-            ownerRegistry.onDeviceConnected(
-                address = address,
-                label = "Test Device",
-                deviceType = SourceDevice.Type.HEADPHONES,
-                receivedAtElapsedMs = 1000L,
-                sequence = 0L,
-            )
+            specs.forEachIndexed { index, spec ->
+                ownerRegistry.onDeviceConnected(
+                    address = spec.address,
+                    label = spec.label,
+                    deviceType = SourceDevice.Type.HEADPHONES,
+                    receivedAtElapsedMs = 1000L + index * 2,
+                    sequence = index.toLong(),
+                )
+            }
         }
 
         suspend fun dispatch(event: VolumeEvent) = dispatcher.dispatch(event)
@@ -210,12 +258,17 @@ class VolumeRateLimiterPersistIntegrationTest : BaseTest() {
 
         fun hardware(stream: AudioStream.Id = AudioStream.Id.STREAM_MUSIC): Int = audioLevels.getValue(stream)
 
-        fun storedMusicVolume(): Float? = devicesFlow.value.first { it.address == address }.config.musicVolume
+        fun storedMusicVolume(address: String = specs.first().address): Float? =
+            devicesFlow.value.first { it.address == address }.config.musicVolume
 
-        fun storedCallVolume(): Float? = devicesFlow.value.first { it.address == address }.config.callVolume
+        fun storedCallVolume(address: String = specs.first().address): Float? =
+            devicesFlow.value.first { it.address == address }.config.callVolume
 
         /** Every updateDevice call, including no-op writes — pins "no second persist attempt". */
         fun totalWriteCount(): Int = writeLog.size
+
+        /** Every setStreamVolume call for the stream — pins "exactly one hardware correction". */
+        fun hardwareWriteCount(stream: AudioStream.Id): Int = hardwareWrites.count { it.first == stream }
 
         private fun toStreamId(rawStreamId: Int): AudioStream.Id =
             AudioStream.Id.entries.first { it.id == rawStreamId }
@@ -225,7 +278,13 @@ class VolumeRateLimiterPersistIntegrationTest : BaseTest() {
                 scope: TestScope,
                 initialMusicVolume: Float,
                 initialCallVolume: Float? = null,
-            ): Fixture = Fixture(scope, initialMusicVolume, initialCallVolume).apply { registerOwner() }
+            ): Fixture = createGroup(
+                scope,
+                listOf(DeviceSpec(address = "AA:BB:CC:DD:EE:FF", musicVolume = initialMusicVolume, callVolume = initialCallVolume)),
+            )
+
+            suspend fun createGroup(scope: TestScope, specs: List<DeviceSpec>): Fixture =
+                Fixture(scope, specs).apply { registerOwner() }
         }
     }
 }


### PR DESCRIPTION
## Summary

- With paired earbuds (devices that connect as one owner group, e.g. Samsung Buds L/R), the volume rate limiter processed each group member separately against shared per-stream state. Two members with different rate-limit settings could produce inconsistent results: a member with a 0ms window could step a blocked jump one level further than allowed, and otherwise the outcome (block entirely vs. allow one step) depended on unspecified device iteration order.
- The limiter now makes one decision per stream and volume change: the most restrictive (longest) rate window among the eligible group members governs the whole group, with at most one hardware correction and one state update per event.
- Single-device setups (the common case) behave exactly as before.
- Follow-up to #237.

## Tests

- New unit tests: no double-step past a sibling's window (both device orders), longest-window-wins determinism (both orders), ineligible siblings don't influence the group window, all-zero windows act as a pure one-step-per-event limiter, and decrease-direction windows aggregate independently from increase windows.
- New end-to-end test: a grouped jump produces exactly one hardware correction and both device configs persist the clamped level; the limiter's self follow-up event adds neither hardware writes nor persists.
- All new regression tests verified to fail against the previous code (the old fold stepped 6→7→8→9 across two events instead of 6→7).
- Full FOSS debug unit suite passes (632 tests).
