### PR TITLE
See your Pro status and switch subscription to a one-time purchase

### DIFF
--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
@@ -21,7 +21,6 @@ import java.time.Instant
 import java.util.UUID
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.math.pow
 
 @Singleton
 class UpgradeRepoFoss @Inject constructor(
@@ -52,7 +51,9 @@ class UpgradeRepoFoss @Inject constructor(
         .distinctUntilChanged()
         .retryWhen { error, attempt ->
             emit(Info(error = error))
-            delay(30_000L * 2.0.pow(attempt.toDouble()).toLong())
+            // Integer, capped backoff: the old 2.0.pow(attempt) formula slept for hours and could
+            // overflow Long into a delay(negative) hot loop.
+            delay((30_000L * (attempt + 1)).coerceAtMost(300_000L))
             true
         }
         .shareIn(scope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)

--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
@@ -58,9 +58,9 @@ class UpgradeRepoFoss @Inject constructor(
         }
         .shareIn(scope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
-    fun openGithubSponsorsPage() {
+    fun openGithubSponsorsPage(): Boolean {
         log(TAG) { "openGithubSponsorsPage()" }
-        webpageTool.open(mainWebsite)
+        return webpageTool.open(mainWebsite)
     }
 
     suspend fun confirmGithubSponsorsUpgrade() {

--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeNavigation.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeNavigation.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 class UpgradeNavigation @Inject constructor() : NavigationEntry {
     override fun EntryProviderScope<NavKey>.setup() {
         entry<Nav.Main.Upgrade> {
-            UpgradeScreenHost()
+            UpgradeScreenHost(manage = it.manage)
         }
     }
 

--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -1,5 +1,8 @@
 package eu.darken.bluemusic.upgrade.ui
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -10,13 +13,18 @@ import androidx.compose.material.icons.twotone.Palette
 import androidx.compose.material.icons.twotone.PlayCircle
 import androidx.compose.material.icons.twotone.Tune
 import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -24,13 +32,21 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.LifecycleEventEffect
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
 import eu.darken.bluemusic.common.error.ErrorEventHandler
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
 
 @Composable
-fun UpgradeScreenHost(vm: UpgradeViewModel = hiltViewModel()) {
+fun UpgradeScreenHost(
+    manage: Boolean,
+    vm: UpgradeViewModel = hiltViewModel(),
+) {
     ErrorEventHandler(vm)
 
     val snackbarHostState = remember { SnackbarHostState() }
@@ -42,18 +58,28 @@ fun UpgradeScreenHost(vm: UpgradeViewModel = hiltViewModel()) {
     LaunchedEffect(vm.events) {
         vm.events.collect { event ->
             when (event) {
-                is UpgradeEvent.SpendMoreTime -> {
-                    snackbarHostState.showSnackbar(message = tooFastMessage)
-                }
+                is UpgradeEvent.SpendMoreTime -> snackbarHostState.showSnackbar(message = tooFastMessage)
             }
         }
     }
 
-    UpgradeScreen(
-        onNavigateBack = { vm.navUp() },
-        onSponsorClick = { vm.openSponsor() },
-        snackbarHostState = snackbarHostState,
-    )
+    val state by vm.state.collectAsStateWithLifecycle()
+
+    // Show the supporter-status view whenever the user is already a supporter (independent of the
+    // manage flag); otherwise the sponsor pitch.
+    if (state?.isSupporter == true) {
+        SupporterStatusScreen(
+            supporterSince = state?.supporterSince,
+            onNavigateBack = { vm.navUp() },
+            onVisitSponsors = { vm.openSponsorPage() },
+        )
+    } else {
+        UpgradeScreen(
+            onNavigateBack = { vm.navUp() },
+            onSponsorClick = { vm.openSponsor() },
+            snackbarHostState = snackbarHostState,
+        )
+    }
 }
 
 @Composable
@@ -85,10 +111,7 @@ fun UpgradeScreen(
                 .fillMaxWidth()
                 .height(48.dp),
         ) {
-            Icon(
-                imageVector = Icons.TwoTone.Favorite,
-                contentDescription = null,
-            )
+            Icon(imageVector = Icons.TwoTone.Favorite, contentDescription = null)
             Text(
                 text = stringResource(R.string.upgrade_screen_sponsor_action),
                 style = MaterialTheme.typography.titleMedium,
@@ -108,13 +131,84 @@ fun UpgradeScreen(
     }
 }
 
+@Composable
+fun SupporterStatusScreen(
+    supporterSince: Instant?,
+    onNavigateBack: () -> Unit,
+    onVisitSponsors: () -> Unit,
+) {
+    UpgradeScreenShell(
+        title = stringResource(R.string.app_name_upgraded),
+        postfix = stringResource(R.string.app_name_upgrade_postfix),
+        onNavigateBack = onNavigateBack,
+    ) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+            ),
+        ) {
+            Column(modifier = Modifier.padding(16.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(imageVector = Icons.TwoTone.Favorite, contentDescription = null)
+                    Text(
+                        text = stringResource(R.string.upgrade_screen_supporter_status_title),
+                        style = MaterialTheme.typography.titleMedium,
+                        modifier = Modifier.padding(start = 8.dp),
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.upgrade_screen_supporter_status_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+                supporterSince?.let { since ->
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Text(
+                        text = stringResource(R.string.upgrade_screen_supporter_since, SUPPORTER_DATE_FORMAT.format(since)),
+                        style = MaterialTheme.typography.bodySmall,
+                    )
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        OutlinedButton(
+            onClick = onVisitSponsors,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+        ) {
+            Icon(imageVector = Icons.TwoTone.Favorite, contentDescription = null)
+            Text(
+                text = stringResource(R.string.upgrade_screen_supporter_visit_action),
+                modifier = Modifier.padding(start = 8.dp),
+            )
+        }
+    }
+}
+
+private val SUPPORTER_DATE_FORMAT: DateTimeFormatter =
+    DateTimeFormatter.ofLocalizedDate(FormatStyle.MEDIUM).withZone(ZoneId.systemDefault())
+
 @Preview2
 @Composable
-fun UpgradeScreenPreview() {
+private fun UpgradeScreenPreview() {
     PreviewWrapper {
-        UpgradeScreen(
+        UpgradeScreen(onNavigateBack = {}, onSponsorClick = {})
+    }
+}
+
+@Preview2
+@Composable
+private fun SupporterStatusScreenPreview() {
+    PreviewWrapper {
+        SupporterStatusScreen(
+            supporterSince = Instant.ofEpochMilli(1_700_000_000_000L),
             onNavigateBack = {},
-            onSponsorClick = {}
+            onVisitSponsors = {},
         )
     }
 }

--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -44,9 +44,14 @@ class UpgradeViewModel @Inject constructor(
     fun openSponsor() {
         if (sponsorPageOpenedAt != null) return
         log(tag) { "openSponsor()" }
+        // Only arm the return-after-5s unlock heuristic if the sponsor page actually opened; otherwise
+        // an unrelated later pause/resume could grant supporter status with no page ever shown.
+        if (!upgradeRepo.openGithubSponsorsPage()) {
+            log(tag) { "Sponsor page didn't open; not arming the unlock heuristic" }
+            return
+        }
         sponsorPageOpenedAt = System.currentTimeMillis()
         hasPausedSinceOpen = false
-        upgradeRepo.openGithubSponsorsPage()
     }
 
     // Status-view variant: an existing supporter re-visiting the sponsor page must NOT re-arm the

--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -9,6 +9,8 @@ import eu.darken.bluemusic.common.flow.SingleEventFlow
 import eu.darken.bluemusic.common.navigation.NavigationController
 import eu.darken.bluemusic.common.ui.ViewModel4
 import eu.darken.bluemusic.upgrade.core.UpgradeRepoFoss
+import kotlinx.coroutines.flow.map
+import java.time.Instant
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,6 +22,16 @@ class UpgradeViewModel @Inject constructor(
 ) : ViewModel4(dispatcherProvider, logTag("Upgrade", "Screen", "VM"), navCtrl) {
 
     val events = SingleEventFlow<UpgradeEvent>()
+
+    // Drives the supporter-status view (shown whenever already a supporter) vs the sponsor pitch.
+    val state = upgradeRepo.upgradeInfo
+        .map { info -> State(isSupporter = info.isUpgraded, supporterSince = info.upgradedAt) }
+        .asStateFlow()
+
+    data class State(
+        val isSupporter: Boolean = false,
+        val supporterSince: Instant? = null,
+    )
 
     private var sponsorPageOpenedAt: Long?
         get() = savedState[KEY_OPENED_AT]
@@ -34,6 +46,13 @@ class UpgradeViewModel @Inject constructor(
         log(tag) { "openSponsor()" }
         sponsorPageOpenedAt = System.currentTimeMillis()
         hasPausedSinceOpen = false
+        upgradeRepo.openGithubSponsorsPage()
+    }
+
+    // Status-view variant: an existing supporter re-visiting the sponsor page must NOT re-arm the
+    // unlock heuristic (which would trigger the "back already?" nudge on return).
+    fun openSponsorPage() {
+        log(tag) { "openSponsorPage()" }
         upgradeRepo.openGithubSponsorsPage()
     }
 

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -20,4 +20,14 @@
     <string name="upgrade_screen_sponsor_action_hint">The alternative are ads, analytics and Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Thank you for supporting open-source development ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Back already? Your support keeps BVM alive!</string>
+
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">View your supporter status</string>
+
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Thanks for your support</string>
+    <string name="upgrade_screen_supporter_status_body">You\'ve unlocked all extra features by supporting open-source development.</string>
+    <string name="upgrade_screen_supporter_since">Supporter since %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visit GitHub Sponsors</string>
 </resources>

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -108,7 +108,9 @@ class UpgradeRepoGplay @Inject constructor(
 
     private suspend fun stampLastProState(fresh: BillingManager.FreshData) {
         val sku = preferredProSku(Info(billingData = fresh.data).upgrades) ?: return
-        val storedSkuId = billingCache.lastProStateSku.value()
+        // Bounded + fail-soft: a hung/full-disk DataStore must not stall this permanent
+        // freshBillingData collector (which would eventually backpressure all later fresh emissions).
+        val storedSkuId = readSafe("lastProStateSku") { billingCache.lastProStateSku.value() }
         val storedType = OurSku.PRO_SKUS.singleOrNull { it.id == storedSkuId }?.type
         // A purchase event is not a full ownership snapshot: a subscription-only event must not
         // downgrade the grace class of a previously confirmed permanent IAP. Full query snapshots
@@ -116,12 +118,20 @@ class UpgradeRepoGplay @Inject constructor(
         val effectiveSkuId = if (
             !fresh.isFullSnapshot && storedType == Sku.Type.IAP && sku.type != Sku.Type.IAP
         ) {
-            storedSkuId
+            storedSkuId ?: sku.id
         } else {
             sku.id
         }
         log(TAG, VERBOSE) { "Fresh Pro state confirmed by $sku, stamping $effectiveSkuId." }
-        billingCache.stampLastProState(effectiveSkuId, System.currentTimeMillis())
+        try {
+            withTimeoutOrNull(CACHE_WRITE_TIMEOUT_MS) {
+                billingCache.stampLastProState(effectiveSkuId, System.currentTimeMillis())
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "stampLastProState write failed: ${e.asLog()}" }
+        }
     }
 
     override val upgradeInfo: Flow<Info> = billingManager.billingData
@@ -371,6 +381,10 @@ class UpgradeRepoGplay @Inject constructor(
         // Bound on a single grace-cache DataStore read, so a hung/full-disk store can't stall the
         // reactive entitlement mapping.
         private const val CACHE_READ_TIMEOUT_MS = 2_000L
+
+        // Bound on the grace-state stamp write, so a hung store can't stall the freshBillingData
+        // bookkeeping collector.
+        private const val CACHE_WRITE_TIMEOUT_MS = 5_000L
 
         // The first Play round-trip after sign-in can take >8s; give the UI a bounded wait before it
         // stops showing Loading, so a dead/slow Play can't pin it there forever.

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flow
@@ -44,7 +45,6 @@ import java.time.Duration
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
-import kotlin.math.pow
 
 @Singleton
 class UpgradeRepoGplay @Inject constructor(
@@ -133,7 +133,7 @@ class UpgradeRepoGplay @Inject constructor(
         .retryWhen { error, attempt ->
             // Ignore Google Play errors if the last pro state was recent
             val now = System.currentTimeMillis()
-            val lastProStateAt = billingCache.lastProStateAt.value()
+            val lastProStateAt = readLastProStateAtSafe()
             log(TAG) { "Catch: now=$now, lastProStateAt=$lastProStateAt, attempt=$attempt, error=$error" }
             if ((now - lastProStateAt) < graceWindowMs()) {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, and just got an error, what is GPlay doing???" }
@@ -141,7 +141,9 @@ class UpgradeRepoGplay @Inject constructor(
             } else {
                 emit(Info(error = error, billingData = null))
             }
-            delay(30_000L * 2.0.pow(attempt.toDouble()).toLong())
+            // Integer, capped backoff: the old 2.0.pow(attempt) formula slept for hours after a handful
+            // of failures and eventually overflowed Long into a delay(negative) hot loop.
+            delay((30_000L * (attempt + 1)).coerceAtMost(300_000L))
             true
         }
         .setupCommonEventHandlers(TAG) { "upgradeInfo2" }
@@ -151,6 +153,9 @@ class UpgradeRepoGplay @Inject constructor(
     // restore banner. Local signal only — a fresh install or switched Google account starts false.
     val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow
         .map { it > 0 }
+        // Fail-soft: a broken/full-disk DataStore must not error out this flow (and the combine that
+        // reads it) — degrade to "not previously pro" instead.
+        .catch { e -> log(TAG, WARN) { "wasEverPro read failed: ${e.asLog()}" }; emit(false) }
         .distinctUntilChanged()
 
     // When we last confirmed a (known) Pro purchase from fresh Play data. Drives the two-stage grace
@@ -158,7 +163,9 @@ class UpgradeRepoGplay @Inject constructor(
     // entitlement has been unconfirmed past GRACE_DIAGNOSTICS_AFTER_MS. Reusing this timestamp (set at
     // confirmation, frozen when the entitlement lapses) instead of a separate "unconfirmed episode"
     // stamp means the diagnostics boundary can't get stuck during a Play outage.
-    val lastProStateAt: Flow<Long> = billingCache.lastProStateAt.flow.distinctUntilChanged()
+    val lastProStateAt: Flow<Long> = billingCache.lastProStateAt.flow
+        .catch { e -> log(TAG, WARN) { "lastProStateAt read failed: ${e.asLog()}" }; emit(0L) }
+        .distinctUntilChanged()
 
     // False until the first authoritative Play round-trip settles OR a fallback timeout elapses, then
     // true. The fallback flow is upstream-INDEPENDENT so a dead Play can't pin the UI on Loading
@@ -258,7 +265,7 @@ class UpgradeRepoGplay @Inject constructor(
             // Mirror the reactive flow's retryWhen: a transient Play error while we were Pro recently
             // keeps us Pro via the grace period; otherwise surface the error so the caller can show
             // the proper "Play unavailable" message instead of a generic restore failure.
-            val lastProStateAt = billingCache.lastProStateAt.value()
+            val lastProStateAt = readLastProStateAtSafe()
             if ((System.currentTimeMillis() - lastProStateAt) < graceWindowMs()) {
                 log(TAG, VERBOSE) { "restore hit a Play error but we were Pro recently -> grace" }
                 Info(gracePeriod = true, billingData = null)
@@ -273,29 +280,45 @@ class UpgradeRepoGplay @Inject constructor(
     // timestamp is stamped by the freshBillingData collector above, not from mapped (possibly
     // replayed) flow data.
     private suspend fun BillingData?.toUpgradeInfo(): Info {
+        // A confirmed purchase wins IMMEDIATELY, before any grace-cache read: never gate a real
+        // entitlement behind a (possibly hung/failing, e.g. full-disk) DataStore read.
+        if (this?.purchases?.isNotEmpty() == true) return Info(billingData = this)
+
+        // Grace fallback: bounded + fail-soft reads so a broken DataStore can neither hang nor throw
+        // out of this reactive mapping (which would loop the flow and stick the screen on loading).
         val now = System.currentTimeMillis()
-        val lastProStateAt = billingCache.lastProStateAt.value()
+        val lastProStateAt = readLastProStateAtSafe()
         log(TAG) { "toUpgradeInfo(): now=$now, lastProStateAt=$lastProStateAt, data=$this" }
-        return when {
-            this?.purchases?.isNotEmpty() == true -> Info(billingData = this)
-
-            (now - lastProStateAt) < graceWindowMs() -> {
-                log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
-                Info(gracePeriod = true, billingData = null)
-            }
-
-            else -> Info(billingData = this)
+        return if ((now - lastProStateAt) < graceWindowMs()) {
+            log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
+            Info(gracePeriod = true, billingData = null)
+        } else {
+            Info(billingData = this)
         }
     }
 
     // Grace window depends on what was last owned: a permanent one-time purchase gets a long window,
-    // a subscription (or an unknown/legacy last SKU) gets the short default.
+    // a subscription (or an unknown/legacy/unreadable last SKU) gets the short default.
     private suspend fun graceWindowMs(): Long {
-        val lastSku = billingCache.lastProStateSku.value()
+        val lastSku = readSafe("lastProStateSku") { billingCache.lastProStateSku.value() }
         val type = OurSku.PRO_SKUS.singleOrNull { it.id == lastSku }?.type
         val window = if (type == Sku.Type.IAP) GRACE_PERIOD_IAP_MS else GRACE_PERIOD_MS
         log(TAG) { "graceWindowMs(): lastSku=$lastSku, type=$type -> ${window}ms" }
         return window
+    }
+
+    // Bounded + fail-soft DataStore read: on hang (timeout) or failure, degrade to "not recently pro"
+    // (0L) so the grace fallback can never freeze or crash the entitlement mapping.
+    private suspend fun readLastProStateAtSafe(): Long =
+        readSafe("lastProStateAt") { billingCache.lastProStateAt.value() } ?: 0L
+
+    private suspend fun <T> readSafe(name: String, read: suspend () -> T): T? = try {
+        withTimeoutOrNull(CACHE_READ_TIMEOUT_MS) { read() }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "$name read failed: ${e.asLog()}" }
+        null
     }
 
     data class Info(
@@ -341,6 +364,10 @@ class UpgradeRepoGplay @Inject constructor(
         val GRACE_PERIOD_IAP_MS = Duration.ofDays(30).toMillis()
         private const val RESTORE_ON_OWNED_TIMEOUT_MS = 15_000L
         private const val REFRESH_TIMEOUT_MS = 30_000L
+
+        // Bound on a single grace-cache DataStore read, so a hung/full-disk store can't stall the
+        // reactive entitlement mapping.
+        private const val CACHE_READ_TIMEOUT_MS = 2_000L
 
         // The first Play round-trip after sign-in can take >8s; give the UI a bounded wait before it
         // stops showing Loading, so a dead/slow Play can't pin it there forever.

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -280,9 +280,12 @@ class UpgradeRepoGplay @Inject constructor(
     // timestamp is stamped by the freshBillingData collector above, not from mapped (possibly
     // replayed) flow data.
     private suspend fun BillingData?.toUpgradeInfo(): Info {
-        // A confirmed purchase wins IMMEDIATELY, before any grace-cache read: never gate a real
-        // entitlement behind a (possibly hung/failing, e.g. full-disk) DataStore read.
-        if (this?.purchases?.isNotEmpty() == true) return Info(billingData = this)
+        // A confirmed KNOWN Pro purchase wins IMMEDIATELY, before any grace-cache read: never gate a
+        // real entitlement behind a (possibly hung/failing, e.g. full-disk) DataStore read. Branch on
+        // MAPPED upgrades, not the raw purchase list — a purchase of only unrecognized product IDs
+        // maps to zero upgrades and must fall through to the grace window, not masquerade as Pro.
+        val confirmed = Info(billingData = this)
+        if (confirmed.upgrades.isNotEmpty()) return confirmed
 
         // Grace fallback: bounded + fail-soft reads so a broken DataStore can neither hang nor throw
         // out of this reactive mapping (which would loop the flow and stick the screen on loading).
@@ -293,7 +296,7 @@ class UpgradeRepoGplay @Inject constructor(
             log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
             Info(gracePeriod = true, billingData = null)
         } else {
-            Info(billingData = this)
+            confirmed
         }
     }
 

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -2,6 +2,7 @@ package eu.darken.bluemusic.upgrade.core
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
+import com.android.billingclient.api.Purchase
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.datastore.value
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
@@ -28,8 +29,10 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.retryWhen
@@ -149,6 +152,32 @@ class UpgradeRepoGplay @Inject constructor(
     val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow
         .map { it > 0 }
         .distinctUntilChanged()
+
+    // When we last confirmed a (known) Pro purchase from fresh Play data. Drives the two-stage grace
+    // display: the quiet "confirming your purchase" stage becomes the diagnostics stage once the
+    // entitlement has been unconfirmed past GRACE_DIAGNOSTICS_AFTER_MS. Reusing this timestamp (set at
+    // confirmation, frozen when the entitlement lapses) instead of a separate "unconfirmed episode"
+    // stamp means the diagnostics boundary can't get stuck during a Play outage.
+    val lastProStateAt: Flow<Long> = billingCache.lastProStateAt.flow.distinctUntilChanged()
+
+    // False until the first authoritative Play round-trip settles OR a fallback timeout elapses, then
+    // true. The fallback flow is upstream-INDEPENDENT so a dead Play can't pin the UI on Loading
+    // forever. NOTE: settled != ownership-known — a fallback-driven settle can flip true before
+    // ownership is known, so every purchase action reachable while settled must be independently
+    // double-bill-safe (the IAP button via the fail-closed gate, the sub button via ITEM_ALREADY_OWNED).
+    val isSettled: Flow<Boolean> = merge(
+        billingManager.freshBillingData.map { true },
+        flow {
+            delay(SETTLE_FALLBACK_MS)
+            emit(true)
+        },
+    )
+        .onStart { emit(false) }
+        .distinctUntilChanged()
+
+    // Fresh SUBS-only Play read for the fail-closed IAP switch gate. Errors propagate (see
+    // BillingManager.querySubscriptions) so the caller fails closed on any failure.
+    suspend fun queryCurrentSubscriptions(): Collection<Purchase> = billingManager.querySubscriptions()
 
     fun launchBillingFlow(
         activity: Activity,
@@ -312,6 +341,10 @@ class UpgradeRepoGplay @Inject constructor(
         val GRACE_PERIOD_IAP_MS = Duration.ofDays(30).toMillis()
         private const val RESTORE_ON_OWNED_TIMEOUT_MS = 15_000L
         private const val REFRESH_TIMEOUT_MS = 30_000L
+
+        // The first Play round-trip after sign-in can take >8s; give the UI a bounded wait before it
+        // stops showing Loading, so a dead/slow Play can't pin it there forever.
+        val SETTLE_FALLBACK_MS = Duration.ofSeconds(10).toMillis()
 
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
 

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
@@ -27,6 +27,7 @@ import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.mapNotNull
@@ -157,7 +158,16 @@ class BillingManager @Inject constructor(
             .setupCommonEventHandlers(TAG) { "fresh-purchase-events" }
             .launchIn(scope)
 
-        purchases
+        // Drive acks from TWO merged sources in a single collector (so ackedTokens stays
+        // single-threaded, no sync needed):
+        //  - `purchases`: the deduped ownership flow. Subscribing here also PINS the connection
+        //    shareIn alive for the process, so billing stays connected in the background for acks.
+        //  - `freshBillingData`: emitted on EVERY fresh Play round-trip (per-connection refresh,
+        //    purchase event, manual refresh) and NOT distinctUntilChanged'd. This re-drives a
+        //    previously-failed ack on the next refresh, since re-querying the SAME still-unacked
+        //    purchase yields a content-equal snapshot that the deduped `purchases` flow would suppress
+        //    — otherwise a failed ack could sit until Play's ~3-day auto-refund.
+        merge(purchases, freshBillingData.map { it.data.purchases })
             .onEach { purchases ->
                 purchases
                     .filter {
@@ -170,13 +180,9 @@ class BillingManager @Inject constructor(
                     }
                     .forEach { purchase ->
                         log(TAG, INFO) { "Acknowledging purchase: $purchase" }
-                        // Retry transient failures inline (bounded, with backoff) rather than relying
-                        // on the shared purchases flow to re-emit: Purchase.equals is content-based and
-                        // the upstream is distinctUntilChanged, so re-querying the SAME still-unacked
-                        // purchase would be deduped and never reach this collector again — risking
-                        // Play's ~3-day auto-refund of unacknowledged purchases. The token is stored
-                        // only on success, so a fully-failed ack still stays eligible on any later
-                        // distinct emission as a last resort.
+                        // Retry transient failures inline (bounded, with backoff). The token is stored
+                        // only on success, so a fully-failed ack stays eligible on the next fresh
+                        // round-trip.
                         if (acknowledgeWithRetry(purchase)) {
                             ackedTokens.add(purchase.purchaseToken)
                         }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
@@ -3,6 +3,7 @@ package eu.darken.bluemusic.upgrade.core.billing
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingResult
+import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.Purchase.PurchaseState
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
@@ -81,6 +82,13 @@ class BillingManager @Inject constructor(
     // Only touched from the sharing collector (onStart/onEach/retryWhen run sequentially there).
     private var demandAtAttemptStart = 0
 
+    // Purchase tokens we've already successfully acknowledged this process. The immutable Purchase
+    // snapshot keeps reporting isAcknowledged=false until a fresh query supersedes it, so the ack
+    // collector below would otherwise re-ack the same purchase on every re-emission. A token is added
+    // ONLY after a successful ack, so a failed ack stays retryable. Touched only from the single ack
+    // collector coroutine — no synchronization needed.
+    private val ackedTokens = mutableSetOf<String>()
+
     private val connection = connectionProvider.connection
         .onStart { demandAtAttemptStart = connectionDemand.value }
         .onEach {
@@ -153,22 +161,24 @@ class BillingManager @Inject constructor(
             .onEach { purchases ->
                 purchases
                     .filter {
-                        val needsAck = !it.isAcknowledged
+                        val needsAck = !it.isAcknowledged && it.purchaseToken !in ackedTokens
 
                         if (needsAck) log(TAG, INFO) { "Needs ACK: $it" }
                         else log(TAG) { "Already ACK'ed: $it" }
 
                         needsAck
                     }
-                    .forEach {
-                        log(TAG, INFO) { "Acknowledging purchase: $it" }
-
-                        try {
-                            useConnection {
-                                acknowledgePurchase(it)
-                            }
-                        } catch (e: Exception) {
-                            log(TAG, ERROR) { "Failed to ancknowledge purchase: $it\n${e.asLog()}" }
+                    .forEach { purchase ->
+                        log(TAG, INFO) { "Acknowledging purchase: $purchase" }
+                        // Retry transient failures inline (bounded, with backoff) rather than relying
+                        // on the shared purchases flow to re-emit: Purchase.equals is content-based and
+                        // the upstream is distinctUntilChanged, so re-querying the SAME still-unacked
+                        // purchase would be deduped and never reach this collector again — risking
+                        // Play's ~3-day auto-refund of unacknowledged purchases. The token is stored
+                        // only on success, so a fully-failed ack still stays eligible on any later
+                        // distinct emission as a last resort.
+                        if (acknowledgeWithRetry(purchase)) {
+                            ackedTokens.add(purchase.purchaseToken)
                         }
                     }
             }
@@ -201,6 +211,32 @@ class BillingManager @Inject constructor(
             .launchIn(scope)
     }
 
+    // Bounded inline ack retry: recovers a transient acknowledge failure (network/service hiccup right
+    // after a purchase) without depending on a fresh distinct purchases emission. Gives up on
+    // BILLING_UNAVAILABLE (nothing to retry against) or after ACK_MAX_RETRIES. Returns whether the
+    // purchase is now acknowledged.
+    private suspend fun acknowledgeWithRetry(purchase: Purchase): Boolean {
+        var attempt = 0
+        while (true) {
+            try {
+                useConnection { acknowledgePurchase(purchase) }
+                return true
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                attempt++
+                val unavailable = e is BillingClientException &&
+                    e.result.responseCode == BillingResponseCode.BILLING_UNAVAILABLE
+                if (unavailable || attempt > ACK_MAX_RETRIES) {
+                    log(TAG, ERROR) { "Giving up acknowledging $purchase after $attempt attempt(s): ${e.asLog()}" }
+                    return false
+                }
+                log(TAG, WARN) { "Ack attempt $attempt failed for $purchase, retrying: ${e.asLog()}" }
+                delay(ACK_RETRY_BASE_MS * attempt)
+            }
+        }
+    }
+
     private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T {
         // Every caller here is active demand (opening the upgrade screen, restore/buy taps, purchase
         // acks) — cut a pending reconnect backoff short. A no-op while the connection is healthy.
@@ -222,6 +258,18 @@ class BillingManager @Inject constructor(
         querySkus(*skus).also {
             log(TAG) { "querySkus(): $it" }
         }
+    }
+
+    // Fresh SUBS-only ownership read for the fail-closed IAP switch gate. Errors PROPAGATE (mapped
+    // user-friendly) so the caller can fail closed on any failure — never swallow into an empty
+    // result, which would look like "no renewing sub" and let a double purchase through.
+    suspend fun querySubscriptions(): Collection<Purchase> = try {
+        useConnection { querySubscriptions() }
+    } catch (e: CancellationException) {
+        throw e
+    } catch (e: Exception) {
+        log(TAG, WARN) { "querySubscriptions() failed:\n${e.asLog()}" }
+        throw e.tryMapUserFriendly()
     }
 
     suspend fun startIapFlow(activity: Activity, sku: Sku, offer: Sku.Subscription.Offer?) {
@@ -246,6 +294,9 @@ class BillingManager @Inject constructor(
     }
 
     companion object {
+        private const val ACK_MAX_RETRIES = 3
+        private const val ACK_RETRY_BASE_MS = 3_000L
+
         internal fun Throwable.tryMapUserFriendly(): Throwable {
             if (this !is BillingClientException) return this
 

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
@@ -47,16 +47,21 @@ data class BillingConnection(
         purchaseEvents,
         querySnapshot.filterNotNull(),
     ) { purchaseEvent, snapshot ->
-        val combined = mutableSetOf<Purchase>()
-
-        combined.addAll(snapshot)
-
+        // Deduplicate by purchaseToken, with the authoritative query snapshot winning on conflict.
+        // The immutable Purchase from a listener event and the one from a later query differ (ack
+        // state; isAutoRenewing flips after a cancel), so Purchase.equals returns false and a plain
+        // Set would keep BOTH — a stale renewing/owned copy would then lock the sub→IAP switch or
+        // retain entitlement after a refund until the connection is recreated. A purchase event still
+        // survives while the snapshot hasn't caught it yet (its token isn't in the snapshot), so a
+        // just-completed purchase is never lost.
+        val byToken = LinkedHashMap<String, Purchase>()
         purchaseEvent
             ?.takeIf { (result, _) -> result.isSuccess }
             ?.let { (_, purchases) -> purchases?.filter { it.purchaseState == PurchaseState.PURCHASED } }
-            ?.let { combined.addAll(it) }
+            ?.forEach { byToken[it.purchaseToken] = it }
+        snapshot.forEach { byToken[it.purchaseToken] = it }
 
-        combined.sortedByDescending { it.purchaseTime }
+        byToken.values.sortedByDescending { it.purchaseTime }
     }.setupCommonEventHandlers(TAG) { "purchases" }
 
     // Non-OK results from onPurchasesUpdated (e.g. async ITEM_ALREADY_OWNED after the Play sheet

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
@@ -45,24 +45,33 @@ data class BillingConnection(
 
     val purchases: Flow<Collection<Purchase>> = combine(
         purchaseEvents,
-        querySnapshot.filterNotNull(),
+        querySnapshot,
     ) { purchaseEvent, snapshot ->
+        val eventPurchases = purchaseEvent
+            ?.takeIf { (result, _) -> result.isSuccess }
+            ?.let { (_, purchases) -> purchases?.filter { it.purchaseState == PurchaseState.PURCHASED } }
+            .orEmpty()
+
+        // Emit only once we have SOMETHING authoritative — a query snapshot OR a completed purchase
+        // event. This keeps the pre-first-query "not pro" flash suppressed, while still surfacing a
+        // purchase completed AFTER the initial ownership refresh failed (snapshot still null), which a
+        // plain querySnapshot.filterNotNull() gate would strand (never acked, never unlocked).
+        if (snapshot == null && eventPurchases.isEmpty()) return@combine null
+
         // Deduplicate by purchaseToken, with the authoritative query snapshot winning on conflict.
         // The immutable Purchase from a listener event and the one from a later query differ (ack
         // state; isAutoRenewing flips after a cancel), so Purchase.equals returns false and a plain
         // Set would keep BOTH — a stale renewing/owned copy would then lock the sub→IAP switch or
         // retain entitlement after a refund until the connection is recreated. A purchase event still
-        // survives while the snapshot hasn't caught it yet (its token isn't in the snapshot), so a
-        // just-completed purchase is never lost.
+        // survives while the snapshot hasn't caught it yet (its token isn't in the snapshot).
         val byToken = LinkedHashMap<String, Purchase>()
-        purchaseEvent
-            ?.takeIf { (result, _) -> result.isSuccess }
-            ?.let { (_, purchases) -> purchases?.filter { it.purchaseState == PurchaseState.PURCHASED } }
-            ?.forEach { byToken[it.purchaseToken] = it }
-        snapshot.forEach { byToken[it.purchaseToken] = it }
+        eventPurchases.forEach { byToken[it.purchaseToken] = it }
+        snapshot?.forEach { byToken[it.purchaseToken] = it }
 
         byToken.values.sortedByDescending { it.purchaseTime }
-    }.setupCommonEventHandlers(TAG) { "purchases" }
+    }
+        .filterNotNull()
+        .setupCommonEventHandlers(TAG) { "purchases" }
 
     // Non-OK results from onPurchasesUpdated (e.g. async ITEM_ALREADY_OWNED after the Play sheet
     // opened). Consumed by a single persistent collector in UpgradeRepoGplay — not an event bus.
@@ -106,8 +115,23 @@ data class BillingConnection(
         val iap = iapJob.await()
         val sub = subJob.await()
         log(TAG) { "Refreshed IAPs=${iap.getOrNull()}, SUBs=${sub.getOrNull()}" }
-        val combined = combinePurchaseResults(iap, sub).also { querySnapshot.value = it }
-        PurchaseRefresh(purchases = combined, isComplete = iap.isSuccess && sub.isSuccess)
+        val combined = combinePurchaseResults(iap, sub)
+        val isComplete = iap.isSuccess && sub.isSuccess
+        // A full snapshot (both queries succeeded) is authoritative and replaces the snapshot. A PARTIAL
+        // refresh (one product type failed) only proves what it FOUND; overwriting with just that type
+        // would drop the un-queried type's known purchases (a both-IAP-and-sub owner would briefly lose
+        // one record). Merge by token onto the prior snapshot instead, so found purchases surface while
+        // the unverifiable type's entitlement is preserved (fail-open — a later full refresh corrects it).
+        val snapshot = if (isComplete) {
+            combined
+        } else {
+            val byToken = LinkedHashMap<String, Purchase>()
+            querySnapshot.value.orEmpty().forEach { byToken[it.purchaseToken] = it }
+            combined.forEach { byToken[it.purchaseToken] = it }
+            byToken.values.sortedByDescending { it.purchaseTime }
+        }
+        querySnapshot.value = snapshot
+        PurchaseRefresh(purchases = snapshot, isComplete = isComplete)
     }
 
     // Never throws except on cancellation, so a single failing product-type query doesn't cancel the

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
@@ -117,6 +117,27 @@ data class BillingConnection(
         Result.failure(e.tryMapUserFriendly())
     }
 
+    // Fresh SUBS-only ownership read for the fail-closed IAP switch gate. PURE READ: it must NOT
+    // write querySnapshot (which holds the combined IAP+SUB ownership snapshot — a SUBS-only write
+    // would drop a known IAP purchase and transiently un-Pro an IAP owner) and must NOT feed the
+    // freshData path. Unions the freshly queried SUBS with the last snapshot, deduped by token with
+    // the FRESH copy winning: a sub the user just cancelled comes back from Play with
+    // isAutoRenewing=false and correctly overwrites a stale renewing snapshot entry, while a sub the
+    // fresh query transiently missed survives from the snapshot (over-blocking the switch is safe;
+    // missing a renewing sub is not). Including any IAP entries from the snapshot is harmless: the
+    // gate only checks isAutoRenewing, and one-time purchases are never auto-renewing.
+    suspend fun querySubscriptions(): Collection<Purchase> {
+        val fresh = queryPurchases(BillingClient.ProductType.SUBS)
+            .filter { it.purchaseState == PurchaseState.PURCHASED }
+        val byToken = LinkedHashMap<String, Purchase>()
+        querySnapshot.value
+            .orEmpty()
+            .filter { it.purchaseState == PurchaseState.PURCHASED }
+            .forEach { byToken[it.purchaseToken] = it }
+        fresh.forEach { byToken[it.purchaseToken] = it }
+        return byToken.values.toList()
+    }
+
     suspend fun acknowledgePurchase(purchase: Purchase): BillingResult {
         val ack = AcknowledgePurchaseParams.newBuilder().apply {
             setPurchaseToken(purchase.purchaseToken)

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeEvents.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeEvents.kt
@@ -1,5 +1,12 @@
 package eu.darken.bluemusic.upgrade.ui
 
 sealed class UpgradeEvents {
+    data object RestoreSucceeded : UpgradeEvents()
     data object RestoreFailed : UpgradeEvents()
+
+    // The fail-closed IAP switch gate blocked a purchase because a subscription is still set to renew.
+    data object SubscriptionStillRenewing : UpgradeEvents()
+
+    // The gate couldn't confirm the subscription state (timeout / Play error) — fail closed.
+    data object SubscriptionCheckFailed : UpgradeEvents()
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeNavigation.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeNavigation.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 class UpgradeNavigation @Inject constructor() : NavigationEntry {
     override fun EntryProviderScope<NavKey>.setup() {
         entry<Nav.Main.Upgrade> {
-            UpgradeScreenHost()
+            UpgradeScreenHost(manage = it.manage)
         }
     }
 

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -144,8 +144,10 @@ fun UpgradeScreen(
             )
 
             loaded != null && loaded.grace != null -> GraceContent(
-                grace = loaded.grace,
-                restoreInProgress = loaded.restoreInProgress,
+                state = loaded,
+                onGoIap = onGoIap,
+                onGoSubscription = onGoSubscription,
+                onGoSubscriptionTrial = onGoSubscriptionTrial,
                 onRestorePurchase = onRestorePurchase,
             )
 
@@ -263,6 +265,7 @@ private fun OwnerContent(
     Spacer(modifier = Modifier.height(16.dp))
     StatusRestoreSection(
         restoreInProgress = state.restoreInProgress,
+        verificationInProgress = state.verificationInProgress,
         onRestorePurchase = onRestorePurchase,
     )
 }
@@ -271,10 +274,13 @@ private fun OwnerContent(
 
 @Composable
 private fun GraceContent(
-    grace: GraceHint,
-    restoreInProgress: Boolean,
+    state: UpgradeUiState.Loaded,
+    onGoIap: () -> Unit,
+    onGoSubscription: () -> Unit,
+    onGoSubscriptionTrial: () -> Unit,
     onRestorePurchase: () -> Unit,
 ) {
+    val grace = state.grace ?: return
     Card(
         modifier = Modifier.fillMaxWidth(),
         colors = CardDefaults.cardColors(
@@ -307,13 +313,23 @@ private fun GraceContent(
         }
     }
 
-    // Only the aged (diagnostics) stage offers a restore escape hatch; the quiet stage stays calm.
+    // The quiet stage stays calm. The aged (diagnostics) stage offers a restore escape hatch AND
+    // re-surfaces the purchase offers, so a genuinely-lapsed subscriber can re-subscribe or switch to
+    // the one-time purchase without waiting the grace window out.
     if (grace.showDiagnostics) {
         Spacer(modifier = Modifier.height(16.dp))
         RestoreButton(
-            restoreInProgress = restoreInProgress,
+            restoreInProgress = state.restoreInProgress,
+            enabled = !state.restoreInProgress && !state.verificationInProgress,
             onRestorePurchase = onRestorePurchase,
             filled = true,
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+        OfferButtons(
+            state = state,
+            onGoIap = onGoIap,
+            onGoSubscription = onGoSubscription,
+            onGoSubscriptionTrial = onGoSubscriptionTrial,
         )
     }
 }
@@ -347,14 +363,43 @@ private fun AcquisitionContent(
     Spacer(modifier = Modifier.height(18.dp))
 
     if (state.wasPreviouslyPro) {
-        RestoreBanner(onRestorePurchase = onRestorePurchase, restoreInProgress = state.restoreInProgress)
+        RestoreBanner(
+            onRestorePurchase = onRestorePurchase,
+            restoreInProgress = state.restoreInProgress,
+            verificationInProgress = state.verificationInProgress,
+        )
         Spacer(modifier = Modifier.height(16.dp))
     }
 
-    // Show/hide by whether an offer EXISTS; enable by whether the action is currently usable. Using
-    // the busy-gated *Enabled flags for visibility would swap the real buttons for the generic
-    // fallback during the unsettled window or while a restore/verify runs.
-    val genericEnabled = !state.restoreInProgress && !state.verificationInProgress
+    OfferButtons(
+        state = state,
+        onGoIap = onGoIap,
+        onGoSubscription = onGoSubscription,
+        onGoSubscriptionTrial = onGoSubscriptionTrial,
+    )
+
+    Spacer(modifier = Modifier.height(16.dp))
+    RestoreButton(
+        restoreInProgress = state.restoreInProgress,
+        enabled = !state.restoreInProgress && !state.verificationInProgress,
+        onRestorePurchase = onRestorePurchase,
+        filled = false,
+    )
+    PriceHint(stringResource(R.string.upgrade_screen_restore_purchase_message))
+}
+
+// The subscription / one-time / generic purchase buttons. Shared by the acquisition screen and the
+// aged grace stage. Show/hide by whether an offer EXISTS (subscriptionAvailable/iapAvailable); enable
+// by whether the action is currently usable (the busy-gated *Enabled flags) — using the busy-gated
+// flags for visibility would swap the real buttons for the generic fallback during the unsettled
+// window or while a restore/verify runs.
+@Composable
+private fun OfferButtons(
+    state: UpgradeUiState.Loaded,
+    onGoIap: () -> Unit,
+    onGoSubscription: () -> Unit,
+    onGoSubscriptionTrial: () -> Unit,
+) {
     val hasSub = state.subscriptionAvailable
     val hasIap = state.iapAvailable
 
@@ -422,7 +467,7 @@ private fun AcquisitionContent(
     if (!hasSub && !hasIap) {
         Button(
             onClick = onGoIap,
-            enabled = genericEnabled,
+            enabled = !state.restoreInProgress && !state.verificationInProgress,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp),
@@ -435,10 +480,6 @@ private fun AcquisitionContent(
             )
         }
     }
-
-    Spacer(modifier = Modifier.height(16.dp))
-    RestoreButton(restoreInProgress = state.restoreInProgress, onRestorePurchase = onRestorePurchase, filled = false)
-    PriceHint(stringResource(R.string.upgrade_screen_restore_purchase_message))
 }
 
 // ---- Shared bits ----
@@ -482,6 +523,7 @@ private fun StatusCard(
 @Composable
 private fun StatusRestoreSection(
     restoreInProgress: Boolean,
+    verificationInProgress: Boolean,
     onRestorePurchase: () -> Unit,
 ) {
     Text(
@@ -495,12 +537,18 @@ private fun StatusRestoreSection(
         color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
     Spacer(modifier = Modifier.height(10.dp))
-    RestoreButton(restoreInProgress = restoreInProgress, onRestorePurchase = onRestorePurchase, filled = false)
+    RestoreButton(
+        restoreInProgress = restoreInProgress,
+        enabled = !restoreInProgress && !verificationInProgress,
+        onRestorePurchase = onRestorePurchase,
+        filled = false,
+    )
 }
 
 @Composable
 private fun RestoreButton(
     restoreInProgress: Boolean,
+    enabled: Boolean,
     onRestorePurchase: () -> Unit,
     filled: Boolean,
 ) {
@@ -518,7 +566,7 @@ private fun RestoreButton(
     if (filled) {
         Button(
             onClick = onRestorePurchase,
-            enabled = !restoreInProgress,
+            enabled = enabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp),
@@ -526,7 +574,7 @@ private fun RestoreButton(
     } else {
         OutlinedButton(
             onClick = onRestorePurchase,
-            enabled = !restoreInProgress,
+            enabled = enabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp),
@@ -551,6 +599,7 @@ private fun PriceHint(text: String) {
 private fun RestoreBanner(
     onRestorePurchase: () -> Unit,
     restoreInProgress: Boolean,
+    verificationInProgress: Boolean,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -570,7 +619,12 @@ private fun RestoreBanner(
                 style = MaterialTheme.typography.bodyMedium,
             )
             Spacer(modifier = Modifier.height(12.dp))
-            RestoreButton(restoreInProgress = restoreInProgress, onRestorePurchase = onRestorePurchase, filled = true)
+            RestoreButton(
+                restoreInProgress = restoreInProgress,
+                enabled = !restoreInProgress && !verificationInProgress,
+                onRestorePurchase = onRestorePurchase,
+                filled = true,
+            )
         }
     }
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -78,6 +78,7 @@ fun UpgradeScreenHost(
         onGoSubscriptionTrial = { vm.onGoSubscriptionTrial(context as Activity) },
         onManageSubscription = { vm.onManageSubscription() },
         onRestorePurchase = { vm.restorePurchase() },
+        onRetry = { vm.onRetry() },
     )
 
     LaunchedEffect(Unit) {
@@ -114,6 +115,7 @@ fun UpgradeScreen(
     onGoSubscriptionTrial: () -> Unit,
     onManageSubscription: () -> Unit,
     onRestorePurchase: () -> Unit,
+    onRetry: () -> Unit,
     snackbarHostState: SnackbarHostState? = null,
 ) {
     val loaded = state as? UpgradeUiState.Loaded
@@ -135,6 +137,8 @@ fun UpgradeScreen(
             state == null || state is UpgradeUiState.Loading -> {
                 CircularProgressIndicator(modifier = Modifier.padding(vertical = 24.dp))
             }
+
+            state is UpgradeUiState.Unavailable -> UnavailableContent(onRetry = onRetry)
 
             loaded != null && isOwner -> OwnerContent(
                 state = loaded,
@@ -331,6 +335,40 @@ private fun GraceContent(
             onGoSubscription = onGoSubscription,
             onGoSubscriptionTrial = onGoSubscriptionTrial,
         )
+    }
+}
+
+// ---- Unavailable (price query failed) ----
+
+@Composable
+private fun UnavailableContent(onRetry: () -> Unit) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer,
+            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = stringResource(R.string.upgrades_gplay_unavailable_error_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = stringResource(R.string.upgrades_gplay_unavailable_error_description),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+    Spacer(modifier = Modifier.height(16.dp))
+    Button(
+        onClick = onRetry,
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(48.dp),
+    ) {
+        Text(text = stringResource(R.string.upgrade_screen_retry_action))
     }
 }
 
@@ -719,7 +757,7 @@ private fun UpgradeScreenAcquisitionPreview() {
         UpgradeScreen(
             state = previewLoaded(),
             onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
-            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {}, onRetry = {},
         )
     }
 }
@@ -731,7 +769,7 @@ private fun UpgradeScreenOwnerSubRenewingPreview() {
         UpgradeScreen(
             state = previewLoaded(ownership = Ownership(subscription = SubscriptionOwnership(isAutoRenewing = true))),
             onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
-            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {}, onRetry = {},
         )
     }
 }
@@ -743,7 +781,7 @@ private fun UpgradeScreenOwnerSubNotRenewingPreview() {
         UpgradeScreen(
             state = previewLoaded(ownership = Ownership(subscription = SubscriptionOwnership(isAutoRenewing = false))),
             onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
-            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {}, onRetry = {},
         )
     }
 }
@@ -755,7 +793,7 @@ private fun UpgradeScreenOwnerIapPreview() {
         UpgradeScreen(
             state = previewLoaded(ownership = Ownership(hasIap = true)),
             onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
-            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {}, onRetry = {},
         )
     }
 }
@@ -767,7 +805,7 @@ private fun UpgradeScreenGraceQuietPreview() {
         UpgradeScreen(
             state = previewLoaded(grace = GraceHint(showDiagnostics = false)),
             onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
-            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {}, onRetry = {},
         )
     }
 }
@@ -779,7 +817,19 @@ private fun UpgradeScreenGraceDiagnosticsPreview() {
         UpgradeScreen(
             state = previewLoaded(grace = GraceHint(showDiagnostics = true)),
             onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
-            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {}, onRetry = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenUnavailablePreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            state = UpgradeUiState.Unavailable(RuntimeException("Play unavailable")),
+            onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {}, onRetry = {},
         )
     }
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -153,6 +153,7 @@ fun UpgradeScreen(
                 onGoSubscription = onGoSubscription,
                 onGoSubscriptionTrial = onGoSubscriptionTrial,
                 onRestorePurchase = onRestorePurchase,
+                onRetry = onRetry,
             )
 
             loaded != null -> AcquisitionContent(
@@ -161,6 +162,7 @@ fun UpgradeScreen(
                 onGoSubscription = onGoSubscription,
                 onGoSubscriptionTrial = onGoSubscriptionTrial,
                 onRestorePurchase = onRestorePurchase,
+                onRetry = onRetry,
             )
         }
     }
@@ -283,6 +285,7 @@ private fun GraceContent(
     onGoSubscription: () -> Unit,
     onGoSubscriptionTrial: () -> Unit,
     onRestorePurchase: () -> Unit,
+    onRetry: () -> Unit,
 ) {
     val grace = state.grace ?: return
     Card(
@@ -334,6 +337,11 @@ private fun GraceContent(
             onGoIap = onGoIap,
             onGoSubscription = onGoSubscription,
             onGoSubscriptionTrial = onGoSubscriptionTrial,
+            onRetry = onRetry,
+            // Grace = the user is Pro but Play can't confirm. Only offer the one-time IAP, which Play
+            // blocks with ITEM_ALREADY_OWNED if already owned; a subscription purchase here could
+            // double-bill an unconfirmed permanent-IAP owner.
+            allowSubscription = false,
         )
     }
 }
@@ -381,6 +389,7 @@ private fun AcquisitionContent(
     onGoSubscription: () -> Unit,
     onGoSubscriptionTrial: () -> Unit,
     onRestorePurchase: () -> Unit,
+    onRetry: () -> Unit,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -414,6 +423,7 @@ private fun AcquisitionContent(
         onGoIap = onGoIap,
         onGoSubscription = onGoSubscription,
         onGoSubscriptionTrial = onGoSubscriptionTrial,
+        onRetry = onRetry,
     )
 
     Spacer(modifier = Modifier.height(16.dp))
@@ -437,8 +447,13 @@ private fun OfferButtons(
     onGoIap: () -> Unit,
     onGoSubscription: () -> Unit,
     onGoSubscriptionTrial: () -> Unit,
+    onRetry: () -> Unit,
+    // Grace passes false: only the one-time IAP (which Play blocks with ITEM_ALREADY_OWNED if already
+    // owned) is safe to offer to an UNCONFIRMED owner. A subscription purchase has no cross-SKU
+    // double-bill protection, so an unconfirmed permanent-IAP owner could pay twice.
+    allowSubscription: Boolean = true,
 ) {
-    val hasSub = state.subscriptionAvailable
+    val hasSub = state.subscriptionAvailable && allowSubscription
     val hasIap = state.iapAvailable
 
     if (hasSub) {
@@ -503,6 +518,9 @@ private fun OfferButtons(
     }
 
     if (!hasSub && !hasIap) {
+        // No offers loaded (e.g. a transient Play price hiccup for a grace/price-independent user).
+        // Give a Retry to reload the offers, plus the generic upgrade button (which re-queries at
+        // purchase time) as a fallback.
         Button(
             onClick = onGoIap,
             enabled = !state.restoreInProgress && !state.verificationInProgress,
@@ -516,6 +534,16 @@ private fun OfferButtons(
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.padding(start = 8.dp),
             )
+        }
+        Spacer(modifier = Modifier.height(8.dp))
+        OutlinedButton(
+            onClick = onRetry,
+            enabled = !state.restoreInProgress && !state.verificationInProgress,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+        ) {
+            Text(text = stringResource(R.string.upgrade_screen_retry_action))
         }
     }
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -1,18 +1,24 @@
 package eu.darken.bluemusic.upgrade.ui
 
+import android.app.Activity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.Autorenew
 import androidx.compose.material.icons.twotone.Devices
 import androidx.compose.material.icons.twotone.Favorite
 import androidx.compose.material.icons.twotone.Palette
 import androidx.compose.material.icons.twotone.PlayCircle
 import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.Tune
-import androidx.compose.foundation.layout.Column
+import androidx.compose.material.icons.twotone.Verified
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -22,6 +28,7 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -36,159 +43,352 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
 import eu.darken.bluemusic.common.error.ErrorEventHandler
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
 
 @Composable
-fun UpgradeScreenHost(vm: UpgradeViewModel = hiltViewModel()) {
+fun UpgradeScreenHost(
+    manage: Boolean,
+    vm: UpgradeViewModel = hiltViewModel(
+        key = "upgrade-$manage",
+        creationCallback = { factory: UpgradeViewModel.Factory -> factory.create(manage = manage) },
+    ),
+) {
     val context = LocalContext.current
+    val snackbarHostState = remember { SnackbarHostState() }
+    val restoreSucceededMessage = stringResource(R.string.upgrade_screen_thanks_toast)
+
     var showRestoreFailedDialog by remember { mutableStateOf(false) }
+    var showStillRenewingDialog by remember { mutableStateOf(false) }
+    var showCheckFailedDialog by remember { mutableStateOf(false) }
 
     ErrorEventHandler(vm)
 
     val state by vm.state.collectAsStateWithLifecycle()
     UpgradeScreen(
         state = state,
+        snackbarHostState = snackbarHostState,
         onNavigateBack = { vm.navUp() },
-        onGoIap = { vm.onGoIap(context as android.app.Activity) },
-        onGoSubscription = { vm.onGoSubscription(context as android.app.Activity) },
-        onGoSubscriptionTrial = { vm.onGoSubscriptionTrial(context as android.app.Activity) },
+        onGoIap = { vm.onGoIap(context as Activity) },
+        onGoSubscription = { vm.onGoSubscription(context as Activity) },
+        onGoSubscriptionTrial = { vm.onGoSubscriptionTrial(context as Activity) },
+        onManageSubscription = { vm.onManageSubscription() },
         onRestorePurchase = { vm.restorePurchase() },
     )
 
     LaunchedEffect(Unit) {
-        vm.events.collect { event: UpgradeEvents ->
+        vm.events.collect { event ->
             when (event) {
-                UpgradeEvents.RestoreFailed -> {
-                    showRestoreFailedDialog = true
-                }
+                UpgradeEvents.RestoreSucceeded -> snackbarHostState.showSnackbar(restoreSucceededMessage)
+                UpgradeEvents.RestoreFailed -> showRestoreFailedDialog = true
+                UpgradeEvents.SubscriptionStillRenewing -> showStillRenewingDialog = true
+                UpgradeEvents.SubscriptionCheckFailed -> showCheckFailedDialog = true
             }
         }
     }
 
     if (showRestoreFailedDialog) {
-        RestoreFailedDialog(
-            onDismiss = { showRestoreFailedDialog = false }
+        RestoreFailedDialog(onDismiss = { showRestoreFailedDialog = false })
+    }
+    if (showStillRenewingDialog) {
+        SubscriptionStillRenewingDialog(
+            onManageSubscription = { vm.onManageSubscription() },
+            onDismiss = { showStillRenewingDialog = false },
         )
+    }
+    if (showCheckFailedDialog) {
+        SubscriptionCheckFailedDialog(onDismiss = { showCheckFailedDialog = false })
     }
 }
 
 @Composable
 fun UpgradeScreen(
-    state: UpgradeViewModel.State?,
+    state: UpgradeUiState?,
     onNavigateBack: () -> Unit,
     onGoIap: () -> Unit,
     onGoSubscription: () -> Unit,
     onGoSubscriptionTrial: () -> Unit,
+    onManageSubscription: () -> Unit,
+    onRestorePurchase: () -> Unit,
+    snackbarHostState: SnackbarHostState? = null,
+) {
+    val loaded = state as? UpgradeUiState.Loaded
+    val isOwner = loaded?.ownership?.ownsAnything == true
+    val inGrace = loaded?.grace != null
+
+    UpgradeScreenShell(
+        // Owners and grace users get the celebratory "Pro" title; acquisition gets the plain pitch title.
+        title = if (isOwner || inGrace) {
+            stringResource(R.string.app_name_upgraded)
+        } else {
+            stringResource(R.string.upgrade_screen_title)
+        },
+        postfix = stringResource(R.string.app_name_upgrade_postfix),
+        onNavigateBack = onNavigateBack,
+        snackbarHostState = snackbarHostState,
+    ) {
+        when {
+            state == null || state is UpgradeUiState.Loading -> {
+                CircularProgressIndicator(modifier = Modifier.padding(vertical = 24.dp))
+            }
+
+            loaded != null && isOwner -> OwnerContent(
+                state = loaded,
+                onGoIap = onGoIap,
+                onManageSubscription = onManageSubscription,
+                onRestorePurchase = onRestorePurchase,
+            )
+
+            loaded != null && loaded.grace != null -> GraceContent(
+                grace = loaded.grace,
+                restoreInProgress = loaded.restoreInProgress,
+                onRestorePurchase = onRestorePurchase,
+            )
+
+            loaded != null -> AcquisitionContent(
+                state = loaded,
+                onGoIap = onGoIap,
+                onGoSubscription = onGoSubscription,
+                onGoSubscriptionTrial = onGoSubscriptionTrial,
+                onRestorePurchase = onRestorePurchase,
+            )
+        }
+    }
+}
+
+// ---- Owner (Pro status) ----
+
+@Composable
+private fun OwnerContent(
+    state: UpgradeUiState.Loaded,
+    onGoIap: () -> Unit,
+    onManageSubscription: () -> Unit,
     onRestorePurchase: () -> Unit,
 ) {
-    val benefits = listOf(
-        UpgradeBenefitItem(Icons.TwoTone.Devices, stringResource(R.string.upgrade_benefit_unlimited_devices)),
-        UpgradeBenefitItem(Icons.TwoTone.PlayCircle, stringResource(R.string.upgrade_benefit_connection_actions)),
-        UpgradeBenefitItem(Icons.TwoTone.Palette, stringResource(R.string.upgrade_benefit_theme_customization)),
-        UpgradeBenefitItem(Icons.TwoTone.Tune, stringResource(R.string.upgrade_benefit_power_controls)),
-        UpgradeBenefitItem(Icons.TwoTone.Favorite, stringResource(R.string.upgrade_benefit_support)),
-    )
+    val ownership = state.ownership
+    val subscription = ownership.subscription
 
-    UpgradeScreenScaffold(
-        title = stringResource(R.string.app_name_upgraded),
-        postfix = stringResource(R.string.app_name_upgrade_postfix),
-        preamble = stringResource(R.string.upgrade_screen_preamble),
-        benefitTitle = stringResource(R.string.upgrade_screen_why_title),
-        benefits = benefits,
-        onNavigateBack = onNavigateBack,
+    BenefitsRecapCard()
+
+    if (ownership.hasIap) {
+        Spacer(modifier = Modifier.height(12.dp))
+        StatusCard(
+            icon = Icons.TwoTone.Stars,
+            title = stringResource(R.string.upgrade_screen_owned_iap_title),
+            body = stringResource(R.string.upgrade_screen_owned_iap_body),
+        )
+    }
+
+    if (subscription != null) {
+        Spacer(modifier = Modifier.height(12.dp))
+        StatusCard(
+            icon = Icons.TwoTone.Autorenew,
+            title = stringResource(R.string.upgrade_screen_owned_sub_title),
+            body = stringResource(
+                if (subscription.isAutoRenewing) {
+                    R.string.upgrade_screen_owned_sub_renewing_body
+                } else {
+                    R.string.upgrade_screen_owned_sub_not_renewing_body
+                },
+            ),
+        ) {
+            if (subscription.isAutoRenewing && ownership.hasIap) {
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(R.string.upgrade_screen_owned_both_warning),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedButton(
+                onClick = onManageSubscription,
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                Text(text = stringResource(R.string.upgrade_screen_manage_subscription))
+            }
+        }
+    }
+
+    // The switch offer: any subscriber who doesn't own the one-time purchase. Locked while the
+    // subscription is still set to renew (buying now would double-bill); unlocked once it won't renew.
+    if (subscription != null && !ownership.hasIap) {
+        val switchUnlocked = !subscription.isAutoRenewing
+        Spacer(modifier = Modifier.height(12.dp))
+        Card(modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.padding(14.dp)) {
+                Text(
+                    text = stringResource(R.string.upgrade_screen_switch_title),
+                    style = MaterialTheme.typography.titleMedium,
+                )
+                state.iapPrice?.let { price ->
+                    Spacer(modifier = Modifier.height(4.dp))
+                    Text(
+                        text = stringResource(R.string.upgrade_screen_iap_action_hint, price),
+                        style = MaterialTheme.typography.bodyMedium,
+                    )
+                }
+                Spacer(modifier = Modifier.height(8.dp))
+                Text(
+                    text = stringResource(
+                        if (switchUnlocked) {
+                            R.string.upgrade_screen_switch_purchase_note
+                        } else {
+                            R.string.upgrade_screen_switch_locked_note
+                        },
+                    ),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+                Button(
+                    onClick = onGoIap,
+                    enabled = switchUnlocked && !state.verificationInProgress && !state.restoreInProgress,
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    if (state.verificationInProgress) {
+                        CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
+                        Spacer(modifier = Modifier.size(8.dp))
+                    }
+                    Text(text = stringResource(R.string.upgrade_screen_iap_action))
+                }
+            }
+        }
+    }
+
+    Spacer(modifier = Modifier.height(16.dp))
+    StatusRestoreSection(
+        restoreInProgress = state.restoreInProgress,
+        onRestorePurchase = onRestorePurchase,
+    )
+}
+
+// ---- Grace (Pro active, Play can't confirm) ----
+
+@Composable
+private fun GraceContent(
+    grace: GraceHint,
+    restoreInProgress: Boolean,
+    onRestorePurchase: () -> Unit,
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
     ) {
-        PricingContent(
-            state = state,
-            onGoIap = onGoIap,
-            onGoSubscription = onGoSubscription,
-            onGoSubscriptionTrial = onGoSubscriptionTrial,
+        Column(modifier = Modifier.padding(16.dp)) {
+            if (grace.showDiagnostics) {
+                Icon(imageVector = Icons.TwoTone.Verified, contentDescription = null)
+            } else {
+                CircularProgressIndicator(modifier = Modifier.size(24.dp), strokeWidth = 2.dp)
+            }
+            Spacer(modifier = Modifier.height(10.dp))
+            Text(
+                text = stringResource(R.string.upgrade_screen_grace_title),
+                style = MaterialTheme.typography.titleMedium,
+            )
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(
+                text = stringResource(
+                    if (grace.showDiagnostics) {
+                        R.string.upgrade_screen_grace_body
+                    } else {
+                        R.string.upgrade_screen_grace_body_short
+                    },
+                ),
+                style = MaterialTheme.typography.bodyMedium,
+            )
+        }
+    }
+
+    // Only the aged (diagnostics) stage offers a restore escape hatch; the quiet stage stays calm.
+    if (grace.showDiagnostics) {
+        Spacer(modifier = Modifier.height(16.dp))
+        RestoreButton(
+            restoreInProgress = restoreInProgress,
             onRestorePurchase = onRestorePurchase,
+            filled = true,
         )
     }
 }
 
+// ---- Acquisition (sales) ----
+
 @Composable
-private fun PricingContent(
-    state: UpgradeViewModel.State?,
+private fun AcquisitionContent(
+    state: UpgradeUiState.Loaded,
     onGoIap: () -> Unit,
     onGoSubscription: () -> Unit,
     onGoSubscriptionTrial: () -> Unit,
     onRestorePurchase: () -> Unit,
 ) {
-    if (state == null) {
-        CircularProgressIndicator(modifier = Modifier.padding(vertical = 12.dp))
-        return
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+        ),
+    ) {
+        Text(
+            text = stringResource(R.string.upgrade_screen_preamble),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSecondaryContainer,
+            modifier = Modifier.padding(14.dp),
+        )
     }
 
-    if (state.wasPreviouslyPro) {
-        RestoreBanner(
-            onRestorePurchase = onRestorePurchase,
-            restoreInProgress = state.restoreInProgress,
-        )
+    Spacer(modifier = Modifier.height(14.dp))
+    BenefitsRecapCard()
+    Spacer(modifier = Modifier.height(18.dp))
 
+    if (state.wasPreviouslyPro) {
+        RestoreBanner(onRestorePurchase = onRestorePurchase, restoreInProgress = state.restoreInProgress)
         Spacer(modifier = Modifier.height(16.dp))
     }
 
-    // While a restore runs, all entitlement actions pause: a purchase flow racing a restore would
-    // just confuse both the user and Play.
-    val actionsEnabled = !state.restoreInProgress
+    // Show/hide by whether an offer EXISTS; enable by whether the action is currently usable. Using
+    // the busy-gated *Enabled flags for visibility would swap the real buttons for the generic
+    // fallback during the unsettled window or while a restore/verify runs.
+    val genericEnabled = !state.restoreInProgress && !state.verificationInProgress
+    val hasSub = state.subscriptionAvailable
+    val hasIap = state.iapAvailable
 
-    val hasSubscriptionOption = state.subState.available || state.trialState.available
-    val hasIapOption = state.iapState.available
-
-    if (state.trialState.available || state.subState.available) {
-        val onPrimaryAction = if (state.trialState.available) onGoSubscriptionTrial else onGoSubscription
-        val primaryLabel = if (state.trialState.available) {
-            stringResource(R.string.upgrade_screen_subscription_trial_action)
-        } else {
-            stringResource(R.string.upgrade_screen_subscription_action)
-        }
-
+    if (hasSub) {
+        val isTrial = state.subscriptionAction == SubscriptionAction.TRIAL
         Button(
-            onClick = onPrimaryAction,
-            enabled = actionsEnabled,
+            onClick = if (isTrial) onGoSubscriptionTrial else onGoSubscription,
+            enabled = state.subscriptionEnabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp),
         ) {
-            Icon(
-                imageVector = Icons.TwoTone.Stars,
-                contentDescription = null,
-            )
+            Icon(imageVector = Icons.TwoTone.Stars, contentDescription = null)
             Text(
-                text = primaryLabel,
+                text = stringResource(
+                    if (isTrial) R.string.upgrade_screen_subscription_trial_action
+                    else R.string.upgrade_screen_subscription_action,
+                ),
                 style = MaterialTheme.typography.titleMedium,
                 modifier = Modifier.padding(start = 8.dp),
             )
         }
-
-        state.subState.formattedPrice?.let { formattedPrice ->
-            Text(
-                text = stringResource(R.string.upgrade_screen_subscription_action_hint, formattedPrice),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp),
-            )
+        state.subscriptionPrice?.let { price ->
+            PriceHint(stringResource(R.string.upgrade_screen_subscription_action_hint, price))
         }
     }
 
-    if (hasSubscriptionOption && hasIapOption) {
-        Spacer(modifier = Modifier.height(12.dp))
-    }
+    if (hasSub && hasIap) Spacer(modifier = Modifier.height(12.dp))
 
-    if (hasIapOption) {
-        if (hasSubscriptionOption) {
+    if (hasIap) {
+        if (hasSub) {
             FilledTonalButton(
                 onClick = onGoIap,
-                enabled = actionsEnabled,
+                enabled = state.iapEnabled,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(48.dp),
@@ -201,15 +401,12 @@ private fun PricingContent(
         } else {
             Button(
                 onClick = onGoIap,
-                enabled = actionsEnabled,
+                enabled = state.iapEnabled,
                 modifier = Modifier
                     .fillMaxWidth()
                     .height(48.dp),
             ) {
-                Icon(
-                    imageVector = Icons.TwoTone.Stars,
-                    contentDescription = null,
-                )
+                Icon(imageVector = Icons.TwoTone.Stars, contentDescription = null)
                 Text(
                     text = stringResource(R.string.upgrade_screen_iap_action),
                     style = MaterialTheme.typography.titleMedium,
@@ -217,32 +414,20 @@ private fun PricingContent(
                 )
             }
         }
-
-        state.iapState.formattedPrice?.let { formattedPrice ->
-            Text(
-                text = stringResource(R.string.upgrade_screen_iap_action_hint, formattedPrice),
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                textAlign = TextAlign.Center,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 8.dp),
-            )
+        state.iapPrice?.let { price ->
+            PriceHint(stringResource(R.string.upgrade_screen_iap_action_hint, price))
         }
     }
 
-    if (!hasSubscriptionOption && !hasIapOption) {
+    if (!hasSub && !hasIap) {
         Button(
             onClick = onGoIap,
-            enabled = actionsEnabled,
+            enabled = genericEnabled,
             modifier = Modifier
                 .fillMaxWidth()
                 .height(48.dp),
         ) {
-            Icon(
-                imageVector = Icons.TwoTone.Stars,
-                contentDescription = null,
-            )
+            Icon(imageVector = Icons.TwoTone.Stars, contentDescription = null)
             Text(
                 text = stringResource(R.string.general_upgrade_action),
                 style = MaterialTheme.typography.titleMedium,
@@ -252,19 +437,76 @@ private fun PricingContent(
     }
 
     Spacer(modifier = Modifier.height(16.dp))
+    RestoreButton(restoreInProgress = state.restoreInProgress, onRestorePurchase = onRestorePurchase, filled = false)
+    PriceHint(stringResource(R.string.upgrade_screen_restore_purchase_message))
+}
 
-    OutlinedButton(
-        onClick = onRestorePurchase,
-        enabled = actionsEnabled,
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(48.dp),
-    ) {
-        if (state.restoreInProgress) {
-            CircularProgressIndicator(
-                modifier = Modifier.size(18.dp),
-                strokeWidth = 2.dp,
-            )
+// ---- Shared bits ----
+
+@Composable
+private fun BenefitsRecapCard() {
+    val benefits = listOf(
+        UpgradeBenefitItem(Icons.TwoTone.Devices, stringResource(R.string.upgrade_benefit_unlimited_devices)),
+        UpgradeBenefitItem(Icons.TwoTone.PlayCircle, stringResource(R.string.upgrade_benefit_connection_actions)),
+        UpgradeBenefitItem(Icons.TwoTone.Palette, stringResource(R.string.upgrade_benefit_theme_customization)),
+        UpgradeBenefitItem(Icons.TwoTone.Tune, stringResource(R.string.upgrade_benefit_power_controls)),
+        UpgradeBenefitItem(Icons.TwoTone.Favorite, stringResource(R.string.upgrade_benefit_support)),
+    )
+    BenefitListCard(title = stringResource(R.string.upgrade_screen_why_title), benefits = benefits)
+}
+
+@Composable
+private fun StatusCard(
+    icon: ImageVector,
+    title: String,
+    body: String,
+    extra: @Composable (() -> Unit)? = null,
+) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(imageVector = icon, contentDescription = null, tint = MaterialTheme.colorScheme.primary)
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
+            Spacer(modifier = Modifier.height(6.dp))
+            Text(text = body, style = MaterialTheme.typography.bodyMedium)
+            extra?.invoke()
+        }
+    }
+}
+
+@Composable
+private fun StatusRestoreSection(
+    restoreInProgress: Boolean,
+    onRestorePurchase: () -> Unit,
+) {
+    Text(
+        text = stringResource(R.string.upgrade_screen_status_restore_title),
+        style = MaterialTheme.typography.titleMedium,
+    )
+    Spacer(modifier = Modifier.height(6.dp))
+    Text(
+        text = stringResource(R.string.upgrade_screen_status_restore_body),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Spacer(modifier = Modifier.height(10.dp))
+    RestoreButton(restoreInProgress = restoreInProgress, onRestorePurchase = onRestorePurchase, filled = false)
+}
+
+@Composable
+private fun RestoreButton(
+    restoreInProgress: Boolean,
+    onRestorePurchase: () -> Unit,
+    filled: Boolean,
+) {
+    val content: @Composable () -> Unit = {
+        if (restoreInProgress) {
+            CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp)
             Text(
                 text = stringResource(R.string.upgrade_screen_restore_purchase_action),
                 modifier = Modifier.padding(start = 8.dp),
@@ -273,9 +515,29 @@ private fun PricingContent(
             Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
         }
     }
+    if (filled) {
+        Button(
+            onClick = onRestorePurchase,
+            enabled = !restoreInProgress,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+        ) { content() }
+    } else {
+        OutlinedButton(
+            onClick = onRestorePurchase,
+            enabled = !restoreInProgress,
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(48.dp),
+        ) { content() }
+    }
+}
 
+@Composable
+private fun PriceHint(text: String) {
     Text(
-        text = stringResource(R.string.upgrade_screen_restore_purchase_message),
+        text = text,
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
         textAlign = TextAlign.Center,
@@ -288,7 +550,7 @@ private fun PricingContent(
 @Composable
 private fun RestoreBanner(
     onRestorePurchase: () -> Unit,
-    restoreInProgress: Boolean = false,
+    restoreInProgress: Boolean,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
@@ -302,135 +564,174 @@ private fun RestoreBanner(
                 text = stringResource(R.string.upgrade_screen_restore_banner_title),
                 style = MaterialTheme.typography.titleMedium,
             )
-
             Spacer(modifier = Modifier.height(6.dp))
-
             Text(
                 text = stringResource(R.string.upgrade_screen_restore_banner_body),
                 style = MaterialTheme.typography.bodyMedium,
             )
-
             Spacer(modifier = Modifier.height(12.dp))
-
-            Button(
-                onClick = onRestorePurchase,
-                enabled = !restoreInProgress,
-                modifier = Modifier.fillMaxWidth(),
-            ) {
-                if (restoreInProgress) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(18.dp),
-                        strokeWidth = 2.dp,
-                    )
-                    Text(
-                        text = stringResource(R.string.upgrade_screen_restore_purchase_action),
-                        modifier = Modifier.padding(start = 8.dp),
-                    )
-                } else {
-                    Text(text = stringResource(R.string.upgrade_screen_restore_purchase_action))
-                }
-            }
+            RestoreButton(restoreInProgress = restoreInProgress, onRestorePurchase = onRestorePurchase, filled = true)
         }
     }
 }
 
-@Preview2
-@Composable
-fun UpgradeScreenPreview() {
-    PreviewWrapper {
-        UpgradeScreen(
-            state = UpgradeViewModel.State(
-                iapState = UpgradeViewModel.State.Iap(
-                    available = true,
-                    formattedPrice = "$4.99",
-                ),
-                subState = UpgradeViewModel.State.Sub(
-                    available = true,
-                    formattedPrice = "$2.99",
-                ),
-                trialState = UpgradeViewModel.State.Trial(
-                    available = true,
-                    formattedPrice = "$2.99"
-                ),
-            ),
-            onNavigateBack = {},
-            onGoIap = {},
-            onGoSubscription = {},
-            onGoSubscriptionTrial = {},
-            onRestorePurchase = {},
-        )
-    }
-}
-
-
-@Preview2
-@Composable
-fun UpgradeScreenPreviouslyProPreview() {
-    PreviewWrapper {
-        UpgradeScreen(
-            state = UpgradeViewModel.State(
-                iapState = UpgradeViewModel.State.Iap(
-                    available = true,
-                    formattedPrice = "$4.99",
-                ),
-                subState = UpgradeViewModel.State.Sub(
-                    available = true,
-                    formattedPrice = "$2.99",
-                ),
-                trialState = UpgradeViewModel.State.Trial(
-                    available = false,
-                    formattedPrice = null,
-                ),
-                wasPreviouslyPro = true,
-            ),
-            onNavigateBack = {},
-            onGoIap = {},
-            onGoSubscription = {},
-            onGoSubscriptionTrial = {},
-            onRestorePurchase = {},
-        )
-    }
-}
+// ---- Dialogs ----
 
 @Composable
-fun RestoreFailedDialog(
-    onDismiss: () -> Unit
-) {
+fun RestoreFailedDialog(onDismiss: () -> Unit) {
     AlertDialog(
         onDismissRequest = onDismiss,
         title = {
             Text(
                 text = stringResource(R.string.general_error_label),
-                style = MaterialTheme.typography.headlineSmall
+                style = MaterialTheme.typography.headlineSmall,
             )
         },
         confirmButton = {
-            TextButton(onClick = onDismiss) {
-                Text(stringResource(id = android.R.string.ok))
-            }
+            TextButton(onClick = onDismiss) { Text(stringResource(id = android.R.string.ok)) }
         },
         text = {
             Text(
                 text = """
                     ${stringResource(R.string.upgrade_screen_restore_purchase_message)}
-                    
+
                     ${stringResource(R.string.upgrade_screen_restore_troubleshooting_msg)}
-                    
+
                     ${stringResource(R.string.upgrade_screen_restore_sync_patience_hint)}
-                    
+
                     ${stringResource(R.string.upgrade_screen_restore_multiaccount_hint)}
-                """.trimIndent()
+                """.trimIndent(),
             )
-        }
+        },
     )
+}
+
+@Composable
+fun SubscriptionStillRenewingDialog(
+    onManageSubscription: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.upgrade_screen_sub_still_renewing_title)) },
+        text = { Text(stringResource(R.string.upgrade_screen_sub_still_renewing_message)) },
+        confirmButton = {
+            TextButton(onClick = {
+                onManageSubscription()
+                onDismiss()
+            }) {
+                Text(stringResource(R.string.upgrade_screen_manage_subscription))
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(id = android.R.string.cancel)) }
+        },
+    )
+}
+
+@Composable
+fun SubscriptionCheckFailedDialog(onDismiss: () -> Unit) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text(stringResource(R.string.general_error_label)) },
+        text = { Text(stringResource(R.string.upgrade_screen_sub_check_failed_message)) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) { Text(stringResource(id = android.R.string.ok)) }
+        },
+    )
+}
+
+// ---- Previews ----
+
+private fun previewLoaded(
+    ownership: Ownership = Ownership(),
+    grace: GraceHint? = null,
+    wasPreviouslyPro: Boolean = false,
+) = UpgradeUiState.Loaded(
+    subscriptionAction = SubscriptionAction.TRIAL,
+    subscriptionEnabled = ownership.subscription == null,
+    subscriptionPrice = "$2.99",
+    iapEnabled = !ownership.hasIap,
+    iapPrice = "$4.99",
+    ownership = ownership,
+    grace = grace,
+    wasPreviouslyPro = wasPreviouslyPro,
+)
+
+@Preview2
+@Composable
+private fun UpgradeScreenAcquisitionPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            state = previewLoaded(),
+            onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
+        )
+    }
 }
 
 @Preview2
 @Composable
-fun RestoreFailedDialogPreview() {
+private fun UpgradeScreenOwnerSubRenewingPreview() {
     PreviewWrapper {
-        RestoreFailedDialog(
-            onDismiss = {}
+        UpgradeScreen(
+            state = previewLoaded(ownership = Ownership(subscription = SubscriptionOwnership(isAutoRenewing = true))),
+            onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
         )
     }
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenOwnerSubNotRenewingPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            state = previewLoaded(ownership = Ownership(subscription = SubscriptionOwnership(isAutoRenewing = false))),
+            onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenOwnerIapPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            state = previewLoaded(ownership = Ownership(hasIap = true)),
+            onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenGraceQuietPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            state = previewLoaded(grace = GraceHint(showDiagnostics = false)),
+            onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun UpgradeScreenGraceDiagnosticsPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            state = previewLoaded(grace = GraceHint(showDiagnostics = true)),
+            onNavigateBack = {}, onGoIap = {}, onGoSubscription = {},
+            onGoSubscriptionTrial = {}, onManageSubscription = {}, onRestorePurchase = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun RestoreFailedDialogPreview() {
+    PreviewWrapper { RestoreFailedDialog(onDismiss = {}) }
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeUiState.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeUiState.kt
@@ -8,6 +8,10 @@ sealed interface UpgradeUiState {
 
     data object Loading : UpgradeUiState
 
+    // Play couldn't return prices (both SKU queries failed/timed out) for a non-owner/non-grace user —
+    // show an error card with a Retry instead of leaving them stuck with no way to pick a plan.
+    data class Unavailable(val error: Throwable) : UpgradeUiState
+
     data class Loaded(
         val subscriptionAction: SubscriptionAction,
         val subscriptionEnabled: Boolean,

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeUiState.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeUiState.kt
@@ -1,0 +1,99 @@
+package eu.darken.bluemusic.upgrade.ui
+
+import eu.darken.bluemusic.upgrade.core.OurSku
+import eu.darken.bluemusic.upgrade.core.UpgradeRepoGplay
+import eu.darken.bluemusic.upgrade.core.billing.SkuDetails
+
+sealed interface UpgradeUiState {
+
+    data object Loading : UpgradeUiState
+
+    data class Loaded(
+        val subscriptionAction: SubscriptionAction,
+        val subscriptionEnabled: Boolean,
+        val subscriptionPrice: String?,
+        val iapEnabled: Boolean,
+        val iapPrice: String?,
+        val ownership: Ownership = Ownership(),
+        val grace: GraceHint? = null,
+        val wasPreviouslyPro: Boolean = false,
+        val restoreInProgress: Boolean = false,
+        val verificationInProgress: Boolean = false,
+    ) : UpgradeUiState {
+
+        // Whether an eligible, not-yet-owned offer EXISTS — independent of transient busy/settle state.
+        // Drives which acquisition buttons are shown; the busy-gated *Enabled flags drive whether they
+        // are clickable. Keeping these separate avoids the real buttons flickering out to a generic
+        // fallback button during the unsettled window or while a restore/verify runs.
+        val subscriptionAvailable: Boolean
+            get() = subscriptionAction != SubscriptionAction.UNAVAILABLE && ownership.subscription == null
+        val iapAvailable: Boolean
+            get() = iapPrice != null && !ownership.hasIap
+    }
+}
+
+// Non-null only while the user is Pro purely via the local grace window (no owned purchase). Stage 1
+// ("confirming your purchase", quiet) becomes stage 2 (diagnostics + restore + offers) once the
+// entitlement has been unconfirmed past the 24h boundary.
+data class GraceHint(val showDiagnostics: Boolean)
+
+data class Ownership(
+    val hasIap: Boolean = false,
+    val subscription: SubscriptionOwnership? = null,
+) {
+    val ownsAnything: Boolean get() = hasIap || subscription != null
+}
+
+data class SubscriptionOwnership(val isAutoRenewing: Boolean)
+
+enum class SubscriptionAction { TRIAL, STANDARD, UNAVAILABLE }
+
+// Conservative: if ANY record for the subscription SKU still claims auto-renew, treat the whole
+// subscription as renewing. This can only under-offer the one-time switch (never wrongly enable it);
+// the actual buy tap re-verifies against a fresh Play query anyway.
+fun UpgradeRepoGplay.Info.toOwnership(): Ownership = Ownership(
+    hasIap = upgrades.any {
+        it.sku == OurSku.Iap.PRO_UPGRADE || it.sku == OurSku.Iap.PRO_UPGRADE_LEGACY
+    },
+    subscription = upgrades
+        .filter { it.sku == OurSku.Sub.PRO_UPGRADE }
+        .takeIf { it.isNotEmpty() }
+        ?.let { subs -> SubscriptionOwnership(isAutoRenewing = subs.any { it.purchase.isAutoRenewing }) },
+)
+
+fun toLoadedState(
+    iap: SkuDetails?,
+    sub: SkuDetails?,
+    ownership: Ownership,
+    grace: GraceHint?,
+    wasPreviouslyPro: Boolean,
+    settled: Boolean,
+    restoreInProgress: Boolean,
+    verificationInProgress: Boolean,
+): UpgradeUiState.Loaded {
+    val iapOffer = iap?.details?.oneTimePurchaseOfferDetails
+    val subOffer = sub?.details?.subscriptionOfferDetails?.singleOrNull {
+        OurSku.Sub.PRO_UPGRADE.BASE_OFFER.matches(it)
+    }
+    val subOfferTrial = sub?.details?.subscriptionOfferDetails?.singleOrNull {
+        OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER.matches(it)
+    }
+    val actionsFree = settled && !restoreInProgress && !verificationInProgress
+    return UpgradeUiState.Loaded(
+        subscriptionAction = when {
+            subOfferTrial != null -> SubscriptionAction.TRIAL
+            subOffer != null -> SubscriptionAction.STANDARD
+            else -> SubscriptionAction.UNAVAILABLE
+        },
+        subscriptionEnabled = (subOffer != null || subOfferTrial != null) &&
+            ownership.subscription == null && actionsFree,
+        subscriptionPrice = subOffer?.pricingPhases?.pricingPhaseList?.firstOrNull()?.formattedPrice,
+        iapEnabled = iapOffer != null && !ownership.hasIap && actionsFree,
+        iapPrice = iapOffer?.formattedPrice,
+        ownership = ownership,
+        grace = grace,
+        wasPreviouslyPro = wasPreviouslyPro,
+        restoreInProgress = restoreInProgress,
+        verificationInProgress = verificationInProgress,
+    )
+}

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -290,37 +290,52 @@ class UpgradeViewModel @AssistedInject constructor(
                 log(tag) { "restorePurchase() ignored, an auto-restore is in progress" }
                 return@launch
             }
-            val restored = coroutineScope {
-                // A warm billing cache answers instantly; pad to a minimum visible duration so the
-                // spinner doesn't flash for a single frame and leave the user unsure anything happened.
+            // Capture the result OR the error inside the scope, then wait out the min-visible pad
+            // before surfacing either — a thrown error must not skip the pad and flash the spinner for
+            // a single frame (previously the throw cancelled the pad job and jumped straight to catch).
+            val outcome = coroutineScope {
                 val minVisible = async { delay(RESTORE_MIN_VISIBLE_MS) }
-                val result = withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+                val result = try {
+                    Result.success(withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() })
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    Result.failure(e)
+                }
                 minVisible.await()
                 result
             }
-            when {
-                restored == null -> {
-                    log(tag, WARN) { "Restore purchase timed out" }
-                    events.tryEmit(UpgradeEvents.RestoreFailed)
-                }
+            outcome.fold(
+                onSuccess = { restored ->
+                    when {
+                        restored == null -> {
+                            log(tag, WARN) { "Restore purchase timed out" }
+                            events.tryEmit(UpgradeEvents.RestoreFailed)
+                        }
 
-                restored.upgrades.isNotEmpty() -> {
-                    log(tag, INFO) { "Restored purchase :))" }
-                    events.tryEmit(UpgradeEvents.RestoreSucceeded)
-                }
+                        restored.upgrades.isNotEmpty() -> {
+                            log(tag, INFO) { "Restored purchase :))" }
+                            events.tryEmit(UpgradeEvents.RestoreSucceeded)
+                        }
 
-                else -> {
-                    // Grace-only (no owned purchase) is not a real restore success.
-                    log(tag, WARN) { "Restore purchase failed (grace-only or not owned)" }
-                    events.tryEmit(UpgradeEvents.RestoreFailed)
-                }
-            }
+                        else -> {
+                            // Grace-only (no owned purchase) is not a real restore success.
+                            log(tag, WARN) { "Restore purchase failed (grace-only or not owned)" }
+                            events.tryEmit(UpgradeEvents.RestoreFailed)
+                        }
+                    }
+                },
+                onFailure = { e ->
+                    // Play/billing error (e.g. service unavailable): surface the proper error dialog
+                    // instead of the generic "restore failed" message.
+                    log(tag, WARN) { "Restore purchase errored: ${e.asLog()}" }
+                    errorEvents.tryEmit(e)
+                },
+            )
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            // Play/billing error (e.g. service unavailable): surface the proper error dialog instead of
-            // the generic "restore failed" message.
-            log(tag, WARN) { "Restore purchase errored: ${e.asLog()}" }
+            log(tag, WARN) { "Restore purchase errored (outer): ${e.asLog()}" }
             errorEvents.tryEmit(e)
         } finally {
             restoring.value = false

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -28,10 +28,12 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Duration
 
@@ -54,8 +56,6 @@ class UpgradeViewModel @AssistedInject constructor(
         manual || auto
     }
 
-    private var hasShownUnavailableError = false
-
     init {
         // Only the acquisition entry (manage=false, opened from an upsell) auto-closes the instant the
         // user becomes Pro. The manage entry (settings status row, manage=true) stays open so an owner
@@ -74,16 +74,24 @@ class UpgradeViewModel @AssistedInject constructor(
         data class Done(val iap: Collection<SkuDetails>?, val sub: Collection<SkuDetails>?) : SkuQueries
     }
 
-    private val skuQueries = flow {
-        emit(SkuQueries.Loading)
-        val result = coroutineScope {
-            val iapJob = async { queryOrNull(OurSku.PRO_SKUS.filterIsInstance<Sku.Iap>()) }
-            val subJob = async { queryOrNull(OurSku.PRO_SKUS.filterIsInstance<Sku.Subscription>()) }
-            SkuQueries.Done(iap = iapJob.await(), sub = subJob.await())
+    // Bumped by onRetry() so a user stuck on the Unavailable state can re-run the price queries
+    // without leaving and reopening the screen.
+    private val skuRetry = MutableStateFlow(0)
+
+    private val skuQueries = skuRetry.flatMapLatest {
+        flow {
+            emit(SkuQueries.Loading)
+            val result = coroutineScope {
+                val iapJob = async { queryOrNull(OurSku.PRO_SKUS.filterIsInstance<Sku.Iap>()) }
+                val subJob = async { queryOrNull(OurSku.PRO_SKUS.filterIsInstance<Sku.Subscription>()) }
+                SkuQueries.Done(iap = iapJob.await(), sub = subJob.await())
+            }
+            emit(result)
         }
-        emit(result)
     }
 
+    // A failed/timed-out price query returns null; the combine surfaces it as the Unavailable state
+    // (with Retry) rather than an error dialog, so the failure has a recovery path on screen.
     private suspend fun queryOrNull(skus: List<Sku>): Collection<SkuDetails>? =
         withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) {
             try {
@@ -91,7 +99,7 @@ class UpgradeViewModel @AssistedInject constructor(
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Exception) {
-                errorEvents.emit(e)
+                log(tag, WARN) { "SKU query failed: ${e.asLog()}" }
                 null
             }
         }
@@ -153,25 +161,17 @@ class UpgradeViewModel @AssistedInject constructor(
         val priceIndependent = ownership.ownsAnything || grace != null
 
         val done = queries as? SkuQueries.Done
-        if (done == null) {
-            hasShownUnavailableError = false
-            if (!priceIndependent) return@combine UpgradeUiState.Loading
-        }
+        if (done == null && !priceIndependent) return@combine UpgradeUiState.Loading
 
         val iap = done?.iap
         val sub = done?.sub
 
+        // Both price queries failed for a user who needs prices -> Unavailable (error card + Retry),
+        // never a dead end. Owners/grace are priceIndependent and fall through to their own content.
         if (done != null && iap == null && sub == null && !priceIndependent) {
-            // Re-runs on every upstream change (e.g. restore progress toggling) — emit the unavailable
-            // error once per failure episode, not once per recombination.
-            if (!hasShownUnavailableError) {
-                hasShownUnavailableError = true
-                errorEvents.emit(
-                    GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out.")),
-                )
-            }
-        } else {
-            hasShownUnavailableError = false
+            return@combine UpgradeUiState.Unavailable(
+                GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out.")),
+            )
         }
 
         toLoadedState(
@@ -190,9 +190,10 @@ class UpgradeViewModel @AssistedInject constructor(
     fun onGoIap(activity: Activity) {
         log(tag) { "onGoIap($activity)" }
         launch {
-            // Mutually exclusive with a restore: a purchase verification and a restore both hit Play,
-            // and running them together can stack result dialogs.
-            if (restoring.value) {
+            // Mutually exclusive with a restore (manual OR the silent already-owned auto-restore): a
+            // purchase verification and a restore both hit Play, and running them together can stack
+            // result dialogs or let a buy race the already-owned recovery.
+            if (restoring.value || upgradeRepo.autoRestoreBusy.first()) {
                 log(tag) { "onGoIap() ignored, a restore is in progress" }
                 return@launch
             }
@@ -254,11 +255,16 @@ class UpgradeViewModel @AssistedInject constructor(
         webpageTool.open(PLAY_SUBSCRIPTION_SITE)
     }
 
+    fun onRetry() {
+        log(tag) { "onRetry()" }
+        skuRetry.update { it + 1 }
+    }
+
     fun restorePurchase() = launch {
-        // Mutually exclusive with the IAP verification gate (see onGoIap): both hit Play and stacking
-        // them can duplicate result dialogs.
-        if (verifying.value) {
-            log(tag) { "restorePurchase() ignored, a verification is in progress" }
+        // Mutually exclusive with the IAP verification gate (see onGoIap) and with the silent
+        // already-owned auto-restore: all hit Play and stacking them can duplicate result dialogs.
+        if (verifying.value || upgradeRepo.autoRestoreBusy.first()) {
+            log(tag) { "restorePurchase() ignored, a verification or auto-restore is in progress" }
             return@launch
         }
         // Single-flight: repeated taps while a restore runs must not stack concurrent restores and

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -190,6 +190,12 @@ class UpgradeViewModel @AssistedInject constructor(
     fun onGoIap(activity: Activity) {
         log(tag) { "onGoIap($activity)" }
         launch {
+            // Mutually exclusive with a restore: a purchase verification and a restore both hit Play,
+            // and running them together can stack result dialogs.
+            if (restoring.value) {
+                log(tag) { "onGoIap() ignored, a restore is in progress" }
+                return@launch
+            }
             // Single-flight: repeated taps while the fail-closed check runs must not stack.
             if (!verifying.compareAndSet(expect = false, update = true)) {
                 log(tag) { "onGoIap() ignored, verification already in progress" }
@@ -249,6 +255,12 @@ class UpgradeViewModel @AssistedInject constructor(
     }
 
     fun restorePurchase() = launch {
+        // Mutually exclusive with the IAP verification gate (see onGoIap): both hit Play and stacking
+        // them can duplicate result dialogs.
+        if (verifying.value) {
+            log(tag) { "restorePurchase() ignored, a verification is in progress" }
+            return@launch
+        }
         // Single-flight: repeated taps while a restore runs must not stack concurrent restores and
         // duplicate result dialogs.
         if (!restoring.compareAndSet(expect = false, update = true)) {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -51,6 +51,13 @@ class UpgradeViewModel @AssistedInject constructor(
     private val restoring = MutableStateFlow(false)
     private val verifying = MutableStateFlow(false)
 
+    // Single ATOMIC entry guard for every Play entitlement action (buy IAP, buy sub, restore). Each
+    // CASes this as its first action, so two can't run concurrently (which could stack Play
+    // round-trips and duplicate result dialogs). Using separate check-then-CAS on verifying/restoring
+    // had a race across the suspending autoRestoreBusy read. verifying/restoring stay for the
+    // per-button spinner UI.
+    private val actionBusy = MutableStateFlow(false)
+
     // Manual restore OR the repo's invisible already-owned auto-restore: either pauses entitlement actions.
     private val restoreBusy = combine(restoring, upgradeRepo.autoRestoreBusy) { manual, auto ->
         manual || auto
@@ -190,19 +197,18 @@ class UpgradeViewModel @AssistedInject constructor(
     fun onGoIap(activity: Activity) {
         log(tag) { "onGoIap($activity)" }
         launch {
-            // Mutually exclusive with a restore (manual OR the silent already-owned auto-restore): a
-            // purchase verification and a restore both hit Play, and running them together can stack
-            // result dialogs or let a buy race the already-owned recovery.
-            if (restoring.value || upgradeRepo.autoRestoreBusy.first()) {
-                log(tag) { "onGoIap() ignored, a restore is in progress" }
+            // Atomic single-flight across ALL entitlement actions (see actionBusy).
+            if (!actionBusy.compareAndSet(expect = false, update = true)) {
+                log(tag) { "onGoIap() ignored, another billing action is in progress" }
                 return@launch
             }
-            // Single-flight: repeated taps while the fail-closed check runs must not stack.
-            if (!verifying.compareAndSet(expect = false, update = true)) {
-                log(tag) { "onGoIap() ignored, verification already in progress" }
-                return@launch
-            }
+            verifying.value = true
             try {
+                // Defer to the silent already-owned auto-restore while it reconciles.
+                if (upgradeRepo.autoRestoreBusy.first()) {
+                    log(tag) { "onGoIap() ignored, an auto-restore is in progress" }
+                    return@launch
+                }
                 // Fail-closed double-billing gate. A fresh SUBS-only Play read on every IAP tap: a
                 // timeout AND any exception both fold to the fail-closed path — we never launch the
                 // one-time purchase while a subscription is (or might still be) renewing.
@@ -226,28 +232,37 @@ class UpgradeViewModel @AssistedInject constructor(
                 }
             } finally {
                 verifying.value = false
+                actionBusy.value = false
             }
         }
     }
 
     fun onGoSubscription(activity: Activity) {
         log(tag) { "onGoSubscription($activity)" }
-        upgradeRepo.launchBillingFlow(
-            activity,
-            OurSku.Sub.PRO_UPGRADE,
-            OurSku.Sub.PRO_UPGRADE.BASE_OFFER,
-            onError = errorEvents::tryEmit,
-        )
+        launchSubscription(activity, OurSku.Sub.PRO_UPGRADE.BASE_OFFER)
     }
 
     fun onGoSubscriptionTrial(activity: Activity) {
         log(tag) { "onGoSubscriptionTrial($activity)" }
-        upgradeRepo.launchBillingFlow(
-            activity,
-            OurSku.Sub.PRO_UPGRADE,
-            OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER,
-            onError = errorEvents::tryEmit,
-        )
+        launchSubscription(activity, OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER)
+    }
+
+    private fun launchSubscription(activity: Activity, offer: Sku.Subscription.Offer) = launch {
+        // Same atomic entry guard as the other actions, so a subscription buy can't start while a
+        // restore/verify is running (and vice versa).
+        if (!actionBusy.compareAndSet(expect = false, update = true)) {
+            log(tag) { "launchSubscription() ignored, another billing action is in progress" }
+            return@launch
+        }
+        try {
+            if (upgradeRepo.autoRestoreBusy.first()) {
+                log(tag) { "launchSubscription() ignored, an auto-restore is in progress" }
+                return@launch
+            }
+            upgradeRepo.launchBillingFlow(activity, OurSku.Sub.PRO_UPGRADE, offer, onError = errorEvents::tryEmit)
+        } finally {
+            actionBusy.value = false
+        }
     }
 
     fun onManageSubscription() {
@@ -261,21 +276,20 @@ class UpgradeViewModel @AssistedInject constructor(
     }
 
     fun restorePurchase() = launch {
-        // Mutually exclusive with the IAP verification gate (see onGoIap) and with the silent
-        // already-owned auto-restore: all hit Play and stacking them can duplicate result dialogs.
-        if (verifying.value || upgradeRepo.autoRestoreBusy.first()) {
-            log(tag) { "restorePurchase() ignored, a verification or auto-restore is in progress" }
+        // Atomic single-flight across ALL entitlement actions (see actionBusy).
+        if (!actionBusy.compareAndSet(expect = false, update = true)) {
+            log(tag) { "restorePurchase() ignored, another billing action is in progress" }
             return@launch
         }
-        // Single-flight: repeated taps while a restore runs must not stack concurrent restores and
-        // duplicate result dialogs.
-        if (!restoring.compareAndSet(expect = false, update = true)) {
-            log(tag) { "restorePurchase() ignored, already in progress" }
-            return@launch
-        }
+        restoring.value = true
         log(tag) { "restorePurchase()" }
 
         try {
+            // Defer to the silent already-owned auto-restore while it reconciles.
+            if (upgradeRepo.autoRestoreBusy.first()) {
+                log(tag) { "restorePurchase() ignored, an auto-restore is in progress" }
+                return@launch
+            }
             val restored = coroutineScope {
                 // A warm billing cache answers instantly; pad to a minimum visible duration so the
                 // spinner doesn't flash for a single frame and leave the user unsure anything happened.
@@ -310,6 +324,7 @@ class UpgradeViewModel @AssistedInject constructor(
             errorEvents.tryEmit(e)
         } finally {
             restoring.value = false
+            actionBusy.value = false
         }
     }
 

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -1,7 +1,11 @@
 package eu.darken.bluemusic.upgrade.ui
 
 import android.app.Activity
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
+import eu.darken.bluemusic.common.WebpageTool
 import eu.darken.bluemusic.common.coroutine.DispatcherProvider
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
@@ -15,29 +19,37 @@ import eu.darken.bluemusic.upgrade.core.OurSku
 import eu.darken.bluemusic.upgrade.core.UpgradeRepoGplay
 import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.bluemusic.upgrade.core.billing.Sku
+import eu.darken.bluemusic.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.take
 import kotlinx.coroutines.withTimeoutOrNull
-import javax.inject.Inject
+import java.time.Duration
 
-@HiltViewModel
-class UpgradeViewModel @Inject constructor(
+@HiltViewModel(assistedFactory = UpgradeViewModel.Factory::class)
+class UpgradeViewModel @AssistedInject constructor(
+    @Assisted private val manage: Boolean,
     dispatcherProvider: DispatcherProvider,
     navCtrl: NavigationController,
     private val upgradeRepo: UpgradeRepoGplay,
+    private val webpageTool: WebpageTool,
 ) : ViewModel4(dispatcherProvider, logTag("Upgrade", "Screen", "VM"), navCtrl) {
 
     val events = SingleEventFlow<UpgradeEvents>()
 
     private val restoring = MutableStateFlow(false)
+    private val verifying = MutableStateFlow(false)
 
-    // Manual restore or the repo's invisible already-owned auto-restore: either pauses the
-    // entitlement actions.
+    // Manual restore OR the repo's invisible already-owned auto-restore: either pauses entitlement actions.
     private val restoreBusy = combine(restoring, upgradeRepo.autoRestoreBusy) { manual, auto ->
         manual || auto
     }
@@ -45,112 +57,170 @@ class UpgradeViewModel @Inject constructor(
     private var hasShownUnavailableError = false
 
     init {
-        upgradeRepo.upgradeInfo
-            .filter { it.isUpgraded }
-            .take(1)
-            .onEach { navUp() }
-            .launchInViewModel()
+        // Only the acquisition entry (manage=false, opened from an upsell) auto-closes the instant the
+        // user becomes Pro. The manage entry (settings status row, manage=true) stays open so an owner
+        // can see their status and switch subscription -> one-time purchase.
+        if (!manage) {
+            upgradeRepo.upgradeInfo
+                .filter { it.isUpgraded }
+                .take(1)
+                .onEach { navUp() }
+                .launchInViewModel()
+        }
     }
 
-    val state = combine(
-        flow {
-            val data = withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) {
-                try {
-                    upgradeRepo.querySkus(*OurSku.PRO_SKUS.filterIsInstance<Sku.Iap>().toTypedArray())
-                } catch (e: Exception) {
-                    errorEvents.emit(e)
-                    null
-                }
+    private sealed interface SkuQueries {
+        data object Loading : SkuQueries
+        data class Done(val iap: Collection<SkuDetails>?, val sub: Collection<SkuDetails>?) : SkuQueries
+    }
+
+    private val skuQueries = flow {
+        emit(SkuQueries.Loading)
+        val result = coroutineScope {
+            val iapJob = async { queryOrNull(OurSku.PRO_SKUS.filterIsInstance<Sku.Iap>()) }
+            val subJob = async { queryOrNull(OurSku.PRO_SKUS.filterIsInstance<Sku.Subscription>()) }
+            SkuQueries.Done(iap = iapJob.await(), sub = subJob.await())
+        }
+        emit(result)
+    }
+
+    private suspend fun queryOrNull(skus: List<Sku>): Collection<SkuDetails>? =
+        withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) {
+            try {
+                upgradeRepo.querySkus(*skus.toTypedArray())
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                errorEvents.emit(e)
+                null
             }
-            emit(data)
-        },
-        flow {
-            val data = withTimeoutOrNull(SKU_QUERY_TIMEOUT_MS) {
-                try {
-                    upgradeRepo.querySkus(*OurSku.PRO_SKUS.filterIsInstance<Sku.Subscription>().toTypedArray())
-                } catch (e: Exception) {
-                    errorEvents.emit(e)
-                    null
-                }
+        }
+
+    // Emits once immediately, then again the moment the entitlement crosses the 24h diagnostics
+    // boundary — every other combined source is distinctUntilChanged and would otherwise never re-fire
+    // while the screen sits open through the transition. flatMapLatest re-arms whenever the
+    // last-confirmed timestamp changes; no-ops (single emission) when there's nothing to wait for.
+    private val graceTick = upgradeRepo.lastProStateAt.flatMapLatest { lastProAt ->
+        if (lastProAt <= 0L) return@flatMapLatest flowOf(Unit)
+        val remaining = GRACE_DIAGNOSTICS_AFTER_MS - (System.currentTimeMillis() - lastProAt)
+        if (remaining <= 0L) {
+            flowOf(Unit)
+        } else {
+            flow {
+                emit(Unit)
+                delay(remaining)
+                emit(Unit)
             }
-            emit(data)
-        },
-        upgradeRepo.upgradeInfo,
+        }
+    }
+
+    private data class Signals(
+        val settled: Boolean,
+        val wasEverPro: Boolean,
+        val lastProStateAt: Long,
+    )
+
+    private val signals = combine(
+        upgradeRepo.isSettled,
         upgradeRepo.wasEverPro,
+        upgradeRepo.lastProStateAt,
+        graceTick,
+    ) { settled, wasEverPro, lastProAt, _ -> Signals(settled, wasEverPro, lastProAt) }
+
+    val state = combine(
+        skuQueries,
+        upgradeRepo.upgradeInfo,
+        signals,
         restoreBusy,
-    ) { iap, sub, current, wasEverPro, isRestoring ->
-        if (iap == null && sub == null) {
-            // This combine re-runs on every upstream change (e.g. restore progress toggling) —
-            // emit the unavailable error once per failure episode, not once per recombination.
+        verifying,
+    ) { queries, current, sig, isRestoring, isVerifying ->
+        val ownership = current.toOwnership()
+
+        // Pro without any owned purchase == grace. Stage 1 shows immediately; the diagnostics stage
+        // appears only once the entitlement has been unconfirmed past the 24h boundary (derived from
+        // the last-confirmed timestamp, which can't get stuck during a Play outage).
+        val grace = if (current.isUpgraded && !ownership.ownsAnything) {
+            GraceHint(
+                showDiagnostics = sig.lastProStateAt > 0L &&
+                    (System.currentTimeMillis() - sig.lastProStateAt) >= GRACE_DIAGNOSTICS_AFTER_MS,
+            )
+        } else {
+            null
+        }
+
+        // Owners and grace users don't need prices, so they must never be blocked on (or shown an
+        // error for) a failed price query.
+        val priceIndependent = ownership.ownsAnything || grace != null
+
+        val done = queries as? SkuQueries.Done
+        if (done == null) {
+            hasShownUnavailableError = false
+            if (!priceIndependent) return@combine UpgradeUiState.Loading
+        }
+
+        val iap = done?.iap
+        val sub = done?.sub
+
+        if (done != null && iap == null && sub == null && !priceIndependent) {
+            // Re-runs on every upstream change (e.g. restore progress toggling) — emit the unavailable
+            // error once per failure episode, not once per recombination.
             if (!hasShownUnavailableError) {
                 hasShownUnavailableError = true
                 errorEvents.emit(
-                    GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out."))
+                    GplayServiceUnavailableException(RuntimeException("IAP and SUB data request timed out.")),
                 )
             }
         } else {
             hasShownUnavailableError = false
         }
 
-        val iapOffer = iap?.singleOrNull { it.sku.id == OurSku.Iap.PRO_UPGRADE.id }?.details?.oneTimePurchaseOfferDetails
-        val iapState = State.Iap(
-            available = iapOffer != null && current.upgrades.none { it.sku == OurSku.Iap.PRO_UPGRADE },
-            formattedPrice = iapOffer?.formattedPrice,
-        )
-
-        val subOffer = sub?.firstOrNull()?.details?.subscriptionOfferDetails?.singleOrNull { offer ->
-            OurSku.Sub.PRO_UPGRADE.BASE_OFFER.matches(offer)
-        }
-        val subState = State.Sub(
-            available = subOffer != null && current.upgrades.none { it.sku == OurSku.Sub.PRO_UPGRADE },
-            formattedPrice = subOffer?.let { it.pricingPhases.pricingPhaseList.firstOrNull()?.formattedPrice },
-        )
-
-        val trialOffer = sub?.firstOrNull()?.details?.subscriptionOfferDetails?.any { offer ->
-            OurSku.Sub.PRO_UPGRADE.TRIAL_OFFER.matches(offer)
-        }
-        val trialState = State.Trial(
-            available = trialOffer == true,
-            formattedPrice = subState.formattedPrice,
-        )
-
-        State(
-            iapState = iapState,
-            subState = subState,
-            trialState = trialState,
+        toLoadedState(
+            iap = iap?.singleOrNull { it.sku == OurSku.Iap.PRO_UPGRADE },
+            sub = sub?.firstOrNull(),
+            ownership = ownership,
+            grace = grace,
             // Hidden while a grace period or an actual purchase keeps the user Pro.
-            wasPreviouslyPro = wasEverPro && !current.isUpgraded,
+            wasPreviouslyPro = sig.wasEverPro && !current.isUpgraded,
+            settled = sig.settled,
             restoreInProgress = isRestoring,
+            verificationInProgress = isVerifying,
         )
     }.asStateFlow()
 
-    data class State(
-        val iapState: Iap,
-        val subState: Sub,
-        val trialState: Trial,
-        val wasPreviouslyPro: Boolean = false,
-        val restoreInProgress: Boolean = false,
-    ) {
-
-        class Iap(
-            val available: Boolean,
-            val formattedPrice: String?,
-        )
-
-        data class Sub(
-            val available: Boolean,
-            val formattedPrice: String?,
-        )
-
-        data class Trial(
-            val available: Boolean,
-            val formattedPrice: String?,
-        )
-    }
-
     fun onGoIap(activity: Activity) {
         log(tag) { "onGoIap($activity)" }
-        upgradeRepo.launchBillingFlow(activity, OurSku.Iap.PRO_UPGRADE, null, onError = errorEvents::tryEmit)
+        launch {
+            // Single-flight: repeated taps while the fail-closed check runs must not stack.
+            if (!verifying.compareAndSet(expect = false, update = true)) {
+                log(tag) { "onGoIap() ignored, verification already in progress" }
+                return@launch
+            }
+            try {
+                // Fail-closed double-billing gate. A fresh SUBS-only Play read on every IAP tap: a
+                // timeout AND any exception both fold to the fail-closed path — we never launch the
+                // one-time purchase while a subscription is (or might still be) renewing.
+                val subscriptions = try {
+                    withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.queryCurrentSubscriptions() }
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(tag, WARN) { "Subscription check failed: ${e.asLog()}" }
+                    null
+                }
+                when {
+                    subscriptions == null -> events.tryEmit(UpgradeEvents.SubscriptionCheckFailed)
+                    subscriptions.any { it.isAutoRenewing } -> events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
+                    else -> upgradeRepo.launchBillingFlow(
+                        activity,
+                        OurSku.Iap.PRO_UPGRADE,
+                        null,
+                        onError = errorEvents::tryEmit,
+                    )
+                }
+            } finally {
+                verifying.value = false
+            }
+        }
     }
 
     fun onGoSubscription(activity: Activity) {
@@ -173,11 +243,14 @@ class UpgradeViewModel @Inject constructor(
         )
     }
 
+    fun onManageSubscription() {
+        log(tag) { "onManageSubscription()" }
+        webpageTool.open(PLAY_SUBSCRIPTION_SITE)
+    }
+
     fun restorePurchase() = launch {
-        // Single-flight: repeated taps while a restore is running (worst case bounded by
-        // RESTORE_TIMEOUT_MS) must not stack concurrent restores and duplicate result dialogs. The
-        // UI also disables the buttons, but that can lag a dispatch turn — this guard is the real
-        // protection.
+        // Single-flight: repeated taps while a restore runs must not stack concurrent restores and
+        // duplicate result dialogs.
         if (!restoring.compareAndSet(expect = false, update = true)) {
             log(tag) { "restorePurchase() ignored, already in progress" }
             return@launch
@@ -185,41 +258,63 @@ class UpgradeViewModel @Inject constructor(
         log(tag) { "restorePurchase()" }
 
         try {
-            val restored = withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+            val restored = coroutineScope {
+                // A warm billing cache answers instantly; pad to a minimum visible duration so the
+                // spinner doesn't flash for a single frame and leave the user unsure anything happened.
+                val minVisible = async { delay(RESTORE_MIN_VISIBLE_MS) }
+                val result = withTimeoutOrNull(RESTORE_TIMEOUT_MS) { upgradeRepo.restorePurchaseNow() }
+                minVisible.await()
+                result
+            }
             when {
                 restored == null -> {
-                    // Play never answered in time; the restore-failed dialog already suggests waiting /
-                    // clearing the Play cache, which fits a timeout too.
                     log(tag, WARN) { "Restore purchase timed out" }
                     events.tryEmit(UpgradeEvents.RestoreFailed)
                 }
 
-                restored.isUpgraded -> log(tag, INFO) { "Restored purchase :))" }
+                restored.upgrades.isNotEmpty() -> {
+                    log(tag, INFO) { "Restored purchase :))" }
+                    events.tryEmit(UpgradeEvents.RestoreSucceeded)
+                }
 
                 else -> {
-                    log(tag, WARN) { "Restore purchase failed" }
+                    // Grace-only (no owned purchase) is not a real restore success.
+                    log(tag, WARN) { "Restore purchase failed (grace-only or not owned)" }
                     events.tryEmit(UpgradeEvents.RestoreFailed)
                 }
             }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
-            // Play/billing error (e.g. service unavailable): surface the proper error dialog instead
-            // of the generic "restore failed" message, so the user can tell the two cases apart.
+            // Play/billing error (e.g. service unavailable): surface the proper error dialog instead of
+            // the generic "restore failed" message.
             log(tag, WARN) { "Restore purchase errored: ${e.asLog()}" }
             errorEvents.tryEmit(e)
         } finally {
-            // Reset only after result handling, so the single-flight guard covers the whole
-            // user-visible action, including dialog emission.
             restoring.value = false
         }
     }
 
+    @AssistedFactory
+    interface Factory {
+        fun create(manage: Boolean): UpgradeViewModel
+    }
+
     companion object {
         private const val RESTORE_TIMEOUT_MS = 15_000L
+        private const val RESTORE_MIN_VISIBLE_MS = 1_500L
 
-        // The very first billing query after Play sign-in can take >8s (measured) while Play warms
-        // up — 5s produced false "Play unavailable" dialogs on slow-but-healthy stores.
+        // Fail-closed gate budget. The billing connection is warm by the time the user taps (SKU/price
+        // queries already ran), so this normally resolves in well under a second.
+        private const val VERIFY_TIMEOUT_MS = 10_000L
+
+        // The very first billing query after Play sign-in can take >8s while Play warms up.
         private const val SKU_QUERY_TIMEOUT_MS = 15_000L
+
+        private val GRACE_DIAGNOSTICS_AFTER_MS = Duration.ofHours(24).toMillis()
+
+        private val PLAY_SUBSCRIPTION_SITE =
+            "https://play.google.com/store/account/subscriptions" +
+                "?sku=${OurSku.Sub.PRO_UPGRADE.id}&package=eu.darken.bluemusic"
     }
 }

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -27,6 +27,38 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store synchronization may take time. Try rebooting, clearing Google Play cache or simply wait.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Multiple accounts can confuse Google Play. Log out of other accounts or install through the Google Play website, which forces associations with a specific account.</string>
 
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">View your Pro status</string>
+
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_iap_title">One-time purchase</string>
+    <string name="upgrade_screen_owned_iap_body">You own BVM Pro forever. Thanks for your support ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Subscription</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Your BVM Pro subscription is active and set to renew.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Your BVM Pro subscription is active but won\'t renew. It stays valid until the end of the current period.</string>
+    <string name="upgrade_screen_owned_both_warning">You have both a subscription and the one-time purchase. Cancel the subscription in Google Play so you\'re not charged again.</string>
+    <string name="upgrade_screen_manage_subscription">Manage subscription</string>
+
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Switch to a one-time purchase</string>
+    <string name="upgrade_screen_switch_purchase_note">This is a separate one-time purchase. It does not cancel or refund your subscription, so cancel that in Google Play too. Use the same Google account for both.</string>
+    <string name="upgrade_screen_switch_locked_note">Available once your subscription is no longer set to renew. Cancel it in Google Play to switch — you keep Pro until the current period ends.</string>
+
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Status looks wrong?</string>
+    <string name="upgrade_screen_status_restore_body">If your purchase isn\'t showing up here, try restoring it.</string>
+
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Confirming your purchase</string>
+    <string name="upgrade_screen_grace_body_short">Hang tight — we\'re double-checking your purchase with Google Play.</string>
+    <string name="upgrade_screen_grace_body">We still can\'t confirm your purchase with Google Play. Try restoring it, or check that you\'re signed in with the right account.</string>
+
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Subscription still active</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Your subscription is still set to renew. Cancel it in Google Play first, then come back to buy the one-time purchase — that way you won\'t be charged twice.</string>
+    <string name="upgrade_screen_sub_check_failed_message">We couldn\'t check your subscription status. Please check your connection and try again.</string>
+
     <string name="upgrades_gplay_already_owned_error_title">Already purchased</string>
     <string name="upgrades_gplay_already_owned_error_description">Use the \"Restore purchase\" option to restore your purchase. If the issue persists, try clearing Google Play cache and restarting your device.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play error</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -54,6 +54,8 @@
     <string name="upgrade_screen_grace_body_short">Hang tight — we\'re double-checking your purchase with Google Play.</string>
     <string name="upgrade_screen_grace_body">We still can\'t confirm your purchase with Google Play. Try restoring it, or check that you\'re signed in with the right account.</string>
 
+    <string name="upgrade_screen_retry_action">Retry</string>
+
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Subscription still active</string>
     <string name="upgrade_screen_sub_still_renewing_message">Your subscription is still set to renew. Cancel it in Google Play first, then come back to buy the one-time purchase — that way you won\'t be charged twice.</string>

--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverScreen.kt
@@ -65,7 +65,7 @@ fun DiscoverScreenHost(vm: DiscoverViewModel = hiltViewModel()) {
     LaunchedEffect(Unit) {
         vm.events.collect { event ->
             when (event) {
-                is DiscoverEvent.RequiresUpgrade -> vm.navTo(Nav.Main.Upgrade)
+                is DiscoverEvent.RequiresUpgrade -> vm.navTo(Nav.Main.Upgrade())
             }
         }
     }
@@ -75,7 +75,7 @@ fun DiscoverScreenHost(vm: DiscoverViewModel = hiltViewModel()) {
             state = state,
             onDeviceSelected = { vm.onDeviceSelected(it) },
             onNavigateBack = { vm.navUp() },
-            onNavigateToUpgrade = { vm.navTo(Nav.Main.Upgrade) },
+            onNavigateToUpgrade = { vm.navTo(Nav.Main.Upgrade()) },
         )
     }
 }

--- a/app/src/main/java/eu/darken/bluemusic/common/WebpageTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/WebpageTool.kt
@@ -15,23 +15,26 @@ class WebpageTool @Inject constructor(
     @param:ApplicationContext private val context: Context,
 ) {
 
-    fun open(address: String) {
-        open(context, address)
-    }
+    // Returns whether an activity was actually started, so callers that gate behaviour on the page
+    // having opened (e.g. the FOSS sponsor unlock heuristic) don't fire when no browser handled it.
+    fun open(address: String): Boolean = open(context, address)
 
     companion object {
-        fun open(context: Context, address: String) {
+        fun open(context: Context, address: String): Boolean {
             val intent = Intent(Intent.ACTION_VIEW, address.toUri()).apply {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
-            try {
+            return try {
                 context.startActivity(intent)
+                true
             } catch (e: ActivityNotFoundException) {
                 log(ERROR) { "Failed to launch. No compatible activity!" }
+                false
             } catch (e: SecurityException) {
                 // Permission Denial: starting Intent { act=android.intent.action.VIEW dat=https://github.com/...
                 // flg=0x10000000 cmp=com.mxtech.videoplayer.pro/com.mxtech.videoplayer.ActivityWebBrowser }
                 log(ERROR) { "Failed to launch activity due to $e" }
+                false
             }
         }
     }

--- a/app/src/main/java/eu/darken/bluemusic/common/navigation/Nav.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/navigation/Nav.kt
@@ -36,9 +36,7 @@ sealed interface Nav : NavigationDestination {
         }
 
         @Serializable
-        data object Upgrade : Main {
-            private fun readResolve(): Any = Upgrade
-        }
+        data class Upgrade(val manage: Boolean = false) : Main
 
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/DeviceConfigScreen.kt
@@ -144,7 +144,7 @@ fun DeviceConfigScreenHost(
                 }
 
                 is ConfigEvent.NavigateBack -> vm.navUp()
-                is ConfigEvent.RequiresPro -> vm.navTo(Nav.Main.Upgrade)
+                is ConfigEvent.RequiresPro -> vm.navTo(Nav.Main.Upgrade())
 
                 is ConfigEvent.RequiresNotificationPolicyAccess -> {
                     val message = when (event.feature) {

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
@@ -104,7 +104,7 @@ fun DevicesScreenHost(vm: DashboardViewModel = hiltViewModel()) {
             onDeviceConfig = { vm.navTo(Nav.Main.DeviceConfig(it)) },
             onDeviceAction = { vm.action(it) },
             onNavigateToSettings = { vm.navTo(Nav.Main.SettingsIndex) },
-            onNavigateToUpgrade = { vm.navTo(Nav.Main.Upgrade) },
+            onNavigateToUpgrade = { vm.navTo(Nav.Main.Upgrade()) },
             onRequestBluetoothPermission = {
                 vm.action(DashboardAction.RequestBluetoothPermission)
             },

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
@@ -39,7 +39,7 @@ constructor(
 
     fun upgrade() = launch {
         log(tag) { "upgrade()" }
-        navTo(Nav.Main.Upgrade)
+        navTo(Nav.Main.Upgrade())
     }
 
     fun onToggleEnabled(enabled: Boolean) = launch {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreen.kt
@@ -172,16 +172,24 @@ fun SettingsIndexScreen(
 
             item { SettingsCategoryHeader(stringResource(R.string.settings_category_other_label)) }
 
-            if (!state.isUpgraded) {
-                item {
-                    SettingsBaseItem(
-                        icon = Icons.TwoTone.Stars,
-                        title = stringResource(R.string.upgrade_prompt_title),
-                        subtitle = stringResource(R.string.upgrade_prompt_body),
-                        onClick = { onNavigateTo(Nav.Main.Upgrade) },
-                    )
-                    SettingsDivider()
-                }
+            item {
+                SettingsBaseItem(
+                    icon = Icons.TwoTone.Stars,
+                    title = if (state.isUpgraded) {
+                        stringResource(R.string.settings_upgrade_status_title)
+                    } else {
+                        stringResource(R.string.upgrade_prompt_title)
+                    },
+                    subtitle = if (state.isUpgraded) {
+                        stringResource(R.string.settings_upgrade_status_desc)
+                    } else {
+                        stringResource(R.string.upgrade_prompt_body)
+                    },
+                    // manage=true so an existing Pro/supporter lands on the status view instead of
+                    // being auto-navigated straight back out.
+                    onClick = { onNavigateTo(Nav.Main.Upgrade(manage = true)) },
+                )
+                SettingsDivider()
             }
 
             item {

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/general/GeneralSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/general/GeneralSettingsViewModel.kt
@@ -73,7 +73,7 @@ constructor(
 
     fun upgrade() = launch {
         log(tag) { "upgrade()" }
-        navTo(Nav.Main.Upgrade)
+        navTo(Nav.Main.Upgrade())
     }
 
     data class State(

--- a/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreenScaffold.kt
+++ b/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreenScaffold.kt
@@ -42,16 +42,16 @@ internal data class UpgradeBenefitItem(
     val text: String,
 )
 
+// Reusable shell: scrolling container + hero + floating back button + optional snackbar, with an
+// arbitrary body slot below the hero. The acquisition scaffold and the Pro-status (owner/grace)
+// screens all build on this so the header/back/scroll behaviour stays identical.
 @Composable
-internal fun UpgradeScreenScaffold(
+internal fun UpgradeScreenShell(
     title: String,
     postfix: String,
-    preamble: String,
-    benefitTitle: String,
-    benefits: List<UpgradeBenefitItem>,
     onNavigateBack: () -> Unit,
     snackbarHostState: SnackbarHostState? = null,
-    actions: @Composable ColumnScope.() -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
 ) {
     Box(modifier = Modifier.fillMaxSize()) {
         Column(
@@ -80,30 +80,7 @@ internal fun UpgradeScreenScaffold(
 
                     Spacer(modifier = Modifier.size(16.dp))
 
-                    Card(
-                        modifier = Modifier.fillMaxWidth(),
-                        colors = CardDefaults.cardColors(
-                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                        ),
-                    ) {
-                        Text(
-                            text = preamble,
-                            style = MaterialTheme.typography.bodyMedium,
-                            color = MaterialTheme.colorScheme.onSecondaryContainer,
-                            modifier = Modifier.padding(14.dp),
-                        )
-                    }
-
-                    Spacer(modifier = Modifier.size(14.dp))
-
-                    BenefitListCard(
-                        title = benefitTitle,
-                        benefits = benefits,
-                    )
-
-                    Spacer(modifier = Modifier.size(18.dp))
-
-                    actions()
+                    content()
                 }
             }
         }
@@ -125,6 +102,52 @@ internal fun UpgradeScreenScaffold(
                     .padding(horizontal = 16.dp, vertical = 8.dp),
             )
         }
+    }
+}
+
+// Acquisition scaffold: the shell plus the standard "why upgrade" pitch (preamble card + benefit
+// list), with an actions slot for the purchase buttons. Used by both flavors' acquisition screens.
+@Composable
+internal fun UpgradeScreenScaffold(
+    title: String,
+    postfix: String,
+    preamble: String,
+    benefitTitle: String,
+    benefits: List<UpgradeBenefitItem>,
+    onNavigateBack: () -> Unit,
+    snackbarHostState: SnackbarHostState? = null,
+    actions: @Composable ColumnScope.() -> Unit,
+) {
+    UpgradeScreenShell(
+        title = title,
+        postfix = postfix,
+        onNavigateBack = onNavigateBack,
+        snackbarHostState = snackbarHostState,
+    ) {
+        Card(
+            modifier = Modifier.fillMaxWidth(),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            ),
+        ) {
+            Text(
+                text = preamble,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer,
+                modifier = Modifier.padding(14.dp),
+            )
+        }
+
+        Spacer(modifier = Modifier.size(14.dp))
+
+        BenefitListCard(
+            title = benefitTitle,
+            benefits = benefits,
+        )
+
+        Spacer(modifier = Modifier.size(18.dp))
+
+        actions()
     }
 }
 
@@ -177,7 +200,7 @@ private fun UpgradeHero(
 }
 
 @Composable
-private fun BenefitListCard(
+internal fun BenefitListCard(
     title: String,
     benefits: List<UpgradeBenefitItem>,
 ) {

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
@@ -13,6 +13,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.CompletableDeferred
@@ -21,6 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -287,6 +289,62 @@ class BillingManagerTest : BaseTest() {
         advanceTimeBy(2_000)
         runCurrent()
         attempts shouldBe 2
+    }
+
+    private fun unacked(token: String) = mockk<Purchase>().apply {
+        every { purchaseState } returns PurchaseState.PURCHASED
+        every { purchaseTime } returns 1_000L
+        every { isAcknowledged } returns false
+        every { purchaseToken } returns token
+    }
+
+    @Test fun `an already-acked token is not acknowledged again on a later emission`() = runTest2 {
+        // The immutable Purchase snapshot keeps reporting isAcknowledged=false until a fresh query
+        // supersedes it, so without a token guard every re-emission would re-ack the same purchase.
+        val ok = BillingResult.newBuilder().setResponseCode(BillingResponseCode.OK).build()
+        val a = unacked("A")
+        val b = unacked("B")
+        val purchasesFlow = MutableStateFlow<Collection<Purchase>>(emptyList())
+        val connection = mockk<BillingConnection>().apply {
+            coEvery { refreshPurchases() } returns
+                BillingConnection.PurchaseRefresh(emptyList(), isComplete = true)
+            every { purchases } returns purchasesFlow
+            every { purchaseEvents } returns emptyFlow()
+            every { purchaseFailures } returns emptyFlow()
+            coEvery { acknowledgePurchase(any()) } returns ok
+        }
+        manager(connection)
+
+        purchasesFlow.value = listOf(a)
+        advanceUntilIdle()
+        purchasesFlow.value = listOf(a, b)
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { connection.acknowledgePurchase(a) }
+        coVerify(exactly = 1) { connection.acknowledgePurchase(b) }
+    }
+
+    @Test fun `an ack that stays unavailable gives up without an endless retry loop`() = runTest2 {
+        val unavailable = BillingResult.newBuilder()
+            .setResponseCode(BillingResponseCode.BILLING_UNAVAILABLE)
+            .build()
+        val a = unacked("A")
+        val purchasesFlow = MutableStateFlow<Collection<Purchase>>(emptyList())
+        val connection = mockk<BillingConnection>().apply {
+            coEvery { refreshPurchases() } returns
+                BillingConnection.PurchaseRefresh(emptyList(), isComplete = true)
+            every { purchases } returns purchasesFlow
+            every { purchaseEvents } returns emptyFlow()
+            every { purchaseFailures } returns emptyFlow()
+            coEvery { acknowledgePurchase(a) } throws BillingClientException(unavailable)
+        }
+        manager(connection)
+
+        purchasesFlow.value = listOf(a)
+        advanceUntilIdle()
+
+        // BILLING_UNAVAILABLE has nothing to retry against -> exactly one attempt, then give up.
+        coVerify(exactly = 1) { connection.acknowledgePurchase(a) }
     }
 
     @Test fun `backoff streak resets after a successful connection`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -85,6 +85,7 @@ class BillingConnectionTest : BaseTest() {
             val owned = mockk<Purchase>().apply {
                 every { purchaseState } returns PurchaseState.PURCHASED
                 every { purchaseTime } returns 1_000L
+                every { purchaseToken } returns "owned"
             }
             val client = mockk<BillingClient>()
             // Single-threaded test dispatcher: first query is INAPP, second is SUBS.
@@ -181,6 +182,42 @@ class BillingConnectionTest : BaseTest() {
         }
     }
 
+    @Test fun `a fresh snapshot supersedes a stale purchase event with the same token`() = runTest2 {
+        // A subscription bought this session (renewing event) that is then cancelled: the authoritative
+        // query snapshot (isAutoRenewing=false) must supersede the stale event by token, not coexist
+        // with it — otherwise the sub->IAP switch stays locked as "renewing".
+        mockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        try {
+            val renewing = mockk<Purchase>().apply {
+                every { purchaseState } returns PurchaseState.PURCHASED
+                every { purchaseTime } returns 1_000L
+                every { purchaseToken } returns "A"
+                every { isAutoRenewing } returns true
+            }
+            val cancelled = mockk<Purchase>().apply {
+                every { purchaseState } returns PurchaseState.PURCHASED
+                every { purchaseTime } returns 1_000L
+                every { purchaseToken } returns "A"
+                every { isAutoRenewing } returns false
+            }
+            val client = mockk<BillingClient>()
+            coEvery { client.queryPurchasesAsync(any<QueryPurchasesParams>()) } returnsMany listOf(
+                PurchasesResult(result(BillingResponseCode.OK), emptyList()),      // refresh INAPP
+                PurchasesResult(result(BillingResponseCode.OK), listOf(cancelled)), // refresh SUBS -> snapshot
+            )
+            val events = MutableStateFlow<Pair<BillingResult, Collection<Purchase>?>?>(
+                result(BillingResponseCode.OK) to listOf(renewing),
+            )
+            val connection = BillingConnection(client, events)
+            connection.refreshPurchases()
+
+            val result = connection.purchases.first()
+            result.map { it.isAutoRenewing } shouldBe listOf(false)
+        } finally {
+            unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+
     // The BillingFlowParams builder calls TextUtils.isEmpty, which is an unmocked Android stub in
     // plain JVM tests — give it its real behavior.
     private fun mockTextUtils() {
@@ -214,6 +251,7 @@ class BillingConnectionTest : BaseTest() {
             val owned = mockk<Purchase>().apply {
                 every { purchaseState } returns PurchaseState.PURCHASED
                 every { purchaseTime } returns 1_000L
+                every { purchaseToken } returns "owned"
             }
             events.value = result(BillingResponseCode.OK) to listOf(owned)
             failures.value = result(BillingResponseCode.USER_CANCELED)

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -182,6 +182,54 @@ class BillingConnectionTest : BaseTest() {
         }
     }
 
+    @Test fun `a purchase event surfaces even before any query snapshot exists`() = runTest2 {
+        // If the initial ownership refresh failed (querySnapshot still null), a purchase completed
+        // afterwards must still reach the purchases flow (to be acked/unlocked), not be stranded until
+        // a later refresh establishes a snapshot.
+        val owned = mockk<Purchase>().apply {
+            every { purchaseState } returns PurchaseState.PURCHASED
+            every { purchaseTime } returns 1_000L
+            every { purchaseToken } returns "X"
+        }
+        val events = MutableStateFlow<Pair<BillingResult, Collection<Purchase>?>?>(
+            result(BillingResponseCode.OK) to listOf(owned),
+        )
+        val connection = BillingConnection(mockk(), events) // no refreshPurchases -> snapshot stays null
+
+        connection.purchases.first() shouldBe listOf(owned)
+    }
+
+    @Test fun `a partial refresh preserves the un-queried product type`() = runTest2 {
+        mockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        try {
+            val iap = mockk<Purchase>().apply {
+                every { purchaseState } returns PurchaseState.PURCHASED
+                every { purchaseTime } returns 1_000L
+                every { purchaseToken } returns "iap"
+            }
+            val sub = mockk<Purchase>().apply {
+                every { purchaseState } returns PurchaseState.PURCHASED
+                every { purchaseTime } returns 2_000L
+                every { purchaseToken } returns "sub"
+            }
+            val client = mockk<BillingClient>()
+            coEvery { client.queryPurchasesAsync(any<QueryPurchasesParams>()) } returnsMany listOf(
+                PurchasesResult(result(BillingResponseCode.OK), listOf(iap)),   // refresh 1 INAPP
+                PurchasesResult(result(BillingResponseCode.OK), listOf(sub)),   // refresh 1 SUBS -> full snapshot
+                PurchasesResult(result(BillingResponseCode.OK), listOf(iap)),   // refresh 2 INAPP
+                PurchasesResult(result(BillingResponseCode.ERROR), emptyList()), // refresh 2 SUBS FAILS
+            )
+            val connection = BillingConnection(client, MutableStateFlow(null))
+            connection.refreshPurchases() // snapshot = [iap, sub]
+
+            val partial = connection.refreshPurchases() // SUBS failed; the sub must not be dropped
+            partial.isComplete shouldBe false
+            partial.purchases.map { it.purchaseToken }.toSet() shouldBe setOf("iap", "sub")
+        } finally {
+            unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+
     @Test fun `a fresh snapshot supersedes a stale purchase event with the same token`() = runTest2 {
         // A subscription bought this session (renewing event) that is then cancelled: the authoritative
         // query snapshot (isAutoRenewing=false) must supersede the stale event by token, not coexist

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -103,6 +103,84 @@ class BillingConnectionTest : BaseTest() {
         }
     }
 
+    @Test fun `querySubscriptions returns the freshly queried subscriptions`() = runTest2 {
+        mockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        try {
+            val sub = mockk<Purchase>().apply {
+                every { purchaseState } returns PurchaseState.PURCHASED
+                every { purchaseTime } returns 1_000L
+                every { purchaseToken } returns "sub-a"
+            }
+            val client = mockk<BillingClient>()
+            coEvery { client.queryPurchasesAsync(any<QueryPurchasesParams>()) } returns
+                PurchasesResult(result(BillingResponseCode.OK), listOf(sub))
+            val connection = BillingConnection(client, MutableStateFlow(null))
+
+            connection.querySubscriptions() shouldBe listOf(sub)
+        } finally {
+            unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+
+    @Test fun `querySubscriptions keeps a snapshot sub a stale empty query missed`() = runTest2 {
+        // Over-block, never miss: a renewing sub already in the last snapshot must survive a transient
+        // stale-empty SUBS query so the fail-closed switch gate can't be fooled into allowing a
+        // double purchase.
+        mockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        try {
+            val subA = mockk<Purchase>().apply {
+                every { purchaseState } returns PurchaseState.PURCHASED
+                every { purchaseTime } returns 1_000L
+                every { purchaseToken } returns "A"
+            }
+            val client = mockk<BillingClient>()
+            coEvery { client.queryPurchasesAsync(any<QueryPurchasesParams>()) } returnsMany listOf(
+                PurchasesResult(result(BillingResponseCode.OK), emptyList()),   // refresh INAPP
+                PurchasesResult(result(BillingResponseCode.OK), listOf(subA)),  // refresh SUBS -> snapshot
+                PurchasesResult(result(BillingResponseCode.OK), emptyList()),   // querySubscriptions: stale empty
+            )
+            val connection = BillingConnection(client, MutableStateFlow(null))
+            connection.refreshPurchases()
+
+            connection.querySubscriptions() shouldBe listOf(subA)
+        } finally {
+            unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+
+    @Test fun `querySubscriptions lets the fresh result win over a stale snapshot entry`() = runTest2 {
+        // A sub the user just cancelled comes back from Play with isAutoRenewing=false and must
+        // overwrite the stale renewing snapshot entry (same token), so the switch can unlock.
+        mockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        try {
+            val renewing = mockk<Purchase>().apply {
+                every { purchaseState } returns PurchaseState.PURCHASED
+                every { purchaseTime } returns 1_000L
+                every { purchaseToken } returns "A"
+                every { isAutoRenewing } returns true
+            }
+            val cancelled = mockk<Purchase>().apply {
+                every { purchaseState } returns PurchaseState.PURCHASED
+                every { purchaseTime } returns 1_000L
+                every { purchaseToken } returns "A"
+                every { isAutoRenewing } returns false
+            }
+            val client = mockk<BillingClient>()
+            coEvery { client.queryPurchasesAsync(any<QueryPurchasesParams>()) } returnsMany listOf(
+                PurchasesResult(result(BillingResponseCode.OK), emptyList()),    // refresh INAPP
+                PurchasesResult(result(BillingResponseCode.OK), listOf(renewing)), // refresh SUBS -> snapshot
+                PurchasesResult(result(BillingResponseCode.OK), listOf(cancelled)), // querySubscriptions: fresh
+            )
+            val connection = BillingConnection(client, MutableStateFlow(null))
+            connection.refreshPurchases()
+
+            val result = connection.querySubscriptions()
+            result.map { it.isAutoRenewing } shouldBe listOf(false)
+        } finally {
+            unmockkStatic("com.android.billingclient.api.BillingClientKotlinKt")
+        }
+    }
+
     // The BillingFlowParams builder calls TextUtils.isEmpty, which is an unmocked Android stub in
     // plain JVM tests — give it its real behavior.
     private fun mockTextUtils() {

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeUiStateTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeUiStateTest.kt
@@ -1,0 +1,108 @@
+package eu.darken.bluemusic.upgrade.ui
+
+import com.android.billingclient.api.ProductDetails
+import eu.darken.bluemusic.upgrade.core.OurSku
+import eu.darken.bluemusic.upgrade.core.billing.SkuDetails
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class UpgradeUiStateTest : BaseTest() {
+
+    private fun iapSku(price: String = "$4.99"): SkuDetails {
+        val details = mockk<ProductDetails> {
+            every { oneTimePurchaseOfferDetails } returns mockk {
+                every { formattedPrice } returns price
+            }
+            every { subscriptionOfferDetails } returns null
+        }
+        return SkuDetails(OurSku.Iap.PRO_UPGRADE, details)
+    }
+
+    @Test fun `ownsAnything reflects iap or subscription`() {
+        Ownership().ownsAnything shouldBe false
+        Ownership(hasIap = true).ownsAnything shouldBe true
+        Ownership(subscription = SubscriptionOwnership(isAutoRenewing = true)).ownsAnything shouldBe true
+    }
+
+    @Test fun `no offers yields unavailable, disabled actions`() {
+        val loaded = toLoadedState(
+            iap = null,
+            sub = null,
+            ownership = Ownership(),
+            grace = null,
+            wasPreviouslyPro = false,
+            settled = true,
+            restoreInProgress = false,
+            verificationInProgress = false,
+        )
+        loaded.subscriptionAction shouldBe SubscriptionAction.UNAVAILABLE
+        loaded.subscriptionEnabled shouldBe false
+        loaded.iapEnabled shouldBe false
+        loaded.iapPrice shouldBe null
+    }
+
+    @Test fun `a one-time offer enables the iap action and exposes its price`() {
+        val loaded = toLoadedState(
+            iap = iapSku(),
+            sub = null,
+            ownership = Ownership(),
+            grace = null,
+            wasPreviouslyPro = false,
+            settled = true,
+            restoreInProgress = false,
+            verificationInProgress = false,
+        )
+        loaded.iapEnabled shouldBe true
+        loaded.iapPrice shouldBe "$4.99"
+    }
+
+    @Test fun `an unsettled billing layer disables the iap action`() {
+        val loaded = toLoadedState(
+            iap = iapSku(),
+            sub = null,
+            ownership = Ownership(),
+            grace = null,
+            wasPreviouslyPro = false,
+            settled = false,
+            restoreInProgress = false,
+            verificationInProgress = false,
+        )
+        loaded.iapEnabled shouldBe false
+        // Price is still surfaced even though the button is disabled.
+        loaded.iapPrice shouldBe "$4.99"
+    }
+
+    @Test fun `offer availability is independent of settle and busy state`() {
+        // Before the billing layer settles, an existing offer must still be reported as AVAILABLE
+        // (so the real button is shown, merely disabled) — never hidden behind the generic fallback.
+        val loaded = toLoadedState(
+            iap = iapSku(),
+            sub = null,
+            ownership = Ownership(),
+            grace = null,
+            wasPreviouslyPro = false,
+            settled = false,
+            restoreInProgress = true,
+            verificationInProgress = false,
+        )
+        loaded.iapAvailable shouldBe true
+        loaded.iapEnabled shouldBe false
+    }
+
+    @Test fun `owning the iap disables the iap action`() {
+        val loaded = toLoadedState(
+            iap = iapSku(),
+            sub = null,
+            ownership = Ownership(hasIap = true),
+            grace = null,
+            wasPreviouslyPro = false,
+            settled = true,
+            restoreInProgress = false,
+            verificationInProgress = false,
+        )
+        loaded.iapEnabled shouldBe false
+    }
+}

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
@@ -4,7 +4,6 @@ import com.android.billingclient.api.Purchase
 import eu.darken.bluemusic.common.navigation.NavigationController
 import eu.darken.bluemusic.upgrade.core.OurSku
 import eu.darken.bluemusic.upgrade.core.UpgradeRepoGplay
-import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.bluemusic.upgrade.core.billing.PurchasedSku
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -358,32 +357,42 @@ class UpgradeViewModelTest : BaseTest() {
         state.await().restoreInProgress shouldBe true
     }
 
-    @Test fun `play-unavailable error is emitted once despite state recombinations`() = runTest2(
+    @Test fun `both price queries failing yields the Unavailable state`() = runTest2(
         context = testDispatcher,
     ) {
         val repo = mockRepo()
         coEvery { repo.querySkus(*anyVararg()) } coAnswers {
-            delay(16_000)
+            delay(16_000) // exceeds the 15s query timeout -> null -> Unavailable
             emptyList()
-        }
-        coEvery { repo.restorePurchaseNow() } coAnswers {
-            delay(1_000)
-            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
         }
         val vm = buildVm(repo)
 
-        val errors = mutableListOf<Throwable>()
-        val errorCollector = launch { vm.errorEvents.collect { errors.add(it) } }
-        val stateCollector = launch { vm.state.collect {} }
+        val state = async {
+            vm.state.filterNotNull().filterIsInstance<UpgradeUiState.Unavailable>().first()
+        }
         advanceUntilIdle()
 
-        vm.restorePurchase()
+        state.await() // resolves only if the Unavailable state was emitted
+    }
+
+    @Test fun `onRetry re-runs the failed price query`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        var calls = 0
+        coEvery { repo.querySkus(*anyVararg()) } coAnswers {
+            calls++
+            throw RuntimeException("Play down")
+        }
+        val vm = buildVm(repo)
+
+        val collector = launch { vm.state.collect {} }
+        advanceUntilIdle()
+        val afterFirst = calls // iap + sub
+
+        vm.onRetry()
         advanceUntilIdle()
 
-        errors.filterIsInstance<GplayServiceUnavailableException>().size shouldBe 1
-
-        errorCollector.cancel()
-        stateCollector.cancel()
+        (calls > afterFirst) shouldBe true
+        collector.cancel()
     }
 
     @Test fun `restore errors surface via errorEvents not RestoreFailed`() = runTest2(

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
@@ -179,6 +179,43 @@ class UpgradeViewModelTest : BaseTest() {
         verify(exactly = 0) { repo.launchBillingFlow(any(), any(), any(), any()) }
     }
 
+    @Test fun `restore is ignored while a verification is in progress`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+            delay(5_000)
+            emptyList()
+        }
+        val vm = buildVm(repo)
+
+        vm.onGoIap(mockk(relaxed = true)) // holds the verifying guard through the SUBS check
+        advanceTimeBy(1_000)
+        vm.restorePurchase() // must be rejected while verifying
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.restorePurchaseNow() }
+    }
+
+    @Test fun `iap verification is ignored while a restore is in progress`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } coAnswers {
+            delay(5_000)
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        }
+        val vm = buildVm(repo)
+
+        vm.restorePurchase() // holds the restoring guard
+        advanceTimeBy(1_000)
+        vm.onGoIap(mockk(relaxed = true)) // must be rejected while restoring
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+        verify(exactly = 0) { repo.launchBillingFlow(any(), any(), any(), any()) }
+    }
+
     @Test fun `restore is single flight`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
         coEvery { repo.restorePurchaseNow() } coAnswers {

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
@@ -1,17 +1,22 @@
 package eu.darken.bluemusic.upgrade.ui
 
+import com.android.billingclient.api.Purchase
 import eu.darken.bluemusic.common.navigation.NavigationController
+import eu.darken.bluemusic.upgrade.core.OurSku
 import eu.darken.bluemusic.upgrade.core.UpgradeRepoGplay
 import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
+import eu.darken.bluemusic.upgrade.core.billing.PurchasedSku
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -45,14 +50,22 @@ class UpgradeViewModelTest : BaseTest() {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoGplay.Info(false, null, null))
         every { wasEverPro } returns MutableStateFlow(false)
         every { autoRestoreBusy } returns MutableStateFlow(false)
+        every { isSettled } returns MutableStateFlow(true)
+        every { lastProStateAt } returns MutableStateFlow(0L)
         coEvery { querySkus(*anyVararg()) } returns emptyList()
+        coEvery { queryCurrentSubscriptions() } returns emptyList()
     }
 
-    private fun buildVm(repo: UpgradeRepoGplay) = UpgradeViewModel(
+    private fun buildVm(repo: UpgradeRepoGplay, manage: Boolean = false) = UpgradeViewModel(
+        manage = manage,
         dispatcherProvider = TestDispatcherProvider(testDispatcher),
         navCtrl = mockk<NavigationController>(relaxed = true),
         upgradeRepo = repo,
+        webpageTool = mockk(relaxed = true),
     )
+
+    private suspend fun UpgradeViewModel.firstLoaded(): UpgradeUiState.Loaded =
+        state.filterNotNull().filterIsInstance<UpgradeUiState.Loaded>().first()
 
     @Test fun `previously pro without current entitlement raises the banner flag`() = runTest2(
         context = testDispatcher,
@@ -61,7 +74,7 @@ class UpgradeViewModelTest : BaseTest() {
         every { repo.wasEverPro } returns MutableStateFlow(true)
         val vm = buildVm(repo)
 
-        val state = async { vm.state.filterNotNull().first() }
+        val state = async { vm.firstLoaded() }
         advanceUntilIdle()
 
         state.await().wasPreviouslyPro shouldBe true
@@ -74,10 +87,96 @@ class UpgradeViewModelTest : BaseTest() {
             MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
         val vm = buildVm(repo)
 
-        val state = async { vm.state.filterNotNull().first() }
+        val state = async { vm.firstLoaded() }
         advanceUntilIdle()
 
         state.await().wasPreviouslyPro shouldBe false
+    }
+
+    @Test fun `grace stays in the quiet stage before 24h`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns
+            MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
+        // Confirmed Pro only an hour ago -> diagnostics not yet.
+        every { repo.lastProStateAt } returns MutableStateFlow(System.currentTimeMillis() - 3_600_000L)
+        val vm = buildVm(repo)
+
+        val state = async { vm.firstLoaded() }
+        advanceUntilIdle()
+
+        state.await().grace?.showDiagnostics shouldBe false
+    }
+
+    @Test fun `grace shows diagnostics after 24h`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns
+            MutableStateFlow(UpgradeRepoGplay.Info(gracePeriod = true, billingData = null))
+        // Last confirmed 25h ago.
+        every { repo.lastProStateAt } returns MutableStateFlow(System.currentTimeMillis() - 90_000_000L)
+        val vm = buildVm(repo)
+
+        val state = async { vm.firstLoaded() }
+        advanceUntilIdle()
+
+        state.await().grace?.showDiagnostics shouldBe true
+    }
+
+    @Test fun `iap gate blocks when a subscription is still renewing`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        val renewingSub = mockk<Purchase> { every { isAutoRenewing } returns true }
+        coEvery { repo.queryCurrentSubscriptions() } returns listOf(renewingSub)
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.SubscriptionStillRenewing
+        verify(exactly = 0) { repo.launchBillingFlow(any(), any(), any(), any()) }
+    }
+
+    @Test fun `iap gate launches when there is no renewing subscription`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.queryCurrentSubscriptions() } returns emptyList()
+        val vm = buildVm(repo)
+
+        vm.onGoIap(mockk(relaxed = true))
+        advanceUntilIdle()
+
+        verify(exactly = 1) { repo.launchBillingFlow(any(), OurSku.Iap.PRO_UPGRADE, null, any()) }
+    }
+
+    @Test fun `iap gate fails closed on a check timeout`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+            delay(11_000) // longer than the 10s verify timeout
+            emptyList()
+        }
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.SubscriptionCheckFailed
+        verify(exactly = 0) { repo.launchBillingFlow(any(), any(), any(), any()) }
+    }
+
+    @Test fun `iap gate fails closed on a check error`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.queryCurrentSubscriptions() } throws RuntimeException("Play down")
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.SubscriptionCheckFailed
+        verify(exactly = 0) { repo.launchBillingFlow(any(), any(), any(), any()) }
     }
 
     @Test fun `restore is single flight`() = runTest2(context = testDispatcher) {
@@ -109,6 +208,62 @@ class UpgradeViewModelTest : BaseTest() {
         coVerify(exactly = 2) { repo.restorePurchaseNow() }
     }
 
+    @Test fun `restore with an owned purchase emits RestoreSucceeded`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        val owned = mockk<UpgradeRepoGplay.Info> {
+            every { upgrades } returns listOf(mockk<PurchasedSku>())
+            every { isUpgraded } returns true
+        }
+        coEvery { repo.restorePurchaseNow() } returns owned
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreSucceeded
+    }
+
+    @Test fun `restore that only reaches grace emits RestoreFailed`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        // grace-only Info has no owned purchases.
+        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test fun `restore pads to a minimum visible duration`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        // Warm cache: answers instantly.
+        coEvery { repo.restorePurchaseNow() } returns
+            UpgradeRepoGplay.Info(gracePeriod = true, billingData = null)
+        val vm = buildVm(repo)
+
+        var fired = false
+        val collector = launch {
+            vm.events.first()
+            fired = true
+        }
+
+        vm.restorePurchase()
+        advanceTimeBy(1_000)
+        // The result event must not fire before the 1.5s min-visible pad elapses.
+        fired shouldBe false
+        advanceTimeBy(1_000)
+        fired shouldBe true
+
+        collector.cancel()
+    }
+
     @Test fun `restore that times out emits RestoreFailed and re-enables the UI`() = runTest2(
         context = testDispatcher,
     ) {
@@ -125,7 +280,6 @@ class UpgradeViewModelTest : BaseTest() {
 
         event.await() shouldBe UpgradeEvents.RestoreFailed
 
-        // The single-flight guard must have re-armed after the timeout.
         vm.restorePurchase()
         advanceUntilIdle()
         coVerify(exactly = 2) { repo.restorePurchaseNow() }
@@ -139,8 +293,10 @@ class UpgradeViewModelTest : BaseTest() {
         }
         val vm = buildVm(repo)
 
-        val states = mutableListOf<UpgradeViewModel.State>()
-        val collector = launch { vm.state.filterNotNull().collect { states.add(it) } }
+        val states = mutableListOf<UpgradeUiState.Loaded>()
+        val collector = launch {
+            vm.state.filterNotNull().filterIsInstance<UpgradeUiState.Loaded>().collect { states.add(it) }
+        }
 
         vm.restorePurchase()
         advanceTimeBy(5_000)
@@ -152,18 +308,6 @@ class UpgradeViewModelTest : BaseTest() {
         collector.cancel()
     }
 
-    @Test fun `restore with no purchase emits RestoreFailed`() = runTest2(context = testDispatcher) {
-        val repo = mockRepo()
-        coEvery { repo.restorePurchaseNow() } returns UpgradeRepoGplay.Info(false, null, null)
-        val vm = buildVm(repo)
-
-        val event = async { vm.events.first() }
-        vm.restorePurchase()
-        advanceUntilIdle()
-
-        event.await() shouldBe UpgradeEvents.RestoreFailed
-    }
-
     @Test fun `auto-restore busy state pauses the ui like a manual restore`() = runTest2(
         context = testDispatcher,
     ) {
@@ -171,7 +315,7 @@ class UpgradeViewModelTest : BaseTest() {
         every { repo.autoRestoreBusy } returns MutableStateFlow(true)
         val vm = buildVm(repo)
 
-        val state = async { vm.state.filterNotNull().first() }
+        val state = async { vm.firstLoaded() }
         advanceUntilIdle()
 
         state.await().restoreInProgress shouldBe true
@@ -181,7 +325,6 @@ class UpgradeViewModelTest : BaseTest() {
         context = testDispatcher,
     ) {
         val repo = mockRepo()
-        // Both SKU queries exceed the 15s query timeout -> "Play unavailable" episode.
         coEvery { repo.querySkus(*anyVararg()) } coAnswers {
             delay(16_000)
             emptyList()
@@ -197,7 +340,6 @@ class UpgradeViewModelTest : BaseTest() {
         val stateCollector = launch { vm.state.collect {} }
         advanceUntilIdle()
 
-        // Restore progress toggling recombines the state twice more.
         vm.restorePurchase()
         advanceUntilIdle()
 
@@ -220,7 +362,6 @@ class UpgradeViewModelTest : BaseTest() {
 
         error.await().message shouldBe "Play unavailable"
 
-        // The single-flight guard must have re-armed after the error.
         vm.restorePurchase()
         advanceUntilIdle()
         coVerify(exactly = 2) { repo.restorePurchaseNow() }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModelTest.kt
@@ -300,6 +300,29 @@ class UpgradeViewModelTest : BaseTest() {
         collector.cancel()
     }
 
+    @Test fun `a restore error still waits the minimum visible duration`() = runTest2(
+        context = testDispatcher,
+    ) {
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } throws RuntimeException("Play down")
+        val vm = buildVm(repo)
+
+        var fired = false
+        val collector = launch {
+            vm.errorEvents.first()
+            fired = true
+        }
+
+        vm.restorePurchase()
+        advanceTimeBy(1_000)
+        // The error must not surface before the 1.5s min-visible pad (previously a throw skipped it).
+        fired shouldBe false
+        advanceTimeBy(1_000)
+        fired shouldBe true
+
+        collector.cancel()
+    }
+
     @Test fun `restore that times out emits RestoreFailed and re-enables the UI`() = runTest2(
         context = testDispatcher,
     ) {


### PR DESCRIPTION
## What

Adds a Pro/supporter status screen and lets an active Google Play subscriber switch to the one-time purchase before their subscription renews — ported from SD Maid SE (#2563) and CApod (#638).

## Changes

- **Status screen**: the upgrade screen now shows your current entitlement (one-time purchase / subscription / grace period) instead of only a sales pitch. Reachable any time via a new always-visible "Pro status" row in Settings.
- **Subscription → one-time switch**: a subscriber who doesn't own the lifetime purchase gets a switch offer, unlocked once the subscription is no longer set to renew. Every one-time-purchase tap first runs a fresh, fail-closed Google Play check, so you can't be billed twice.
- **Grace period**: transient Play outages show a calm "confirming your purchase" state, escalating to diagnostics + restore after 24h.
- **FOSS**: a parallel supporter-status view.
- **Fixes folded in**: a bounded inline retry for purchase acknowledgement (an unacknowledged purchase would otherwise be auto-refunded by Play after ~3 days), and acquisition buttons no longer flicker to a generic fallback before billing settles.

## Testing

- 709 unit tests pass; both flavors build.
- Smoke-tested on a Pixel 7a: owner status view, restore flow, navigation, and the FOSS supporter view all verified on-device.

## Draft

Draft because the on-device subscription→switch and grace states need an account with an active subscription and aren't yet manually verified on-device (they are covered by unit tests). Will mark ready once those paths are exercised.
