### PR TITLE
Update app translations for 77 languages

### DIFF
--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -20,4 +20,12 @@ en meer…</string>
     <string name="upgrade_screen_sponsor_action_hint">Die alternatief is advertensies, analitiek en Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Dankie dat jy oopbron ontwikkeling ondersteun ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Al terug? Jou ondersteuning hou BVM aan die lewe!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Bekyk jou ondersteunerstatus</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Dankie vir jou ondersteuning</string>
+    <string name="upgrade_screen_supporter_status_body">Jy het alle ekstra kenmerke ontsluit deur oopbronontwikkeling te ondersteun.</string>
+    <string name="upgrade_screen_supporter_since">Ondersteuner sedert %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Besoek GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">አማራጩ ማስታወቂያዎች፣ ትንታኔዎች እና Google Play ናቸው 🙁</string>
     <string name="upgrade_screen_thanks_toast">ክፍት ምንጭ ልማትን ስለደገፉ እናመሰግናለን ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">አልበጅ ተመለሱ? የ።ቡቡ፡ ስሮት BVMን ብርህ ዘተዃል።</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">ደጋፊ ሁኔታዎን ይመልከቱ</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">ድጋፋችሁ ስለወሰዳችሁ አመሰግናለሁ</string>
+    <string name="upgrade_screen_supporter_status_body">ነጻ ምንጭ ልማትን በድጋፍ ሁሉንም ተጨማሪ ባህሪያት አንስተሳሉ።</string>
+    <string name="upgrade_screen_supporter_since">ከ%s ጀምሮ ደጋፊ</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors ይጎብኙ</string>
 </resources>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">البديل هو الإعلانات والتحليلات و Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">شكراً على دعمك لتطوير المصادر المفتوحة ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">عدت بالفعل؟ دعمك يبقي BVM حياً!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">عرض حالة الداعم الخاصة بك</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">شكرًا لدعمك</string>
+    <string name="upgrade_screen_supporter_status_body">لقد فتحت جميع الميزات الإضافية بدعمك لتطوير المصدر المفتوح.</string>
+    <string name="upgrade_screen_supporter_since">داعم منذ %s</string>
+    <string name="upgrade_screen_supporter_visit_action">زيارة GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -20,4 +20,12 @@ və daha çox…</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativ reklamlar, analitika və Google Play-dir 🙁</string>
     <string name="upgrade_screen_thanks_toast">Açıq mənbə inkişafını dəstəklədiyiniz üçün təşəkkür edirik ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Artıq qayıtdınız? Dəstəyiniz BVM-i yaşatır!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Dəstəkçi statusunuza baxın</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Dəstəyiniz üçün təşəkkürlər</string>
+    <string name="upgrade_screen_supporter_status_body">Açıq mənbə inkişafını dəstəklədiyiniz üçün bütün əlavə funksiyaların kilidini açdınız.</string>
+    <string name="upgrade_screen_supporter_since">%s tarixindən dəstəkçi</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors səhifəsinə baxın</string>
 </resources>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Альтэрнатыва - рэклама, аналітыка і Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Дзякуй за падтрымку распрацоўкі з адкрытым зыходным кодам ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Ужо задавольна? Ваша падтрымка трымае BVM ў жыцці!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Праглядзець ваш статус спонсара</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Дзякуй за вашу падтрымку</string>
+    <string name="upgrade_screen_supporter_status_body">Вы разблакіравалі ўсе дадатковыя функцыі, падтрымаўшы распрацоўку адкрытага кода.</string>
+    <string name="upgrade_screen_supporter_since">Спонсар з %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Наведаць GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Алтернативата са реклами, анализи и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Благодаря ви, че подкрепяте разработката с отворен код ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Вече се върнахте? Вашата подкрепа поддържа BVM живо!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Вижте статуса си на поддържник</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Благодарим за подкрепата</string>
+    <string name="upgrade_screen_supporter_status_body">Отключихте всички допълнителни функции, като подкрепихте разработката с отворен код.</string>
+    <string name="upgrade_screen_supporter_since">Поддържник от %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Посетете GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">বিকল্প হল বিজ্ঞাপন, বিশ্লেষণ এবং Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ওপেন সোর্স ডেভেলপমেন্ট সমর্থন করার জন্য আপনাকে ধন্যবাদ ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ইতিমধ্যে ফিরে গেলেন? আপনার সমর্থন BVM জীবিত রাখে!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">আপনার সমর্থক স্ট্যাটাস দেখুন</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">আপনার সহায়তার জন্য ধন্যবাদ</string>
+    <string name="upgrade_screen_supporter_status_body">ওপেন-সোর্স ডেভেলপমেন্টকে সহায়তা করে আপনি সমস্ত অতিরিক্ত বৈশিষ্ট্য আনলক করেছেন।</string>
+    <string name="upgrade_screen_supporter_since">%s থেকে সমর্থক</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors-এ যান</string>
 </resources>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">L\'alternativa són els anuncis, les analítiques i Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gràcies per donar suport al desenvolupament de codi obert ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Ja heu tornat? El vostre suport manté viu el BVM!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Consulteu el vostre estat de col·laborador</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Gràcies pel vostre suport</string>
+    <string name="upgrade_screen_supporter_status_body">Heu desbloquejat totes les funcions addicionals per donar suport al desenvolupament de codi obert.</string>
+    <string name="upgrade_screen_supporter_since">Col·laborador des de %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visiteu GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Alternativou jsou reklamy, analytika a Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Děkujeme vám za podporu vývoje open-source ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Už jste zpět? Vaše podpora udržuje BVM naživu!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Zobrazit stav podporovatele</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Díky za vaši podporu</string>
+    <string name="upgrade_screen_supporter_status_body">Podporou open-source vývoje jste si odemkli všechny extra funkce.</string>
+    <string name="upgrade_screen_supporter_since">Podporovatel od %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Navštívit GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -20,4 +20,12 @@ og mere…</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativet er annoncer, analyser og Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Tak, fordi du støtter open source-udvikling ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Tilbage allerede? Din støtte holder BVM i live!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Se din supporter-status</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Tak for din støtte</string>
+    <string name="upgrade_screen_supporter_status_body">Du har låst op for alle ekstra funktioner ved at støtte open source-udvikling.</string>
+    <string name="upgrade_screen_supporter_since">Supporter siden %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Besøg GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -20,4 +20,12 @@ und mehr…</string>
     <string name="upgrade_screen_sponsor_action_hint">Die Alternative sind Anzeigen, Analysen und Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Vielen Dank für Deine Unterstützung der Open-Source-Entwicklung ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Schon zurück? Deine Unterstützung hält BVM am Leben!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Deinen Unterstützerstatus ansehen</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Danke für deine Unterstützung</string>
+    <string name="upgrade_screen_supporter_status_body">Du hast alle Zusatzfunktionen freigeschaltet, indem du die Open-Source-Entwicklung unterstützt hast.</string>
+    <string name="upgrade_screen_supporter_since">Unterstützer seit %s</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors besuchen</string>
 </resources>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Η εναλλακτική λύση είναι οι διαφημίσεις, τα αναλυτικά και το Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Σας ευχαριστούμε που υποστηρίζετε την ανάπτυξη ανοιχτού κώδικα ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Ήρθες πίσω τόσο γρήγορα; Η υποστήριξή σου κρατάει το BVM ζωντανό!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Δες την κατάσταση υποστηρικτή σου</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Ευχαριστούμε για την υποστήριξή σου</string>
+    <string name="upgrade_screen_supporter_status_body">Ξεκλείδωσες όλα τα επιπλέον χαρακτηριστικά υποστηρίζοντας την ανάπτυξη ανοιχτού κώδικα.</string>
+    <string name="upgrade_screen_supporter_since">Υποστηρικτής από %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Επισκέψου το GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-eo-rUY/strings.xml
+++ b/app/src/foss/res/values-eo-rUY/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">La alternativo estas reklamoj, analizoj kaj Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Dankon pro subteno de malfermita kodo ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Jam reen? Via subteno konservas BVM viva!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Vidu vian subtenantan staton</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Dankon pro via subteno</string>
+    <string name="upgrade_screen_supporter_status_body">Vi malŝlosis ĉiujn aldonajn funkciojn per subteno de malfermitkoda programado.</string>
+    <string name="upgrade_screen_supporter_since">Subtenanto ekde %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Vizitu GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Las alternativas son anuncios, analíticas y Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo de código abierto ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">¿Ya te vas? ¡Tu apoyo mantiene vivo a BVM!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Mirá tu estado de colaborador</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Gracias por tu apoyo</string>
+    <string name="upgrade_screen_supporter_status_body">Desbloqueaste todas las funciones extra al apoyar el desarrollo de código abierto.</string>
+    <string name="upgrade_screen_supporter_since">Colaborador desde %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visitar GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">La alternativa son los anuncios, las analíticas y Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo libre ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">¿Ya te vas? ¡Tu apoyo mantiene vivo a BVM!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Consulta tu estado de colaborador</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Gracias por tu apoyo</string>
+    <string name="upgrade_screen_supporter_status_body">Desbloqueaste todas las funciones adicionales al apoyar el desarrollo de código abierto.</string>
+    <string name="upgrade_screen_supporter_since">Colaborador desde %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visita GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">La alternativa son los anuncios, las analíticas y Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo del código abierto ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">¿Ya de vuelta? ¡Tu apoyo mantiene BVM vivo!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Consulta tu estado de colaborador</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Gracias por tu apoyo</string>
+    <string name="upgrade_screen_supporter_status_body">Has desbloqueado todas las funciones adicionales al apoyar el desarrollo de código abierto.</string>
+    <string name="upgrade_screen_supporter_since">Colaborador desde %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visita GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -20,4 +20,12 @@ ja veel…</string>
     <string name="upgrade_screen_sponsor_action_hint">Teiseks võimaluseks on reklaamid, analüüs ja Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Aitäh, et toetate avatud lähtekoodiga arendamist ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Juba tagasi? Sinu toetus hoiab BVM elus!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Vaata oma toetaja staatust</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Täname toetuse eest</string>
+    <string name="upgrade_screen_supporter_status_body">Oled avanud kõik lisafunktsioonid, toetades avatud lähtekoodiga arendust.</string>
+    <string name="upgrade_screen_supporter_since">Toetaja alates %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Ava GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Alternatiboa iragarkinak, analisiak eta Google Play dira 🙁</string>
     <string name="upgrade_screen_thanks_toast">Eskerrik asko iturburu irekiko garapena babesten duzulako ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Itzuli al zara jada? Zure laguntzak BVM bizirik mantentzen du!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Ikusi zure laguntzaile-egoera</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Eskerrik asko zure laguntzagatik</string>
+    <string name="upgrade_screen_supporter_status_body">Ezaugarri gehigarri guztiak desblokeatu dituzu iturburu irekiko garapena babestuz.</string>
+    <string name="upgrade_screen_supporter_since">Laguntzaile %s(e)tik</string>
+    <string name="upgrade_screen_supporter_visit_action">Bisitatu GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">جایگزین تبلیغات، تجزیه و تحلیل و Google Play 🙁 هستند</string>
     <string name="upgrade_screen_thanks_toast">از شما برای حمایت از توسعه منبع باز سپاسگزاریم ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">زود بازگشتی؟ حمایت شما BVM را زنده نگه می‌دارد!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">وضعیت حامی خود را مشاهده کنید</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">با تشکر از حمایت شما</string>
+    <string name="upgrade_screen_supporter_status_body">با حمایت از توسعه متن‌باز، تمام امکانات اضافی را باز کرده‌اید.</string>
+    <string name="upgrade_screen_supporter_since">حامی از %s</string>
+    <string name="upgrade_screen_supporter_visit_action">بازدید از GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -20,4 +20,12 @@ ja paljon muuta…</string>
     <string name="upgrade_screen_sponsor_action_hint">Vaihtoehto on mainokset, analytiikka ja Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Kiitos avoimen lähdekoodin kehityksen tukemisesta ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Palasit jo? Tukesi pitää BVM:n hengissä!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Katso tukijatilasi</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Kiitos tuestasi</string>
+    <string name="upgrade_screen_supporter_status_body">Olet avannut kaikki lisäominaisuudet tukemalla avoimen lähdekoodin kehitystä.</string>
+    <string name="upgrade_screen_supporter_since">Tukija %s alkaen</string>
+    <string name="upgrade_screen_supporter_visit_action">Vieraile GitHub Sponsorsissa</string>
 </resources>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -20,4 +20,12 @@ at marami pa…</string>
     <string name="upgrade_screen_sponsor_action_hint">Ang alternative ay ads, analytics at Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Salamat sa pagsuporta sa open-source development ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Bumalik na agad? Ang iyong suporta ay nagpapanatiling buhay ang BVM!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Tingnan ang iyong supporter status</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Salamat sa iyong suporta</string>
+    <string name="upgrade_screen_supporter_status_body">Na-unlock mo na ang lahat ng extra na feature sa pagsuporta sa open-source development.</string>
+    <string name="upgrade_screen_supporter_since">Supporter simula %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Bisitahin ang GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -20,4 +20,12 @@ et plus…</string>
     <string name="upgrade_screen_sponsor_action_hint">L’alternative est des publicités, des analyses et Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Merci de soutenir le développement libre ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Déjà de retour ? Votre soutien maintient BVM en vie !</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Consultez votre statut de contributeur</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Merci pour votre soutien</string>
+    <string name="upgrade_screen_supporter_status_body">Vous avez débloqué toutes les fonctionnalités supplémentaires en soutenant le développement open source.</string>
+    <string name="upgrade_screen_supporter_since">Contributeur depuis %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visitez GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -20,4 +20,12 @@ e moito máis…</string>
     <string name="upgrade_screen_sponsor_action_hint">A alternativa son anuncios, análises e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Grazas por apoiar o desenvolvemento de código aberto ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">¿Xa de volta? O teu apoio mantén BVM vivo!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Ver o teu estado de colaborador</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Grazas polo teu apoio</string>
+    <string name="upgrade_screen_supporter_status_body">Desbloqueaches todas as funcións extra por apoiar o desenvolvemento de código aberto.</string>
+    <string name="upgrade_screen_supporter_since">Colaborador desde %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visitar GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">विज्ञापन, एनालिटिक्स और गूगल प्ले ये सभी वैकल्पिक है🙁</string>
     <string name="upgrade_screen_thanks_toast">ओपन-सोर्स विकास ❤️ का समर्थन करने के लिए धन्यवाद</string>
     <string name="upgrade_screen_sponsor_too_fast">वापस आ गए? आपका सहयोग BVM को जीवित रखता है!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">अपनी समर्थक स्थिति देखें</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">आपके समर्थन के लिए धन्यवाद</string>
+    <string name="upgrade_screen_supporter_status_body">ओपन-सोर्स विकास का समर्थन करके आपने सभी अतिरिक्त सुविधाएं अनलॉक कर ली हैं।</string>
+    <string name="upgrade_screen_supporter_since">%s से समर्थक</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors पर जाएं</string>
 </resources>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -20,4 +20,12 @@ i još mnogo toga…</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativa su oglasi, analitika i Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Hvala vam što podržavate razvoj otvorenog koda ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Već se vraćate? Vaša podrška održava BVM živim!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Pogledajte svoj status podupiratelja</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Hvala na podršci</string>
+    <string name="upgrade_screen_supporter_status_body">Otključali ste sve dodatne značajke podržavajući razvoj otvorenog koda.</string>
+    <string name="upgrade_screen_supporter_since">Podupiratelj od %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Posjetite GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Az alternatívák a hirdetések, az elemzések és a Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Köszönjük, hogy támogatod a nyílt forráskódú fejlesztést ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Már vissza is tértél? A támogatásod életben tartja a BVM-et!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Támogatói állapotod megtekintése</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Köszönjük a támogatásod</string>
+    <string name="upgrade_screen_supporter_status_body">A nyílt forráskódú fejlesztés támogatásával feloldottad az összes extra funkciót.</string>
+    <string name="upgrade_screen_supporter_since">Támogató %s óta</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors megtekintése</string>
 </resources>

--- a/app/src/foss/res/values-hy-rAM/strings.xml
+++ b/app/src/foss/res/values-hy-rAM/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Այլընտրանքը գովազդներն են, վերլուծությունը և Google Play-ը 🙁</string>
     <string name="upgrade_screen_thanks_toast">Շնորհակալություն բաց կոդով զարգացումը աջակցելու համար ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Արդեն հետ եք՞ Դզեր աժակցությունը կենդանի ե BVM ապրելում։</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Դիտեք ձեր աջակցողի կարգավիճակը</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Շնորհակալություն ձեր աջակցության համար</string>
+    <string name="upgrade_screen_supporter_status_body">Բացել եք բոլոր լրացուցիչ հնարավորությունները՝ աջակցելով բաց կոդով զարգացմանը։</string>
+    <string name="upgrade_screen_supporter_since">Աջակցող՝ %s-ից</string>
+    <string name="upgrade_screen_supporter_visit_action">Այցելեք GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Alternatifnya adalah iklan, analitik, dan Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Terima kasih karena telah mendukung pengembangan sumber terbuka ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Sudah balik? Dukunganmu membuat BVM tetap hidup!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Lihat status pendukung Anda</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Terima kasih atas dukungan Anda</string>
+    <string name="upgrade_screen_supporter_status_body">Anda telah membuka semua fitur tambahan dengan mendukung pengembangan open-source.</string>
+    <string name="upgrade_screen_supporter_since">Pendukung sejak %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Kunjungi GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Valkosturinn eru auglýsingar, greiningar og Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Takk fyrir að styðja opna hugbúnaðarþróun ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Kominn aftur strax? Stuðningur þinn heldur BVM lifandi!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Skoða stuðningsstöðu þína</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Takk fyrir stuðninginn</string>
+    <string name="upgrade_screen_supporter_status_body">Þú hefur opnað alla aukaeiginleika með því að styðja þróun opins hugbúnaðar.</string>
+    <string name="upgrade_screen_supporter_since">Stuðningsaðili síðan %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Heimsækja GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -20,4 +20,12 @@ e altro ancora…</string>
     <string name="upgrade_screen_sponsor_action_hint">L\'alternativa sono annunci, analytics e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Grazie per aver supportato lo sviluppo open-source ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Già di ritorno? Il tuo supporto mantiene BVM in vita!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Visualizza il tuo stato di sostenitore</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Grazie per il tuo supporto</string>
+    <string name="upgrade_screen_supporter_status_body">Hai sbloccato tutte le funzionalità extra sostenendo lo sviluppo open-source.</string>
+    <string name="upgrade_screen_supporter_since">Sostenitore dal %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visita GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">האלטרנטיבה הן מודעות, אנליטיקס ו-Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">תודה שתמכת בפיתוח קוד פתוח ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">חזרת כבר? התמיכה שלך שומרת על BVM בחיים!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">הצגת סטטוס התומך שלכם</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">תודה על התמיכה שלכם</string>
+    <string name="upgrade_screen_supporter_status_body">פתחתם את כל התכונות הנוספות בזכות התמיכה בפיתוח קוד פתוח.</string>
+    <string name="upgrade_screen_supporter_since">תומכים מאז %s</string>
+    <string name="upgrade_screen_supporter_visit_action">בקרו ב-GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">代替は広告や分析そしてGoogle Playになります</string>
     <string name="upgrade_screen_thanks_toast">オープンソースでの開発に協力してくれてありがとうございます ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">もう戻ってきた？あなたのサポートが BVM を支えています！</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">サポーターステータスを確認</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">ご支援ありがとうございます</string>
+    <string name="upgrade_screen_supporter_status_body">オープンソース開発を支援することで、すべての追加機能をアンロックしました。</string>
+    <string name="upgrade_screen_supporter_since">%sからサポーター</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsorsにアクセス</string>
 </resources>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">ალტერნატივა არის რეკლამა, ანალიტიკა და Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">გმადლობთ ღია კოდის განვითარების მხარდაჭერისთვის ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">უკვე დაბრუნდით? თქვენი მხარდაძერება BVM-ს სიცოცხლეს!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">იხილეთ თქვენი მხარდამჭერის სტატუსი</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">მადლობა მხარდაჭერისთვის</string>
+    <string name="upgrade_screen_supporter_status_body">ღია კოდის განვითარების მხარდაჭერით გახსენთ ყველა დამატებითი ფუნქცია.</string>
+    <string name="upgrade_screen_supporter_since">მხარდაჭერი %s-დან</string>
+    <string name="upgrade_screen_supporter_visit_action">ეწვიეთ GitHub Sponsors-ს</string>
 </resources>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">ជម្រើសផ្សេងគឺការផ្សាយពាណិជ្ជកម្ម ការវិភាគ និង Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">សូមអរគុណសម្រាប់ការគាំទ្រការអភិវឌ្ឍន៍ប្រភពបើកចំហ ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ត្រឡប់ក្រោយរួចហើយ? ការគាំទ្ររបស់អ្នកជួយរក្សា BVM ឱ្យដំណើរការ!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">មើលស្ថានភាពអ្នកគាំទ្ររបស់អ្នក</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">សូមអរគុណសម្រាប់ការគាំទ្ររបស់អ្នក</string>
+    <string name="upgrade_screen_supporter_status_body">អ្នកបានដោះសោលក្ខណៈពិសេសបន្ថែមទាំងអស់ ដោយការគាំទ្រការអភិវឌ្ឍន៍កូដបើកចំហា។</string>
+    <string name="upgrade_screen_supporter_since">អ្នកគាំទ្រតាំងពី %s</string>
+    <string name="upgrade_screen_supporter_visit_action">ចូលមើល GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-kmr-rTR/strings.xml
+++ b/app/src/foss/res/values-kmr-rTR/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Alternatif reklam, analitik û Google Play ye</string>
     <string name="upgrade_screen_thanks_toast">Spas ji bo pishtgiriya çavkaniya vekirî</string>
     <string name="upgrade_screen_sponsor_too_fast">Vegeriyaye? Pishtgiriya te BVM zindî dihêle!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Statûya piştgirêrê xwe bibînin</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Spasî li piştgirîya we</string>
+    <string name="upgrade_screen_supporter_status_body">We bi piştgirî dan pêşevekiriya çavkanîya vekirî hemû taybetmendiyên zêde tê destxistîn.</string>
+    <string name="upgrade_screen_supporter_since">Piştgirêr ji %s û vir ve</string>
+    <string name="upgrade_screen_supporter_visit_action">Biçin GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-kn-rIN/strings.xml
+++ b/app/src/foss/res/values-kn-rIN/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">ಪರ್ಯಾಯ ಜಾಹೀರಾತುಗಳು, ವಿಶ್ಲೇಷಣೆ ಮತ್ತು Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ಓಪನ್-ಸೋರ್ಸ್ ಅಭಿವರ್ಧನೆಗೆ ಬೆಂಬಲಿಸಿದ್ದಕ್ಕೆ ಧನ್ಯವಾದಗಳು ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ಇಷ್ಟು ಬೇಗನೇ ಹಿಂದೆ? ನಿಮ್ಮ ಬೆಂಬಲು BVM ಅನ್ನು ಬಳಿಯಾಗಿಸುತ್ತದೆ!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">ನಿಮ್ಮ ಬೆಂಬಲಕಾರ ಸ್ಥಿತಿಯನ್ನು ವೀಕ್ಷಿಸಿ</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">ನಿಮ್ಮ ಬೆಂಬಲಕ್ಕಾಗಿ ಧನ್ಯವಾದ</string>
+    <string name="upgrade_screen_supporter_status_body">ನೀವು ಓಪನ್-ಸೋರ್ಸ್ ಅಭಿವೃದ್ಧಿಯನ್ನು ಬೆಂಬಲಿಸುವ ಮೂಲಕ ಎಲ್ಲಾ ಹೆಚ್ಚುವರಿ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಅನ್‌ಲಾಕ್ ಮಾಡಿದ್ದೀರಿ.</string>
+    <string name="upgrade_screen_supporter_since">%s ಇಂದ ಬೆಂಬಲಕಾರ</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors ಭೇಟಿ ಮಾಡಿ</string>
 </resources>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">다른 방식은 광고, 데이터 수집, 그리고 플레이 스토어입니다 🙁</string>
     <string name="upgrade_screen_thanks_toast">오픈소스 개발을 지원해주셔서 감사합니다 ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">벌써 돌아오셨군요? 여러분의 지원이 BVM을 살아있게 합니다!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">후원자 상태 보기</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">성원에 감사드립니다</string>
+    <string name="upgrade_screen_supporter_status_body">오픈소스 개발을 지원해 주셔서 모든 추가 기능이 잠금 해제되었습니다.</string>
+    <string name="upgrade_screen_supporter_since">%s부터 후원자</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors 방문</string>
 </resources>

--- a/app/src/foss/res/values-ky-rKG/strings.xml
+++ b/app/src/foss/res/values-ky-rKG/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Альтернатив жарнамалар, аналитика жана Google Play болот 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ачык код ишкерленишти колдоодогунуңуз үчүн рахмат ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Альдынан кайтып келдиңизби? Сиздин колдоо БВМди жашат устайт!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Колдоочу статусун көрүңүз</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Колдооңуз үчүн рахмат</string>
+    <string name="upgrade_screen_supporter_status_body">Ачык коддуу чулууну колдоо аркылуу сиз бардык кошумча функцияларды ачтыңыз.</string>
+    <string name="upgrade_screen_supporter_since">%s дан бери колдоочу</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsorsга барыңыз</string>
 </resources>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">ທາງເລືອກແມ່ນໂຄສະນາ, ການວິເຄາະ ແລະ Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ຂອບໃຈສໍາລັບການສະໜັບສະໜູນການພັດທະນາແຫຼ່ງເປີດ ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ກັບມາແລ້ວຫຣືອ? ການສນັບສນຸນຂອງທ່ານບຳຣຸງ BVM ໄດ້!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">ເບິ່ງສະຖານະຜູ້ສະໝັບສະໝູນຂອງທ່ານ</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">ຂອບໃຈສຳລັບການສະໝັບສະໝູນຂອງທ່ານ</string>
+    <string name="upgrade_screen_supporter_status_body">ທ່ານໄດ້ປົດລັອກຄຸນສົມບັດພິເສດທັງໝົດໂດຍການສະໝັບສະໝູນການພັດທະນາລະໝັດເປີດ.</string>
+    <string name="upgrade_screen_supporter_since">ຜູ້ສະໝັບສະໝູນຕັ້ງແຕ່ %s</string>
+    <string name="upgrade_screen_supporter_visit_action">ໄປທີ່ GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -20,4 +20,12 @@ ir daugiau…</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatyva yra reklamos, analitika ir Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ačiū, kad remiате atvirojo kodo plėtrą ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Jau grįžote? Jūsų parama palaiko BVM gyvą!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Peržiūrėkite savo rėmėjo būseną</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Dėkojame už paramą</string>
+    <string name="upgrade_screen_supporter_status_body">Atrakinote visas papildomas funkcijas remdami atvirojo kodo kūrimą.</string>
+    <string name="upgrade_screen_supporter_since">Rėmėjas nuo %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Apsilankykite „GitHub Sponsors“</string>
 </resources>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Alternatīva ir reklāmas, analītika un Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Paldies par atklātā koda attīstības atbalstīšanu ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Jau atpakaļ? Jūsu atbalsts uztur BSP dzīvu!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Skatīt savu atbalstītāja statusu</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Paldies par atbalstu</string>
+    <string name="upgrade_screen_supporter_status_body">Tu esi atbloķējis visas papildu funkcijas, atbalstot atvērtā koda izstrādi.</string>
+    <string name="upgrade_screen_supporter_since">Atbalstītājs kopš %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Apmeklēt GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Алтернативата се реклами, аналитика и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ви благодариме што го поддржувате развојот на отворен код ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Веќе се вратија? Вашата поддршка го одржува BVM на живот!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Погледнете го вашиот статус на поддржувач</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Ви благодариме за поддршката</string>
+    <string name="upgrade_screen_supporter_status_body">Ги отклучивте сите додатни функции со поддржување на развојот со отворен код.</string>
+    <string name="upgrade_screen_supporter_since">Поддржувач од %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Посетете GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">പരസ്യങ്ങൾ, അനലിറ്റിക്‌സ്, ഗൂഗിൾ പ്ലേ എന്നിവയാണ് ബദൽ🙁</string>
     <string name="upgrade_screen_thanks_toast">ഓപ്പൺ സോഴ്‌സ് വികസനത്തെ പിന്തുണച്ചതിന് നന്ദി ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ഇത്രയും വേഗം പിന്തിരിച്ചു? നിങ്ങളുടെ പിന്തുണ BVM നിലനിർത്തുന്നു!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">നിങ്ങളുടെ സപ്പോർടർ സ്റ്റാറ്റസ് കാണുക</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">നിങ്ങളുടെ പിന്തുണയ്ക്കുള്ള നന്ദി</string>
+    <string name="upgrade_screen_supporter_status_body">തുറന്ന സോഴ്സ് വികസനത്തെ പിന്തുണച്ച് നിങ്ങൾ എല്ലാ അധിക സവിശേഷതകളും അൻലോക്ക് ചെയ്തിരിക്കുന്നു.</string>
+    <string name="upgrade_screen_supporter_since">%s മുതൽ സപ്പോർടർ</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors സന്ദർശിക്കുക</string>
 </resources>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Өөр сонголт бол зар сурталчилгаа, шинжилгээ, Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Нээлттэй эхийн хөгжлийг дэмжсэнд баярлалаа ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Аль буцлаа вүү? Таны дэмжләлт BVM-иг амьд байлгадаг!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Дэмжигчийн статусаа үзэх</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Таны дэмжлэгт баярлалаа</string>
+    <string name="upgrade_screen_supporter_status_body">Та нээлттэй эхийн хөгжүүлэлтийг дэмжсэнээр бүх нэмэлт функцийг нээсэн байна.</string>
+    <string name="upgrade_screen_supporter_since">%s-ээс дэмжигч</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub спонсорыг зочилох</string>
 </resources>

--- a/app/src/foss/res/values-mr-rIN/strings.xml
+++ b/app/src/foss/res/values-mr-rIN/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">पर्याय म्हणजे अॅड, अॅनालिटिक्स आणि Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ओपन-सोर्स विकासाला पाठिंबा दिल्याबद्दल धन्यवाद ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">आधीच माघारी? तुमच्या सहयोगाने BVM जिवंत राहते!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">आपली समर्थक स्थिती पहा</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">आपल्या समर्थनाबद्दल धन्यवाद</string>
+    <string name="upgrade_screen_supporter_status_body">ओपन-सोर्स विकासाला समर्थन देऊन आपण सर्व अतिरिक्त वैशिष्ट्ये अनलॉक केली आहेत.</string>
+    <string name="upgrade_screen_supporter_since">%s पासून समर्थक</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors ला भेट द्या</string>
 </resources>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -20,4 +20,12 @@ dan banyak lagi…</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatifnya ialah iklan, analitik dan Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Terima kasih kerana menyokong pembangunan sumber terbuka ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Dah balik? Sokongan anda menghidupkan BVM!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Lihat status penyokong anda</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Terima kasih atas sokongan anda</string>
+    <string name="upgrade_screen_supporter_status_body">Anda telah membuka semua ciri tambahan dengan menyokong pembangunan sumber terbuka.</string>
+    <string name="upgrade_screen_supporter_since">Penyokong sejak %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Lawati GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">အခြားရွေးချယ်စရာမှာ ကြော်ငြာများ၊ ခွဲခြမ်းစိတ်ဖြာခြင်းနှင့် Google Play တို့ဖြစ်သည် 🙁</string>
     <string name="upgrade_screen_thanks_toast">ပွင့်လင်းရင်းမြစ် ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးပေးသည့်အတွက် ကျေးဇူးတင်ပါသည် ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ပြန်ရောက်လာပြီးလား? သင့၏ ထောက်ပံ့ထားမှုသည် BVM ကို ရှင်သနသောဆီပါ!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">သင်၏တောက်ခံသူအဆင့်ကိုကြည့်ရှုပါ</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">သင်၏တောက်ခံမှုအတွက်ကျေးဇူးတင်ပါသည်</string>
+    <string name="upgrade_screen_supporter_status_body">သင်သည် အဖွင့်အရင်းအမြစ်ဆော့ဝဲလ်တီထွင်မှုကို တောက်ခံခြင်းဖြင့် အပိုင်းအခြင်းအားလုံး ဖွင့်လှစ်ခဲ့ပါပြီ။</string>
+    <string name="upgrade_screen_supporter_since">%s မှစျ်လ် အတောက်အပံပေးသူ</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors သွားကြည့်ပါ</string>
 </resources>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">विकल्प विज्ञापन, विश्लेषण र Google Play हुन् 🙁</string>
     <string name="upgrade_screen_thanks_toast">खुला स्रोत विकासलाई समर्थन गरेकोमा धन्यवाद ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">फेरि फर्किए? तपाईंको सहयोगले BVM जिवित राख्छ!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">आफ्नो समर्थक स्थिति हेर्नुहोस्</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">तपाईंको समर्थनको लागि धन्यवाद</string>
+    <string name="upgrade_screen_supporter_status_body">तपाईंले खुला-स्रोत विकास समर्थन गरेर सबै अतिरिक्त सुविधाहरू अनलक गर्नुभएको छ।</string>
+    <string name="upgrade_screen_supporter_since">%s देखि समर्थक</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors भेट्नुहोस्</string>
 </resources>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -20,4 +20,12 @@ en meer…</string>
     <string name="upgrade_screen_sponsor_action_hint">Het alternatief zijn advertenties, analyses en Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Bedankt voor het ondersteunen van open-sourceontwikkeling ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Al terug? Jouw steun houdt BVM levend!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Bekijk je ondersteunersstatus</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Bedankt voor je ondersteuning</string>
+    <string name="upgrade_screen_supporter_status_body">Je hebt alle extra functies ontgrendeld door open-source-ontwikkeling te ondersteunen.</string>
+    <string name="upgrade_screen_supporter_since">Supporter sinds %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Bezoek GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-no/strings.xml
+++ b/app/src/foss/res/values-no/strings.xml
@@ -20,4 +20,12 @@ og mer…</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativet er annonser, analyser og Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Takk for at du støtter utviklingen som har åpen kildekode ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Tilbake allerede? Din støtte holder BVM i live!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Se din støtterstatus</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Takk for din støtte</string>
+    <string name="upgrade_screen_supporter_status_body">Du har låst opp alle ekstrafunksjoner ved å støtte utvikling av åpen kildekode.</string>
+    <string name="upgrade_screen_supporter_since">Støtter siden %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Besøk GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-pcm-rNG/strings.xml
+++ b/app/src/foss/res/values-pcm-rNG/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Di alternative na ads, analytics and Google Play</string>
     <string name="upgrade_screen_thanks_toast">Thank you for supporting open-source development</string>
     <string name="upgrade_screen_sponsor_too_fast">You don come back? Your support dey keep BVM alive!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">See your supporter status</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Thank you for your support</string>
+    <string name="upgrade_screen_supporter_status_body">You don unlock all extra features because you support open-source development.</string>
+    <string name="upgrade_screen_supporter_since">Supporter since %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visit GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -20,4 +20,12 @@ i więcej…</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatywą są reklamy, analityka i Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Dziękuję za wsparcie rozwoju oprogramowania otwarto źródłowego❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Już wróciłeś? Twoje wsparcie utrzymuje BVM przy życiu!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Zobacz status swojego wsparcia</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Dziękujemy za wsparcie</string>
+    <string name="upgrade_screen_supporter_status_body">Odblokowałeś wszystkie dodatkowe funkcje dzięki wsparciu rozwoju open source.</string>
+    <string name="upgrade_screen_supporter_since">Wspierający od %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Odwiedź GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -20,4 +20,12 @@ e muito mais…</string>
     <string name="upgrade_screen_sponsor_action_hint">A alternativa são anúncios, análises e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Obrigado por apoiar o desenvolvimento de código aberto ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Voltou tão rápido? Seu apoio mantém o BVM vivo!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Visualizar seu status de apoiador</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Obrigado pelo seu apoio</string>
+    <string name="upgrade_screen_supporter_status_body">Você desbloqueou todos os recursos extras ao apoiar o desenvolvimento de código aberto.</string>
+    <string name="upgrade_screen_supporter_since">Apoiador desde %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visite GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -20,4 +20,12 @@ e mais…</string>
     <string name="upgrade_screen_sponsor_action_hint">A alternativa são anúncios, análises e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Obrigado por apoiar o desenvolvimento de código aberto ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Já voltou? O seu apoio mantém o BVM vivo!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Ver o teu estado de apoiante</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Obrigado pelo teu apoio</string>
+    <string name="upgrade_screen_supporter_status_body">Desbloqueaste todas as funcionalidades extra ao apoiares o desenvolvimento open-source.</string>
+    <string name="upgrade_screen_supporter_since">Apoiante desde %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visitar GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-rm/strings.xml
+++ b/app/src/foss/res/values-rm/strings.xml
@@ -20,4 +20,12 @@ e dapli…</string>
     <string name="upgrade_screen_sponsor_action_hint">L\'alternativa è reclamas, analytics e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Grazia per sustegnair il svilup open-source ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Turnà? Tia sustegnaziun mantegna BVM viv!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Mira tia status da supporter</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Grazia per tia sapport</string>
+    <string name="upgrade_screen_supporter_status_body">Tu has debloccà totas las funczias extras perquai che tu supporter il svilup da software open-source.</string>
+    <string name="upgrade_screen_supporter_since">Supporter dapi %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visita GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">O alternativă sunt reclamele, analizele și Google Play🙁</string>
     <string name="upgrade_screen_thanks_toast">Mulțumesc că îmi suporți această dezvoltare open-source❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Ai revenit deja? Sprijinul tău menține BVM în viață!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Verifică starea ta de suporter</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Mulțumim pentru sprijinul tău</string>
+    <string name="upgrade_screen_supporter_status_body">Ai deblocat toate funcțiile extra sprijinind dezvoltarea open-source.</string>
+    <string name="upgrade_screen_supporter_since">Suporter de la %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Vizitează GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Альтернатива — реклама, аналитика и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Спасибо за поддержку разработки с открытым исходным кодом ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Уже вернулись? Ваша поддержка помогает BVM жить!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Посмотреть статус поддержки</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Спасибо за вашу поддержку</string>
+    <string name="upgrade_screen_supporter_status_body">Вы разблокировали все дополнительные функции, поддержав разработку open-source проекта.</string>
+    <string name="upgrade_screen_supporter_since">Поддерживает с %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Открыть GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -20,4 +20,12 @@ e àteru…</string>
     <string name="upgrade_screen_sponsor_action_hint">S\'alternativa sunt sa pubblicidade, s\'anàlisi e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gràtzias pro sustènnere s\'isvilupu de còdighe abertu ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Giai torradu? Su sustegnu tuo mantenat BVM in vida!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Bili su tuo istadu de suportador</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Grazie pro tuo suportu</string>
+    <string name="upgrade_screen_supporter_status_body">Has desbloccadu totu sas funzionalidades extras suportande su sviluppu open-source.</string>
+    <string name="upgrade_screen_supporter_since">Suportador dae %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Visita GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">විකල්පය දැන්වීම්, විශ්ලේෂණ සහ Google Play වේ 🙁</string>
     <string name="upgrade_screen_thanks_toast">විවෘත මූලාශ්‍ර සංවර්ධනයට සහාය දීම ගැන ස්තූතියි ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">මදින්ම පැරලි? ඔබේ සහාය BVM ජීවත් වෙයි!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">ඔබගේ සහායක තත්වය බලන්න</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">ඔබගේ සහයොගයට ස්තුතිවන්තයි</string>
+    <string name="upgrade_screen_supporter_status_body">ඔබ විවර්තන-මූලාශ්‍ර සංවර්ධනයට සහය දැක්වීමෙන් සියලු අතිරේක විශේෂාග අවත් කළ හැකි වී.</string>
+    <string name="upgrade_screen_supporter_since">%s සිට සහායක</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors බලන්න</string>
 </resources>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -20,4 +20,12 @@ a viac…</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatívou sú reklamy, analytika a Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ďakujem za podporu vývoja open-source ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Už späť? Vaša podpora udržiava BVM nažive!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Zobraziť svoj stav podporovateľa</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Ďakujeme za vašu podporu</string>
+    <string name="upgrade_screen_supporter_status_body">Odomkli ste všetky extra funkcie podporou vývoja otvoreného zdrojového kódu.</string>
+    <string name="upgrade_screen_supporter_since">Podporovateľ od %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Navštívte GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Druga možnost so oglasi, analitika in Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Hvala za podporo odprtokodnemu razvoju ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Že nazaj? Vaša podpora ohranja BVM pri življenju!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Oglejte si status podpornika</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Hvala za vašo podporo</string>
+    <string name="upgrade_screen_supporter_status_body">Odklenili ste vse dodatne funkcije s podporo razvoju odprtokodnega programja.</string>
+    <string name="upgrade_screen_supporter_since">Podpornik od %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Obiščite GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -20,4 +20,12 @@ dhe më shumë…</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativa janë reklamat, analitika dhe Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Faleminderit për mbështetjen e zhvillimit me burim të hapur ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Kthehesh tashmë? Mbështetja juaj e mban BVM gjallë!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Shikoni statusin e mbështetësit tuaj</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Faleminderit për mbështetjen tuaj</string>
+    <string name="upgrade_screen_supporter_status_body">Ju keni shkyçur të gjitha veçoritë shtesë duke mbështetur zhvillimin e burimit të hapur.</string>
+    <string name="upgrade_screen_supporter_since">Mbështetës që nga %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Vizitoni GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Алтернатива су рекламе, аналитика и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Хвала вам што подржавате развој отвореног кода ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Већ одлазиш? Твоја подршка одржава BVM живим!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Прегледајте статус подржавача</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Хвала на подршци</string>
+    <string name="upgrade_screen_supporter_status_body">Откључали сте све додатне функције подржавањем развоја отвореног кода.</string>
+    <string name="upgrade_screen_supporter_since">Подржавач од %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Посетите GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -20,4 +20,12 @@ och mer…</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativet är annonser, analys och Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Tack för att du stöder utveckling med öppen källkod ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Tillbaka redan? Ditt stöd håller BVM vid liv!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Visa din stödjestatus</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Tack för ditt stöd</string>
+    <string name="upgrade_screen_supporter_status_body">Du har låst upp alla extra funktioner genom att stödja utveckling av öppen källkod.</string>
+    <string name="upgrade_screen_supporter_since">Stödjare sedan %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Besök GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Mbadala ni matangazo, uchambuzi na Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Asante kwa kuunga mkono maendeleo ya chanzo wazi ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Umirudi tayari? Msaada wako unaihifadhi BVM hai!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Tazama hali yako ya mchangiaji</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Asante kwa msaada wako</string>
+    <string name="upgrade_screen_supporter_status_body">Umefungua vipengele vyote vya ziada kwa kusaidia maendeleo ya chanzo huria.</string>
+    <string name="upgrade_screen_supporter_since">Mchangiaji tangu %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Tembelea GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">மாற்று விளம்பரங்கள், பகுப்பாய்வுகள் மற்றும் Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">திறந்த மூல மேம்பாட்டை ஆதரித்ததற்கு நன்றி ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ஏற்கனவே திரும்பிவிட்டீர்களா? உங்கள் மொத்தம் BVMஐ உயிரோடு வைக்கிறது!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">உங்கள் ஆதரவாளர் நிலையைக் காணவும்</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">உங்கள் ஆதரவுக்கு நன்றி</string>
+    <string name="upgrade_screen_supporter_status_body">திறந்த மூல மென்பொருள் மேம்பாட்டை ஆதரிப்பதன் மூலம் நீங்கள் அனைத்து கூடுதல் அம்சங்களையும் திறக்க முடிந்துவிட்டீர்கள்.</string>
+    <string name="upgrade_screen_supporter_since">%s முதல் ஆதரவாளர்</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors ஐப் பார்வையிடவும்</string>
 </resources>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">ప్రత్యామనాయం ప్రకటనలు, అనలిటిక్స్ మరియు Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ఓపెన్ సోర్స్ అభివృద్ధికి మద్దతు ఇచ్చినందుకు ధన్యవాదాలు ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ఇప్పుడే వెనక్కు వెళ్తున్నారా? మీ సహాయంతో BVM జీవంతో ఉంటుంది!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">మీ సపోర్టర్ స్థితిని చూడండి</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">మీ సపోర్టు కోసం ధన్యవాదాలు</string>
+    <string name="upgrade_screen_supporter_status_body">ఓపెన్-సోర్స్ డెవలప్‌మెంట్‌కు సపోర్ట్ చేయడం ద్వారా మీరు అన్ని అదనపు ఫీచర్‌లను అన్‌లాక్ చేసారు.</string>
+    <string name="upgrade_screen_supporter_since">%s నుండి సపోర్టర్</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub స్పాన్సర్‌లను సందర్శించండి</string>
 </resources>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">ทางเลือกคือโฆษณา การวิเคราะห์ และ Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ขอบคุณสำหรับการสนับสนุนการพัฒนาโอเพ่นซอร์ส ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast"></string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">ดูสถานะผู้สนับสนุนของคุณ</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">ขอบคุณสำหรับการสนับสนุนของคุณ</string>
+    <string name="upgrade_screen_supporter_status_body">คุณได้ปลดล็อกฟีเจอร์พิเศษทั้งหมดโดยการสนับสนุนการพัฒนาโอเพนซอร์ส</string>
+    <string name="upgrade_screen_supporter_since">ผู้สนับสนุนตั้งแต่ %s</string>
+    <string name="upgrade_screen_supporter_visit_action">เยี่ยมชม GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -20,4 +20,12 @@ ve daha fazlası…</string>
     <string name="upgrade_screen_sponsor_action_hint">Bunun alternatifi reklamlar, analizler ve Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Açık kaynak gelişimini desteklediğiniz için teşekkür ederiz ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Geri mi döndünüz? Desteğiniz BVM\'yi ayakta tutuyor!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Destekçi durumunuzu görüntüleyin</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Desteğiniz için teşekkür ederiz</string>
+    <string name="upgrade_screen_supporter_status_body">Açık kaynak geliştirmeyi destekleyerek tüm ekstra özelliklerin kilidini açtınız.</string>
+    <string name="upgrade_screen_supporter_since">Şu tarihten beri destekçi: %s</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors\'ı ziyaret edin</string>
 </resources>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Альтернативою є реклама, аналітика та Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Дякуємо за підтримку розробки з відкритим кодом ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Вже повернулися? Ваша підтримка допомагає BVM продовжувати свою роботу!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Переглянути свій статус прихильника</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Дякуємо за вашу підтримку</string>
+    <string name="upgrade_screen_supporter_status_body">Ви розблокували всі додаткові функції, підтримавши розробку відкритого коду.</string>
+    <string name="upgrade_screen_supporter_since">Прихильник з %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Відвідати GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">متبادل اشتہارات، تجزیات اور Google Play ہیں 🙁</string>
     <string name="upgrade_screen_thanks_toast">اوپن سورس ڈیولپمنٹ کی حمایت کرنے کا شکریہ ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ابھی واپس؟ آپ کی حمایت BVM کو زندہ رکھتی ہے!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">اپنی سپورٹر حالت دیکھیں</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">آپ کی سپورٹ کے لیے شکریہ</string>
+    <string name="upgrade_screen_supporter_status_body">آپ نے اوپن سورس ڈوئیلپ منٹ کی سپورٹ کر کے تمام اضافی خصوصیات کو کھول دیا ہے۔</string>
+    <string name="upgrade_screen_supporter_since">%s سے سپورٹر</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsors وزٹ کریں</string>
 </resources>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -20,4 +20,12 @@ va boshqalar…</string>
     <string name="upgrade_screen_sponsor_action_hint">Muqobil reklama, tahlil va Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ochiq manba rivojlanishini qo\'llab-quvvatlaganingiz uchun rahmat ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Allaqachon ketayapsizmi? Sizning qo\'llab-quvvatlashingiz BVM ni tirik saqlaydi!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Tarafdor statusini ko\'ring</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Qo\'llab-quvvatlashingiz uchun rahmat</string>
+    <string name="upgrade_screen_supporter_status_body">Siz ochiq kodli taraqqiyotni qo\'llab-quvvatlab, barcha qo\'shimcha xususiyatlarni ochib oldingiz.</string>
+    <string name="upgrade_screen_supporter_since">Tarafdor: %s dan beri</string>
+    <string name="upgrade_screen_supporter_visit_action">GitHub Sponsorsni ziyoratlang</string>
 </resources>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -20,4 +20,12 @@ và nhiều hơn nữa…</string>
     <string name="upgrade_screen_sponsor_action_hint">Giải pháp thay thế là quảng cáo, phân tích và Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Cảm ơn bạn đã hỗ trợ phát triển mã nguồn mở ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Quay lại rồi? Sự ủng hộ của bạn giúp BVM tồn tại!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Xem trạng thái người ủng hộ của bạn</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Cảm ơn sự ủng hộ của bạn</string>
+    <string name="upgrade_screen_supporter_status_body">Bạn đã mở khóa tất cả các tính năng bổ sung nhờ ủng hộ phát triển mã nguồn mở.</string>
+    <string name="upgrade_screen_supporter_since">Người ủng hộ từ %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Truy cập GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">取而代之的是广告、分析和 Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">感谢您支持开源开发 ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">这么快就回来了？您的支持让 BVM 持续运行！</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">查看您的支持者状态</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">感谢您的支持</string>
+    <string name="upgrade_screen_supporter_status_body">您通过支持开源开发已解锁所有额外功能。</string>
+    <string name="upgrade_screen_supporter_since">自 %s 以来的支持者</string>
+    <string name="upgrade_screen_supporter_visit_action">访问 GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">替代品為廣告、分析和 Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">感謝您對開放原始碼開發的支持 ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">已經回去了？你的支持讓 BVM 持續運行！</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">查看您的支援者狀態</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">感謝您的支持</string>
+    <string name="upgrade_screen_supporter_status_body">您已通過支持開源開發來解鎖所有額外功能。</string>
+    <string name="upgrade_screen_supporter_since">自 %s 以來的支援者</string>
+    <string name="upgrade_screen_supporter_visit_action">前往 GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -20,4 +20,12 @@
     <string name="upgrade_screen_sponsor_action_hint">替代品為廣告、分析和 Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">感謝您對開放原始碼開發的支持 ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">這麼快就回來了？你的支持讓 BVM 得以持續！</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">查看您的支持者狀態</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">感謝您的支持</string>
+    <string name="upgrade_screen_supporter_status_body">您已透過支持開源開發而解鎖所有額外功能。</string>
+    <string name="upgrade_screen_supporter_since">支持者自 %s 起</string>
+    <string name="upgrade_screen_supporter_visit_action">造訪 GitHub Sponsors</string>
 </resources>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -17,4 +17,12 @@
     <string name="upgrade_screen_sponsor_action_hint">Enye indlela izikhangiso, ukuhlaziya ne-Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ngiyabonga ngokusekela ukuthuthukiswa komthombo ovulekile ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Ubuyile kakade? Ukusekela kwakho kugcina i-BVM iphila!</string>
+    <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
+    <string name="settings_upgrade_status_title">BVM FOSS</string>
+    <string name="settings_upgrade_status_desc">Buka isimo sakho se-supporter</string>
+    <!-- Supporter status view -->
+    <string name="upgrade_screen_supporter_status_title">Ngiyabonga ngokusekela kwakho</string>
+    <string name="upgrade_screen_supporter_status_body">Uvule lonke izici ezongeza ngokusekela umthuthukiso we-open-source.</string>
+    <string name="upgrade_screen_supporter_since">Isekeli kusukela %s</string>
+    <string name="upgrade_screen_supporter_visit_action">Vakashela i-GitHub Sponsors</string>
 </resources>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Die inskrywing kos %s per jaar.</string>
     <string name="upgrade_screen_iap_action">Eenmalige aankoop</string>
     <string name="upgrade_screen_iap_action_hint">Die eenmalige aankoop kos %s.</string>
+    <string name="upgrade_screen_offer_divider_or">of</string>
+    <string name="upgrade_screen_offer_same_features">Dieselfde kenmerke, net verskillende prysmodelle.</string>
     <string name="upgrade_screen_thanks_toast">Jy is die beste! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Herstel aankoop</string>
+    <string name="upgrade_screen_restore_banner_title">Reeds BVM Pro gekoop?</string>
+    <string name="upgrade_screen_restore_banner_body">Dit lyk of jy voorheen op hierdie toestel opgegradeer het. Herstel jou aankoop om dit weer te ontsluit.</string>
     <string name="upgrade_screen_restore_purchase_message">Jou opgradering is geldig oor toestelle op dieselfde Google-rekening.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Foutherstel wenke vir onerkende opgraderings:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sinkronisasie kan tyd neem. Probeer herlaai, maak Google Play kas skoon of wag net.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Veelvuldige rekeninge kan Google Play verwar. Meld af van ander rekeninge of installeer deur die Google Play webwerf, wat assosiasies met \'n spesifieke rekening dwing.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Bekyk jou Pro-status</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Geluk!</string>
+    <string name="upgrade_screen_owned_congrats_body">Jy het BVM Pro — dankie dat jy ontwikkeling ondersteun. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Eenmalige aankoop</string>
+    <string name="upgrade_screen_owned_iap_body">Jy besit BVM Pro vir altyd. Dankie vir jou ondersteuning ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Subskripsie</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Jou BVM Pro-subskripsie is aktief en gestel om te hernu.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Jou BVM Pro-subskripsie is aktief, maar sal nie hernu word nie. Dit bly geldig tot die einde van die huidige tydperk.</string>
+    <string name="upgrade_screen_owned_both_warning">Jy het beide \'n subskripsie en die eenmalige aankoop. Kanselleer die subskripsie in Google Play sodat jy nie weer gehef word nie.</string>
+    <string name="upgrade_screen_manage_subscription">Bestuur subskripsie</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Wissel na \'n eenmalige aankoop</string>
+    <string name="upgrade_screen_switch_purchase_note">Dit is \'n aparte eenmalige aankoop. Dit kanselleer of terugbetaal nie jou subskripsie nie, so kanselleer dit ook in Google Play. Gebruik dieselfde Google-rekening vir albei.</string>
+    <string name="upgrade_screen_switch_locked_note">Beskikbaar sodra jou subskripsie nie meer gestel is om te hernu nie. Kanselleer dit in Google Play om te wissel — jy behou Pro tot die huidige tydperk eindig.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Lyk die status verkeerd?</string>
+    <string name="upgrade_screen_status_restore_body">As jou aankoop nie hier verskyn nie, probeer dit herstel.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Bevestig jou aankoop</string>
+    <string name="upgrade_screen_grace_body_short">Hou vas — ons is besig om jou aankoop dubbel te bevestig by Google Play.</string>
+    <string name="upgrade_screen_grace_body">Ons kan steeds nie jou aankoop by Google Play bevestig nie. Probeer dit herstel, of maak seker jy is aangemeld met die regte rekening.</string>
+    <string name="upgrade_screen_retry_action">Probeer weer</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Subskripsie steeds aktief</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Jou subskripsie is steeds gestel om te hernu. Kanselleer dit eers in Google Play, kom dan terug om die eenmalige aankoop te koop — so word jy nie twee keer gehef nie.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Ons kon nie jou subskripsiestatus bevestig nie. Kyk asseblief jou verbinding en probeer weer.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Reeds gekoop</string>
+    <string name="upgrades_gplay_already_owned_error_description">Gebruik die \"Herstel aankoop\"-opsie om jou aankoop te herstel. As die probleem voortduur, probeer om die Google Play-kas skoon te maak en jou toestel te herbegin.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-fout</string>
+    <string name="upgrades_gplay_internal_error_description">\'n Interne Google Play-fout het voorgekom. Probeer asseblief die volgende:\n\n• Herbegin jou toestel\n• Maak die Google Play Store-kas skoon\n• Probeer later weer</string>
+    <string name="upgrades_gplay_network_error_title">Verbindingsfout</string>
+    <string name="upgrades_gplay_network_error_description">Kan nie aan Google Play koppel nie. Kyk asseblief jou internetverbinding en probeer weer.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play is nie beskikbaar nie</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan nie aan Google Play koppel nie. Is Google Play geïnstalleer en opgedateer? Is jou Google-rekening aangemeld? Probeer om die kas van die Google Play-toepassing skoon te maak en jou toestel herlaai.</string>
     <string name="upgrades_no_purchases_found_check_account">Geen aankope gevind nie. Gebruik jy die regte rekening?</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">ደንበኝነቱ በዓመት %s ያስከፍላል።</string>
     <string name="upgrade_screen_iap_action">አንድ ጊዜ ግዢ</string>
     <string name="upgrade_screen_iap_action_hint">አንድ ጊዜ ግዢው %s ያስከፍላል።</string>
+    <string name="upgrade_screen_offer_divider_or">ወይም</string>
+    <string name="upgrade_screen_offer_same_features">ተመሳሳይ ባህሪዎች፣ በቅንዓት የተለያዩ ዋጋ ሞዴሎች።</string>
     <string name="upgrade_screen_thanks_toast">እርስዎ ምርጥ ነዎት! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">ግዢን ወደነበረበት መልስ</string>
+    <string name="upgrade_screen_restore_banner_title">ቀድሞ BVM Pro ገዙ?</string>
+    <string name="upgrade_screen_restore_banner_body">ቀድሞ በዚህ መሳሪያ ላይ ሻመም ይመስላል። ገዝተውዎትን ወደ ሪስ አድርገው ዓላ።</string>
     <string name="upgrade_screen_restore_purchase_message">ማሻሻያዎ በተመሳሳይ Google መለያ ላይ በመሳሪያዎች ላይ ልክ ነው።</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">ለማይታወቁ ማሻሻያዎች የመላ ፍለጋ ምክሮች፡</string>
     <string name="upgrade_screen_restore_sync_patience_hint">የPlay Store ሲምሪዝሽን ጊዜ ሊወስድ ይችላል። እንደገና ማስጀመር፣ የGoogle Play መሸጎጫ ማጥራት ወይም ብቻ መጠበቅ ይሞክሩ።</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ብዙ መለያዎች Google Play ማምታታት ይችላሉ። ከሌሎች መለያዎች ይወጡ ወይም በGoogle Play ድርጣቢያ በኩል ይጫኑ፣ ይህም ከተወሰነ መለያ ጋር ግንኙነቶችን ያስገድዳል።</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Pro ሁኔታዎ ይመልከቱ</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">እንቋዕ!</string>
+    <string name="upgrade_screen_owned_congrats_body">BVM Pro አግኝተዋል — ልማትን ከደገፋችሁ ምስጋና ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">አንድ ጊዜ ግዢ</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro ለዘላለም የዎትን ነው። ድጋፊነታችሁ ምስጋና ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">ምዝገባ</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">የBVM Pro ምዝገባዎ ንቁ ነው እና ለመደስ ተዘጋጁ</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">የBVM Pro ምዝገባዎ ንቁ ነው ግን አይሐድስም። እስከ ያሁኑ ወር መጨረሻ ትክክል ነው</string>
+    <string name="upgrade_screen_owned_both_warning">ምዝገባ እና ነጠላ ግዢ ሁለቱም አለብዎ። Google Play ውስጥ ምዝገባውን ሰርዙ ስለዚህ እንደገና ክፍያ አይሰጣችሁም</string>
+    <string name="upgrade_screen_manage_subscription">ምዝገባ አስተዳዳር</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">ወደ ነጠላ ግዥ ተሸጋገር</string>
+    <string name="upgrade_screen_switch_purchase_note">ይህ ተለያዩ ነጠላ ግዥ ነው። ሰደቤ ግዳጅዎን አይሰርዝም ወይም አይመልሰውም። ስለዚህ ግዳጅዎን በGoogle Play ላይም ይሰርዙ። ሁለቱንም ተመሳሳይ Google ሒሳብ ይጠቀሙ።</string>
+    <string name="upgrade_screen_switch_locked_note">ሰደቤ ግዳጅዎ እንደገና ሚሞላ ካልተደረገ በኋላ ይገኛል። ለመሸጋገር በGoogle Play ላይ ይሰርዙ — ወደ አሁኑ ጊዜ ሳበቃ ድረስ Pro ይጠብቀዋል።</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">ሁኔታ ትክክል አይመስልም?</string>
+    <string name="upgrade_screen_status_restore_body">ግዥዎ እዚህ ካልታየ ግዥዎን ለመመለስ ይሞክሩ።</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">ግዥዎን ማረጋገጥ</string>
+    <string name="upgrade_screen_grace_body_short">ይዘቅዙ — ግዥዎን Google Play ጋር ማረጋገጥ ነው።</string>
+    <string name="upgrade_screen_grace_body">ግዥዎን Google Play ጋር አሁንም ማረጋገጥ አንችልም። ግዥዎን ለመመለስ ይሞክሩ ወይም ትክክለኛው Google ሒሳብ ጋር ተመዝገቡ።</string>
+    <string name="upgrade_screen_retry_action">ድጋሚ ሞክር</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">ምዝገባ ገና ንቁ ነው</string>
+    <string name="upgrade_screen_sub_still_renewing_message">ምዝገባዎ ገና እንደገና ለማደስ ተዘጋጅቶ ነው። በመጀመሪያ በGoogle Play ውስጥ ሰርዙት፣ ከዚያም ወደዚህ ተመለሱ አንድ ጊዜ ግዢ ለመግዛት - በዚህ መንገድ ሁለት ጊዜ ክፍያ አይወስዱም።</string>
+    <string name="upgrade_screen_sub_check_failed_message">ምዝገባዎን ሁኔታ ማረጋገጥ አልቻልንም። እባክዎ ግንኙነትዎን ይፈትሹ እና ድጋሚ ሞክሩ።</string>
+    <string name="upgrades_gplay_already_owned_error_title">ተገዛ ነው</string>
+    <string name="upgrades_gplay_already_owned_error_description">\'ግዢ ወደ ኋላ መመለስ\' አማራጭ ተጠቀም ግዢዎን ለመመለስ። ችግሩ ካልተፈታ፣ Google Play ካሽ ይጽደ እና መሳሪያዎን ድጋሚ ያስጀምሩ።</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play ስህተት</string>
+    <string name="upgrades_gplay_internal_error_description">የGoogle Play ውስጣዊ ስህተት ተከስቷል። እባክዎ የሚከተሉትን ሞክሩ:\n\n• መሳሪያዎን ድጋሚ ያስጀምሩ\n• Google Play Store ካሽ ይጽደ\n• ቆይተው ድጋሚ ሞክሩ</string>
+    <string name="upgrades_gplay_network_error_title">ግንኙነት ስህተት</string>
+    <string name="upgrades_gplay_network_error_description">ከGoogle Play ጋር ለመገናኘት አልተቻለም። እባክዎ የኢንተርኔት ግንኙነትዎን ምልከቱ እና እንደገና ይሞክሩ።</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play አይገኝም</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ወደ Google Play መገናኘት አይቻል። Google Play የተገጀተ እና ወደ ላይ የተዘመኘትነ? የGoogle አካወንት የነጩ ክ? Google Play አፕሊኬስንን በሜᇍ ካስቀጁ መሣሪያውን አስለስለስ ያስፈለግላ።</string>
     <string name="upgrades_no_purchases_found_check_account">ምንም ግዢዎች አልተገኙም። ትክክለኛውን መለያ እየተጠቀሙ ነው?</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">الاشتراك يكلف %s لكل سنة.</string>
     <string name="upgrade_screen_iap_action">شراء مرة واحدة</string>
     <string name="upgrade_screen_iap_action_hint">تكلفة الشراء لمرة واحدة %s.</string>
+    <string name="upgrade_screen_offer_divider_or">أو</string>
+    <string name="upgrade_screen_offer_same_features">نفس الميزات، فقط بنماذج تسعير مختلفة.</string>
     <string name="upgrade_screen_thanks_toast">أنت الأفضل ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">استعادة المُشتَرَى</string>
+    <string name="upgrade_screen_restore_banner_title">هل اشتريت BVM Pro من قبل؟</string>
+    <string name="upgrade_screen_restore_banner_body">يبدو أنك قمت بالترقية على هذا الجهاز من قبل. استعد عملية الشراء لإلغاء القفل مرة أخرى.</string>
     <string name="upgrade_screen_restore_purchase_message">الترقية الخاصة بك صالحة لكل الأجهزة باستخدام نفس حساب Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">نصائح استكشاف الأخطاء في الترقيات غير المعترف بها:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">قد تستغرق مزامنة متجر التشغيل وقتاً طويلا. حاول إعادة التشغيل، مسح ذاكرة التخزين المؤقت لـ Google Play أو الانتظار قليلا.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">الحسابات المتعددة يمكنها إرباك Google Play. سجّل الخروج من الحسابات الأخرى أو ثبّت من خلال موقع Google Play، الذي يفرض الرّبط مع حساب معين.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">عرض حالة Pro الخاصة بك</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">تهانينا!</string>
+    <string name="upgrade_screen_owned_congrats_body">لقد حصلت على BVM Pro — شكرًا لدعمك التطوير. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">شراء مرة واحدة</string>
+    <string name="upgrade_screen_owned_iap_body">أنت تمتلك BVM Pro إلى الأبد. شكرًا لدعمك ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">الاشتراك</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">اشتراكك في BVM Pro نشط ومُعد للتجديد.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">اشتراكك في BVM Pro نشط لكنه لن يتجدد. يظل ساريًا حتى نهاية الفترة الحالية.</string>
+    <string name="upgrade_screen_owned_both_warning">لديك كل من الاشتراك والشراء لمرة واحدة. ألغِ الاشتراك في Google Play حتى لا تُخصم منك رسوم مرة أخرى.</string>
+    <string name="upgrade_screen_manage_subscription">إدارة الاشتراك</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">التبديل إلى شراء لمرة واحدة</string>
+    <string name="upgrade_screen_switch_purchase_note">هذا شراء منفصل لمرة واحدة. لا يؤدي إلى إلغاء اشتراكك أو استرداد قيمته، لذا ألغِ الاشتراك في Google Play أيضًا. استخدم نفس حساب Google للاثنين.</string>
+    <string name="upgrade_screen_switch_locked_note">متاح بمجرد أن يصبح اشتراكك غير مُعد للتجديد. ألغه في Google Play للتبديل — ستحتفظ بـ Pro حتى نهاية الفترة الحالية.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">هل تبدو الحالة غير صحيحة؟</string>
+    <string name="upgrade_screen_status_restore_body">إذا لم تظهر عملية الشراء هنا، فحاول استعادتها.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">جارٍ تأكيد عملية الشراء</string>
+    <string name="upgrade_screen_grace_body_short">لحظات من فضلك — نتحقق مرة أخرى من عملية الشراء الخاصة بك مع Google Play.</string>
+    <string name="upgrade_screen_grace_body">ما زلنا غير قادرين على تأكيد عملية الشراء الخاصة بك مع Google Play. حاول استعادتها، أو تحقق من أنك مسجل الدخول بالحساب الصحيح.</string>
+    <string name="upgrade_screen_retry_action">إعادة المحاولة</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">الاشتراك ما زال نشطًا</string>
+    <string name="upgrade_screen_sub_still_renewing_message">اشتراكك لا يزال مُعدًا للتجديد. ألغه في Google Play أولاً، ثم عد لشراء الشراء لمرة واحدة — بهذه الطريقة لن تُخصم منك رسوم مرتين.</string>
+    <string name="upgrade_screen_sub_check_failed_message">لم نتمكن من التحقق من حالة اشتراكك. يُرجى التحقق من اتصالك والمحاولة مرة أخرى.</string>
+    <string name="upgrades_gplay_already_owned_error_title">تم الشراء بالفعل</string>
+    <string name="upgrades_gplay_already_owned_error_description">استخدم خيار \"استعادة الشراء\" لاستعادة عملية الشراء الخاصة بك. إذا استمرت المشكلة، حاول مسح ذاكرة التخزين المؤقتة لـ Google Play وإعادة تشغيل جهازك.</string>
+    <string name="upgrades_gplay_internal_error_title">خطأ في Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">حدث خطأ داخلي في Google Play. يُرجى تجربة ما يلي:\n\n• إعادة تشغيل جهازك\n• مسح ذاكرة التخزين المؤقتة لمتجر Google Play\n• المحاولة مرة أخرى لاحقًا</string>
+    <string name="upgrades_gplay_network_error_title">خطأ في الاتصال</string>
+    <string name="upgrades_gplay_network_error_description">تعذر الاتصال بـ Google Play. يُرجى التحقق من اتصالك بالإنترنت والمحاولة مرة أخرى.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play غير متاح</string>
     <string name="upgrades_gplay_unavailable_error_description">يتعذر على Bluetooth Volume Manager الاتصال بـ Google Play. هل تم تثبيت Google Play وتحديثه؟ هل تم تسجيل الدخول إلى حسابك في Google؟ حاول مسح ذاكرة التخزين المؤقت لتطبيق Google Play وإعادة تشغيل جهازك.</string>
     <string name="upgrades_no_purchases_found_check_account">لم يتم العثور على عملية الشراء. هل تستخدم حساب Google الصحيح؟</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Abunə ildə %s başa gəlir.</string>
     <string name="upgrade_screen_iap_action">Birdəfəlik alış</string>
     <string name="upgrade_screen_iap_action_hint">Birdəfəlik alış %s başa gəlir.</string>
+    <string name="upgrade_screen_offer_divider_or">və ya</string>
+    <string name="upgrade_screen_offer_same_features">Eyni funksiyalar, sadəcə fərqli qiymət modelləri.</string>
     <string name="upgrade_screen_thanks_toast">Siz ən yaxşısınız! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Alışı bərpa et</string>
+    <string name="upgrade_screen_restore_banner_title">Artıq BVM Pro almısınız?</string>
+    <string name="upgrade_screen_restore_banner_body">Görünür, siz bu cihazda əvvəllər yeniləmisiniz. Onu yenidən açmaq üçün alışınızı bərpa edin.</string>
     <string name="upgrade_screen_restore_purchase_message">Yeniləməniz eyni Google hesabında cihazlar arasında keçərlidir.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Tanınmayan yeniləmələr üçün problemlərin həlli məsləhətləri:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sinxronlaşdırması vaxt ala bilər. Yenidən başlatmağı, Google Play keşini təmizləməyi və ya sadəcə gözləməyi sınayın.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Çoxlu hesablar Google Play-i çaşdıra bilər. Digər hesablardan çıxın və ya Google Play veb saytı vasitəsilə quraşdırın ki, bu da müəyyən hesabla əlaqələri məcbur edir.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Pro statusunuza baxın</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Təbriklər!</string>
+    <string name="upgrade_screen_owned_congrats_body">BVM Pro sizdədir — inkişafı dəstəklədiyiniz üçün təşəkkürlər. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Birdəfəlik alış</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro həmişəlik sizindir. Dəstəyiniz üçün təşəkkürlər ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abunəlik</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">BVM Pro abunəliyiniz aktivdir və yenilənməyə təyin edilib.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">BVM Pro abunəliyiniz aktivdir, lakin yenilənməyəcək. O, cari dövrün sonuna qədər etibarlı qalacaq.</string>
+    <string name="upgrade_screen_owned_both_warning">Sizdə həm abunəlik, həm də birdəfəlik alış var. Yenidən ödəniş alınmaması üçün abunəliyi Google Play-də ləğv edin.</string>
+    <string name="upgrade_screen_manage_subscription">Abunəliyi idarə edin</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Birdəfəlik alışa keçin</string>
+    <string name="upgrade_screen_switch_purchase_note">Bu ayrı bir birdəfəlik alışdır. O, abunəliyinizi ləğv etmir və ya pulunu geri qaytarmır, ona görə də onu da Google Play-də ləğv edin. Hər ikisi üçün eyni Google hesabından istifadə edin.</string>
+    <string name="upgrade_screen_switch_locked_note">Abunəliyiniz artıq yenilənməyə təyin edilmədikdə əlçatan olur. Keçmək üçün onu Google Play-də ləğv edin — cari dövr bitənə qədər Pro-nu saxlayacaqsınız.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Status səhv görünür?</string>
+    <string name="upgrade_screen_status_restore_body">Əgər alışınız burada görünmürsə, onu bərpa etməyə çalışın.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Alışınız təsdiqlənir</string>
+    <string name="upgrade_screen_grace_body_short">Bir az gözləyin — Google Play ilə alışınızı yenidən yoxlayırıq.</string>
+    <string name="upgrade_screen_grace_body">Google Play ilə alışınızı hələ də təsdiqləyə bilmirik. Onu bərpa etməyə çalışın və ya doğru hesabla daxil olduğunuzu yoxlayın.</string>
+    <string name="upgrade_screen_retry_action">Yenidən cəhd edin</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abunəlik hələ də aktivdir</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Abunəliyiniz hələ də yenilənməyə təyin edilib. Əvvəlcə onu Google Play-də ləğv edin, sonra birdəfəlik alışı almaq üçün geri qayıdın — bu şəkildə iki dəfə ödəniş almayacaqsınız.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Abunəlik statusunuzu yoxlaya bilmədik. Zəhmət olmasa bağlantınızı yoxlayın və yenidən cəhd edin.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Artıq alınıb</string>
+    <string name="upgrades_gplay_already_owned_error_description">Alışınızı bərpa etmək üçün \"Alışı bərpa et\" seçimindən istifadə edin. Problem davam edərsə, Google Play keşini təmizləməyə və cihazınızı yenidən başlatmağa çalışın.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play xətası</string>
+    <string name="upgrades_gplay_internal_error_description">Daxili Google Play xətası baş verdi. Zəhmət olmasa aşağıdakıları sınayın:\n\n• Cihazınızı yenidən başladın\n• Google Play Store keşini təmizləyin\n• Sonra yenidən cəhd edin</string>
+    <string name="upgrades_gplay_network_error_title">Bağlantı xətası</string>
+    <string name="upgrades_gplay_network_error_description">Google Play-ə qoşulmaq mümkün olmadı. Zəhmət olmasa internet bağlantınızı yoxlayın və yenidən cəhd edin.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play əlçatan deyil</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play-ə qoşula bilmir. Google Play quraşdırılıb və yenilənib? Google Hesabınıza daxil olubsunuz? Google Play tətbiqinin keşini təmizləməyə və cihazınızı yenidən başlatmağa çalışın.</string>
     <string name="upgrades_no_purchases_found_check_account">Heç bir alış tapılmadı. Düzgün hesabdan istifadə edirsiniz?</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Падпіска каштуе %s у год.</string>
     <string name="upgrade_screen_iap_action">Аднаразовая пакупка</string>
     <string name="upgrade_screen_iap_action_hint">Аднаразовая пакупка каштуе %s.</string>
+    <string name="upgrade_screen_offer_divider_or">або</string>
+    <string name="upgrade_screen_offer_same_features">Тыя ж функцыі, проста іншыя мадэлі коштаў.</string>
     <string name="upgrade_screen_thanks_toast">Вы найлепшы! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Аднавіць пакупку</string>
+    <string name="upgrade_screen_restore_banner_title">Ужо купілі BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Падобна, вы ўжо абнаўляліся на гэтай прыладзе раней. Аднавіце пакупку, каб разблакіраваць яе зноў.</string>
     <string name="upgrade_screen_restore_purchase_message">Ваша абнаўленне дзейнічае на ўсіх прыладах з аднолькавым уліковым запісам Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Парады па вырашэнню непаладак пры нераспазнаных абнаўленнях:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Сінхранізацыя з Play Store можа заняць пэўны час. Паспрабуйце перазагрузіцца, ачысціць кэш Google Play або проста пачакаць.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Некалькі ўліковых запісаў могуць заблытаць Google Play. Выйдзіце з іншых уліковых запісаў або ўсталюйце праз вэб-сайт Google Play, які вызначае сувязь з пэўным уліковым запісам.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Праглядзець ваш Pro-статус</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Віншуем!</string>
+    <string name="upgrade_screen_owned_congrats_body">Вы атрымалі BVM Pro — дзякуй за падтрымку распрацоўкі. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Аднаразовая пакупка</string>
+    <string name="upgrade_screen_owned_iap_body">Вы валодаеце BVM Pro назаўжды. Дзякуй за вашу падтрымку ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Падпіска</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Ваша падпіска BVM Pro актыўная і будзе аднаўляцца.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша падпіска BVM Pro актыўная, але не будзе аднаўляцца. Яна застаецца дзейснай да канца бягучага перыяду.</string>
+    <string name="upgrade_screen_owned_both_warning">У вас ёсць і падпіска, і аднаразовая пакупка. Скасуйце падпіску ў Google Play, каб з вас не спаганялі плату зноў.</string>
+    <string name="upgrade_screen_manage_subscription">Кіраваць падпіскай</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Перайсці на аднаразовую пакупку</string>
+    <string name="upgrade_screen_switch_purchase_note">Гэта асобная аднаразовая пакупка. Яна не скасоўвае і не вяртае сродкі за вашу падпіску, таму скасуйце яе таксама ў Google Play. Выкарыстоўвайце адзін і той жа акаунт Google для абадвух.</string>
+    <string name="upgrade_screen_switch_locked_note">Даступна, калі ваша падпіска больш не будзе аднаўляцца. Скасуйце яе ў Google Play, каб пераключыцца — вы захаваеце Pro да канца бягучага перыяду.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Статус выглядае няправільна?</string>
+    <string name="upgrade_screen_status_restore_body">Калі ваша пакупка тут не адлюстроўваецца, паспрабуйце яе аднавіць.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Пацвярджэнне вашай пакупкі</string>
+    <string name="upgrade_screen_grace_body_short">Крыху пачакайце — мы паўторна правераем вашу пакупку чараз Google Play.</string>
+    <string name="upgrade_screen_grace_body">Мы ўсё яшчэ не можам пацвердзіць вашу пакупку чараз Google Play. Паспрабуйце аднавіць яе або праверце, што вы ўвайшлі ў патрэбны акаунт.</string>
+    <string name="upgrade_screen_retry_action">Паўтарыць</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Падпіска ўсё яшчэ актыўная</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Ваша падпіска ўсё яшчэ будзе аднаўляцца. Скасуйце яе ў Google Play спачатку, потым вярніцеся, каб купіць аднаразовую пакупку — такім чынам з вас не спагоняць плату двайчы.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Мы не змаглі праверыць статус вашай падпіскі. Праверце злучэнне і паспрабуйце зноў.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Ужо куплена</string>
+    <string name="upgrades_gplay_already_owned_error_description">Скарыстайцеся апцыяй «Аднавіць пакупку», каб аднавіць вашу пакупку. Калі праблема застаецца, паспрабуйце ачысціць кэш Google Play і перазапусціць прыладу.</string>
+    <string name="upgrades_gplay_internal_error_title">Памылка Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Адбылася ўнутраняя памылка Google Play. Паспрабуйце наступнае:\n\n• Перазапусціце прыладу\n• Ачысціце кэш Google Play Store\n• Паспрабуйце зноў пазней</string>
+    <string name="upgrades_gplay_network_error_title">Памылка злучэння</string>
+    <string name="upgrades_gplay_network_error_description">Не ўдалося падключыцца да Google Play. Праверце інтэрнэт-злучэнне і паспрабуйце зноў.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play недаступны</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не можа падключыцца да Google Play. Ці устанаўлены і абнаўлены Google Play? Ці ўвойдзены ваш акаўнт Google? Спрабуйце ачысціць кэш Google Play і перазагрузіць прыладу.</string>
     <string name="upgrades_no_purchases_found_check_account">Пакупак не знойдзена. Вы выкарыстоўваеце правільны ўліковы запіс?</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Абонаментът струва %s годишно.</string>
     <string name="upgrade_screen_iap_action">Еднократна покупка</string>
     <string name="upgrade_screen_iap_action_hint">Еднократната покупка струва %s.</string>
+    <string name="upgrade_screen_offer_divider_or">или</string>
+    <string name="upgrade_screen_offer_same_features">Същите функции, само различни модели на ценообразуване.</string>
     <string name="upgrade_screen_thanks_toast">Вие сте най-добрите! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Възстановете покупката</string>
+    <string name="upgrade_screen_restore_banner_title">Вече сте купили BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Изглежда, че вече сте надградили на това устройство. Възстановете покупката си, за да я отключите отново.</string>
     <string name="upgrade_screen_restore_purchase_message">Вашето надстройване е валидно на устройства със същия Google акаунт.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Съвети за отстраняване на проблеми за неразпознати надстройвания:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизацията на Play Store може да отнеме време. Опитайте рестартиране, изчистване на кеша на Google Play или просто изчакайте.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Множествените акаунти могат да объркат Google Play. Излезте от други акаунти или инсталирайте чрез уебсайта на Google Play, който принуждава асоциации с конкретен акаунт.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Вижте своя Pro статус</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Поздравления!</string>
+    <string name="upgrade_screen_owned_congrats_body">Вече имате BVM Pro — благодарим ви, че подкрепяте разработката. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Еднократна покупка</string>
+    <string name="upgrade_screen_owned_iap_body">Притежавате BVM Pro завинаги. Благодарим ви за подкрепата ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Абонамент</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Вашият абонамент за BVM Pro е активен и ще се поднови.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Вашият абонамент за BVM Pro е активен, но няма да се поднови. Той остава валиден до края на текущия период.</string>
+    <string name="upgrade_screen_owned_both_warning">Имате едновременно абонамент и еднократна покупка. Отменете абонамента в Google Play, за да не бъдете таксувани отново.</string>
+    <string name="upgrade_screen_manage_subscription">Управление на абонамента</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Преминаване към еднократна покупка</string>
+    <string name="upgrade_screen_switch_purchase_note">Това е отделна еднократна покупка. Тя не отменя и не възстановява средствата от абонамента ви, така че отменете и него в Google Play. Използвайте един и същ акаунт в Google за двете.</string>
+    <string name="upgrade_screen_switch_locked_note">Налично, след като абонаментът ви вече не е зададен за подновяване. Отменете го в Google Play, за да преминете — запазвате Pro до края на текущия период.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Статусът изглежда грешен?</string>
+    <string name="upgrade_screen_status_restore_body">Ако покупката ви не се показва тук, опитайте да я възстановите.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Потвърждаване на покупката ви</string>
+    <string name="upgrade_screen_grace_body_short">Изчакайте малко — проверяваме отново покупката ви в Google Play.</string>
+    <string name="upgrade_screen_grace_body">Все още не можем да потвърдим покупката ви в Google Play. Опитайте да я възстановите или проверете дали сте влезли с правилния акаунт.</string>
+    <string name="upgrade_screen_retry_action">Опитай отново</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Абонаментът все още е активен</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Абонаментът ви все още е зададен за подновяване. Първо го отменете в Google Play, а след това се върнете, за да купите еднократната покупка — така няма да бъдете таксувани два пъти.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Не успяхме да проверим статуса на абонамента ви. Моля, проверете връзката си и опитайте отново.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Вече закупено</string>
+    <string name="upgrades_gplay_already_owned_error_description">Използвайте опцията „Възстановяване на покупка“, за да възстановите покупката си. Ако проблемът продължи, опитайте да изчистите кеша на Google Play и да рестартирате устройството си.</string>
+    <string name="upgrades_gplay_internal_error_title">Грешка в Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Възникна вътрешна грешка в Google Play. Моля, опитайте следното:\n\n• Рестартирайте устройството си\n• Изчистете кеша на Google Play Store\n• Опитайте отново по-късно</string>
+    <string name="upgrades_gplay_network_error_title">Грешка при връзката</string>
+    <string name="upgrades_gplay_network_error_description">Не може да се установи връзка с Google Play. Моля, проверете интернет връзката си и опитайте отново.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play не е достъпен</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може да се свърже с Google Play. Инсталиран ли е Google Play и актуален ли е? Влязъл ли е вашият Google акаунт? Опитайте да изчистите кеша на приложението Google Play и да рестартирате устройството си.</string>
     <string name="upgrades_no_purchases_found_check_account">Не са намерени покупки. Използвате ли правилния акаунт?</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">সাবস্ক্রিপশনে প্রতি এক বছরে %s খরচ হয়।</string>
     <string name="upgrade_screen_iap_action">এককালীন ক্রয়</string>
     <string name="upgrade_screen_iap_action_hint">একবারেই কিনে ফেলতে খরচ হবে: %s.</string>
+    <string name="upgrade_screen_offer_divider_or">অথবা</string>
+    <string name="upgrade_screen_offer_same_features">একই বৈশিষ্ট্য, শুধু মূল্য নির্ধারণের মডেল ভিন্ন।</string>
     <string name="upgrade_screen_thanks_toast">আপনি সেরা ভাই আপনি সেরা! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">ক্রয় পুনরুদ্ধার</string>
+    <string name="upgrade_screen_restore_banner_title">আগে থেকেই BVM Pro কিনেছেন?</string>
+    <string name="upgrade_screen_restore_banner_body">মনে হচ্ছে আপনি আগে এই ডিভাইসে আপগ্রেড করেছিলেন। এটি আবার আনলক করতে আপনার ক্রয় পুনরুদ্ধার করুন।</string>
     <string name="upgrade_screen_restore_purchase_message">আপনার আপগ্রেড একই Google অ্যাকাউন্টের ডিভাইস জুড়ে বৈধ।</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">অচেনা আপগ্রেডের জন্য সমস্যা সমাধানের টিপস:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">প্লে স্টোর সিঙ্ক্রোনাইজেশনে সময় লাগতে পারে। রিবুট করার চেষ্টা করুন, Google Play ক্যাশে সাফ করুন বা অপেক্ষা করুন।</string>
     <string name="upgrade_screen_restore_multiaccount_hint">একাধিক অ্যাকাউন্ট Google Play কে বিভ্রান্ত করতে পারে। অন্যান্য অ্যাকাউন্ট থেকে লগ আউট করুন বা Google Play ওয়েবসাইটের মাধ্যমে ইনস্টল করুন, যা একটি নির্দিষ্ট অ্যাকাউন্টের সাথে যুক্ত হতে বাধ্য করে।</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">আপনার Pro স্ট্যাটাস দেখুন</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">অভিনন্দন!</string>
+    <string name="upgrade_screen_owned_congrats_body">আপনি BVM Pro পেয়ে গেছেন — ডেভেলপমেন্টে সহায়তা করার জন্য ধন্যবাদ। ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">এককালীন ক্রয়</string>
+    <string name="upgrade_screen_owned_iap_body">আপনি চিরতরে BVM Pro-এর মালিক। আপনার সহায়তার জন্য ধন্যবাদ ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">সাবস্ক্রিপশন</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">আপনার BVM Pro সাবস্ক্রিপশন সক্রিয় এবং নবায়ন করার জন্য সেট করা আছে।</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">আপনার BVM Pro সাবস্ক্রিপশন সক্রিয় আছে কিন্তু নবায়ন হবে না। এটি বর্তমান মেয়াদ শেষ না হওয়া পর্যন্ত বৈধ থাকবে।</string>
+    <string name="upgrade_screen_owned_both_warning">আপনার কাছে সাবস্ক্রিপশন এবং একবারের ক্রয় উভয়ই আছে। আবার চার্জ এড়াতে Google Play-তে সাবস্ক্রিপশন বাতিল করুন।</string>
+    <string name="upgrade_screen_manage_subscription">সাবস্ক্রিপশন পরিচালনা করুন</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">একবারের ক্রয়ে পরিবর্তন করুন</string>
+    <string name="upgrade_screen_switch_purchase_note">এটি একটি আলাদা একবারের ক্রয়। এটি আপনার সাবস্ক্রিপশন বাতিল বা ফেরত দেয় না, তাই সেটিও Google Play-তে বাতিল করুন। উভয়ের জন্য একই Google অ্যাকাউন্ট ব্যবহার করুন।</string>
+    <string name="upgrade_screen_switch_locked_note">আপনার সাবস্ক্রিপশন আর নবায়নের জন্য সেট না থাকলে এটি উপলব্ধ হবে। পরিবর্তন করতে Google Play-তে এটি বাতিল করুন — বর্তমান মেয়াদ শেষ না হওয়া পর্যন্ত আপনি Pro বজায় রাখবেন।</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">স্ট্যাটাস ভুল মনে হচ্ছে?</string>
+    <string name="upgrade_screen_status_restore_body">যদি আপনার ক্রয় এখানে না দেখায়, তাহলে এটি পুনরুদ্ধার করার চেষ্টা করুন।</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">আপনার ক্রয় নিশ্চিত করা হচ্ছে</string>
+    <string name="upgrade_screen_grace_body_short">একটু অপেক্ষা করুন — আমরা Google Play-র সাথে আপনার ক্রয় আবার যাচাই করছি।</string>
+    <string name="upgrade_screen_grace_body">আমরা এখনও Google Play-এর সাথে আপনার ক্রয় নিশ্চিত করতে পারছি না। এটি পুনরুদ্ধার করার চেষ্টা করুন, অথবা আপনি সঠিক অ্যাকাউন্টে সাইন ইন করেছেন কিনা তা যাচাই করুন।</string>
+    <string name="upgrade_screen_retry_action">আবার চেষ্টা করুন</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">সাবস্ক্রিপশন এখনও সক্রিয়</string>
+    <string name="upgrade_screen_sub_still_renewing_message">আপনার সাবস্ক্রিপশন এখনও নবায়নের জন্য সেট করা আছে। প্রথমে Google Play-তে এটি বাতিল করুন, তারপর একবারের ক্রয় কিনতে ফিরে আসুন — এভাবে আপনার কাছ থেকে দুইবার চার্জ নেওয়া হবে না।</string>
+    <string name="upgrade_screen_sub_check_failed_message">আমরা আপনার সাবস্ক্রিপশন স্ট্যাটাস যাচাই করতে পারিনি। অনুগ্রহ করে আপনার সংযোগ যাচাই করে আবার চেষ্টা করুন।</string>
+    <string name="upgrades_gplay_already_owned_error_title">ইতিমধ্যে কেনা হয়েছে</string>
+    <string name="upgrades_gplay_already_owned_error_description">আপনার ক্রয় পুনরুদ্ধার করতে \"ক্রয় পুনরুদ্ধার করুন\" অপশনটি ব্যবহার করুন। সমস্যা থেকেই গেলে, Google Play ক্যাশে সাফ করে আপনার ডিভাইস পুনরায় চালু করার চেষ্টা করুন।</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play ত্রুটি</string>
+    <string name="upgrades_gplay_internal_error_description">একটি অভ্যন্তরীণ Google Play ত্রুটি ঘটেছে। অনুগ্রহ করে নিম্নলিখিতগুলো চেষ্টা করুন:\n\n• আপনার ডিভাইস পুনরায় চালু করুন\n• Google Play Store ক্যাশে সাফ করুন\n• পরে আবার চেষ্টা করুন</string>
+    <string name="upgrades_gplay_network_error_title">সংযোগ ত্রুটি</string>
+    <string name="upgrades_gplay_network_error_description">Google Play-এর সাথে সংযোগ করা যাচ্ছে না। অনুগ্রহ করে আপনার ইন্টারনেট সংযোগ যাচাই করে আবার চেষ্টা করুন।</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play অনুপলব্ধ৷</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play-এ সংযোগ করতে পারছে না। কি Google Play ইনস্টল এবং আপডেট আছে? আপনার Google অ্যাকাউন্ট লগইন করা আছে? Google Play অ্যাপের ক্যাশ পরিষ্কার করে ডিভাইস রিবুট করুন।</string>
     <string name="upgrades_no_purchases_found_check_account">আপনার পার্সেস পাওয়া যায় নাই। আপনি সঠিক অ্যাকাউন্ট ব্যবহার করছেন?</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">El preu de la subscripció és de %s anuals.</string>
     <string name="upgrade_screen_iap_action">Compra única</string>
     <string name="upgrade_screen_iap_action_hint">El preu de la compra única és de %s.</string>
+    <string name="upgrade_screen_offer_divider_or">o</string>
+    <string name="upgrade_screen_offer_same_features">Mateixes funcions, només canvia el model de preus.</string>
     <string name="upgrade_screen_thanks_toast">Sou el millor! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restaura la compra</string>
+    <string name="upgrade_screen_restore_banner_title">Ja heu comprat BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Sembla que ja vau actualitzar en aquest dispositiu abans. Restaureu la vostra compra per tornar-la a desbloquejar.</string>
     <string name="upgrade_screen_restore_purchase_message">La vostra millora és vàlida en tots els dispositius del mateix compte de Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Consells de resolució de problemes per a millores no reconegudes:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronització del Play Store pot trigar un temps. Proveu de reiniciar, esborrar la memòria cau del Google Play o simplement espereu.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Diversos comptes poden confondre el Google Play. Tanqueu la sessió d\'altres comptes o instal·leu-lo a través del lloc web del Google Play, que obliga a associar-los amb un compte específic.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Consulteu el vostre estat Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Enhorabona!</string>
+    <string name="upgrade_screen_owned_congrats_body">Ja teniu BVM Pro. Gràcies per donar suport al desenvolupament. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Compra única</string>
+    <string name="upgrade_screen_owned_iap_body">Teniu BVM Pro per sempre. Gràcies pel vostre suport ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Subscripció</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">La vostra subscripció a BVM Pro està activa i es renovarà.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">La vostra subscripció a BVM Pro està activa però no es renovarà. Es mantindrà vàlida fins al final del període actual.</string>
+    <string name="upgrade_screen_owned_both_warning">Teniu tant la subscripció com la compra única. Cancel·leu la subscripció a Google Play perquè no us tornin a cobrar.</string>
+    <string name="upgrade_screen_manage_subscription">Gestiona la subscripció</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Canvieu a una compra única</string>
+    <string name="upgrade_screen_switch_purchase_note">Això és una compra única independent. No cancel·la ni reemborsa la vostra subscripció, així que cancel·leu-la també a Google Play. Utilitzeu el mateix compte de Google per a totes dues.</string>
+    <string name="upgrade_screen_switch_locked_note">Disponible quan la vostra subscripció ja no estigui configurada per renovar-se. Cancel·leu-la a Google Play per canviar: mantindreu el Pro fins que acabi el període actual.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">L\'estat sembla incorrecte?</string>
+    <string name="upgrade_screen_status_restore_body">Si la vostra compra no apareix aquí, proveu de restaurar-la.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">S\'està confirmant la vostra compra</string>
+    <string name="upgrade_screen_grace_body_short">Espereu un moment: estem verificant la vostra compra amb Google Play.</string>
+    <string name="upgrade_screen_grace_body">Encara no podem confirmar la vostra compra amb Google Play. Proveu de restaurar-la o comproveu que heu iniciat sessió amb el compte correcte.</string>
+    <string name="upgrade_screen_retry_action">Reintenta</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">La subscripció encara està activa</string>
+    <string name="upgrade_screen_sub_still_renewing_message">La vostra subscripció encara està configurada per renovar-se. Cancel·leu-la primer a Google Play i després torneu per comprar la compra única; així no us cobraran dues vegades.</string>
+    <string name="upgrade_screen_sub_check_failed_message">No hem pogut comprovar l’estat de la vostra subscripció. Comproveu la vostra connexió i torneu-ho a provar.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Ja comprat</string>
+    <string name="upgrades_gplay_already_owned_error_description">Feu servir l\'opció «Restaura la compra» per restaurar la compra. Si el problema persisteix, proveu d\'esborrar la memòria cau del Google Play i reinicieu el dispositiu.</string>
+    <string name="upgrades_gplay_internal_error_title">Error del Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">S\'ha produït un error intern del Google Play. Proveu el següent:\n\n• Reinicieu el dispositiu\n• Esborreu la memòria cau del Google Play Store\n• Torneu-ho a provar més tard</string>
+    <string name="upgrades_gplay_network_error_title">Error de connexió</string>
+    <string name="upgrades_gplay_network_error_description">No es pot connectar al Google Play. Comproveu la connexió a Internet i torneu-ho a provar.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no es pot connectar a Google Play. Google Play està instal·lat i actualitzat? El vostre compte de Google ha iniciat sessió? Proveu d’esborrar la memòria cau de Google Play i reinicieu el dispositiu.</string>
     <string name="upgrades_no_purchases_found_check_account">No s\'han trobat compres. Esteu fent servir el compte correcte?</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Předplatné stojí %s ročně.</string>
     <string name="upgrade_screen_iap_action">Jednorázový nákup</string>
     <string name="upgrade_screen_iap_action_hint">Jednorázový nákup stojí %s.</string>
+    <string name="upgrade_screen_offer_divider_or">nebo</string>
+    <string name="upgrade_screen_offer_same_features">Stejné funkce, jen jiné cenové modely.</string>
     <string name="upgrade_screen_thanks_toast">Jste nejlepší! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Obnovit nákup</string>
+    <string name="upgrade_screen_restore_banner_title">Už jste si koupili BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Vypadá to, že jste na tomto zařízení už upgradovali. Obnovte svůj nákup a odemkněte to znovu.</string>
     <string name="upgrade_screen_restore_purchase_message">Vaše navýšení licence je platné pro všechny zařízení se stejným účtem Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Tipy pro řešení problémů s nerozpoznaným navýšením licence:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Synchronizace Obchodu Play může chvíli trvat. Zkuste restartovat, vymazat mezipaměť Google Play nebo prostě počkat.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Více účtů může zmást Google Play. Odhlaste se z ostatních účtů nebo nainstalujte přes webové stránky Google Play, což vynucuje asociace s konkrétním účtem.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Zobrazit stav Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Gratulujeme!</string>
+    <string name="upgrade_screen_owned_congrats_body">Máte BVM Pro — díky, že podporujete vývoj. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Jednorázový nákup</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro vlastníte navždy. Díky za vaši podporu ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Předplatné</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Vaše předplatné BVM Pro je aktivní a nastavené na obnovení.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Vaše předplatné BVM Pro je aktivní, ale neobnoví se. Zůstane platné do konce aktuálního období.</string>
+    <string name="upgrade_screen_owned_both_warning">Máte jak předplatné, tak jednorázový nákup. Zrušte předplatné v Google Play, aby vám nebyla znovu naúčtována platba.</string>
+    <string name="upgrade_screen_manage_subscription">Spravovat předplatné</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Přejít na jednorázový nákup</string>
+    <string name="upgrade_screen_switch_purchase_note">Toto je samostatný jednorázový nákup. Nezruší ani nevrátí peníze za vaše předplatné, takže ho zrušte v Google Play také. Pro obojí použijte stejný účet Google.</string>
+    <string name="upgrade_screen_switch_locked_note">Dostupné, jakmile vaše předplatné již nebude nastaveno na obnovení. Zrušte ho v Google Play a přepněte — Pro si ponecháte až do konce aktuálního období.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Stav vypadá špatně?</string>
+    <string name="upgrade_screen_status_restore_body">Pokud se váš nákup zde nezobrazuje, zkuste ho obnovit.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Potvrzujeme váš nákup</string>
+    <string name="upgrade_screen_grace_body_short">Vydržte — dvakrát kontrolujeme váš nákup u Google Play.</string>
+    <string name="upgrade_screen_grace_body">Stále se nám nedaří potvrdit váš nákup u Google Play. Zkuste ho obnovit, nebo zkontrolujte, zda jste přihlášeni ke správnému účtu.</string>
+    <string name="upgrade_screen_retry_action">Opakovat</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Předplatné je stále aktivní</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Vaše předplatné je stále nastaveno na obnovení. Nejprve ho zrušte v Google Play a pak se vraťte a kupte jednorázový nákup — takto vám nebude účtováno dvakrát.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nepodařilo se nám zkontrolovat stav vašeho předplatného. Zkontrolujte prosím připojení a zkuste to znovu.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Již zakoupeno</string>
+    <string name="upgrades_gplay_already_owned_error_description">Použijte možnost \"Obnovit nákup\" k obnovení nákupu. Pokud problém přetrvává, zkuste vyčistit mezipaměť Google Play a restartovat zařízení.</string>
+    <string name="upgrades_gplay_internal_error_title">Chyba Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Došlo k interní chybě Google Play. Zkuste následující kroky:\n\n• Restartujte zařízení\n• Vyčistěte mezipaměť obchodu Google Play\n• Zkuste to znovu později</string>
+    <string name="upgrades_gplay_network_error_title">Chyba připojení</string>
+    <string name="upgrades_gplay_network_error_description">Nelze se připojit k Google Play. Zkontrolujte připojení k internetu a zkuste to znovu.</string>
     <string name="upgrades_gplay_unavailable_error_title">Služba Google Play není k dispozici</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager se nemůže připojit ke Google Play. Je Google Play nainstalován a aktuální? Jste přihlášeni ke svému účtu Google? Zkuste vymazat mezipaměť aplikace Google Play a restartovat zařízení.</string>
     <string name="upgrades_no_purchases_found_check_account">Nebyly nalezeny žádné nákupy. Používáte správný účet?</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Abonnementet koster %s pr. år.</string>
     <string name="upgrade_screen_iap_action">Engangskøb</string>
     <string name="upgrade_screen_iap_action_hint">Engangskøbet koster %s.</string>
+    <string name="upgrade_screen_offer_divider_or">eller</string>
+    <string name="upgrade_screen_offer_same_features">Samme funktioner, bare forskellige prismodeller.</string>
     <string name="upgrade_screen_thanks_toast">Du er den bedste! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Gendan køb</string>
+    <string name="upgrade_screen_restore_banner_title">Har du allerede købt BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Det ser ud til, at du har opgraderet på denne enhed før. Gendan dit køb for at låse det op igen.</string>
     <string name="upgrade_screen_restore_purchase_message">Din opgradering er gyldig på tværs af enheder på den samme Google-konto.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Fejlfindingstips til ukendte opgraderinger:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Synkronisering af Play Butik kan tage tid. Prøv at genstarte, rydde Google Play-cachen eller bare vent.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Flere konti kan forvirre Google Play. Log ud af andre konti, eller installer via Google Play-hjemmesiden, som fremtvinger tilknytning til en bestemt konto.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Se din Pro-status</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Tillykke!</string>
+    <string name="upgrade_screen_owned_congrats_body">Du har BVM Pro — tak for at støtte udviklingen. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Engangskøb</string>
+    <string name="upgrade_screen_owned_iap_body">Du ejer BVM Pro for altid. Tak for din støtte ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abonnement</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Dit BVM Pro-abonnement er aktivt og indstillet til at blive fornyet.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Dit BVM Pro-abonnement er aktivt, men bliver ikke fornyet. Det forbliver gyldigt indtil udgangen af den nuværende periode.</string>
+    <string name="upgrade_screen_owned_both_warning">Du har både et abonnement og engangskøbet. Annuller abonnementet i Google Play, så du ikke bliver opkrævet igen.</string>
+    <string name="upgrade_screen_manage_subscription">Administrer abonnement</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Skift til et engangskøb</string>
+    <string name="upgrade_screen_switch_purchase_note">Dette er et separat engangskøb. Det annullerer eller refunderer ikke dit abonnement, så annuller også det i Google Play. Brug den samme Google-konto til begge.</string>
+    <string name="upgrade_screen_switch_locked_note">Tilgængelig, når dit abonnement ikke længere er indstillet til at blive fornyet. Annuller det i Google Play for at skifte — du beholder Pro, indtil den nuværende periode udløber.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Ser statussen forkert ud?</string>
+    <string name="upgrade_screen_status_restore_body">Hvis dit køb ikke vises her, så prøv at gendanne det.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Bekræfter dit køb</string>
+    <string name="upgrade_screen_grace_body_short">Vent lidt — vi dobbelttjekker dit køb med Google Play.</string>
+    <string name="upgrade_screen_grace_body">Vi kan stadig ikke bekræfte dit køb med Google Play. Prøv at gendanne det, eller tjek at du er logget ind med den rigtige konto.</string>
+    <string name="upgrade_screen_retry_action">Prøv igen</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonnement stadig aktivt</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Dit abonnement er stadig indstillet til at blive fornyet. Annuller det i Google Play først, og kom derefter tilbage for at købe engangskøbet — på den måde bliver du ikke opkrævet to gange.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Vi kunne ikke tjekke din abonnementsstatus. Tjek din forbindelse, og prøv igen.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Allerede købt</string>
+    <string name="upgrades_gplay_already_owned_error_description">Brug indstillingen \"Gendan køb\" for at gendanne dit køb. Hvis problemet fortsætter, så prøv at rydde Google Play-cachen og genstarte din enhed.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-fejl</string>
+    <string name="upgrades_gplay_internal_error_description">Der opstod en intern Google Play-fejl. Prøv følgende:\n\n• Genstart din enhed\n• Ryd cachen for Google Play Store\n• Prøv igen senere</string>
+    <string name="upgrades_gplay_network_error_title">Forbindelsesfejl</string>
+    <string name="upgrades_gplay_network_error_description">Kunne ikke oprette forbindelse til Google Play. Tjek din internetforbindelse, og prøv igen.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play er utilgængelig</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan ikke oprette forbindelse til Google Play. Er Google Play installeret og opdateret? Er din Google-konto logget ind? Prov at rydde cachen i Google Play-appen og genstarte din enhed.</string>
     <string name="upgrades_no_purchases_found_check_account">Ingen køb fundet. Bruger du den rigtige konto?</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Das Abonnement kostet %s pro Jahr.</string>
     <string name="upgrade_screen_iap_action">Einmaliger Kauf</string>
     <string name="upgrade_screen_iap_action_hint">Der einmalige Kauf kostet %s.</string>
+    <string name="upgrade_screen_offer_divider_or">oder</string>
+    <string name="upgrade_screen_offer_same_features">Gleiche Funktionen, nur unterschiedliche Preismodelle.</string>
     <string name="upgrade_screen_thanks_toast">Du bist super! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Kauf wiederherstellen</string>
+    <string name="upgrade_screen_restore_banner_title">Bereits BVM Pro gekauft?</string>
+    <string name="upgrade_screen_restore_banner_body">Es sieht so aus, als hättest du auf diesem Gerät bereits ein Upgrade durchgeführt. Stelle deinen Kauf wieder her, um es erneut freizuschalten.</string>
     <string name="upgrade_screen_restore_purchase_message">Dein Upgrade ist für alle Geräte mit demselben Google-Konto gültig.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Fehlerbehebungstipps bei nicht erkannten Upgrades:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Die Synchronisation im Play Store kann etwas dauern. Versuch es mit einem Neustart, leere den Google Play Cache oder warte einfach.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Mehrere Konten können Google Play durcheinanderbringen. Melde dich von anderen Konten ab oder installiere über die Google Play-Website, um die Zuordnung zu einem bestimmten Konto zu erzwingen.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Deinen Pro-Status ansehen</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Glückwunsch!</string>
+    <string name="upgrade_screen_owned_congrats_body">Du hast BVM Pro — danke, dass du die Entwicklung unterstützt. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Einmaliger Kauf</string>
+    <string name="upgrade_screen_owned_iap_body">Du besitzt BVM Pro für immer. Danke für deine Unterstützung ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abo</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Dein BVM Pro-Abo ist aktiv und wird verlängert.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Dein BVM Pro-Abo ist aktiv, wird aber nicht verlängert. Es bleibt bis zum Ende des aktuellen Zeitraums gültig.</string>
+    <string name="upgrade_screen_owned_both_warning">Du hast sowohl ein Abo als auch den einmaligen Kauf. Kündige das Abo in Google Play, damit du nicht erneut belastet wirst.</string>
+    <string name="upgrade_screen_manage_subscription">Abo verwalten</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Zum einmaligen Kauf wechseln</string>
+    <string name="upgrade_screen_switch_purchase_note">Dies ist ein separater einmaliger Kauf. Er kündigt dein Abo nicht und erstattet auch keine Kosten, kündige es also zusätzlich in Google Play. Verwende für beides dasselbe Google-Konto.</string>
+    <string name="upgrade_screen_switch_locked_note">Verfügbar, sobald dein Abo nicht mehr verlängert wird. Kündige es in Google Play, um zu wechseln — du behältst Pro bis zum Ende des aktuellen Zeitraums.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Status sieht falsch aus?</string>
+    <string name="upgrade_screen_status_restore_body">Falls dein Kauf hier nicht angezeigt wird, versuche ihn wiederherzustellen.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Dein Kauf wird bestätigt</string>
+    <string name="upgrade_screen_grace_body_short">Einen Moment — wir überprüfen deinen Kauf noch einmal bei Google Play.</string>
+    <string name="upgrade_screen_grace_body">Wir können deinen Kauf bei Google Play immer noch nicht bestätigen. Versuche ihn wiederherzustellen oder prüfe, ob du mit dem richtigen Konto angemeldet bist.</string>
+    <string name="upgrade_screen_retry_action">Erneut versuchen</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abo noch aktiv</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Dein Abo wird noch verlängert. Kündige es zuerst in Google Play und komm dann zurück, um den einmaligen Kauf zu tätigen — so wirst du nicht doppelt belastet.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Wir konnten deinen Abostatus nicht überprüfen. Bitte prüfe deine Verbindung und versuche es erneut.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Bereits gekauft</string>
+    <string name="upgrades_gplay_already_owned_error_description">Verwende die Option \"Auswahl wiederherstellen\", um Deinen Kauf wiederherzustellen. Falls das Problem weiterhin besteht, versuche den Google Play Cache zu leeren und Dein Gerät neu zu starten.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play Fehler</string>
+    <string name="upgrades_gplay_internal_error_description">Ein interner Fehler bei Google Play ist aufgetreten. Bitte versuche Folgendes:\n\n• Starte dein Gerät neu\n• Leere den Cache des Google Play Stores\n• Versuche es später erneut</string>
+    <string name="upgrades_gplay_network_error_title">Verbindungsfehler</string>
+    <string name="upgrades_gplay_network_error_description">Verbindung zu Google Play nicht möglich. Bitte überprüfe Deine Internetverbindung und versuche es erneut.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ist nicht verfügbar</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kann keine Verbindung zu Google Play herstellen. Ist Google Play installiert und aktuell? Ist dein Google-Konto angemeldet? Versuche, den Cache der Google Play-App zu leeren und dein Gerät neu zu starten.</string>
     <string name="upgrades_no_purchases_found_check_account">Keine Käufe gefunden. Verwendest Du das richtige Konto?</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Η συνδρομή κοστίζει %s ετησίως.</string>
     <string name="upgrade_screen_iap_action">Εφάπαξ αγορά</string>
     <string name="upgrade_screen_iap_action_hint">Η εφάπαξ αγορά κοστίζει %s.</string>
+    <string name="upgrade_screen_offer_divider_or">ή</string>
+    <string name="upgrade_screen_offer_same_features">Ίδια χαρακτηριστικά, απλώς διαφορετικά μοντέλα τιμολόγησης.</string>
     <string name="upgrade_screen_thanks_toast">Είστε οι καλύτεροι! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Επαναφορά αγοράς</string>
+    <string name="upgrade_screen_restore_banner_title">Έχεις ήδη αγοράσει το BVM Pro;</string>
+    <string name="upgrade_screen_restore_banner_body">Φαίνεται πως έκανες αναβάθμιση σε αυτή τη συσκευή παλαιότερα. Κάνε επαναφορά της αγοράς σου για να την ξεκλειδώσεις ξανά.</string>
     <string name="upgrade_screen_restore_purchase_message">Η αναβάθμιση σας είναι έγκυρη σε συσκευές στον ίδιο λογαριασμό Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Συμβουλές αντιμετώπισης προβλημάτων για μη αναγνωρισμένες αναβαθμίσεις:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Ο συγχρονισμός του Play Store ενδέχεται να πάρει χρόνο. Δοκιμάστε να κάνετε επανεκκίνηση, να καθαρίσετε την προσωρινή μνήμη του Google Play ή απλώς να περιμένετε.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Πολλοί λογαριασμοί μπορεί να μπερδέψουν το Google Play. Αποσυνδεθείτε από άλλους λογαριασμούς ή εγκαταστήστε το μέσω του ιστότοπου Google Play, κάτι που αναγκάζει τους συσχετισμούς με έναν συγκεκριμένο λογαριασμό.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Δες την κατάσταση Pro σου</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Συγχαρητήρια!</string>
+    <string name="upgrade_screen_owned_congrats_body">Απέκτησες το BVM Pro — ευχαριστούμε που υποστηρίζεις την ανάπτυξη. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Εφάπαξ αγορά</string>
+    <string name="upgrade_screen_owned_iap_body">Το BVM Pro είναι δικό σου για πάντα. Ευχαριστούμε για την υποστήριξη ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Συνδρομή</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Η συνδρομή σου στο BVM Pro είναι ενεργή και έχει οριστεί να ανανεωθεί.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Η συνδρομή σου στο BVM Pro είναι ενεργή αλλά δεν θα ανανεωθεί. Παραμένει έγκυρη μέχρι το τέλος της τρέχουσας περιόδου.</string>
+    <string name="upgrade_screen_owned_both_warning">Έχεις και συνδρομή και εφάπαξ αγορά. Ακύρωσε τη συνδρομή στο Google Play ώστε να μην χρεωθείς ξανά.</string>
+    <string name="upgrade_screen_manage_subscription">Διαχείριση συνδρομής</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Αλλαγή σε εφάπαξ αγορά</string>
+    <string name="upgrade_screen_switch_purchase_note">Αυτή είναι μια ξεχωριστή εφάπαξ αγορά. Δεν ακυρώνει ούτε επιστρέφει τα χρήματα της συνδρομής σου, γι\' αυτό ακύρωσέ την και στο Google Play. Χρησιμοποίησε τον ίδιο λογαριασμό Google και για τις δύο.</string>
+    <string name="upgrade_screen_switch_locked_note">Διαθέσιμο μόλις η συνδρομή σου δεν είναι πλέον ρυθμισμένη να ανανεωθεί. Ακύρωσέ την στο Google Play για να αλλάξεις — κρατάς το Pro μέχρι να λήξει η τρέχουσα περίοδος.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Η κατάσταση φαίνεται λάθος;</string>
+    <string name="upgrade_screen_status_restore_body">Αν η αγορά σου δεν εμφανίζεται εδώ, δοκίμασε να την επαναφέρεις.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Επιβεβαίωση της αγοράς σου</string>
+    <string name="upgrade_screen_grace_body_short">Λίγη υπομονή — ελέγχουμε ξανά την αγορά σου με το Google Play.</string>
+    <string name="upgrade_screen_grace_body">Δεν μπορούμε ακόμα να επιβεβαιώσουμε την αγορά σου με το Google Play. Δοκίμασε να την επαναφέρεις ή έλεγξε ότι έχεις συνδεθεί με τον σωστό λογαριασμό.</string>
+    <string name="upgrade_screen_retry_action">Δοκίμασε ξανά</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Η συνδρομή είναι ακόμα ενεργή</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Η συνδρομή σου εξακολουθεί να είναι ρυθμισμένη να ανανεωθεί. Ακύρωσέ την πρώτα στο Google Play και μετά επέστρεψε για να αγοράσεις την εφάπαξ αγορά — έτσι δεν θα χρεωθείς δύο φορές.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Δεν μπορέσαμε να ελέγξουμε την κατάσταση της συνδρομής σου. Έλεγξε τη σύνδεσή σου και δοκίμασε ξανά.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Ήδη αγορασμένο</string>
+    <string name="upgrades_gplay_already_owned_error_description">Χρησιμοποιήστε την επιλογή \"Επαναφορά αγοράς\" για να επαναφέρετε την αγορά σας. Εάν το πρόβλημα παραμένει, δοκιμάστε να καθαρίσετε την προσωρινή μνήμη του Google Play και να επανεκκινήσετε τη συσκευή σας.</string>
+    <string name="upgrades_gplay_internal_error_title">Σφάλμα Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Παρουσιάστηκε εσωτερικό σφάλμα του Google Play. Δοκιμάστε τα εξής:\n\n• Επανεκκινήστε τη συσκευή σας\n• Καθαρίστε την προσωρινή μνήμη του Google Play Store\n• Δοκιμάστε ξανά αργότερα</string>
+    <string name="upgrades_gplay_network_error_title">Σφάλμα σύνδεσης</string>
+    <string name="upgrades_gplay_network_error_description">Αδυναμία σύνδεσης με το Google Play. Ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.</string>
     <string name="upgrades_gplay_unavailable_error_title">Το Google Play δεν είναι διαθέσιμο</string>
     <string name="upgrades_gplay_unavailable_error_description">Το Bluetooth Volume Manager δεν μπορεί να συνδεθεί με το Google Play. Είναι το Google Play εγκατεστημένο και ενημερωμένο; Έχετε συνδεθεί με τον λογαριασμό Google σας; Δοκιμάστε να διαγράψετε την προσωρινή μνήμη της εφαρμογής Google Play και να επανεκκινήσετε τη συσκευή σας.</string>
     <string name="upgrades_no_purchases_found_check_account">Δεν βρέθηκαν αγορές. Χρησιμοποιείτε τον σωστό λογαριασμό;</string>

--- a/app/src/gplay/res/values-eo-rUY/strings.xml
+++ b/app/src/gplay/res/values-eo-rUY/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">La abono kostas %s jare.</string>
     <string name="upgrade_screen_iap_action">Unufoja aĉeto</string>
     <string name="upgrade_screen_iap_action_hint">La unufoja aĉeto kostas %s.</string>
+    <string name="upgrade_screen_offer_divider_or">aŭ</string>
+    <string name="upgrade_screen_offer_same_features">Samaj funkcioj, nur malsamaj prezmodeligoj.</string>
     <string name="upgrade_screen_thanks_toast">Vi estas la plej bona! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restarigi aĉeton</string>
+    <string name="upgrade_screen_restore_banner_title">Ĉu vi jam aĉetis BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Ŝajnas, ke vi antaŭe ĝisdatigis ĉi tiun aparaton. Restaŭru vian aĉeton por malŝlosi ĝin denove.</string>
     <string name="upgrade_screen_restore_purchase_message">Via plibonigo validas tra aparatoj sur la sama Google-konto.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Konsiletoj pri solvado de problemoj por nerekoneblaj plibonigoj:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La sinkronigado de Play Store povas daŭri. Provu restarigi, forigi la kaŝmemoron de Google Play aŭ simple atendi.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Multoblaj kontoj povas konfuzi Google Play. Elsalutu el aliaj kontoj aŭ instalu per la retejo de Google Play, kiu devigas asociadon kun specifa konto.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Vidu vian Pro-staton</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Gratulojn!</string>
+    <string name="upgrade_screen_owned_congrats_body">Vi havas BVM Pro — dankon pro la subteno de disvolvado. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Unufoja aĉeto</string>
+    <string name="upgrade_screen_owned_iap_body">Vi posedas BVM Pro ĉiam. Dankon pro via subteno ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abono</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Via abono de BVM Pro estas aktiva kaj starigita por renoviĝi.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Via abono de BVM Pro estas aktiva sed ne renoviĝos. Ĝi restas valida ĝis la fino de la nuna periodo.</string>
+    <string name="upgrade_screen_owned_both_warning">Vi havas kaj abonon kaj unufojan aĉeton. Nuligu la abonon en Google Play por ne esti ŝarĝita denove.</string>
+    <string name="upgrade_screen_manage_subscription">Administri abonon</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Ŝanĝi al unufoja aĉeto</string>
+    <string name="upgrade_screen_switch_purchase_note">Ĉi tio estas aparta unufoja aĉeto. Ĝi ne nuligos aŭ repagos vian abonon, do nuligu tion ankaŭ en Google Play. Uzu la saman Google-konton por ambaŭ.</string>
+    <string name="upgrade_screen_switch_locked_note">Havebla kiam via abono ne plu estas starigita por renoviĝi. Nuligu ĝin en Google Play por ŝanĝi — vi konservas Pro ĝis la fino de la nuna periodo.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Ĉu la stato ŝajnas malĝusta?</string>
+    <string name="upgrade_screen_status_restore_body">Se via aĉeto ne aperas ĉi tie, provu ĝin refari.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Konfirmante vian aĉeton</string>
+    <string name="upgrade_screen_grace_body_short">Atenda momenton — ni duoble kontrolas vian aĉeton kun Google Play.</string>
+    <string name="upgrade_screen_grace_body">Ni daŭre ne povas konfirmi vian aĉeton kun Google Play. Provu rekuperi ĝin, aŭ kontrolu, ke vi estas ensalutita per la ĝusta konto.</string>
+    <string name="upgrade_screen_retry_action">Reprovu</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonado daŭre aktiva</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Via abonado estas daŭre agordita por renovi. Nuligu ĝin en Google Play unue, poste revenu por aĉeti unufojan aĉeton — tiele vi ne estos ŝarĝita dufoje.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Ni ne povis kontroli vian abonadan staton. Bonvolu kontroli vian konekton kaj provu denove.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Jam aĉetita</string>
+    <string name="upgrades_gplay_already_owned_error_description">Uzu la \"Rekuperi aĉeton\" eblecon por rekuperi vian aĉeton. Se la problemo daŭras, provu forviŝi la kaŝmemoron de Google Play Store kaj restartigi vian aparaton.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play eraro</string>
+    <string name="upgrades_gplay_internal_error_description">Interna Google Play eraro okazis. Bonvolu provi jenon:\n\n• Restartigu vian aparaton\n• Forviŝu la kaŝmemoron de Google Play Store\n• Provu denove poste</string>
+    <string name="upgrades_gplay_network_error_title">Konekta eraro</string>
+    <string name="upgrades_gplay_network_error_description">Ne eblas konektiĝi al Google Play. Bonvolu kontroli vian interretan konekton kaj provu denove.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ne estas disponebla</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ne povas konektiĝi al Google Play. Ču Google Play estas instalita kaj ĝisdatigita? Ču via Google-konto estas ensalutinta? Provu forigi la kaŝmemoron de la aplikaĵo Google Play kaj restartiĝi vian aparaton.</string>
     <string name="upgrades_no_purchases_found_check_account">Neniaj aĉetoj trovis. Ču vi uzas la ĝustan konton?</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">La suscripción cuesta %s al año.</string>
     <string name="upgrade_screen_iap_action">Compra única</string>
     <string name="upgrade_screen_iap_action_hint">La compra única cuesta %s.</string>
+    <string name="upgrade_screen_offer_divider_or">o</string>
+    <string name="upgrade_screen_offer_same_features">Las mismas funciones, solo cambian los modelos de precios.</string>
     <string name="upgrade_screen_thanks_toast">¡Sos el mejor! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar la compra</string>
+    <string name="upgrade_screen_restore_banner_title">¿Ya compraste BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Parece que ya actualizaste este dispositivo antes. Restaurá tu compra para desbloquearlo de nuevo.</string>
     <string name="upgrade_screen_restore_purchase_message">La actualización es válida para todos los dispositivos de la misma cuenta de Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Consejos para solucionar problemas de actualizaciones no reconocidas:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronización de Play Store puede llevar un tiempo. Intenta reiniciar, limpiar la caché de Google Play o simplemente esperar.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Varias cuentas pueden confundir a Google Play. Cierra la sesión de otras cuentas o instala a través del sitio web de Google Play, que obliga las asociaciones con una cuenta específica.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Mirá tu estado Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">¡Felicitaciones!</string>
+    <string name="upgrade_screen_owned_congrats_body">Ya tenés BVM Pro — gracias por apoyar el desarrollo. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Compra única</string>
+    <string name="upgrade_screen_owned_iap_body">Sos dueño de BVM Pro para siempre. Gracias por tu apoyo ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Suscripción</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Tu suscripción a BVM Pro está activa y configurada para renovarse.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Tu suscripción a BVM Pro está activa pero no se va a renovar. Sigue siendo válida hasta el final del período actual.</string>
+    <string name="upgrade_screen_owned_both_warning">Tenés tanto una suscripción como la compra única. Cancelá la suscripción en Google Play para que no te cobren de nuevo.</string>
+    <string name="upgrade_screen_manage_subscription">Gestionar suscripción</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Cambiar a una compra única</string>
+    <string name="upgrade_screen_switch_purchase_note">Esta es una compra única separada. No cancela ni reembolsa tu suscripción, así que cancelala también en Google Play. Usá la misma cuenta de Google para ambas.</string>
+    <string name="upgrade_screen_switch_locked_note">Disponible una vez que tu suscripción ya no esté configurada para renovarse. Cancelala en Google Play para cambiar — mantenés Pro hasta que termine el período actual.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">¿El estado se ve mal?</string>
+    <string name="upgrade_screen_status_restore_body">Si tu compra no aparece acá, probá restaurarla.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Confirmando tu compra</string>
+    <string name="upgrade_screen_grace_body_short">Esperá un toque — estamos volviendo a verificar tu compra con Google Play.</string>
+    <string name="upgrade_screen_grace_body">Todavía no podemos confirmar tu compra con Google Play. Probá restaurarla, o fijate que hayas iniciado sesión con la cuenta correcta.</string>
+    <string name="upgrade_screen_retry_action">Reintentar</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Suscripción todavía activa</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción todavía está configurada para renovarse. Cancelala primero en Google Play y después volvé para comprar la compra única — así no te cobran dos veces.</string>
+    <string name="upgrade_screen_sub_check_failed_message">No pudimos verificar el estado de tu suscripción. Revisá tu conexión y probá de nuevo.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Ya comprado</string>
+    <string name="upgrades_gplay_already_owned_error_description">Usá la opción \"Restaurar compra\" para restaurar tu compra. Si el problema persiste, probá borrar la caché de Google Play y reiniciar tu dispositivo.</string>
+    <string name="upgrades_gplay_internal_error_title">Error de Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Ocurrió un error interno de Google Play. Probá lo siguiente:\n\n• Reiniciá tu dispositivo\n• Borrá la caché de Google Play Store\n• Intentá de nuevo más tarde</string>
+    <string name="upgrades_gplay_network_error_title">Error de conexión</string>
+    <string name="upgrades_gplay_network_error_description">No se pudo conectar con Google Play. Revisá tu conexión a internet y probá de nuevo.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no está disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no puede conectarse a Google Play. ¿Está instalado y actualizado Google Play? ¿Tu cuenta de Google está iniciada? Intentá limpiar el caché de la app de Google Play y reiniciar tu dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">La suscripción cuesta %s por año.</string>
     <string name="upgrade_screen_iap_action">Compra única</string>
     <string name="upgrade_screen_iap_action_hint">La compra única cuesta %s.</string>
+    <string name="upgrade_screen_offer_divider_or">o</string>
+    <string name="upgrade_screen_offer_same_features">Las mismas funciones, solo con modelos de precio diferentes.</string>
     <string name="upgrade_screen_thanks_toast">¡Eres el mejor! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar compra</string>
+    <string name="upgrade_screen_restore_banner_title">¿Ya compraste BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Parece que ya actualizaste este dispositivo antes. Restaura tu compra para desbloquearlo de nuevo.</string>
     <string name="upgrade_screen_restore_purchase_message">Tu actualización es válida en dispositivos con la misma cuenta de Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Consejos de solución de problemas para actualizaciones no reconocidas:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronización de Play Store puede tomar tiempo. Intenta reiniciar, limpiar el caché de Google Play o simplemente esperar.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Las múltiples cuentas pueden confundir a Google Play. Cierra sesión en otras cuentas o instala a través del sitio web de Google Play, que fuerza asociaciones con una cuenta específica.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Consulta tu estado Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">¡Felicidades!</string>
+    <string name="upgrade_screen_owned_congrats_body">Ya tienes BVM Pro; gracias por apoyar el desarrollo. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Compra única</string>
+    <string name="upgrade_screen_owned_iap_body">Eres dueño de BVM Pro para siempre. Gracias por tu apoyo ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Suscripción</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Tu suscripción a BVM Pro está activa y se renovará.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Tu suscripción a BVM Pro está activa, pero no se renovará. Sigue siendo válida hasta el final del periodo actual.</string>
+    <string name="upgrade_screen_owned_both_warning">Tienes tanto una suscripción como la compra única. Cancela la suscripción en Google Play para que no se te cobre de nuevo.</string>
+    <string name="upgrade_screen_manage_subscription">Administrar suscripción</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Cambiar a una compra única</string>
+    <string name="upgrade_screen_switch_purchase_note">Esta es una compra única independiente. No cancela ni reembolsa tu suscripción, así que cancélala también en Google Play. Usa la misma cuenta de Google para ambas.</string>
+    <string name="upgrade_screen_switch_locked_note">Disponible cuando tu suscripción ya no esté configurada para renovarse. Cancélala en Google Play para cambiar; conservas Pro hasta que termine el periodo actual.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">¿El estado se ve incorrecto?</string>
+    <string name="upgrade_screen_status_restore_body">Si tu compra no aparece aquí, intenta restaurarla.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Confirmando tu compra</string>
+    <string name="upgrade_screen_grace_body_short">Espera un momento: estamos verificando de nuevo tu compra con Google Play.</string>
+    <string name="upgrade_screen_grace_body">Todavía no podemos confirmar tu compra con Google Play. Intenta restaurarla o verifica que hayas iniciado sesión con la cuenta correcta.</string>
+    <string name="upgrade_screen_retry_action">Reintentar</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Suscripción todavía activa</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción todavía está configurada para renovarse. Cancélala primero en Google Play y luego regresa a comprar la compra única; así no se te cobrará dos veces.</string>
+    <string name="upgrade_screen_sub_check_failed_message">No pudimos verificar el estado de tu suscripción. Revisa tu conexión e intenta de nuevo.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Ya comprado</string>
+    <string name="upgrades_gplay_already_owned_error_description">Usa la opción \"Restaurar compra\" para restaurar tu compra. Si el problema persiste, intenta borrar la caché de Google Play y reiniciar tu dispositivo.</string>
+    <string name="upgrades_gplay_internal_error_title">Error de Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Ocurrió un error interno de Google Play. Intenta lo siguiente:\n\n• Reinicia tu dispositivo\n• Borra la caché de Google Play Store\n• Inténtalo más tarde</string>
+    <string name="upgrades_gplay_network_error_title">Error de conexión</string>
+    <string name="upgrades_gplay_network_error_description">No se pudo conectar con Google Play. Revisa tu conexión a internet e intenta de nuevo.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no está disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no puede conectarse a Google Play. ¿Está Google Play instalado y actualizado? ¿Está tu cuenta de Google conectada? Intenta limpiar la caché de la app Google Play y reiniciar tu dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">La suscripción cuesta %s al año.</string>
     <string name="upgrade_screen_iap_action">Compra única</string>
     <string name="upgrade_screen_iap_action_hint">La compra única tiene un precio de %s.</string>
+    <string name="upgrade_screen_offer_divider_or">o</string>
+    <string name="upgrade_screen_offer_same_features">Las mismas funciones, solo que con distintos modelos de precios.</string>
     <string name="upgrade_screen_thanks_toast">¡Eres el mejor! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar la compra</string>
+    <string name="upgrade_screen_restore_banner_title">¿Ya compraste BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Parece que ya actualizaste este dispositivo antes. Restaura tu compra para desbloquearlo de nuevo.</string>
     <string name="upgrade_screen_restore_purchase_message">La actualización es válida para todos los dispositivos de la misma cuenta de Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Consejos para solucionar problemas de actualizaciones no reconocidas:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronización de Play Store puede tardar. Prueba a reiniciar, borrar la caché de Google Play o simplemente espera.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Varias cuentas pueden confundir a Google Play. Cierra la sesión de otras cuentas o instala a través del sitio web de Google Play, que obliga las asociaciones con una cuenta específica.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Consulta tu estado Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">¡Enhorabuena!</string>
+    <string name="upgrade_screen_owned_congrats_body">Ya tienes BVM Pro — gracias por apoyar el desarrollo. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Compra única</string>
+    <string name="upgrade_screen_owned_iap_body">Tienes BVM Pro para siempre. Gracias por tu apoyo ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Suscripción</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Tu suscripción de BVM Pro está activa y configurada para renovarse.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Tu suscripción de BVM Pro está activa, pero no se renovará. Seguirá siendo válida hasta el final del período actual.</string>
+    <string name="upgrade_screen_owned_both_warning">Tienes tanto una suscripción como la compra única. Cancela la suscripción en Google Play para que no se te vuelva a cobrar.</string>
+    <string name="upgrade_screen_manage_subscription">Gestionar suscripción</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Cambiar a una compra única</string>
+    <string name="upgrade_screen_switch_purchase_note">Esta es una compra única independiente. No cancela ni reembolsa tu suscripción, así que cancélala también en Google Play. Usa la misma cuenta de Google para ambas.</string>
+    <string name="upgrade_screen_switch_locked_note">Disponible cuando tu suscripción ya no esté configurada para renovarse. Cancélala en Google Play para cambiar — conservas Pro hasta que termine el período actual.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">¿El estado no parece correcto?</string>
+    <string name="upgrade_screen_status_restore_body">Si tu compra no aparece aquí, intenta restaurarla.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Confirmando tu compra</string>
+    <string name="upgrade_screen_grace_body_short">Un momento — estamos verificando de nuevo tu compra con Google Play.</string>
+    <string name="upgrade_screen_grace_body">Todavía no podemos confirmar tu compra con Google Play. Intenta restaurarla o comprueba que has iniciado sesión con la cuenta correcta.</string>
+    <string name="upgrade_screen_retry_action">Reintentar</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Suscripción todavía activa</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción todavía está configurada para renovarse. Cancélala primero en Google Play y luego vuelve para comprar la compra única — así no se te cobrará dos veces.</string>
+    <string name="upgrade_screen_sub_check_failed_message">No pudimos comprobar el estado de tu suscripción. Comprueba tu conexión e inténtalo de nuevo.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Ya comprado</string>
+    <string name="upgrades_gplay_already_owned_error_description">Usa la opción «Restaurar compra» para restaurar tu compra. Si el problema persiste, intenta borrar la caché de Google Play y reiniciar tu dispositivo.</string>
+    <string name="upgrades_gplay_internal_error_title">Error de Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Se produjo un error interno de Google Play. Prueba lo siguiente:\n\n• Reinicia tu dispositivo\n• Borra la caché de Google Play Store\n• Inténtalo de nuevo más tarde</string>
+    <string name="upgrades_gplay_network_error_title">Error de conexión</string>
+    <string name="upgrades_gplay_network_error_description">No se pudo conectar con Google Play. Comprueba tu conexión a internet e inténtalo de nuevo.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no está disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no puede conectarse a Google Play. ¿Está Google Play instalado y actualizado? ¿Has iniciado sesión con tu cuenta de Google? Prueba a borrar la caché de la aplicación Google Play y reinicia tu dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Tellimus maksab %s aastas.</string>
     <string name="upgrade_screen_iap_action">Ühekordne ost</string>
     <string name="upgrade_screen_iap_action_hint">Ühekordne ost maksab %s.</string>
+    <string name="upgrade_screen_offer_divider_or">või</string>
+    <string name="upgrade_screen_offer_same_features">Samad võimalused, ainult erinevad hinnamudelid.</string>
     <string name="upgrade_screen_thanks_toast">Olete parim! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Taasta ost</string>
+    <string name="upgrade_screen_restore_banner_title">Oled juba BVM Pro ostnud?</string>
+    <string name="upgrade_screen_restore_banner_body">Tundub, et oled selles seadmes varem uuendanud. Taasta oma ost, et see uuesti avada.</string>
     <string name="upgrade_screen_restore_purchase_message">Uuendus kehtib kõigis seda Google`i kontot kasutavates seadmetes.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Tundmatute uuenduste lahendamise nõuanded:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play poe ajakohastamine võib võtta aega. Ürita taaskäivitada, tühjendada Google\'i poe vahemälu või lihtsalt oota.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Google\'i pood ei pruugi mitme kontoga toime tulla. Logi teistelt kontodelt välja või paigalda Google\'i poe veebilehe kaudu, mis tuvastab seose kindla kontoga.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Vaata oma Pro olekut</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Õnnitlused!</string>
+    <string name="upgrade_screen_owned_congrats_body">Sul on nüüd BVM Pro — täname arenduse toetamise eest. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Ühekordne ost</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro kuulub sulle igaveseks. Täname toetuse eest ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Tellimus</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Sinu BVM Pro tellimus on aktiivne ja uueneb automaatselt.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Sinu BVM Pro tellimus on aktiivne, kuid ei uuene. See kehtib kuni praeguse perioodi lõpuni.</string>
+    <string name="upgrade_screen_owned_both_warning">Sul on olemas nii tellimus kui ka ühekordne ost. Tühista tellimus rakenduses Google Play, et sinult uuesti raha ei võetaks.</string>
+    <string name="upgrade_screen_manage_subscription">Halda tellimust</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Lülitu ühekordsele ostule</string>
+    <string name="upgrade_screen_switch_purchase_note">See on eraldiseisev ühekordne ost. See ei tühista ega tagasta sinu tellimust, seega tühista see samuti rakenduses Google Play. Kasuta mõlema jaoks sama Google\'i kontot.</string>
+    <string name="upgrade_screen_switch_locked_note">Saadaval, kui sinu tellimus enam ei uuene. Tühista see rakenduses Google Play, et üle lülituda — Pro jääb sulle kuni praeguse perioodi lõpuni.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Vale?</string>
+    <string name="upgrade_screen_status_restore_body">Kui sinu ost siin ei kuva, proovi see taastada.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Teie ostu kinnitamine</string>
+    <string name="upgrade_screen_grace_body_short">Palun oota — kontrollime sinu ostu Google Play kaudu üle.</string>
+    <string name="upgrade_screen_grace_body">Me ei suuda ikka veel sinu ostu Google Play kaudu kinnitada. Proovi see taastada või kontrolli, kas oled sisse logitud õige kontoga.</string>
+    <string name="upgrade_screen_retry_action">Proovi uuesti</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Tellimus on endiselt kasutusel</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Sinu tellimus uueneb endiselt. Tühista see kõigepealt rakenduses Google Play ja tule siis tagasi, et osta ühekordne ost — nii ei arveldata sind kaks korda.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Me ei saanud sinu tellimuse olekut kontrollida. Palun kontrolli oma internetiühendust ja proovi uuesti.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Juba ostetud</string>
+    <string name="upgrades_gplay_already_owned_error_description">Ostu taastamiseks kasuta „Taasta ost“ valikut. Mure püsimisel ürita tühjendada Google Play vahemälu ja taaskäivitada seadet.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play viga</string>
+    <string name="upgrades_gplay_internal_error_description">Seadmes tekkis Google Play viga. Proovige järgmist:\n\n• Seadme taaskäivitamine\n• Google Play Store vahemälu tühjendamine\n• Hiljem uuesti proovimine</string>
+    <string name="upgrades_gplay_network_error_title">Ühenduse viga</string>
+    <string name="upgrades_gplay_network_error_description">Ühendumine Google Playga nurjus. Kontrollige internetiühendust ja proovige uuesti.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play pole saadaval</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ei suuda ühenduda Google Playga. Kas Google Play on paigaldatud ja ajakohane? Kas olete Google\'i kontole sisse logitud? Proovige tühjendada Google Play rakenduse vahemälu ja taaskäivitada seade.</string>
     <string name="upgrades_no_purchases_found_check_account">Oste ei leitud. Kas kasutate õiget kontot?</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Harpidetza urtero %s-ko prezioa du.</string>
     <string name="upgrade_screen_iap_action">Erosketa bakarra</string>
     <string name="upgrade_screen_iap_action_hint">Erosketa bakarraren prezioa %s-koa da.</string>
+    <string name="upgrade_screen_offer_divider_or">edo</string>
+    <string name="upgrade_screen_offer_same_features">Ezaugarri berberak, prezio-eredu desberdinekin.</string>
     <string name="upgrade_screen_thanks_toast">Hoberena zara! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Berreskuratu erosketa</string>
+    <string name="upgrade_screen_restore_banner_title">Jada BVM Pro erosi duzu?</string>
+    <string name="upgrade_screen_restore_banner_body">Badirudi lehenago eguneratu zenuela gailu honetan. Berreskuratu zure erosketa berriro desblokeatzeko.</string>
     <string name="upgrade_screen_restore_purchase_message">Zure igoera baliozkoa da Googleko kontu berean dauden gailuen bidez.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Aitortu gabeko eguneratze-arazoak konpontzeko aholkuak:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Storeren sinkronizazioak denbora behar izan dezake. Saiatu berrabiarazten, Google Play katxea ezabatzen edo, besterik gabe, itxaron.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Kontu anitzek Google Play nahas dezakete. Beste kontu batzuetatik atera edo Google Play webgunearen bidez instalatu, eta horrek elkarteak kontu zehatz batekin behartzen ditu.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Ikusi zure Pro egoera</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Zorionak!</string>
+    <string name="upgrade_screen_owned_congrats_body">BVM Pro eskuratu duzu — eskerrik asko garapena babesteagatik. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Erosketa bakarra</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro betiko duzu. Eskerrik asko zure laguntzagatik ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Harpidetza</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Zure BVM Pro harpidetza aktibo dago eta berritzeko ezarrita.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Zure BVM Pro harpidetza aktibo dago, baina ez da berrituko. Uneko epearen amaierara arte baliozkoa izango da.</string>
+    <string name="upgrade_screen_owned_both_warning">Harpidetza eta ordainketa bakarreko erosketa, biak dituzu. Utzi harpidetza Google Play-n berriz kobra ez diezazuten.</string>
+    <string name="upgrade_screen_manage_subscription">Kudeatu harpidetza</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Aldatu ordainketa bakarreko erosketara</string>
+    <string name="upgrade_screen_switch_purchase_note">Hau ordainketa bakarreko erosketa independente bat da. Ez du zure harpidetza bertan behera uzten edo itzultzen, beraz utzi hori ere Google Play-n. Erabili Google kontu bera bietarako.</string>
+    <string name="upgrade_screen_switch_locked_note">Zure harpidetza berritzeko ezarrita ez dagoenean egongo da eskuragarri. Utzi Google Play-n aldatzeko — Pro mantenduko duzu uneko epea amaitu arte.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Egoerak oker dirudi?</string>
+    <string name="upgrade_screen_status_restore_body">Zure erosketa hemen agertzen ez bada, saiatu berreskuratzen.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Zure erosketa berresten</string>
+    <string name="upgrade_screen_grace_body_short">Itxaron pixka bat — zure erosketa berrikusten ari gara Google Play-rekin.</string>
+    <string name="upgrade_screen_grace_body">Oraindik ezin dugu zure erosketa Google Play-rekin baieztatu. Saiatu berreskuratzen, edo egiaztatu kontu egokiarekin saioa hasi duzula.</string>
+    <string name="upgrade_screen_retry_action">Saiatu berriro</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Harpidetza oraindik aktibo</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Zure harpidetza oraindik berritzeko ezarrita dago. Utzi lehenbizi Google Play-n, eta gero itzuli ordainketa bakarreko erosketa egitera — horrela ez zaituzte bi aldiz kobratuko.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Ezin izan dugu zure harpidetzaren egoera egiaztatu. Egiaztatu zure konexioa eta saiatu berriro.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Jada erosita</string>
+    <string name="upgrades_gplay_already_owned_error_description">Erabili \"Berreskuratu erosketa\" aukera zure erosketa berreskuratzeko. Arazoak jarraitzen badu, saiatu Google Play-ren cachea garbitzen eta gailua berrabiarazten.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play errorea</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play-ren barne errore bat gertatu da. Saiatu ondorengoak egiten:\n\n• Berrabiarazi zure gailua\n• Garbitu Google Play Store-ren cachea\n• Saiatu berriro geroago</string>
+    <string name="upgrades_gplay_network_error_title">Konexio errorea</string>
+    <string name="upgrades_gplay_network_error_description">Ezin izan da Google Play-rekin konektatu. Egiaztatu zure interneteko konexioa eta saiatu berriro.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ez dago erabilgarri</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager-ek ezin du Google Play-ra konektatu. Google Play instalatuta eta eguneratuta al dago? Zure Google kontua saioa hasi al du? Saiatu Google Play aplikazioaren cachea garbitzen eta gailua berrabiarazten.</string>
     <string name="upgrades_no_purchases_found_check_account">Ez dira erosketarik aurkitu. Kontu zuzena erabiltzen ari zara?</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">هزینه اشتراک سالیانه %s است.</string>
     <string name="upgrade_screen_iap_action">خرید یکباره</string>
     <string name="upgrade_screen_iap_action_hint">هزینه خرید یک‌باره %s است.</string>
+    <string name="upgrade_screen_offer_divider_or">یا</string>
+    <string name="upgrade_screen_offer_same_features">امکانات یکسان، فقط مدل‌های قیمت‌گذاری متفاوت.</string>
     <string name="upgrade_screen_thanks_toast">تو بهترینی! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">بازیابی خرید</string>
+    <string name="upgrade_screen_restore_banner_title">قبلاً BVM Pro را خریده‌اید؟</string>
+    <string name="upgrade_screen_restore_banner_body">به نظر می‌رسد قبلاً در این دستگاه ارتقا داده‌اید. خرید خود را بازیابی کنید تا دوباره باز شود.</string>
     <string name="upgrade_screen_restore_purchase_message">به‌روزرسانی شما در تمامی دستگاه‌های موجود در همان حساب Google معتبر است.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">نکات عیب یابی ارتقاهای ناشناخته:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">ممکن است همگام‌سازی فروشگاه Google Play کمی زمان ببرد. سعی کنید دستگاه خود را مجدداً راه‌اندازی کنید، کش برنامه Google Play را پاک کنید یا کمی صبر کنید.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">داشتن حساب‌های متعدد می‌تواند Google Play را گیج کند. از سایر حساب‌ها خارج شوید یا از طریق وب‌سایت Google Play نصب کنید، که انجمن‌ها را با یک حساب خاص تحمیل می‌کند.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">وضعیت Pro خود را مشاهده کنید</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">تبریک می‌گوییم!</string>
+    <string name="upgrade_screen_owned_congrats_body">شما BVM Pro را دارید — با تشکر از حمایتتان از توسعه. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">خرید یکباره</string>
+    <string name="upgrade_screen_owned_iap_body">شما برای همیشه مالک BVM Pro هستید. با تشکر از حمایتتان ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">اشتراک</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">اشتراک BVM Pro شما فعال است و برای تمدید تنظیم شده است.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">اشتراک BVM Pro شما فعال است اما تمدید نخواهد شد. تا پایان دوره فعلی معتبر باقی می‌ماند.</string>
+    <string name="upgrade_screen_owned_both_warning">شما هم اشتراک و هم خرید یک‌باره را دارید. برای اینکه دوباره از شما هزینه دریافت نشود، اشتراک را در Google Play لغو کنید.</string>
+    <string name="upgrade_screen_manage_subscription">مدیریت اشتراک</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">تغییر به خرید یک‌باره</string>
+    <string name="upgrade_screen_switch_purchase_note">این یک خرید یک‌باره جداگانه است. اشتراک شما را لغو یا بازپرداخت نمی‌کند، بنابراین آن را هم در Google Play لغو کنید. از یک حساب Google یکسان برای هر دو استفاده کنید.</string>
+    <string name="upgrade_screen_switch_locked_note">زمانی در دسترس است که اشتراک شما دیگر برای تمدید تنظیم نشده باشد. برای تغییر، آن را در Google Play لغو کنید — تا پایان دوره فعلی Pro را نگه می‌دارید.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">وضعیت اشتباه به نظر می‌رسد؟</string>
+    <string name="upgrade_screen_status_restore_body">اگر خرید شما اینجا نمایش داده نمی‌شود، سعی کنید آن را بازیابی کنید.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">در حال تأیید خرید شما</string>
+    <string name="upgrade_screen_grace_body_short">کمی صبر کنید — در حال بررسی مجدد خرید شما با Google Play هستیم.</string>
+    <string name="upgrade_screen_grace_body">هنوز نمی‌توانیم خرید شما را با Google Play تأیید کنیم. سعی کنید آن را بازیابی کنید، یا بررسی کنید که با حساب درست وارد شده‌اید.</string>
+    <string name="upgrade_screen_retry_action">تلاش مجدد</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">اشتراک هنوز فعال است</string>
+    <string name="upgrade_screen_sub_still_renewing_message">اشتراک شما هنوز برای تمدید تنظیم شده است. ابتدا آن را در Google Play لغو کنید، سپس برای خرید یک‌باره برگردید — این‌طور دو بار از شما هزینه دریافت نمی‌شود.</string>
+    <string name="upgrade_screen_sub_check_failed_message">نتوانستیم وضعیت اشتراک شما را بررسی کنیم. لطفاً اتصال خود را بررسی کرده و دوباره تلاش کنید.</string>
+    <string name="upgrades_gplay_already_owned_error_title">قبلاً خریداری شده</string>
+    <string name="upgrades_gplay_already_owned_error_description">برای بازیابی خرید خود از گزینه «بازیابی خرید» استفاده کنید. اگر مشکل ادامه داشت، سعی کنید کش Google Play را پاک کرده و دستگاه خود را دوباره راه‌اندازی کنید.</string>
+    <string name="upgrades_gplay_internal_error_title">خطای Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">یک خطای داخلی Google Play رخ داد. لطفاً موارد زیر را امتحان کنید:\n\n• دستگاه خود را دوباره راه‌اندازی کنید\n• کش فروشگاه Google Play را پاک کنید\n• بعداً دوباره تلاش کنید</string>
+    <string name="upgrades_gplay_network_error_title">خطای اتصال</string>
+    <string name="upgrades_gplay_network_error_description">اتصال به Google Play ممکن نیست. لطفاً اتصال اینترنت خود را بررسی کرده و دوباره تلاش کنید.</string>
     <string name="upgrades_gplay_unavailable_error_title">گوگل پلی در دسترس نیست</string>
     <string name="upgrades_gplay_unavailable_error_description">مدیر صدای بلوتوث نمی‌تواند به Google Play وصل شود. آیا Google Play نصب و به‌روز است؟ آیا حساب گوگلتان وارد شده؟ حافظه‌پنهان برنامه Google Play را پاک کنید و دستگاه را راه‌اندازی مجدد کنید.</string>
     <string name="upgrades_no_purchases_found_check_account">هیچ خریدی یافت نشد. آیا از حساب صحیح استفاده می‌کنید؟</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Tilaus maksaa %s vuodessa.</string>
     <string name="upgrade_screen_iap_action">Kertaostos</string>
     <string name="upgrade_screen_iap_action_hint">Kertaostos maksaa %s.</string>
+    <string name="upgrade_screen_offer_divider_or">tai</string>
+    <string name="upgrade_screen_offer_same_features">Samat ominaisuudet, vain erilaiset hinnoittelumallit.</string>
     <string name="upgrade_screen_thanks_toast">Olet paras! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Palauta ostos</string>
+    <string name="upgrade_screen_restore_banner_title">Ostitko jo BVM Pro:n?</string>
+    <string name="upgrade_screen_restore_banner_body">Näyttää siltä, että olet päivittänyt tämän laitteen aiemmin. Palauta ostoksesi avataksesi sen uudelleen.</string>
     <string name="upgrade_screen_restore_purchase_message">Päivityksesi on voimassa laitteissa samalla Google-tilillä.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Vianmääritysvinkkejä tunnistamattomille päivityksille:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store -synkronointi voi kestää. Kokeile uudelleenkäynnistystä, Google Play -välimuistin tyhjentämistä tai vain odottamista.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Useat tilit voivat hämmentää Google Playta. Kirjaudu ulos muista tileistä tai asenna Google Play -verkkosivuston kautta, joka pakottaa yhteydet tiettyyn tiliin.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Katso Pro-tilasi</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Onnittelut!</string>
+    <string name="upgrade_screen_owned_congrats_body">Sinulla on nyt BVM Pro — kiitos, että tuet kehitystä. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Kertaostos</string>
+    <string name="upgrade_screen_owned_iap_body">Omistat BVM Pron ikuisesti. Kiitos tuestasi ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Tilaus</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">BVM Pro -tilauksesi on aktiivinen ja se uusiutuu automaattisesti.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">BVM Pro -tilauksesi on aktiivinen, mutta se ei uusiudu. Se on voimassa nykyisen jakson loppuun asti.</string>
+    <string name="upgrade_screen_owned_both_warning">Sinulla on sekä tilaus että kertaosto. Peruuta tilaus Google Playssa, ettei sinulta veloiteta uudelleen.</string>
+    <string name="upgrade_screen_manage_subscription">Hallinnoi tilausta</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Vaihda kertaostoon</string>
+    <string name="upgrade_screen_switch_purchase_note">Tämä on erillinen kertaosto. Se ei peru tai palauta tilaustasi, joten peruuta myös se Google Playssa. Käytä samaa Google-tiliä molemmissa.</string>
+    <string name="upgrade_screen_switch_locked_note">Käytettävissä, kun tilauksesi ei enää uusiudu automaattisesti. Peruuta se Google Playssa vaihtaaksesi — säilytät Pro-ominaisuudet nykyisen jakson loppuun asti.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Näyttääkö tila väärältä?</string>
+    <string name="upgrade_screen_status_restore_body">Jos ostoksesi ei näy täällä, yritä palauttaa se.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Vahvistetaan ostostasi</string>
+    <string name="upgrade_screen_grace_body_short">Odota hetki — tarkistamme ostoksesi vielä kerran Google Playsta.</string>
+    <string name="upgrade_screen_grace_body">Emme vieläkään pysty vahvistamaan ostostasi Google Playsta. Yritä palauttaa se tai tarkista, että olet kirjautunut oikealla tilillä.</string>
+    <string name="upgrade_screen_retry_action">Yritä uudelleen</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Tilaus on yhä aktiivinen</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Tilauksesi uusiutuu yhä automaattisesti. Peruuta se ensin Google Playssa ja palaa sitten ostamaan kertaosto — näin sinulta ei veloiteta kahdesti.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Emme pystyneet tarkistamaan tilauksesi tilaa. Tarkista yhteytesi ja yritä uudelleen.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Jo ostettu</string>
+    <string name="upgrades_gplay_already_owned_error_description">Käytä \"Palauta ostos\" -toimintoa palauttaaksesi ostoksesi. Jos ongelma jatkuu, tyhjennä Google Play -välimuisti ja käynnistä laite uudelleen.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play -virhe</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play-yhteydessä tapahtui sisäinen virhe. Kokeile seuraavia:\n\n• Käynnistä laite uudelleen\n• Tyhjennä Google Play Store -välimuisti\n• Yritä myöhemmin uudelleen</string>
+    <string name="upgrades_gplay_network_error_title">Yhteysvirhe</string>
+    <string name="upgrades_gplay_network_error_description">Google Playhin ei saatu yhteyttä. Tarkista internetyhteytesi ja yritä uudelleen.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ei ole käytettävissä</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ei voi yhdistää Google Playhin. Onko Google Play asennettu ja ajan tasalla? Onko Google-tilisi kirjautunut sisään? Kokeile tyhjenntää Google Play -sovelluksen välimuisti ja käynnistä laite uudelleen.</string>
     <string name="upgrades_no_purchases_found_check_account">Ostoja ei löytynyt. Käytätkö oikeaa tiliä?</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Ang subscription ay nagkakahalaga ng %s bawat taon.</string>
     <string name="upgrade_screen_iap_action">One-time na pagbili</string>
     <string name="upgrade_screen_iap_action_hint">Ang one-time na pagbili ay nagkakahalaga ng %s.</string>
+    <string name="upgrade_screen_offer_divider_or">o</string>
+    <string name="upgrade_screen_offer_same_features">Parehong mga feature, iba lang ang pricing model.</string>
     <string name="upgrade_screen_thanks_toast">Ikaw ang pinakamahusay! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">I-restore ang pagbili</string>
+    <string name="upgrade_screen_restore_banner_title">Nabili mo na ba ang BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Mukhang na-upgrade mo na ang device na ito dati. I-restore ang iyong purchase para ma-unlock ulit ito.</string>
     <string name="upgrade_screen_restore_purchase_message">Ang iyong pag-upgrade ay balido sa lahat ng mga device sa parehong Google account.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Mga tip sa pag-troubleshoot para sa mga hindi kinikilalang pag-upgrade:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Ang Play Store synchronization ay maaaring tumagal ng oras. Subukang mag-reboot, i-clear ang Google Play cache o maghintay lamang.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Ang maramihang mga account ay maaaring makalito sa Google Play. Mag-log out mula sa ibang mga account o mag-install sa pamamagitan ng Google Play website, na napipilitang nakipag-ugnayan sa isang partikular na account.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Tingnan ang iyong Pro status</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Binabati kita!</string>
+    <string name="upgrade_screen_owned_congrats_body">Nakuha mo na ang BVM Pro — salamat sa pagsuporta sa development. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">One-time na pagbili</string>
+    <string name="upgrade_screen_owned_iap_body">Pag-aari mo na ang BVM Pro magpakailanman. Salamat sa iyong suporta ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Suskripsyon</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Aktibo ang iyong BVM Pro subscription at naka-set na mag-renew.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Aktibo ang iyong BVM Pro subscription pero hindi ito mag-re-renew. Mananatili itong valid hanggang matapos ang kasalukuyang period.</string>
+    <string name="upgrade_screen_owned_both_warning">Meron kang parehong subscription at one-time purchase. I-cancel ang subscription sa Google Play para hindi ka na sisingilin ulit.</string>
+    <string name="upgrade_screen_manage_subscription">Pamahalaan ang subscription</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Lumipat sa one-time purchase</string>
+    <string name="upgrade_screen_switch_purchase_note">Ito ay hiwalay na one-time purchase. Hindi nito kina-cancel o rine-refund ang iyong subscription, kaya i-cancel din iyon sa Google Play. Gamitin ang parehong Google account para sa dalawa.</string>
+    <string name="upgrade_screen_switch_locked_note">Magiging available ito kapag hindi na naka-set mag-renew ang iyong subscription. I-cancel ito sa Google Play para makalipat — mananatili sa iyo ang Pro hanggang matapos ang kasalukuyang period.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Mali ang status?</string>
+    <string name="upgrade_screen_status_restore_body">Kung hindi lumalabas dito ang iyong purchase, subukan itong i-restore.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Kinukumpirma ang iyong purchase</string>
+    <string name="upgrade_screen_grace_body_short">Sandali lang — dinodoble-check namin ang iyong purchase sa Google Play.</string>
+    <string name="upgrade_screen_grace_body">Hindi pa rin namin makumpirma ang iyong purchase sa Google Play. Subukan itong i-restore, o tingnan kung naka-sign in ka sa tamang account.</string>
+    <string name="upgrade_screen_retry_action">Ulitin</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Aktibo pa rin ang subscription</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Naka-set pa rin mag-renew ang iyong subscription. I-cancel muna ito sa Google Play, tapos bumalik para bilhin ang one-time purchase — sa ganoong paraan hindi ka masisingil nang dalawang beses.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Hindi namin nasuri ang status ng iyong subscription. Pakisuri ang iyong koneksyon at subukan ulit.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Nabili na</string>
+    <string name="upgrades_gplay_already_owned_error_description">Gamitin ang opsyong \"I-restore ang purchase\" para i-restore ang iyong purchase. Kung nagpapatuloy ang isyu, subukang i-clear ang Google Play cache at i-restart ang iyong device.</string>
+    <string name="upgrades_gplay_internal_error_title">Error sa Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">May naganap na internal na error sa Google Play. Pakisubukan ang mga sumusunod:\n\n• I-restart ang iyong device\n• I-clear ang Google Play Store cache\n• Subukan ulit mamaya</string>
+    <string name="upgrades_gplay_network_error_title">Error sa koneksyon</string>
+    <string name="upgrades_gplay_network_error_description">Hindi makakonekta sa Google Play. Pakisuri ang iyong internet connection at subukan ulit.</string>
     <string name="upgrades_gplay_unavailable_error_title">Ang Google Play ay kasalukoyang hindi magagamit</string>
     <string name="upgrades_gplay_unavailable_error_description">Hindi makakonekta ang Bluetooth Volume Manager sa Google Play. Naka-install ba at updated ang Google Play? Naka-log in ba ang iyong Google Account? Subukang i-clear ang cache ng Google Play app at i-reboot ang iyong device.</string>
     <string name="upgrades_no_purchases_found_check_account">Walang nahanap na mga binili. Ginagamit mo ba ang iyong tamang account?</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">L’abonnement coûte %s par an.</string>
     <string name="upgrade_screen_iap_action">Achat unique</string>
     <string name="upgrade_screen_iap_action_hint">L’achat unique coûte %s.</string>
+    <string name="upgrade_screen_offer_divider_or">ou</string>
+    <string name="upgrade_screen_offer_same_features">Les mêmes fonctionnalités, juste des modèles de tarification différents.</string>
     <string name="upgrade_screen_thanks_toast">Vous êtes formidable ! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Rétablir l’achat</string>
+    <string name="upgrade_screen_restore_banner_title">Vous avez déjà acheté BVM Pro ?</string>
+    <string name="upgrade_screen_restore_banner_body">Il semble que vous ayez déjà effectué une mise à niveau sur cet appareil. Restaurez votre achat pour le débloquer à nouveau.</string>
     <string name="upgrade_screen_restore_purchase_message">Votre surclassement est valide sur tous les appareils connectés au même compte Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Conseils de dépannage pour les surclassements non reconnus :</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La synchronisation avec Google Play peut prendre du temps. Essayez de redémarrer votre appareil, de vider le cache de Google Play ou simplement d’attendre.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Plusieurs comptes peuvent perturber Google Play. Déconnectez-vous des autres comptes ou installez l’appli en utilisant le site Web de Google Play, ce qui force l’association avec un compte précis.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Consultez votre statut Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Félicitations !</string>
+    <string name="upgrade_screen_owned_congrats_body">Vous avez BVM Pro — merci de soutenir le développement. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Achat unique</string>
+    <string name="upgrade_screen_owned_iap_body">Vous possédez BVM Pro pour toujours. Merci de votre soutien. ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abonnement</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Votre abonnement BVM Pro est actif et se renouvellera.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Votre abonnement BVM Pro est actif mais ne sera pas renouvelé. Il reste valable jusqu’à la fin de la période en cours.</string>
+    <string name="upgrade_screen_owned_both_warning">Vous avez à la fois un abonnement et l’achat unique. Annulez l’abonnement dans Google Play pour ne pas être facturé à nouveau.</string>
+    <string name="upgrade_screen_manage_subscription">Gérer l’abonnement</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Passer à un achat unique</string>
+    <string name="upgrade_screen_switch_purchase_note">Il s’agit d’un achat unique distinct. Il n’annule ni ne rembourse votre abonnement, alors annulez-le également dans Google Play. Utilisez le même compte Google pour les deux.</string>
+    <string name="upgrade_screen_switch_locked_note">Disponible une fois que votre abonnement n’est plus configuré pour se renouveler. Annulez-le dans Google Play pour changer — vous conservez Pro jusqu’à la fin de la période en cours.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Le statut semble incorrect ?</string>
+    <string name="upgrade_screen_status_restore_body">Si votre achat n’apparaît pas ici, essayez de le restaurer.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Confirmation de votre achat</string>
+    <string name="upgrade_screen_grace_body_short">Patientez — nous vérifions à nouveau votre achat auprès de Google Play.</string>
+    <string name="upgrade_screen_grace_body">Nous n’arrivons toujours pas à confirmer votre achat auprès de Google Play. Essayez de le restaurer, ou vérifiez que vous êtes connecté avec le bon compte.</string>
+    <string name="upgrade_screen_retry_action">Réessayer</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonnement toujours actif</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Votre abonnement est toujours configuré pour se renouveler. Annulez-le d’abord dans Google Play, puis revenez acheter l’achat unique — ainsi vous ne serez pas facturé deux fois.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nous n’avons pas pu vérifier le statut de votre abonnement. Veuillez vérifier votre connexion et réessayer.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Déjà acheté</string>
+    <string name="upgrades_gplay_already_owned_error_description">Utilisez l\'option « Rétablir l’achat ». Si le problème persiste, essayez de vider le cache de Google Play et de redémarrer votre appareil.</string>
+    <string name="upgrades_gplay_internal_error_title">Erreur Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Une erreur interne Google Play est survenue. Essayez de :\n\n• Redémarrer votre appareil\n• Vider le cache du magasin Google Play\n• Réessayer plus tard</string>
+    <string name="upgrades_gplay_network_error_title">Erreur de connexion</string>
+    <string name="upgrades_gplay_network_error_description">Impossible de se connecter à Google Play. Vérifiez votre connexion à Internet et réessayez.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play est inaccessible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ne peut pas se connecter à Google Play. Google Play est-il installé et à jour ? Votre compte Google est-il connecté ? Essayez de vider le cache de l’appli Google Play et de redémarrer votre appareil.</string>
     <string name="upgrades_no_purchases_found_check_account">Aucun achat n’a été trouvé. Utilisez-vous le bon compte ?</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">A subscrición custa %s ao ano.</string>
     <string name="upgrade_screen_iap_action">Compra única</string>
     <string name="upgrade_screen_iap_action_hint">A compra única custa %s.</string>
+    <string name="upgrade_screen_offer_divider_or">ou</string>
+    <string name="upgrade_screen_offer_same_features">As mesmas funcións, só cambian os modelos de prezos.</string>
     <string name="upgrade_screen_thanks_toast">Es o mellor! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar compra</string>
+    <string name="upgrade_screen_restore_banner_title">Xa mercaches BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Parece que xa actualizaches neste dispositivo antes. Restaura a túa compra para desbloqueala de novo.</string>
     <string name="upgrade_screen_restore_purchase_message">A túa actualización é válida en dispositivos coa mesma conta de Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Consellos de solución de problemas para actualizacións non recoñecidas:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">A sincronización de Play Store pode levar tempo. Proba reiniciar, limpar a caché de Google Play ou simplemente esperar.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Múltiples contas poden confundir Google Play. Pecha sesión noutras contas ou instala a través do sitio web de Google Play, que forza asociacións cunha conta específica.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Ver o teu estado Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Noraboa!</string>
+    <string name="upgrade_screen_owned_congrats_body">Xa tes BVM Pro — grazas por apoiar o desenvolvemento. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Compra única</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro é teu para sempre. Grazas polo teu apoio ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Subscrición</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">A túa subscrición BVM Pro está activa e configurada para renovarse.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">A túa subscrición BVM Pro está activa pero non se renovará. Permanece válida ata o final do período actual.</string>
+    <string name="upgrade_screen_owned_both_warning">Tes tanto a subscrición coma a compra única. Cancela a subscrición en Google Play para non ser cobrado de novo.</string>
+    <string name="upgrade_screen_manage_subscription">Xestionar subscrición</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Cambiar a unha compra única</string>
+    <string name="upgrade_screen_switch_purchase_note">Esta é unha compra única separada. Non cancela nin reembolsa a túa subscrición, así que cancela tamén esa en Google Play. Usa a mesma conta de Google para ambas.</string>
+    <string name="upgrade_screen_switch_locked_note">Dispoñible unha vez que a túa subscrición xa non estea configurada para renovarse. Cancélaa en Google Play para cambiar — manterás Pro ata que remate o período actual.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">O estado parece incorrecto?</string>
+    <string name="upgrade_screen_status_restore_body">Se a túa compra non aparece aquí, tenta restaurala.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Confirmando a túa compra</string>
+    <string name="upgrade_screen_grace_body_short">Un momento — estamos verificando de novo a túa compra con Google Play.</string>
+    <string name="upgrade_screen_grace_body">Aínda non podemos confirmar a túa compra con Google Play. Tenta restaurala, ou comproba que iniciaches sesión coa conta correcta.</string>
+    <string name="upgrade_screen_retry_action">Reintentar</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Subscrición aínda activa</string>
+    <string name="upgrade_screen_sub_still_renewing_message">A túa subscrición aínda está configurada para renovarse. Cancélaa primeiro en Google Play e despois volve para mercar a compra única — así non se che cobrará dúas veces.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Non puidemos comprobar o estado da túa subscrición. Comproba a túa conexión e téntao de novo.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Xa mercado</string>
+    <string name="upgrades_gplay_already_owned_error_description">Usa a opción \"Restaurar compra\" para restaurar a túa compra. Se o problema persiste, tenta limpar a caché de Google Play e reiniciar o teu dispositivo.</string>
+    <string name="upgrades_gplay_internal_error_title">Erro de Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Produciuse un erro interno de Google Play. Tenta o seguinte:\n\n• Reinicia o teu dispositivo\n• Limpa a caché da Google Play Store\n• Téntao de novo máis tarde</string>
+    <string name="upgrades_gplay_network_error_title">Erro de conexión</string>
+    <string name="upgrades_gplay_network_error_description">Non foi posible conectar con Google Play. Comproba a túa conexión a internet e téntao de novo.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play non está dispoñible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager non pode conectarse a Google Play. ¿Está Google Play instalado e actualizado? ¿Iniciaches sesión na túa conta de Google? Proba a borrar a caché da app Google Play e reinicia o dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Non se atoparon compras. Estás usando a conta correcta?</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">सदस्यता का मूल्य %s प्रति वर्ष है।</string>
     <string name="upgrade_screen_iap_action">एक-बार खरीदे</string>
     <string name="upgrade_screen_iap_action_hint">एकमुश्त खरीदारी का मूल्य %s है।</string>
+    <string name="upgrade_screen_offer_divider_or">या</string>
+    <string name="upgrade_screen_offer_same_features">वही सुविधाएँ, बस अलग मूल्य निर्धारण मॉडल।</string>
     <string name="upgrade_screen_thanks_toast">आप सर्वश्रेष्ठ हैं! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">खरीदारी पुनर्स्थापित करें</string>
+    <string name="upgrade_screen_restore_banner_title">पहले ही BVM Pro खरीद लिया?</string>
+    <string name="upgrade_screen_restore_banner_body">ऐसा लगता है कि आपने पहले इस डिवाइस पर अपग्रेड किया था। इसे फिर से अनलॉक करने के लिए अपनी खरीदारी पुनर्स्थापित करें।</string>
     <string name="upgrade_screen_restore_purchase_message">आपका अपग्रेड एक ही Google खाते पर सभी उपकरणों में मान्य है।</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">अपहचानित अपग्रेड के लिए समस्या निवारण युक्तियाँ:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store सिंक्रोनाइज़ेशन में समय लग सकता है। रीबूट करने, Google Play कैश साफ़ करने या बस प्रतीक्षा करने का प्रयास करें।</string>
     <string name="upgrade_screen_restore_multiaccount_hint">कई खाते Google Play को भ्रमित कर सकते हैं। अन्य खातों से लॉग आउट करें या Google Play वेबसाइट के माध्यम से इंस्टॉल करें, जो एक विशिष्ट खाते के साथ संबंध को बाध्य करता है।</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">अपनी Pro स्थिति देखें</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">बधाई हो!</string>
+    <string name="upgrade_screen_owned_congrats_body">आपने BVM Pro प्राप्त कर लिया है — विकास का समर्थन करने के लिए धन्यवाद। ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">एक-बार खरीदे</string>
+    <string name="upgrade_screen_owned_iap_body">आप BVM Pro हमेशा के लिए स्वामी हैं। आपके समर्थन के लिए धन्यवाद ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">सदस्यता</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">आपकी BVM Pro सदस्यता सक्रिय है और नवीनीकृत होने के लिए सेट है।</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">आपकी BVM Pro सदस्यता सक्रिय है लेकिन नवीनीकृत नहीं होगी। यह मौजूदा अवधि के अंत तक मान्य रहेगी।</string>
+    <string name="upgrade_screen_owned_both_warning">आपके पास सदस्यता और एकमुश्त खरीदारी दोनों हैं। दोबारा शुल्क न लगे इसके लिए Google Play में सदस्यता रद्द करें।</string>
+    <string name="upgrade_screen_manage_subscription">सदस्यता प्रबंधित करें</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">एकमुश्त खरीदारी पर स्विच करें</string>
+    <string name="upgrade_screen_switch_purchase_note">यह एक अलग एकमुश्त खरीदारी है। यह आपकी सदस्यता को रद्द या रिफंड नहीं करती, इसलिए उसे भी Google Play में रद्द करें। दोनों के लिए एक ही Google खाते का उपयोग करें।</string>
+    <string name="upgrade_screen_switch_locked_note">यह तभी उपलब्ध होगा जब आपकी सदस्यता नवीनीकृत होने के लिए सेट न हो। स्विच करने के लिए इसे Google Play में रद्द करें — आप मौजूदा अवधि समाप्त होने तक Pro बनाए रखते हैं।</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">स्थिति गलत लग रही है?</string>
+    <string name="upgrade_screen_status_restore_body">अगर आपकी खरीदारी यहां नहीं दिख रही है, तो उसे पुनर्स्थापित करने का प्रयास करें।</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">आपकी खरीदारी की पुष्टि की जा रही है</string>
+    <string name="upgrade_screen_grace_body_short">थोड़ा रुकिए — हम Google Play से आपकी खरीदारी की दोबारा जांच कर रहे हैं।</string>
+    <string name="upgrade_screen_grace_body">हम अभी भी Google Play से आपकी खरीदारी की पुष्टि नहीं कर पा रहे हैं। इसे पुनर्स्थापित करने का प्रयास करें, या जांचें कि आप सही खाते से साइन इन हैं।</string>
+    <string name="upgrade_screen_retry_action">पुनः प्रयास करें</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">सदस्यता अभी भी सक्रिय है</string>
+    <string name="upgrade_screen_sub_still_renewing_message">आपकी सदस्यता अभी भी नवीनीकृत होने के लिए सेट है। पहले इसे Google Play में रद्द करें, फिर एकमुश्त खरीदारी करने के लिए वापस आएं — इस तरह आपसे दो बार शुल्क नहीं लिया जाएगा।</string>
+    <string name="upgrade_screen_sub_check_failed_message">हम आपकी सदस्यता की स्थिति जांच नहीं सके। कृपया अपना कनेक्शन जांचें और फिर से प्रयास करें।</string>
+    <string name="upgrades_gplay_already_owned_error_title">पहले ही खरीदा जा चुका है</string>
+    <string name="upgrades_gplay_already_owned_error_description">अपनी खरीदारी को पुनर्स्थापित करने के लिए \"खरीदारी पुनर्स्थापित करें\" विकल्प का उपयोग करें। अगर समस्या बनी रहती है, तो Google Play कैश साफ़ करके अपना डिवाइस पुनः प्रारंभ करके देखें।</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play त्रुटि</string>
+    <string name="upgrades_gplay_internal_error_description">एक आंतरिक Google Play त्रुटि हुई। कृपया निम्नलिखित प्रयास करें:\n\n• अपना डिवाइस पुनः प्रारंभ करें\n• Google Play Store कैश साफ़ करें\n• बाद में फिर से प्रयास करें</string>
+    <string name="upgrades_gplay_network_error_title">कनेक्शन त्रुटि</string>
+    <string name="upgrades_gplay_network_error_description">Google Play से कनेक्ट नहीं हो सका। कृपया अपना इंटरनेट कनेक्शन जांचें और फिर से प्रयास करें।</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play अनुपलब्ध है</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play से कनेक्ट नहीं हो सकता। क्या Google Play इंस्टॉल और अप-टू-डेट है? क्या आपका Google खाता लॉग इन है? Google Play ऐप का कैश साफ़ करने और अपने डिवाइस को रीबूट करने का प्रयास करें।</string>
     <string name="upgrades_no_purchases_found_check_account">कोई खरीदारी जानकारी नहीं मिली। क्या आप सही खाते का उपयोग कर रहे हैं?</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Pretplata košta %s godišnje.</string>
     <string name="upgrade_screen_iap_action">Jednokratna kupnja</string>
     <string name="upgrade_screen_iap_action_hint">Jednokratna kupnja košta %s.</string>
+    <string name="upgrade_screen_offer_divider_or">ili</string>
+    <string name="upgrade_screen_offer_same_features">Iste značajke, samo drukčiji modeli cijena.</string>
     <string name="upgrade_screen_thanks_toast">Najbolji ste! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Obnovi kupnju</string>
+    <string name="upgrade_screen_restore_banner_title">Već ste kupili BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Izgleda da ste ovaj uređaj već nadogradili prije. Vratite svoju kupnju kako biste je ponovno otključali.</string>
     <string name="upgrade_screen_restore_purchase_message">Vaša nadogradnja vrijedi na svim uređajima s istim Google računom.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Savjeti za rješavanje problema s neprepoznatim nadogradnjama:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Sinkronizacija Trgovine Play može potrajati. Pokušajte ponovno pokrenuti uređaj, očistiti predmemoriju Google Playa ili jednostavno pričekajte.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Više računa može zbuniti Google Play. Odjavite se s drugih računa ili instalirajte putem Google Play web stranice, što prisiljava povezivanje s određenim računom.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Pogledajte svoj Pro status</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Čestitamo!</string>
+    <string name="upgrade_screen_owned_congrats_body">Imate BVM Pro — hvala što podržavate razvoj. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Jednokratna kupnja</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro je vaš zauvijek. Hvala na podršci ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Pretplata</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Vaša BVM Pro pretplata je aktivna i postavljena je za automatsko obnavljanje.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Vaša BVM Pro pretplata je aktivna, ali se neće obnoviti. Ostaje valjana do kraja trenutnog razdoblja.</string>
+    <string name="upgrade_screen_owned_both_warning">Imate i pretplatu i jednokratnu kupnju. Otkažite pretplatu u Google Playu kako vam ne bi ponovno naplatili.</string>
+    <string name="upgrade_screen_manage_subscription">Upravljaj pretplatom</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Prijeđi na jednokratnu kupnju</string>
+    <string name="upgrade_screen_switch_purchase_note">Ovo je zasebna jednokratna kupnja. Ne otkazuje niti vraća novac za vašu pretplatu, stoga otkažite i to u Google Playu. Koristite isti Google račun za oboje.</string>
+    <string name="upgrade_screen_switch_locked_note">Dostupno kada vaša pretplata više nije postavljena za obnavljanje. Otkažite je u Google Playu kako biste prešli — zadržavate Pro do kraja trenutnog razdoblja.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Status izgleda pogrešno?</string>
+    <string name="upgrade_screen_status_restore_body">Ako se vaša kupnja ne prikazuje ovdje, pokušajte je vratiti.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Potvrđivanje vaše kupnje</string>
+    <string name="upgrade_screen_grace_body_short">Samo malo — dvostruko provjeravamo vašu kupnju s Google Playom.</string>
+    <string name="upgrade_screen_grace_body">I dalje ne možemo potvrditi vašu kupnju s Google Playom. Pokušajte je vratiti ili provjerite jeste li prijavljeni s pravim računom.</string>
+    <string name="upgrade_screen_retry_action">Pokušaj ponovno</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Pretplata je i dalje aktivna</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Vaša pretplata je i dalje postavljena za obnavljanje. Prvo je otkažite u Google Playu, a zatim se vratite kako biste kupili jednokratnu kupnju — tako vam neće biti naplaćeno dvaput.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nismo mogli provjeriti status vaše pretplate. Provjerite svoju vezu i pokušajte ponovno.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Već kupljeno</string>
+    <string name="upgrades_gplay_already_owned_error_description">Upotrijebite opciju \"Vrati kupnju\" kako biste vratili svoju kupnju. Ako se problem nastavi, pokušajte očistiti predmemoriju Google Playa i ponovno pokrenuti uređaj.</string>
+    <string name="upgrades_gplay_internal_error_title">Greška Google Playa</string>
+    <string name="upgrades_gplay_internal_error_description">Došlo je do interne greške Google Playa. Pokušajte sljedeće:\n\n• Ponovno pokrenite uređaj\n• Očistite predmemoriju Google Play Storea\n• Pokušajte ponovno kasnije</string>
+    <string name="upgrades_gplay_network_error_title">Greška veze</string>
+    <string name="upgrades_gplay_network_error_description">Nije moguće povezati se s Google Playom. Provjerite internetsku vezu i pokušajte ponovno.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nije dostupan</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager se ne može spojiti na Google Play. Je li Google Play instaliran i ažuriran? Je li vaš Google račun prijavljen? Pokušajte obrisati predmemoriju aplikacije Google Play i restartajte uređaj.</string>
     <string name="upgrades_no_purchases_found_check_account">Nema pronađenih kupnji. Koristite li pravi račun?</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Az előfizetés évi %s.</string>
     <string name="upgrade_screen_iap_action">Egyszeri vásárlás</string>
     <string name="upgrade_screen_iap_action_hint">Az egyszeri vásárlás ára %s.</string>
+    <string name="upgrade_screen_offer_divider_or">vagy</string>
+    <string name="upgrade_screen_offer_same_features">Ugyanazok a funkciók, csak más árazási modell.</string>
     <string name="upgrade_screen_thanks_toast">Te vagy a legjobb! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Vásárlás visszaállítása</string>
+    <string name="upgrade_screen_restore_banner_title">Már megvetted a BVM Pro-t?</string>
+    <string name="upgrade_screen_restore_banner_body">Úgy tűnik, korábban már frissítettél ezen az eszközön. Állítsd vissza a vásárlásod, hogy újra feloldd.</string>
     <string name="upgrade_screen_restore_purchase_message">A frissítés az ugyanazon Google-fiókhoz tartozó összes eszközre érvényes.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Hibaelhárítási tippek a fel nem ismert frissítésekhez:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">A Play Áruház szinkronizálása időbe telhet. Próbáld meg az újraindítást, a Google Play gyorsítótárának törlését vagy egyszerűen várj.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">A több fiók összezavarhatja a Google Play-t. Jelentkezz ki más fiókokból, vagy telepítsd a Google Play weboldalán keresztül, amely kikényszeríti a meghatározott fiókkal való társítást.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Pro állapotod megtekintése</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Gratulálunk!</string>
+    <string name="upgrade_screen_owned_congrats_body">Megvan a BVM Pro — köszönjük, hogy támogatod a fejlesztést. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Egyszeri vásárlás</string>
+    <string name="upgrade_screen_owned_iap_body">A BVM Pro örökre a tiéd. Köszönjük a támogatásod ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Előfizetés</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">A BVM Pro előfizetésed aktív, és megújulásra van állítva.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">A BVM Pro előfizetésed aktív, de nem fog megújulni. Az aktuális időszak végéig marad érvényben.</string>
+    <string name="upgrade_screen_owned_both_warning">Előfizetésed is van, és az egyszeri vásárlás is megvan. Mondd le az előfizetést a Google Playben, hogy ne terheljenek meg újra.</string>
+    <string name="upgrade_screen_manage_subscription">Előfizetés kezelése</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Váltás egyszeri vásárlásra</string>
+    <string name="upgrade_screen_switch_purchase_note">Ez egy külön, egyszeri vásárlás. Nem mondja le és nem téríti vissza az előfizetésed, ezért azt is mondd le a Google Playben. Mindkettőhöz ugyanazt a Google-fiókot használd.</string>
+    <string name="upgrade_screen_switch_locked_note">Akkor lesz elérhető, ha az előfizetésed már nincs megújulásra állítva. Mondd le a Google Playben a váltáshoz — a Pro megmarad az aktuális időszak végéig.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Furcsának tűnik az állapot?</string>
+    <string name="upgrade_screen_status_restore_body">Ha a vásárlásod nem jelenik meg itt, próbáld visszaállítani.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Vásárlás megerősítése</string>
+    <string name="upgrade_screen_grace_body_short">Egy pillanat — kétszer is ellenőrizzük a vásárlásod a Google Playnél.</string>
+    <string name="upgrade_screen_grace_body">Még mindig nem tudjuk megerősíteni a vásárlásod a Google Playnél. Próbáld visszaállítani, vagy ellenőrizd, hogy a megfelelő fiókkal vagy bejelentkezve.</string>
+    <string name="upgrade_screen_retry_action">Újra</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Az előfizetés még aktív</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Az előfizetésed még megújulásra van állítva. Először mondd le a Google Playben, majd gyere vissza, hogy megvedd az egyszeri vásárlást — így nem terhelnek meg kétszer.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nem sikerült ellenőrizni az előfizetésed állapotát. Ellenőrizd a kapcsolatod, és próbáld újra.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Már megvásárolva</string>
+    <string name="upgrades_gplay_already_owned_error_description">Használd a „Vásárlás visszaállítása” opciót a vásárlásod visszaállításához. Ha a probléma továbbra is fennáll, próbáld törölni a Google Play gyorsítótárát, és indítsd újra a készüléked.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play hiba</string>
+    <string name="upgrades_gplay_internal_error_description">Belső Google Play hiba történt. Próbáld ki a következőket:\n\n• Indítsd újra a készüléked\n• Töröld a Google Play Áruház gyorsítótárát\n• Próbáld újra később</string>
+    <string name="upgrades_gplay_network_error_title">Kapcsolati hiba</string>
+    <string name="upgrades_gplay_network_error_description">Nem sikerült kapcsolódni a Google Playhez. Ellenőrizd az internetkapcsolatod, és próbáld újra.</string>
     <string name="upgrades_gplay_unavailable_error_title">A Google Play nem elérhető</string>
     <string name="upgrades_gplay_unavailable_error_description">A Bluetooth Volume Manager nem tud csatlakozni a Google Playhez. Telepítve és naprакész a Google Play? Be vagy jelentkezve a Google-fiókodba? Próbáld meg törölni a Google Play alkalmazás gyorsítótárát és indítsd újra az eszközt.</string>
     <string name="upgrades_no_purchases_found_check_account">Nem található vásárlás. A megfelelő fiókot használja?</string>

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Բաժանորդագրությունը արժե %s տարեկան:</string>
     <string name="upgrade_screen_iap_action">Միանգամյա գնում</string>
     <string name="upgrade_screen_iap_action_hint">Միանգամյա գնումը արժե %s:</string>
+    <string name="upgrade_screen_offer_divider_or">կամ</string>
+    <string name="upgrade_screen_offer_same_features">Նույն հնարավորությունները, պարզապես տարբեր գնագոյացման մոդելներ։</string>
     <string name="upgrade_screen_thanks_toast">Դուք լավագույնն եք! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Վերականգնել գնումը</string>
+    <string name="upgrade_screen_restore_banner_title">Արդեն գնե՞լ եք BVM Pro-ն</string>
+    <string name="upgrade_screen_restore_banner_body">Կարծես դուք արդեն արդիականացրել եք այս սարքում։ Վերականգնեք ձեր գնումը՝ այն կրկին բացելու համար։</string>
     <string name="upgrade_screen_restore_purchase_message">Ձեր թարմացումը գործում է նույն Google հաշվով սարքերում:</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Խնդիրների լուծման խորհուրդներ չճանաչված թարմացումների համար՝</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store համաժամանակեցումը կարող է ժամանակ խլել: Փորձեք վերագործարկել, մաքրել Google Play քեշը կամ պարզապես սպասել:</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Բազմաթիվ հաշիվները կարող են շփոթեցնել Google Play-ին: Դուրս եկեք այլ հաշիվներից կամ տեղադրեք Google Play կայքի միջոցով, որը ստիպում է կապեր կոնկրետ հաշվի հետ:</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Դիտեք ձեր Pro կարգավիճակը</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Շնորհավորում ենք!</string>
+    <string name="upgrade_screen_owned_congrats_body">Դուք ունեք BVM Pro — շնորհակալություն մշակումն աջակցելու համար։ ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Միանգամյա գնում</string>
+    <string name="upgrade_screen_owned_iap_body">Դուք BVM Pro-ի սեփականատերն եք ընդմիշտ։ Շնորհակալություն ձեր աջակցության համար ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Բաժանորդագրություն</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Ձեր BVM Pro բաժանորդագրությունը ակտիվ է և կնորոգվի։</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Ձեր BVM Pro բաժանորդագրությունը ակտիվ է, բայց չի կնորոգվի։ Այն վավեր կմնա մինչև ընթացիկ շրջանի ավարտը։</string>
+    <string name="upgrade_screen_owned_both_warning">Դուք ունեք ե’ւ բաժանորդագրություն, ե’ւ միանվագ գնում։ Չեղարկեք բաժանորդագրությունը Google Play-ում, որպեսզի կրկին գումար չգանձվի ձեզանից։</string>
+    <string name="upgrade_screen_manage_subscription">Կառավարել բաժանորդագրությունը</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Անցնել միանվագ գնման</string>
+    <string name="upgrade_screen_switch_purchase_note">Սա առանձին միանվագ գնում է։ Այն չի չեղարկում կամ չի փոխհատուցում ձեր բաժանորդագրությունը, ուստի չեղարկեք այն Google Play-ում ևս։ Երկուսի համար էլ օգտագործեք նույն Google հաշիվը։</string>
+    <string name="upgrade_screen_switch_locked_note">Հասանելի է, երբ ձեր բաժանորդագրությունն այլևս նախատեսված չէ երկարաձգվել։ Չեղարկեք այն Google Play-ում, որպեսզի անցնեք — դուք կպահպանեք Pro-ն մինչև ընթացիկ շրջանի ավարտը։</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Կարգավիճակը սխա՞լ է թվում։</string>
+    <string name="upgrade_screen_status_restore_body">Եթե ձեր գնումն այստեղ չի երևում, փորձեք վերականգնել այն։</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Ձեր գնման հաստատում</string>
+    <string name="upgrade_screen_grace_body_short">Մի փոքր սպասեք — մենք կրկնակի ստուգում ենք ձեր գնումը Google Play-ի հետ։</string>
+    <string name="upgrade_screen_grace_body">Մենք դեռ չենք կարողանում հաստատել ձեր գնումը Google Play-ի հետ։ Փորձեք վերականգնել այն կամ ստուգեք, որ մուտք եք գործել ճիշտ հաշվով։</string>
+    <string name="upgrade_screen_retry_action">Կրկին փորձել</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Բաժանորդագրությունը դեռ ակտիվ է</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Ձեր բաժանորդագրությունը դեռ նախատեսված է երկարաձգվել։ Նախ չեղարկեք այն Google Play-ում, ապա վերադարձեք՝ միանվագ գնումը կատարելու համար — այդպես ձեզանից գումար կրկնակի չի գանձվի։</string>
+    <string name="upgrade_screen_sub_check_failed_message">Մենք չկարողացանք ստուգել ձեր բաժանորդագրության կարգավիճակը։ Ստուգեք ձեր կապը և կրկին փորձեք։</string>
+    <string name="upgrades_gplay_already_owned_error_title">Արդեն գնված է</string>
+    <string name="upgrades_gplay_already_owned_error_description">Օգտագործեք «Վերականգնել գնումը» տարբերակը՝ ձեր գնումը վերականգնելու համար։ Եթե խնդիրը շարունակվում է, փորձեք մաքրել Google Play-ի քեշը և վերագործարկել ձեր սարքը։</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-ի սխալ</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play-ում տեղի է ունեցել ներքին սխալ։ Փորձեք հետևյալը՝\n\n• Վերագործարկեք ձեր սարքը\n• Մաքրեք Google Play Store-ի քեշը\n• Փորձեք կրկին ավելի ուշ</string>
+    <string name="upgrades_gplay_network_error_title">Կապի սխալ</string>
+    <string name="upgrades_gplay_network_error_description">Հնարավոր չէ միանալ Google Play-ին։ Ստուգեք ձեր ինտերնետ կապը և կրկին փորձեք։</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play հասանելի չէ</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager-ե հնարավորություն չունի կապուտվել Google Play-ին։ Google Play տեղադրված և արդիականացված ե՞ Կիրարնեք Google հաշվիե մուտքագրված ե՞ Պորդեք մաքրել Google Play տվյալե և վերագնել սարքե։</string>
     <string name="upgrades_no_purchases_found_check_account">Գնումներ չեն գտնվել: Օգտագործում եք ճիշտ հաշիվը:</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Langganan harganya %s per tahun.</string>
     <string name="upgrade_screen_iap_action">Sekali bayar</string>
     <string name="upgrade_screen_iap_action_hint">Sekali bayar harganya %s.</string>
+    <string name="upgrade_screen_offer_divider_or">atau</string>
+    <string name="upgrade_screen_offer_same_features">Fitur yang sama, hanya model harga yang berbeda.</string>
     <string name="upgrade_screen_thanks_toast">Terbaik! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Pulihkan pembelian</string>
+    <string name="upgrade_screen_restore_banner_title">Sudah membeli BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Sepertinya Anda pernah meningkatkan ke versi Pro di perangkat ini sebelumnya. Pulihkan pembelian Anda untuk membukanya kembali.</string>
     <string name="upgrade_screen_restore_purchase_message">Peningkatan Anda berlaku di semua perangkat dengan akun Google yang sama.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Tips pemecahan masalah untuk peningkatan yang tidak dikenali:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Sinkronisasi Play Store mungkin memerlukan waktu. Coba restart, bersihkan cache Google Play, atau tunggu sebentar.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Beberapa akun dapat membingungkan Google Play. Keluar dari akun lain atau pasang aplikasi melalui situs web Google Play, yang memaksa penghubungan dengan akun tertentu.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Lihat status Pro Anda</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Selamat!</string>
+    <string name="upgrade_screen_owned_congrats_body">Anda telah mendapatkan BVM Pro — terima kasih telah mendukung pengembangan. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Sekali bayar</string>
+    <string name="upgrade_screen_owned_iap_body">Anda memiliki BVM Pro selamanya. Terima kasih atas dukungan Anda ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Langganan</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Langganan BVM Pro Anda aktif dan diatur untuk diperpanjang.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Langganan BVM Pro Anda aktif tetapi tidak akan diperpanjang. Langganan tetap berlaku hingga akhir periode saat ini.</string>
+    <string name="upgrade_screen_owned_both_warning">Anda memiliki langganan sekaligus pembelian satu kali. Batalkan langganan di Google Play agar Anda tidak dikenai biaya lagi.</string>
+    <string name="upgrade_screen_manage_subscription">Kelola langganan</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Beralih ke pembelian satu kali</string>
+    <string name="upgrade_screen_switch_purchase_note">Ini adalah pembelian satu kali yang terpisah. Ini tidak membatalkan atau mengembalikan dana langganan Anda, jadi batalkan juga langganan tersebut di Google Play. Gunakan akun Google yang sama untuk keduanya.</string>
+    <string name="upgrade_screen_switch_locked_note">Tersedia setelah langganan Anda tidak lagi diatur untuk diperpanjang. Batalkan di Google Play untuk beralih — Anda tetap memiliki Pro hingga periode saat ini berakhir.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Status terlihat salah?</string>
+    <string name="upgrade_screen_status_restore_body">Jika pembelian Anda tidak muncul di sini, coba pulihkan.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Mengonfirmasi pembelian Anda</string>
+    <string name="upgrade_screen_grace_body_short">Mohon tunggu — kami sedang memeriksa ulang pembelian Anda dengan Google Play.</string>
+    <string name="upgrade_screen_grace_body">Kami masih belum dapat mengonfirmasi pembelian Anda dengan Google Play. Coba pulihkan, atau periksa apakah Anda masuk dengan akun yang benar.</string>
+    <string name="upgrade_screen_retry_action">Coba lagi</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Langganan masih aktif</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Langganan Anda masih diatur untuk diperpanjang. Batalkan terlebih dahulu di Google Play, lalu kembali untuk membeli pembelian satu kali — dengan begitu Anda tidak akan dikenai biaya dua kali.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Kami tidak dapat memeriksa status langganan Anda. Silakan periksa koneksi Anda dan coba lagi.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Sudah dibeli</string>
+    <string name="upgrades_gplay_already_owned_error_description">Gunakan opsi \"Pulihkan pembelian\" untuk memulihkan pembelian Anda. Jika masalah berlanjut, coba hapus cache Google Play dan mulai ulang perangkat Anda.</string>
+    <string name="upgrades_gplay_internal_error_title">Kesalahan Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Terjadi kesalahan internal Google Play. Silakan coba langkah berikut:\n\n• Mulai ulang perangkat Anda\n• Hapus cache Google Play Store\n• Coba lagi nanti</string>
+    <string name="upgrades_gplay_network_error_title">Kesalahan koneksi</string>
+    <string name="upgrades_gplay_network_error_description">Tidak dapat terhubung ke Google Play. Silakan periksa koneksi internet Anda dan coba lagi.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play tidak tersedia</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager tidak dapat terhubung ke Google Play. Apakah Google Play sudah terpasang dan diperbarui? Apakah Akun Google Anda sudah masuk? Coba hapus cache aplikasi Google Play dan mulai ulang perangkat Anda.</string>
     <string name="upgrades_no_purchases_found_check_account">Pembelian tidak ditemukan. Apakah Anda menggunakan akun yang benar?</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Áskriftin kostar %s á ári.</string>
     <string name="upgrade_screen_iap_action">Einskiptiskaup</string>
     <string name="upgrade_screen_iap_action_hint">Einskiptiskaup kosta %s.</string>
+    <string name="upgrade_screen_offer_divider_or">eða</string>
+    <string name="upgrade_screen_offer_same_features">Sömu eiginleikar, bara mismunandi verðlagningarleiðir.</string>
     <string name="upgrade_screen_thanks_toast">Þú ert bestur! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Endurheimta kaup</string>
+    <string name="upgrade_screen_restore_banner_title">Þegar keypt BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Það lítur út fyrir að þú hafir uppfært á þessu tæki áður. Endurheimtu kaupin þín til að opna það aftur.</string>
     <string name="upgrade_screen_restore_purchase_message">Uppfærslan þín gildir á tækjum með sama Google reikning.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Úrræðaleitarráð fyrir óþekktar uppfærslur:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store samstilling getur tekið tíma. Reyndu að endurræsa, hreinsa Google Play skyndiminni eða bara bíða.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Margir reikningar geta ruglað Google Play. Skráðu þig út úr öðrum reikningum eða settu upp í gegnum Google Play vefsíðuna, sem neyðir tengsl við ákveðinn reikning.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Skoða Pro-stöðu þína</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Til hamingju!</string>
+    <string name="upgrade_screen_owned_congrats_body">Þú ert með BVM Pro — takk fyrir að styðja þróunina. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Einskiptiskaup</string>
+    <string name="upgrade_screen_owned_iap_body">Þú átt BVM Pro að eilífu. Takk fyrir stuðninginn ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Áskrift</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Áskriftin þín að BVM Pro er virk og stillt á að endurnýjast.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Áskriftin þín að BVM Pro er virk en mun ekki endurnýjast. Hún gildir til loka núverandi tímabils.</string>
+    <string name="upgrade_screen_owned_both_warning">Þú ert bæði með áskrift og eingreiðslukaup. Segðu upp áskriftinni í Google Play svo ekki verði rukað af þér aftur.</string>
+    <string name="upgrade_screen_manage_subscription">Stjórna áskrift</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Skipta yfir í eingreiðslukaup</string>
+    <string name="upgrade_screen_switch_purchase_note">Þetta er sérstakt eingreiðslukaup. Það segir ekki upp áskriftinni þinni né endurgreiðir hana, svo segðu henni líka upp í Google Play. Notaðu sama Google-reikning fyrir bæði.</string>
+    <string name="upgrade_screen_switch_locked_note">Í boði þegar áskriftin þín er ekki lengur stillt á að endurnýjast. Segðu henni upp í Google Play til að skipta — þú heldur Pro til loka núverandi tímabils.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Lítur staðan út fyrir að vera röng?</string>
+    <string name="upgrade_screen_status_restore_body">Ef kaupin þín birtast ekki hér skaltu reyna að endurheimta þau.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Staðfesti kaupin þín</string>
+    <string name="upgrade_screen_grace_body_short">Andaðu rólega — við erum að tvítékka kaupin þín hjá Google Play.</string>
+    <string name="upgrade_screen_grace_body">Við getum enn ekki staðfest kaupin þín hjá Google Play. Reyndu að endurheimta þau, eða athugaðu hvort þú sért innskráð(ur) með réttan reikning.</string>
+    <string name="upgrade_screen_retry_action">Reyna aftur</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Áskrift enn virk</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Áskriftin þín er enn stillt á að endurnýjast. Segðu henni upp í Google Play fyrst og komdu svo aftur til að kaupa eingreiðslukaupin — þannig verðurðu ekki rukuð(ur) tvisvar.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Við gátum ekki athugað áskriftarstöðu þína. Athugaðu nettenginguna og reyndu aftur.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Þegar keypt</string>
+    <string name="upgrades_gplay_already_owned_error_description">Notaðu valkostinn „Endurheimta kaup“ til að endurheimta kaupin þín. Ef vandamálið er viðvarandi skaltu reyna að hreinsa skyndiminni Google Play og endurræsa tækið.</string>
+    <string name="upgrades_gplay_internal_error_title">Villa í Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Innri villa kom upp í Google Play. Prófaðu eftirfarandi:\n\n• Endurræstu tækið\n• Hreinsaðu skyndiminni Google Play Store\n• Reyndu aftur síðar</string>
+    <string name="upgrades_gplay_network_error_title">Tengingarvilla</string>
+    <string name="upgrades_gplay_network_error_description">Ekki tókst að tengjast Google Play. Athugaðu nettenginguna og reyndu aftur.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play er ekki tiltækt</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager getur ekki tengst Google Play. Er Google Play uppsett og uppfært? Ertu skráður inn á Google reikninginn? Prófaðu að hreinsa skyndiminnni Google Play forritsins og endurræsa tækið þit.</string>
     <string name="upgrades_no_purchases_found_check_account">Engin kaup fundust. Ertu að nota réttan reikning?</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">L\'abbonamento costa %s all\'anno.</string>
     <string name="upgrade_screen_iap_action">Acquisto una tantum</string>
     <string name="upgrade_screen_iap_action_hint">L\'acquisto una tantum costa %s.</string>
+    <string name="upgrade_screen_offer_divider_or">o</string>
+    <string name="upgrade_screen_offer_same_features">Le stesse funzionalità, solo modelli di prezzo diversi.</string>
     <string name="upgrade_screen_thanks_toast">Sei il migliore! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Ripristina acquisto</string>
+    <string name="upgrade_screen_restore_banner_title">Hai già acquistato BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Sembra che tu abbia già effettuato l’upgrade su questo dispositivo. Ripristina il tuo acquisto per sbloccarlo di nuovo.</string>
     <string name="upgrade_screen_restore_purchase_message">La versione PRO è valida per tutti i dispositivi connessi all\'account Google con cui hai effettuato l\'acquisto.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Suggerimenti di risoluzione dei problemi per gli acquisti non riconosciuti:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronizzazione del Play Store potrebbe richiedere tempo. Prova a riavviare, cancellare la cache di Google Play o semplicemente ad aspettare.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Più account possono confondere Google Play. Esci dagli altri account o installare da PC attraverso il sito web di Google Play, che costringe le associazioni con un account specifico.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Visualizza il tuo stato Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Congratulazioni!</string>
+    <string name="upgrade_screen_owned_congrats_body">Hai ottenuto BVM Pro — grazie per aver sostenuto lo sviluppo. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Acquisto una tantum</string>
+    <string name="upgrade_screen_owned_iap_body">Possiedi BVM Pro per sempre. Grazie per il tuo supporto ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abbonamento</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Il tuo abbonamento a BVM Pro è attivo e impostato per il rinnovo.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Il tuo abbonamento a BVM Pro è attivo ma non si rinnoverà. Rimane valido fino alla fine del periodo corrente.</string>
+    <string name="upgrade_screen_owned_both_warning">Hai sia un abbonamento che l’acquisto una tantum. Annulla l’abbonamento in Google Play per non essere addebitato di nuovo.</string>
+    <string name="upgrade_screen_manage_subscription">Gestisci abbonamento</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Passa a un acquisto una tantum</string>
+    <string name="upgrade_screen_switch_purchase_note">Questo è un acquisto una tantum separato. Non annulla né rimborsa il tuo abbonamento, quindi annullalo anche in Google Play. Usa lo stesso account Google per entrambi.</string>
+    <string name="upgrade_screen_switch_locked_note">Disponibile quando il tuo abbonamento non è più impostato per il rinnovo. Annullalo in Google Play per effettuare il passaggio — manterrai Pro fino alla fine del periodo corrente.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Lo stato non sembra corretto?</string>
+    <string name="upgrade_screen_status_restore_body">Se il tuo acquisto non compare qui, prova a ripristinarlo.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Conferma del tuo acquisto in corso</string>
+    <string name="upgrade_screen_grace_body_short">Un attimo — stiamo verificando il tuo acquisto con Google Play.</string>
+    <string name="upgrade_screen_grace_body">Non riusciamo ancora a confermare il tuo acquisto con Google Play. Prova a ripristinarlo, oppure verifica di aver effettuato l’accesso con l’account giusto.</string>
+    <string name="upgrade_screen_retry_action">Riprova</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abbonamento ancora attivo</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Il tuo abbonamento è ancora impostato per il rinnovo. Annullalo prima in Google Play, poi torna qui per acquistare l’acquisto una tantum — in questo modo non ti verrà addebitato due volte.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Non siamo riusciti a verificare lo stato del tuo abbonamento. Controlla la tua connessione e riprova.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Già acquistato</string>
+    <string name="upgrades_gplay_already_owned_error_description">Usa l’opzione \"Ripristina acquisto\" per ripristinare il tuo acquisto. Se il problema persiste, prova a cancellare la cache di Google Play e a riavviare il dispositivo.</string>
+    <string name="upgrades_gplay_internal_error_title">Errore di Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Si è verificato un errore interno di Google Play. Prova quanto segue:\n\n• Riavvia il dispositivo\n• Cancella la cache del Google Play Store\n• Riprova più tardi</string>
+    <string name="upgrades_gplay_network_error_title">Errore di connessione</string>
+    <string name="upgrades_gplay_network_error_description">Impossibile connettersi a Google Play. Controlla la tua connessione internet e riprova.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play non è disponibile</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager non riesce a connettersi a Google Play. Google Play è installato e aggiornato? Il tuo account Google è connesso? Prova a cancellare la cache dell’app Google Play e a riavviare il dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nessun acquisto trovato. Stai usando l\'account corretto?</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">המנוי עולה %s לשנה.</string>
     <string name="upgrade_screen_iap_action">רכישה חד-פעמית</string>
     <string name="upgrade_screen_iap_action_hint">רכישה חד-פעמית עולה %s.</string>
+    <string name="upgrade_screen_offer_divider_or">או</string>
+    <string name="upgrade_screen_offer_same_features">אותן תכונות, רק מודלים שונים של תמחור.</string>
     <string name="upgrade_screen_thanks_toast">אתה הכי טוב! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">שחזור רכישה</string>
+    <string name="upgrade_screen_restore_banner_title">כבר קניתם את BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">נראה ששדרגתם במכשיר הזה בעבר. שחזרו את הרכישה כדי לפתוח אותה מחדש.</string>
     <string name="upgrade_screen_restore_purchase_message">השדרוג שלך תקף בכל המכשירים המחוברים לחשבון Google זה.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">עצות לפתרון בעיות עבור שדרוגים לא מזוהים:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">הסנכרון של גוגל פליי עשוי לקחת זמן. נסה לאתחל מחדש, לנקות את המטמון של גוגל פליי או פשוט המתן.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">חשבונות מרובים יכולים לבלבל את Google Play. התנתק מחשבונות אחרים או התקן דרך אתר Google Play, מה שמאלץ שיוכים עם חשבון ספציפי.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">הצגת סטטוס ה-Pro שלכם</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">מזל טוב!</string>
+    <string name="upgrade_screen_owned_congrats_body">יש לכם את BVM Pro — תודה על התמיכה בפיתוח. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">רכישה חד-פעמית</string>
+    <string name="upgrade_screen_owned_iap_body">יש לכם את BVM Pro לתמיד. תודה על התמיכה ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">מנוי</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">המנוי שלכם ל-BVM Pro פעיל ומוגדר להתחדש.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">המנוי שלכם ל-BVM Pro פעיל אך לא יתחדש. הוא יישאר בתוקף עד סוף התקופה הנוכחית.</string>
+    <string name="upgrade_screen_owned_both_warning">יש לכם גם מנוי וגם רכישה חד-פעמית. בטלו את המנוי ב-Google Play כדי שלא תחויבו שוב.</string>
+    <string name="upgrade_screen_manage_subscription">ניהול המנוי</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">מעבר לרכישה חד-פעמית</string>
+    <string name="upgrade_screen_switch_purchase_note">זו רכישה חד-פעמית נפרדת. היא לא מבטלת או מזכה את המנוי שלכם, אז בטלו אותו גם ב-Google Play. השתמשו באותו חשבון Google עבור שניהם.</string>
+    <string name="upgrade_screen_switch_locked_note">זמין לאחר שהמנוי שלכם כבר לא מוגדר להתחדש. בטלו אותו ב-Google Play כדי לעבור — תשמרו על Pro עד לסיום התקופה הנוכחית.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">הסטטוס נראה לא נכון?</string>
+    <string name="upgrade_screen_status_restore_body">אם הרכישה שלכם לא מופיעה כאן, נסו לשחזר אותה.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">מאשרים את הרכישה שלכם</string>
+    <string name="upgrade_screen_grace_body_short">רגע אחד — אנחנו בודקים שוב את הרכישה שלכם מול Google Play.</string>
+    <string name="upgrade_screen_grace_body">עדיין לא הצלחנו לאשר את הרכישה שלכם מול Google Play. נסו לשחזר אותה, או בדקו שאתם מחוברים לחשבון הנכון.</string>
+    <string name="upgrade_screen_retry_action">נסו שוב</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">המנוי עדיין פעיל</string>
+    <string name="upgrade_screen_sub_still_renewing_message">המנוי שלכם עדיין מוגדר להתחדש. בטלו אותו קודם ב-Google Play, ואז חזרו לקנות את הרכישה החד-פעמית — כך לא תחויבו פעמיים.</string>
+    <string name="upgrade_screen_sub_check_failed_message">לא הצלחנו לבדוק את סטטוס המנוי שלכם. בדקו את החיבור שלכם ונסו שוב.</string>
+    <string name="upgrades_gplay_already_owned_error_title">כבר נרכש</string>
+    <string name="upgrades_gplay_already_owned_error_description">השתמשו באפשרות \"שחזור רכישה\" כדי לשחזר את הרכישה שלכם. אם הבעיה נמשכת, נסו לנקות את מטמון Google Play ולהפעיל מחדש את המכשיר שלכם.</string>
+    <string name="upgrades_gplay_internal_error_title">שגיאת Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">אירעה שגיאה פנימית של Google Play. נסו את הפעולות הבאות:\n\n• הפעילו מחדש את המכשיר שלכם\n• נקו את מטמון חנות Google Play\n• נסו שוב מאוחר יותר</string>
+    <string name="upgrades_gplay_network_error_title">שגיאת חיבור</string>
+    <string name="upgrades_gplay_network_error_description">לא ניתן להתחבר ל-Google Play. בדקו את חיבור האינטרנט שלכם ונסו שוב.</string>
     <string name="upgrades_gplay_unavailable_error_title">החנות של גוגל לא זמינה כרגע</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager לא מצליחה להתחבר ל-Google Play. האם Google Play מותקן ומעודכן? האם חשבון Google שלך מחובר? נסה לנקות את המטמון של אפליקציית Google Play ולהפעיל מחדש את המכשיר.</string>
     <string name="upgrades_no_purchases_found_check_account">לא נמצאו רכישות. האם אתה משתמש בחשבון הנכון?</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">定期購入は、年/%sのお支払いです。</string>
     <string name="upgrade_screen_iap_action">1 回限りの購入</string>
     <string name="upgrade_screen_iap_action_hint">1回限りの購入は、%sのお支払いです。</string>
+    <string name="upgrade_screen_offer_divider_or">または</string>
+    <string name="upgrade_screen_offer_same_features">機能は同じで、料金プランが異なるだけです。</string>
     <string name="upgrade_screen_thanks_toast">あなたは最高です！ ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">購入を復元</string>
+    <string name="upgrade_screen_restore_banner_title">すでにBVM Proを購入済みですか?</string>
+    <string name="upgrade_screen_restore_banner_body">このデバイスで以前アップグレードされているようです。購入を復元して、もう一度ロックを解除してください。</string>
     <string name="upgrade_screen_restore_purchase_message">アップグレードは同じGoogleアカウントであれば全ての端末で適用されます。</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">トラブルが起きた際のヒント</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Playストアの同期には時間がかかる場合があります。 そのまましばらくお待ちください。改善されない場合は、再起動するか、Playストアのキャッシュを削除してみてください。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">複数のGoogleアカウントでログインしてあると、Playストアで不具合が発生する場合があります。 他のアカウントからログアウトするか、Web版Playストアからインストールすることで、正常にGoogleアカウントとの連携がされます。</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Proステータスを確認</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">おめでとうございます!</string>
+    <string name="upgrade_screen_owned_congrats_body">BVM Proを入手しました。開発を応援してくれてありがとうございます。❤️</string>
+    <string name="upgrade_screen_owned_iap_title">1 回限りの購入</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Proを永久に所有しています。応援ありがとうございます ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">サブスクリプション</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">BVM Proのサブスクリプションは有効で、更新される設定になっています。</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">BVM Proのサブスクリプションは有効ですが、更新されません。現在の期間の終了まで有効です。</string>
+    <string name="upgrade_screen_owned_both_warning">サブスクリプションと買い切り購入の両方をお持ちです。二重に請求されないよう、Google Playでサブスクリプションを解約してください。</string>
+    <string name="upgrade_screen_manage_subscription">サブスクリプションを管理</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">買い切り購入に切り替える</string>
+    <string name="upgrade_screen_switch_purchase_note">これは別の買い切り購入です。サブスクリプションは自動的に解約または返金されないため、Google Playでもサブスクリプションを解約してください。両方で同じGoogleアカウントを使用してください。</string>
+    <string name="upgrade_screen_switch_locked_note">サブスクリプションが更新されない設定になると利用できます。切り替えるにはGoogle Playで解約してください—現在の期間が終わるまではProを利用できます。</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">ステータスがおかしいですか?</string>
+    <string name="upgrade_screen_status_restore_body">購入がここに表示されない場合は、復元をお試しください。</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">購入を確認しています</string>
+    <string name="upgrade_screen_grace_body_short">少々お待ちください。Google Playで購入内容を再確認しています。</string>
+    <string name="upgrade_screen_grace_body">Google Playで購入を確認できません。復元を試すか、正しいアカウントでサインインしているか確認してください。</string>
+    <string name="upgrade_screen_retry_action">再試行</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">サブスクリプションはまだ有効です</string>
+    <string name="upgrade_screen_sub_still_renewing_message">サブスクリプションはまだ更新される設定になっています。まずGoogle Playで解約してから、買い切り購入に戻ってください。そうすれば二重に請求されません。</string>
+    <string name="upgrade_screen_sub_check_failed_message">サブスクリプションの状態を確認できませんでした。接続を確認してもう一度お試しください。</string>
+    <string name="upgrades_gplay_already_owned_error_title">購入済みです</string>
+    <string name="upgrades_gplay_already_owned_error_description">「購入を復元」オプションを使用して購入を復元してください。問題が解決しない場合は、Google Playのキャッシュを消去してデバイスを再起動してください。</string>
+    <string name="upgrades_gplay_internal_error_title">Google Playエラー</string>
+    <string name="upgrades_gplay_internal_error_description">Google Playの内部エラーが発生しました。以下をお試しください:\n\n• デバイスを再起動する\n• Google Playストアのキャッシュを消去する\n• しばらくしてから再度お試しください</string>
+    <string name="upgrades_gplay_network_error_title">接続エラー</string>
+    <string name="upgrades_gplay_network_error_description">Google Playに接続できません。インターネット接続を確認してもう一度お試しください。</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Playは利用できません</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager は Google Play に接続できません。Google Play はインストールされており、最新の状態ですか？Google アカウントにログインしていますか？Google Play アプリのキャッシュをクリアしてデバイスを再起動してみてください。</string>
     <string name="upgrades_no_purchases_found_check_account">購入が確認できませんでした。正しいアカウントを使用していますでしょうか？</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">გამოწერა ღირს %s წელიწადში.</string>
     <string name="upgrade_screen_iap_action">ერთჯერადი შეძენა</string>
     <string name="upgrade_screen_iap_action_hint">ერთჯერადი შეძენა ღირს %s.</string>
+    <string name="upgrade_screen_offer_divider_or">ან</string>
+    <string name="upgrade_screen_offer_same_features">იგივე ფუნქციები, უბრალოდ განსხვავებული ფასის მოდელები.</string>
     <string name="upgrade_screen_thanks_toast">Საუკეთესო ხარ! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">შეძენის აღდგენა</string>
+    <string name="upgrade_screen_restore_banner_title">უკვე შეიძინეთ BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">როგორც ჩანს, ამ მოწყობილობაზე ადრე უკვე განაახლეთ. აღადგინეთ თქვენი შენაძენი, რომ ხელახლა გახსნათ.</string>
     <string name="upgrade_screen_restore_purchase_message">თქვენი განახლება მოქმედებს ყველა მოწყობილობაზე იმავე Google ანგარიშით.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">ამოუცნობი განახლებების პრობლემების მოგვარების რჩევები:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store სინქრონიზაციას შეიძლება დრო დასჭირდეს. სცადეთ გადატვირთვა, Google Play ქეშის გასუფთავება ან უბრალოდ დაელოდეთ.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">მრავალი ანგარიში შეიძლება აბნევდეს Google Play-ს. გამოდით სხვა ანგარიშებიდან ან დააინსტალირეთ Google Play ვებსაიტის მეშვეობით, რაც აიძულებს კონკრეტულ ანგარიშთან ასოციაციას.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">იხილეთ თქვენი Pro სტატუსი</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">გილოცავთ!</string>
+    <string name="upgrade_screen_owned_congrats_body">თქვენ გაქვთ BVM Pro — მადლობა განვითარების მხარდაჭერისთვის. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">ერთჯერადი შეძენა</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro სამუდამოდ გეკუთვნით. მადლობა თქვენი მხარდაჭერისთვის ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">გამოწერა</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">თქვენი BVM Pro გამოწერა აქტიურია და განახლდება ავტომატურად.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">თქვენი BVM Pro გამოწერა აქტიურია, მაგრამ არ განახლდება. ის ძალაში რჩება მიმდინარე პერიოდის დასრულებამდე.</string>
+    <string name="upgrade_screen_owned_both_warning">თქვენ გაქვთ როგორც გამოწერა, ასევე ერთჯერადი შენაძენი. გააუქმეთ გამოწერა Google Play-ში, რომ ხელახლა არ გადაგახდევინონ.</string>
+    <string name="upgrade_screen_manage_subscription">გამოწერის მართვა</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">გადართვა ერთჯერად შენაძენზე</string>
+    <string name="upgrade_screen_switch_purchase_note">ეს ცალკე ერთჯერადი შენაძენია. ის არ აუქმებს ან არ აბრუნებს თანხას თქვენს გამოწერაზე, ამიტომ ის ცალკე გააუქმეთ Google Play-ში. ორივესთვის გამოიყენეთ იგივე Google ანგარიში.</string>
+    <string name="upgrade_screen_switch_locked_note">ხელმისაწვდომი გახდება, როცა თქვენი გამოწერა აღარ იქნება ავტომატური განახლების რეჟიმში. გადასართავად გააუქმეთ ის Google Play-ში — Pro-ს შეინარჩუნებთ მიმდინარე პერიოდის დასრულებამდე.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">სტატუსი არასწორად გამოიყურება?</string>
+    <string name="upgrade_screen_status_restore_body">თუ თქვენი შენაძენი აქ არ ჩანს, სცადეთ მისი აღდგენა.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">თქვენი შენაძენის დადასტურება</string>
+    <string name="upgrade_screen_grace_body_short">დაელოდეთ — ვამოწმებთ თქვენს შენაძენს Google Play-სთან.</string>
+    <string name="upgrade_screen_grace_body">ჯერ კიდევ ვერ ვადასტურებთ თქვენს შენაძენს Google Play-სთან. სცადეთ მისი აღდგენა, ან შეამოწმეთ, რომ სწორი ანგარიშით ხართ შესული.</string>
+    <string name="upgrade_screen_retry_action">თავიდან ცდა</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">გამოწერა ჯერ კიდევ აქტიურია</string>
+    <string name="upgrade_screen_sub_still_renewing_message">თქვენი გამოწერა ჯერ კიდევ ავტომატურად განახლდება. ჯერ გააუქმეთ ის Google Play-ში, შემდეგ დაბრუნდით ერთჯერადი შენაძენის შესაძენად — ასე ორჯერ არ გადაგახდევინებენ.</string>
+    <string name="upgrade_screen_sub_check_failed_message">ვერ შევძელით თქვენი გამოწერის სტატუსის შემოწმება. გთხოვთ, შეამოწმოთ თქვენი კავშირი და ხელახლა სცადოთ.</string>
+    <string name="upgrades_gplay_already_owned_error_title">უკვე შეძენილია</string>
+    <string name="upgrades_gplay_already_owned_error_description">გამოიყენეთ „შენაძენის აღდგენა\" ოფცია თქვენი შენაძენის აღსადგენად. თუ პრობლემა გრძელდება, სცადეთ Google Play-ის ქეშის გასუფთავება და მოწყობილობის გადატვირთვა.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-ის შეცდომა</string>
+    <string name="upgrades_gplay_internal_error_description">მოხდა Google Play-ის შიდა შეცდომა. გთხოვთ სცადოთ შემდეგი:\n\n• გადატვირთეთ მოწყობილობა\n• გაასუფთავეთ Google Play Store-ის ქეში\n• სცადეთ მოგვიანებით</string>
+    <string name="upgrades_gplay_network_error_title">კავშირის შეცდომა</string>
+    <string name="upgrades_gplay_network_error_description">ვერ ხერხდება Google Play-სთან დაკავშირება. გთხოვთ, შეამოწმოთ თქვენი ინტერნეტ კავშირი და ხელახლა სცადოთ.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play მიუწვდომელია</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager-ს არ შეუძლია Google Play-ზე დაკავშირება. დაყენებულია Google Play დაყენებულია და განახლებულია? ეში თქვენი Google ანგარიში შესულია? სცადეთ Google Play აპის ქეშის გასუფთავება და მოწყობილობის გადატვირთვა.</string>
     <string name="upgrades_no_purchases_found_check_account">შესყიდვები ვერ მოიძებნა. სწორ ანგარიშს იყენებთ?</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">ការជាវមានតម្លៃ %s ក្នុងមួយឆ្នាំ។</string>
     <string name="upgrade_screen_iap_action">ការជាវតែម្ដងរួច</string>
     <string name="upgrade_screen_iap_action_hint">ការជាវតែម្ដងរួចតម្លៃ %s។</string>
+    <string name="upgrade_screen_offer_divider_or">ឬ</string>
+    <string name="upgrade_screen_offer_same_features">លក្ខណៈពិសេសដូចគ្នា គ្រាន់តែម៉ូដែលកំណត់តម្លៃខុសគ្នា។</string>
     <string name="upgrade_screen_thanks_toast">អ្នកជាមនុស្សល្អបំផុត! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">ស្តារការជាវមកវិញ</string>
+    <string name="upgrade_screen_restore_banner_title">បានទិញ BVM Pro រួចហើយមែនទេ?</string>
+    <string name="upgrade_screen_restore_banner_body">ហាក់ដូចជាអ្នកបានអាប់ស្រ្គេតលើឧបករណ៍នេះពីមុនមក។ សូមស្តារការទិញរបស់អ្នកឡើងវិញ ដើម្បីដោះសោវាម្តងទៀត។</string>
     <string name="upgrade_screen_restore_purchase_message">ការដំឡើងរបស់អ្នកមានសុពលភាពនៅលើឧបករណ៍នានានៅលើគណនី Google ដូចគ្នា។</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">គន្លឹះដោះស្រាយបញ្ហាសម្រាប់ការដំឡើងដែលមិនបានទទួលស្គាល់៖</string>
     <string name="upgrade_screen_restore_sync_patience_hint">ការធ្វើសមកាលកម្ម Play Store អាចចំណាយពេល។ សាកល្បងចាប់ផ្តើមឡើងវិញ សម្អាតឃ្លាំងសម្ងាត់ Google Play ឬគ្រាន់តែរង់ចាំ។</string>
     <string name="upgrade_screen_restore_multiaccount_hint">គណនីច្រើនអាចធ្វើឱ្យ Google Play ច្រឡំ។ ចេញពីគណនីផ្សេងទៀត ឬដំឡើងតាមរយៈគេហទំព័រ Google Play ដែលបង្ខំការភ្ជាប់ជាមួយគណនីជាក់លាក់។</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">មើលស្ថានភាព Pro របស់អ្នក</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">សូមអបអរសាទរ!</string>
+    <string name="upgrade_screen_owned_congrats_body">អ្នកមាន BVM Pro ហើយ — សូមអរគុណសម្រាប់ការគាំទ្រការអភិវឌ្ឍន៍។ ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">ការជាវតែម្ដងរួច</string>
+    <string name="upgrade_screen_owned_iap_body">អ្នកជាកម្មសិទ្ធិករ BVM Pro ជារៀងរហូត។ សូមអរគុណសម្រាប់ការគាំទ្ររបស់អ្នក ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">ការជាវ</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">ការជាវ BVM Pro របស់អ្នកកំពុងសកម្ម ហើយត្រូវបានកំណត់ឱ្យបន្តជាថ្មី។</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">ការជាវ BVM Pro របស់អ្នកកំពុងសកម្ម ប៉ុន្តែនឹងមិនបន្តជាថ្មីទេ។ វានៅតែមានសុពលភាពរហូតដល់ចុងបញ្ចប់នៃរយៈពេលបច្ចុប្បន្ន។</string>
+    <string name="upgrade_screen_owned_both_warning">អ្នកមានទាំងការជាវ និងការទិញតែម្តង។ សូមលុបចោលការជាវនៅក្នុង Google Play ដើម្បីកុំឱ្យអ្នកត្រូវបានគិតប្រាក់ម្តងទៀត។</string>
+    <string name="upgrade_screen_manage_subscription">គ្រប់គ្រងការជាវ</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">ប្តូរទៅជាការទិញតែម្តង</string>
+    <string name="upgrade_screen_switch_purchase_note">នេះជាការទិញតែម្តងដាច់ដោយឡែក។ វាមិនលុបចោល ឬសងប្រាក់ការជាវរបស់អ្នកទេ ដូច្នេះសូមលុបចោលការជាវនោះនៅក្នុង Google Play ដែរ។ សូមប្រើគណនី Google ដូចគ្នាសម្រាប់ទាំងពីរ។</string>
+    <string name="upgrade_screen_switch_locked_note">អាចប្រើបានតែនៅពេលដែលការជាវរបស់អ្នកលែងត្រូវបានកំណត់ឱ្យបន្តជាថ្មី។ សូមលុបចោលវានៅក្នុង Google Play ដើម្បីប្តូរ — អ្នកនៅតែរក្សា Pro រហូតដល់រយៈពេលបច្ចុប្បន្នបញ្ចប់។</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">ស្ថានភាពមើលទៅមិនត្រឹមត្រូវ?</string>
+    <string name="upgrade_screen_status_restore_body">ប្រសិនបើការទិញរបស់អ្នកមិនបង្ហាញនៅទីនេះទេ សូមព្យាយាមស្តារវាឡើងវិញ។</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">កំពុងបញ្ជាក់ការទិញរបស់អ្នក</string>
+    <string name="upgrade_screen_grace_body_short">សូមរង់ចាំបន្តិច — យើងកំពុងពិនិត្យការទិញរបស់អ្នកម្តងទៀតជាមួយ Google Play។</string>
+    <string name="upgrade_screen_grace_body">យើងនៅតែមិនអាចបញ្ជាក់ការទិញរបស់អ្នកជាមួយ Google Play បានទេ។ សូមព្យាយាមស្តារវាឡើងវិញ ឬពិនិត្យមើលថាអ្នកបានចូលគណនីត្រឹមត្រូវ។</string>
+    <string name="upgrade_screen_retry_action">ព្យាយាមម្តងទៀត</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">ការជាវនៅតែសកម្ម</string>
+    <string name="upgrade_screen_sub_still_renewing_message">ការជាវរបស់អ្នកនៅតែត្រូវបានកំណត់ឱ្យបន្តជាថ្មី។ សូមលុបចោលវានៅក្នុង Google Play ជាមុនសិន បន្ទាប់មកត្រឡប់មកទិញការទិញតែម្តងវិញ — ដោយវិធីនេះអ្នកនឹងមិនត្រូវបានគិតប្រាក់ពីរដងទេ។</string>
+    <string name="upgrade_screen_sub_check_failed_message">យើងមិនអាចពិនិត្យស្ថានភាពការជាវរបស់អ្នកបានទេ។ សូមពិនិត្យការតភ្ជាប់របស់អ្នក ហើយព្យាយាមម្តងទៀត។</string>
+    <string name="upgrades_gplay_already_owned_error_title">បានទិញរួចហើយ</string>
+    <string name="upgrades_gplay_already_owned_error_description">សូមប្រើជម្រើស \"ស្តារការទិញ\" ដើម្បីស្តារការទិញរបស់អ្នក។ ប្រសិនបើបញ្ហានៅតែកើតមាន សូមព្យាយាមសម្អាតឃ្លាំងសម្ងាត់ Google Play ហើយចាប់ផ្តើមឧបករណ៍របស់អ្នកឡើងវិញ។</string>
+    <string name="upgrades_gplay_internal_error_title">កំហុស Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">កំហុសផ្ទៃក្នុងរបស់ Google Play បានកើតឡើង។ សូមព្យាយាមធ្វើដូចខាងក្រោម៖\n\n• ចាប់ផ្តើមឧបករណ៍របស់អ្នកឡើងវិញ\n• សម្អាតឃ្លាំងសម្ងាត់ Google Play Store\n• ព្យាយាមម្តងទៀតនៅពេលក្រោយ</string>
+    <string name="upgrades_gplay_network_error_title">កំហុសការតភ្ជាប់</string>
+    <string name="upgrades_gplay_network_error_description">មិនអាចភ្ជាប់ទៅ Google Play បានទេ។ សូមពិនិត្យការតភ្ជាប់អ៊ីនធឺណិតរបស់អ្នក ហើយព្យាយាមម្តងទៀត។</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play មិនអាចប្រើបាន</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager មិនអាចភ្ជាប់ទៅ Google Play បានទេ។ តើ Google Play ត្រូវបានដំឡើងហើយទាន់សម័យទេ? តើគណនី Google របស់អ្នកបានចូលហើយទេ? សូមព្យាយាមមើលការសម្អាតឃ្លាំងសម្ងាត់នៃកម្មវិធី Google Play ហើយចាប់ផ្ដើមដំណើរការឧបករណ៍ឡើងវិញ។</string>
     <string name="upgrades_no_purchases_found_check_account">រកមិនឃើញការទិញ។ តើអ្នកកំពុងប្រើគណនីត្រឹមត្រូវទេ?</string>

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Aboneyê salê %s lêdixe.</string>
     <string name="upgrade_screen_iap_action">Kirîna yekcar</string>
     <string name="upgrade_screen_iap_action_hint">Kirîna yekcar %s lêdixe.</string>
+    <string name="upgrade_screen_offer_divider_or">an</string>
+    <string name="upgrade_screen_offer_same_features">Heman taybetmendî, tenê bihaye cuda ye.</string>
     <string name="upgrade_screen_thanks_toast">Hûn herî baş in! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Kirîna vegerîne</string>
+    <string name="upgrade_screen_restore_banner_title">Tu berê BVM Pro kîrî?</string>
+    <string name="upgrade_screen_restore_banner_body">Xuya dike ku tu berê li vî aparatî upgrade kî. Kîrîna xwe vegere bike û dîsa vekî bike.</string>
     <string name="upgrade_screen_restore_purchase_message">Nuvekirinê we li ser hemû cîhazên bi heman hesabê Google derbasdar e.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Rêgezên çareserkirinê ji bo nuvekirinên nenas:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Hevdengkirina Play Store dibe ku wext bigire. Vegere, cache ya Google Play pak bike an tenê bisekine.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Hesabên gelek dikarin Google Play tevlihev bikin. Ji hesabên din derkeve an bi malpera Google Play saz bike.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Rewşa Pro-ya xwe bibîne</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Pîroz be!</string>
+    <string name="upgrade_screen_owned_congrats_body">Tu BVM Pro wergirt — spas ji bo piştgiriya pêşkeftinê. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Kîrîna yek carê</string>
+    <string name="upgrade_screen_owned_iap_body">Tu BVM Pro ji bo herî demî xwedî ye. Spas ji bo piştgiriya te ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abonekirî</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Abonekiriya BVM Pro ya te çalak e û li ser nûkiriyanî ye.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Abonekiriya BVM Pro ya te çalak e lê nabe ku tê danîn. Ew derbasdar dimîne heya qedc demanê vê.</string>
+    <string name="upgrade_screen_owned_both_warning">Tu hem abonekirî hem jî kirrîna yek carî heye. Abonekiriya di Google Play de betal bike da tu carekê din nexas nebe.</string>
+    <string name="upgrade_screen_manage_subscription">Abonekirî rêvebir bike</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Veguherîn kirrîna yek carî</string>
+    <string name="upgrade_screen_switch_purchase_note">Ev kirrîna yek carî ya veqetandî ye. Ew abonekiriya te nabetal nakin û paşveger nake, ji ber vê tu ew di Google Play de jî betal bike. Hesabê Google yek tewhe ji bo herdu yê bikar bîn.</string>
+    <string name="upgrade_screen_switch_locked_note">Dema abonekiriya te nabe ku tê danîn derketî ye. Ew di Google Play de betal bike da tu biguherînî — tu Pro heya qedc demanê vê hildigre.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Statusa ne rast xuya dike?</string>
+    <string name="upgrade_screen_status_restore_body">Heke kirrîna te li vir nabêje, hewl bide ku tê bersivekirin.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Kirina kirînanê xwe tê piştrast kirin</string>
+    <string name="upgrade_screen_grace_body_short">Hûn bimînin — em kirina kirînanê xwe bi Google Play re dîsa kontrol dikin.</string>
+    <string name="upgrade_screen_grace_body">Em hîn jî kirina kirînanê xwe bi Google Play re piştrast nakin. Hûn dikarin wê vegerandin, an jî kontrol bikin ku hûn bi hevsabê rast têkeve ne.</string>
+    <string name="upgrade_screen_retry_action">Dîsa biceribînin</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Bendavî hîn jî çalak e</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Bendavî xwe hîn jî bo nûkirinê mîhenk kiriye. Ew di Google Play de bê yekemîn betal bikin, paşê vegerin û kire xweze bikin — bi vî awayî du caran lê vatin nabe.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Em nikarî rewşa bendavî xwe kontrol bikin. Girêdanê xwe kontrol bikin û dîsa biceribînin.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Jixwe kirî ye</string>
+    <string name="upgrades_gplay_already_owned_error_description">Vebijarka Kirina Vegerandin bikar bînin da ku kirina xwe vegerandin. Eger pirsgêrk berdewam be, derbasbûna Google Play paqij bikin û amûra xwe dîsa destpê bikin.</string>
+    <string name="upgrades_gplay_internal_error_title">Xebata Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Xeleteke navxweyî yê Google Play-ê derket. Ji kerema xwe hewldanên jêrîn bîngeh bikin:\n\n• Avazkirin yê amûrê xwe\n• Gihîştina Google Play-ê bihîstin\n• Piştî demek dîsa hewl bidin</string>
+    <string name="upgrades_gplay_network_error_title">Xeleteke girêdanê</string>
+    <string name="upgrades_gplay_network_error_description">Nabigihije Google Play-ê. Linkê internet xwe kontrol bikin û dîsa hewl bidin.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nayê dîtin</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nikare bi Google Play re girêbide. Ma Google Play saz û nûkirî ye? Cache ya Google Play pak bike û cîhazê xwe ji nû ve bixebite.</string>
     <string name="upgrades_no_purchases_found_check_account">Kirîn nehatin dîtin. Hûn hesabê rast bikar tînin?</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">ಚಂದಾಸಮ್ಮತಿಗೆ ಪ್ರತಿ ವರ್ಷ %s ಖರ್ಚಾಗುತ್ತದೆ.</string>
     <string name="upgrade_screen_iap_action">ಒಂದು ಬಾರಿನ ಖರೀದು</string>
     <string name="upgrade_screen_iap_action_hint">ಒಂದು ಬಾರಿನ ಖರೀದು %s ಖರ್ಚಾಗುತ್ತದೆ.</string>
+    <string name="upgrade_screen_offer_divider_or">ಅಥವಾ</string>
+    <string name="upgrade_screen_offer_same_features">ಅದೇ ವೈಶಿಷ್ಟ್ಯಗಳು, ಕೇವಲ ವಿಭಿನ್ನ ಬೆಲೆ ಮಾದರಿಗಳು.</string>
     <string name="upgrade_screen_thanks_toast">ನೀವು ಅತ್ಯುತ್ತಮರು! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">ಖರೀದು ಮರುಸ್ಥಾಪಿಸಿ</string>
+    <string name="upgrade_screen_restore_banner_title">ಈಗಾಗಲೇ BVM Pro ಖರೀದಿಸಿದ್ದೀರಾ?</string>
+    <string name="upgrade_screen_restore_banner_body">ನೀವು ಈ ಸಾಧನದಲ್ಲಿ ಮೊದಲೇ ನವೀಕರಣ ಮಾಡಿದ್ದರೆ ತೋರುತ್ತದೆ. ಅದನ್ನು ಮತ್ತೆ ಅನ್ಲಾಕ್ ಮಾಡಲು ನಿಮ್ಮ ಖರೀದಿ ಪುನರುದ್ಧಾರ ಮಾಡಿ.</string>
     <string name="upgrade_screen_restore_purchase_message">ನಿಮ್ಮ ದರ್ಜೆಯೇರಿಕೆ ಅದೇ Google ಖಾತೆಯಲ್ಲಿನ ಸಾಧನಗಳಲ್ಲಿ ಮಾನ್ಯವಾಗಿರುತ್ತದೆ.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">ಗುರುತಿಸಾಲ್ಪಡದ ದರ್ಜೆಯೇರಿಕೆಗಳಿಗೆ ತೊಂದರೆ ನಿವಾರಣೆ ಸೂಚನೆಗಳು:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store ಸಿಂಕ್ರೈನಿಕರಣಕ್ಕೆ ಸಮಯ ಕೆಲವುತ್ತದೆ. ಮರುಬುಟ್ ಮಾಡಿ, Google Play ಕ್ಯಾಚೆ ತೆರವುಮಾಡಿ ಅಥವಾ ಕಾಯಿರಿ.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ಬಹುಖಾತೆಗಳು Google Play ಅನ್ನು ಗೊಂದಲಗೊಳಿಸಬಹುದು. ಇತರ ಖಾತೆಗಳಿಂದ ಲಾಗ್ ಆಉಟ್ ಮಾಡಿ ಅಥವಾ Google Play ವೆಬ್ ತಾಣದ ಮೂಲಕ ಇನ್ಸ್ಟಾಲ್ ಮಾಡಿ.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">ನಿಮ್ಮ ಪ್ರೋ ಸ್ಥಿತಿ ನೋಡಿ</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">ಅಭಿನಂದನೆ!</string>
+    <string name="upgrade_screen_owned_congrats_body">ನೀವು BVM Pro ಪಡೆದಿದ್ದೀರಿ — ಅಭಿವೃದ್ಧಿ ಬೆಂಬಲಿಸಿದ್ದಕ್ಕೆ ಧನ್ಯವಾದಗಳು. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">ಏಕ-ಕಾಲೀನ ಖರೀದಿ</string>
+    <string name="upgrade_screen_owned_iap_body">ನೀವು BVM Pro ಚಿರಕಾಲಕ್ಕೆ ಸ್ವಾಧೀನ ಮಾಡಿಕೊಂಡಿದ್ದೀರಿ. ನಿಮ್ಮ ಬೆಂಬಲಕ್ಕೆ ಧನ್ಯವಾದಗಳು ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">ಸದಸ್ಯತೆ</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">ನಿಮ್ಮ BVM Pro ಸದಸ್ಯತೆ ಸಕ್ರಿಯ ಮತ್ತು ನವೀಕರಣಕ್ಕಾಗಿ ಹೊಂದಿಸಿದೆ.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">ನಿಮ್ಮ BVM Pro ಸದಸ್ಯತೆ ಸಕ್ರಿಯವಾಗಿದೆ ಆದರೆ ನವೀಕರಣವಾಗುವುದಿಲ್ಲ. ಅದು ಪ್ರಸ್ತುತ ಅವಧಿಯ ಅಂತ್ಯ ವರೆಗೆ ಮಾನ್ಯವಾಗಿರುತ್ತದೆ.</string>
+    <string name="upgrade_screen_owned_both_warning">ನೀವು ಸದಸ್ಯತೆ ಮತ್ತು ಏಕ-ಬಾರಿ ಖರೀದಿ ಎರಡನ್ನೂ ಹೊಂದಿದ್ದೀರಿ. Google Play ನಲ್ಲಿ ಸದಸ್ಯತೆಯನ್ನು ರದ್ದುಗೊಳಿಸಿ ಆದ್ದರಿಂದ ನಿಮ್ಮನ್ನು ಮತ್ತೆ ಚಾರ್ಜ ಮಾಡಲಾಗುವುದಿಲ್ಲ.</string>
+    <string name="upgrade_screen_manage_subscription">ಸದಸ್ಯತೆಯನ್ನು ನಿರ್ವಹಿಸಿ</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">ಏಕ-ಬಾರಿ ಖರೀದಿಗೆ ಬದಲಿಕೊಳ್ಳಿ</string>
+    <string name="upgrade_screen_switch_purchase_note">ಇದು ಪ್ರತ್ಯೇಕ ಏಕ-ಬಾರಿ ಖರೀದಿ. ಇದು ನಿಮ್ಮ ಸದಸ್ಯತೆಯನ್ನು ರದ್ದುಗೊಳಿಸುವುದಿಲ್ಲ ಅಥವಾ ಮರುಪಾವತಿ ಮಾಡುವುದಿಲ್ಲ, ಆದ್ದರಿಂದ ಅದನ್ನು Google Play ನಲ್ಲಿಯೂ ರದ್ದುಗೊಳಿಸಿ. ಎರಡಕ್ಕೂ ಅದೇ Google ಖಾತೆಯನ್ನು ಬಳಸಿ.</string>
+    <string name="upgrade_screen_switch_locked_note">ನಿಮ್ಮ ಸದಸ್ಯತೆ ನವೀಕರಣಕ್ಕಾಗಿ ಹೊಂದಿಸದಿರುವ ಬಳಿಕ ಲಭ್ಯವಾಗುತ್ತದೆ. ಬದಲಿಕೊಳ್ಳಲು Google Play ನಲ್ಲಿ ಅದನ್ನು ರದ್ದುಗೊಳಿಸಿ — ನೀವು ಪ್ರಸ್ತುತ ಅವಧಿ ಅಂತ್ಯ ವರೆಗೆ Pro ಅನ್ನು ಇರಿಸಿಕೊಳ್ಳುತ್ತೀರಿ.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">ಸ್ಥಿತಿ ತಪ್ಪಾಗಿ ತೋರುತ್ತಿದೆಯೇ?</string>
+    <string name="upgrade_screen_status_restore_body">ನಿಮ್ಮ ಖರೀದಿ ಇಲ್ಲಿ ಕಾಣಿಸದಿದ್ದರೆ, ಅದನ್ನು ಮರುಸ್ಥಾಪಿಸಲು ಪ್ರಯತ್ನಿಸಿ.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">ನಿಮ್ಮ ಖರೀದಿ ದೃಢೀಕರಿಸಲಾಗುತ್ತಿದೆ</string>
+    <string name="upgrade_screen_grace_body_short">ಸರಿ, ನಿಮ್ಮ ಖರೀದಿಯನ್ನು Google Play ಜೊತೆ ಮತ್ತೆ ಪರಿಶೀಲಿಸುತ್ತಿದ್ದೇವೆ.</string>
+    <string name="upgrade_screen_grace_body">Google Play ಜೊತೆ ನಿಮ್ಮ ಖರೀದಿ ದೃಢೀಕರಿಸಲು ನಾವು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ಅದನ್ನು ಮರುಸ್ಥಾಪಿಸಲು ಪ್ರಯತ್ನಿಸಿ, ಅಥವಾ ನೀವು ಸರಿಯಾದ ಖಾತೆಯೊಂದಿಗೆ ಸೈನ್ ಇನ್ ಮಾಡಿರುವಿರಾ ಎಂದು ಪರಿಶೀಲಿಸಿ.</string>
+    <string name="upgrade_screen_retry_action">ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">ಸದಸ್ಯತ್ವ ಇನ್ನೂ ಸಕ್ರಿಯವಾಗಿದೆ</string>
+    <string name="upgrade_screen_sub_still_renewing_message">ನಿಮ್ಮ ಸದಸ್ಯತ್ವ ನವೀಕರಣ ಮಾಡಲು ಇನ್ನೂ ಹೊಂದಿಸಲಾಗಿದೆ. ಇದನ್ನು ಮೊದಲು Google Play ನಲ್ಲಿ ರದ್ದುಗೊಳಿಸಿ, ನಂತರ ಏಕಕಾಲೀನ ಖರೀದಿಗಾಗಿ ಹಿಂತಿರುಗಿ — ಆ ರೀತಿಯಲ್ಲಿ ನಿಮಗೆ ಎರಡು ಬಾರಿ ಚಾರ್ಜ್ ಆಗುವುದಿಲ್ಲ.</string>
+    <string name="upgrade_screen_sub_check_failed_message">ನಾವು ನಿಮ್ಮ ಸದಸ್ಯತ್ವ ಸ್ಥಿತಿ ಪರಿಶೀಲಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ನಿಮ್ಮ ಸಂಪರ್ಕ ಪರಿಶೀಲಿಸಿ ಮತ್ತು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
+    <string name="upgrades_gplay_already_owned_error_title">ಈಗಾಗಲೇ ಖರೀದಿಸಲಾಗಿದೆ</string>
+    <string name="upgrades_gplay_already_owned_error_description">ನಿಮ್ಮ ಖರೀದಿ ಮರುಸ್ಥಾಪಿಸಲು \"ಖರೀದಿ ಮರುಸ್ಥಾಪಿಸಿ\" ಆಯ್ಕೆ ಬಳಸಿ. ಸಮಸ್ಯೆ ಪುನರಾವರ್ತಿತವಾಗುತ್ತಲೇ ಇದ್ದರೆ, Google Play ಕ್ಯಾಶೆ ಸ್ವಚ್ಛ ಮಾಡಲು ಪ್ರಯತ್ನಿಸಿ ಮತ್ತು ನಿಮ್ಮ ಸಾಧನವನ್ನು ಮತ್ತೆ ಪ್ರಾರಂಭಿಸಿ.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play ದೋಷ</string>
+    <string name="upgrades_gplay_internal_error_description">ಗೂಗಲ್ ಪ್ಲೇ ನಲ್ಲಿ ಆಂತರಿಕ ದೋಷ ಸಂಭವಿಸಿದೆ. ದಯವಿಟ್ಟು ಈ ಕೆಳಗಿನವುಗಳನ್ನು ಪ್ರಯತ್ನಿಸಿ:\n\n• ನಿಮ್ಮ ಸಾಧನವನ್ನು ಮರುಪ್ರಾರಂಭಿಸಿ\n• ಗೂಗಲ್ ಪ್ಲೇ ಸ್ಟೋರ್ ಕ್ಯಾಶ್ ತೆರವುಗೊಳಿಸಿ\n• ನಂತರ ಪುನಃ ಪ್ರಯತ್ನಿಸಿ</string>
+    <string name="upgrades_gplay_network_error_title">ಸಂಪರ್ಕ ದೋಷ</string>
+    <string name="upgrades_gplay_network_error_description">ಗೂಗಲ್ ಪ್ಲೇಗೆ ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ನಿಮ್ಮ ಇಂಟರ್ನೆಟ್ ಸಂಪರ್ಕವನ್ನು ಪರಿಶೀಲಿಸಿ ಮತ್ತು ಪುನಃ ಪ್ರಯತ್ನಿಸಿ.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ಲಭ್ಯವಿಲ್ಲ</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play ಗೆ ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ. Google Play ಇನ್ಸ್ಟಾಲ್ ಆಗಿ ನವೀಕರಿಸಲಾಗಿದೆಯೇ? ನಿಮ್ಮ Google ಖಾತೆ ಲಾಗಿನ್ ಆಗಿದೆಯೇ? Google Play ಅಪ್ ಕ್ಯಾಚೆ ತೆರವುಮಾಡಿ ಮರುಬುಟ್ ಮಾಡಿ.</string>
     <string name="upgrades_no_purchases_found_check_account">ಯಾವುದೇ ಖರೀದಿಗಳು ಕಂಡುಬಂದಿಲ್ಲ. ನೀವು ಸರಿಯಾದ ಖಾತೆಯನ್ನು ಬಳಸುತ್ತಿದ್ದೀರಾ?</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">구독은 매년 %s 가 청구됩니다.</string>
     <string name="upgrade_screen_iap_action">영구적 구매</string>
     <string name="upgrade_screen_iap_action_hint">영구적으로 구매하면 %s 이(가) 청구됩니다.</string>
+    <string name="upgrade_screen_offer_divider_or">또는</string>
+    <string name="upgrade_screen_offer_same_features">동일한 기능, 가격 모델만 다릅니다.</string>
     <string name="upgrade_screen_thanks_toast">감사합니다! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">구매 복원</string>
+    <string name="upgrade_screen_restore_banner_title">이미 BVM Pro를 구매하셨나요?</string>
+    <string name="upgrade_screen_restore_banner_body">이 기기에서 이전에 업그레이드하신 것 같습니다. 구매 내역을 복원하여 다시 잠금을 해제하세요.</string>
     <string name="upgrade_screen_restore_purchase_message">업그레이드는 동일한 Google 계정의 모든 기기에서 유효합니다.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">인식할 수 없는 업그레이드에 대한 문제 해결 팁:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play 스토어 동기화는 시간이 걸릴 수 있습니다. 재부팅하거나 Google Play 캐시를 지우거나 잠시 기다려 보세요.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">기기에 등록된 여러 개의 계정으로 인해 Google Play가 혼동될 수 있습니다. 다른 계정을 로그아웃하거나 Google Play 웹사이트를 통해 설치하면 특정 계정과 강제로 연결됩니다.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Pro 상태 보기</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">축하합니다!</string>
+    <string name="upgrade_screen_owned_congrats_body">BVM Pro를 구매하셨습니다 — 개발을 지원해 주셔서 감사합니다. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">영구적 구매</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro를 영구 소유하고 계십니다. 성원에 감사드립니다 ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">구독</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">BVM Pro 구독이 활성화되어 있으며 자동 갱신됩니다.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">BVM Pro 구독이 활성화되어 있지만 갱신되지 않습니다. 현재 결제 주기가 끝날 때까지 유효합니다.</string>
+    <string name="upgrade_screen_owned_both_warning">구독과 일회성 구매를 모두 보유하고 계십니다. 다시 청구되지 않도록 Google Play에서 구독을 취소하세요.</string>
+    <string name="upgrade_screen_manage_subscription">구독 관리</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">일회성 구매로 전환</string>
+    <string name="upgrade_screen_switch_purchase_note">이는 별도의 일회성 구매입니다. 구독을 취소하거나 환불하지 않으므로 Google Play에서도 구독을 취소해야 합니다. 둘 다 동일한 Google 계정을 사용하세요.</string>
+    <string name="upgrade_screen_switch_locked_note">구독이 더 이상 자동 갱신되지 않을 때 사용할 수 있습니다. 전환하려면 Google Play에서 구독을 취소하세요 — 현재 결제 주기가 끝날 때까지는 Pro를 계속 사용할 수 있습니다.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">상태가 잘못된 것 같나요?</string>
+    <string name="upgrade_screen_status_restore_body">구매 내역이 여기에 표시되지 않는다면 복원을 시도해 보세요.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">구매 확인 중</string>
+    <string name="upgrade_screen_grace_body_short">잠시만 기다려 주세요 — Google Play에서 구매 내역을 다시 확인하고 있습니다.</string>
+    <string name="upgrade_screen_grace_body">Google Play에서 구매 내역을 아직 확인할 수 없습니다. 복원을 시도하거나 올바른 계정으로 로그인되어 있는지 확인하세요.</string>
+    <string name="upgrade_screen_retry_action">다시 시도</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">구독이 아직 활성 상태입니다</string>
+    <string name="upgrade_screen_sub_still_renewing_message">구독이 아직 자동 갱신으로 설정되어 있습니다. 먼저 Google Play에서 구독을 취소한 다음 돌아와서 일회성 구매를 진행하세요 — 그러면 두 번 청구되지 않습니다.</string>
+    <string name="upgrade_screen_sub_check_failed_message">구독 상태를 확인할 수 없습니다. 연결 상태를 확인하고 다시 시도해 주세요.</string>
+    <string name="upgrades_gplay_already_owned_error_title">이미 구매함</string>
+    <string name="upgrades_gplay_already_owned_error_description">\"구매 복원\" 옵션을 사용하여 구매 내역을 복원하세요. 문제가 계속되면 Google Play 캐시를 삭제하고 기기를 재시작해 보세요.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play 오류</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play 내부 오류가 발생했습니다. 다음을 시도해 보세요:\n\n• 기기 재시작\n• Google Play 스토어 캐시 삭제\n• 나중에 다시 시도</string>
+    <string name="upgrades_gplay_network_error_title">연결 오류</string>
+    <string name="upgrades_gplay_network_error_description">Google Play에 연결할 수 없습니다. 인터넷 연결을 확인하고 다시 시도해 주세요.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play에 연결할 수 없음</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager가 Google Play에 연결할 수 없습니다. Google Play가 설치되어 있고 최신 버전인가요? Google 계정이 로그인되어 있나요? Google Play 앱의 캐시를 지우고 기기를 재부팅해 보세요.</string>
     <string name="upgrades_no_purchases_found_check_account">구매 항목을 찾을 수 없습니다. 올바른 계정을 사용 중인가요?</string>

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Жазылык жылына %s түрүн.</string>
     <string name="upgrade_screen_iap_action">Бир жолку сатып алуу</string>
     <string name="upgrade_screen_iap_action_hint">Бир жолку сатып алуу %s түрүн.</string>
+    <string name="upgrade_screen_offer_divider_or">же</string>
+    <string name="upgrade_screen_offer_same_features">Бирдей функциялар, жөн гана баа моделдери ар башка.</string>
     <string name="upgrade_screen_thanks_toast">Сиз ең жакшысыз! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Сатып алууну берновулоо</string>
+    <string name="upgrade_screen_restore_banner_title">Буга чейин BVM Pro сатып алдыңыз?</string>
+    <string name="upgrade_screen_restore_banner_body">Окшоп турганча, сиз ушул түзүлмөдө мурда жаңырттыңыз. Аны кайра ачуу үчүн сатып алууңузду калыбына келтириңиз.</string>
     <string name="upgrade_screen_restore_purchase_message">Сиздин апгрейд бирдей Google аккаунттагы бардык түзмөктөрдө жарамдуу.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Танылбаган апгрейддер үчүн күйүү чечүү кеңештҩрүлөрү:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store синхрондоо уакыт алышы мүмкүн. Чүмүрлөө, Google Play кэшин тазалоону немесе жой күтүүдү бүлкүүнүз карап көрүңүз.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Бирден көп аккаунт Google Play арачан чаташтырат. Башка аккаунттардан чыгыңыз немесе белгилүү аккаунт менен байланышты мәжбүрлеечи Google Play вебсайты аркылу уруксаттырында орнотуңуз.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Сиздин Pro абалын көрүңүз</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Куттуктаймын!</string>
+    <string name="upgrade_screen_owned_congrats_body">Сизде BVM Pro бар — өнүктүрүүгө колдоо көрсөткөнүңүз үчүн рахмат. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Бир жолку сатып алуу</string>
+    <string name="upgrade_screen_owned_iap_body">Сизде BVM Pro түбөлүк. Колдоо көрсөткөнүңүз үчүн рахмат ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Подписка</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Сиздин BVM Pro подпискасы белсенди жана кайталанууга коюлган.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Сиздин BVM Pro подпискасы белсенди, бирок кайталанбайт. Ал азыркы мезгилдин аягына чейин жарактуу.</string>
+    <string name="upgrade_screen_owned_both_warning">Сизде подписка жана бир жолу сатып алуу бар. Кайра төлөм алынбашы үчүн подписканы Google Play\'де жокко чыгарыңыз.</string>
+    <string name="upgrade_screen_manage_subscription">Подписканы башкаруу</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Бир жолу сатып алууга өтүү</string>
+    <string name="upgrade_screen_switch_purchase_note">Бул өзүнчө бир жолу сатып алуу. Ал сиздин подписканы жокко чыгарбайт же акча кайтарбайт, ошондуктан Google Play\'де да жокко чыгарыңыз. Экөө үчүн бир эле Google аккаунтту колдонуңуз.</string>
+    <string name="upgrade_screen_switch_locked_note">Подписка кайталанууга коюлбай калгандан кийин жеткиликтүү болот. Өтүү үчүн Google Play\'де аны жокко чыгарыңыз — азыркы мезгил бүткөнгө чейин Pro сакталат.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Статус туура эмес көрүнүп жатабы?</string>
+    <string name="upgrade_screen_status_restore_body">Эгер сиздин сатып алуу бул жерде көрүнбөсө, аны калыбына келтирүүгө аракет кылыңыз.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Сатып алууну ырастоо</string>
+    <string name="upgrade_screen_grace_body_short">Бир аз кутуңуз — биз сатып алууңузду Google Play менен кайра текшерүүдө турабыз.</string>
+    <string name="upgrade_screen_grace_body">Биз дагы эле сатып алууңузду Google Play менен ырастай албайбыз. Аны калыбына келтирүүгө аракет кылыңыз же туура аккаунтка киргениңизди текшерүңүз.</string>
+    <string name="upgrade_screen_retry_action">Кайра аракет кылуу</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Жазылуу дагы эле активдүү</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Сиздин жазылуу дагы эле кайталанууга коюлган. Адегенде аны Google Play\'де жокко чыгарыңыз, андан кийин бир жолу сатып алуу үчүн кайра келиңиз — ошентип эки жолу төлөбойсуңуз.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Биз сиздин жазылуу статусун текшей албадык. Байланышыңызды текшеңиз жана кайра аракет кылыңыз.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Мурда сатылып алынган</string>
+    <string name="upgrades_gplay_already_owned_error_description">\"Сатып алууну калыбына келтирүү\" опциясын колдонуп, сатып алууңузду калыбына келтириңиз. Эгер проблема сакталса, Google Play кэшин тазалап жана түзмөгүңүздү кайра жүктөп көрүңүз.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play катасы</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play ички катасы пайда болду. Төмөндөгүлөрдү аракет кылып көрүңүз:\n\n• Түзмөгүңүздү кайта баштаңыз\n• Google Play Store кэшин тазалаңыз\n• Кийинчереэк аракет кылыңыз</string>
+    <string name="upgrades_gplay_network_error_title">Байланыш катасы</string>
+    <string name="upgrades_gplay_network_error_description">Google Play\'ге туташуу мүмкүн болбоду. Интернет байланышыңызды текшериңиз жана кайра аракет кылыңыз.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play жетиштүүсүз</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play га байлана албайт. Google Play орнотулган жана жаңыртылганбы? Google аккаунтыңызга киргенбе? Google Play кэшин тазалап, түзмөгүңүздү кайра чүмүрлөө көрүңүз.</string>
     <string name="upgrades_no_purchases_found_check_account">Эч кандай сатып алуулар табылган жок. Туура каттоо эсебин колдонуп жатасызбы?</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">ການສະໝັກສະມາຊິກລາຄາ %s ຕໍ່ປີ.</string>
     <string name="upgrade_screen_iap_action">ການຊື້ຄັ້ງດຽວ</string>
     <string name="upgrade_screen_iap_action_hint">ການຊື້ຄັ້ງດຽວລາຄາ %s.</string>
+    <string name="upgrade_screen_offer_divider_or">ຫຼື</string>
+    <string name="upgrade_screen_offer_same_features">ຄຸນສົມບັດຄືກັນ, ພຽງແຕ່ຮູບແບບລາຄາແຕກຕ່າງກັນ.</string>
     <string name="upgrade_screen_thanks_toast">ທ່ານດີທີ່ສຸດ! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">ກູ້ຄືນການຊື້</string>
+    <string name="upgrade_screen_restore_banner_title">ຊື້ BVM Pro ແລ້ວບໍ?</string>
+    <string name="upgrade_screen_restore_banner_body">ເບິ່ງຄືວ່າທ່ານໄດ້ອັບເກຣດອຸປະກອນນີ້ມາກ່ອນແລ້ວ. ກູ້ຄືນການຊື້ຂອງທ່ານເພື່ອປົດລັອກມັນອີກຄັ້ງ.</string>
     <string name="upgrade_screen_restore_purchase_message">ການອັບເກຣດຂອງທ່ານໃຊ້ໄດ້ກັບອຸປະກອນຕ່າງໆໃນບັນຊີ Google ດຽວກັນ.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">ຄຳແນະນຳການແກ້ໄຂບັນຫາສຳລັບການອັບເກຣດທີ່ບໍ່ຮັບຮູ້:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">ການຊິງຄ໌ Play Store ອາດໃຊ້ເວລາ. ລອງຣີບູດ, ລ້າງແຄສ Google Play ຫຼືພຽງແຕ່ລໍຖ້າ.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ບັນຊີຫຼາຍບັນຊີສາມາດເຮັດໃຫ້ Google Play ສັບສົນ. ອອກຈາກລະບົບຈາກບັນຊີອື່ນ ຫຼືຕິດຕັ້ງຜ່ານເວັບໄຊ Google Play, ເຊິ່ງບັງຄັບການເຊື່ອມໂຍງກັບບັນຊີສະເພາະ.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">ເບິ່ງສະຖານະ Pro ຂອງທ່ານ</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">ຂໍສະແດງຄວາມຍິນດີ!</string>
+    <string name="upgrade_screen_owned_congrats_body">ທ່ານໄດ້ BVM Pro ແລ້ວ — ຂອບໃຈທີ່ສະໜັບສະໜູນການພັດທະນາ. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">ການຊື້ຄັ້ງດຽວ</string>
+    <string name="upgrade_screen_owned_iap_body">ທ່ານເປັນເຈົ້າຂອງ BVM Pro ຕະຫຼອດໄປ. ຂອບໃຈສຳລັບການສະໜັບສະໜູນຂອງທ່ານ ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">ການສະໝັກສະມາຊິກ</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">ການສະໝັກສະມາຊິກ BVM Pro ຂອງທ່ານກຳລັງເປີດໃຊ້ງານ ແລະ ຕັ້ງໄວ້ໃຫ້ຕໍ່ອາຍຸ.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">ການສະໝັກສະມາຊິກ BVM Pro ຂອງທ່ານກຳລັງເປີດໃຊ້ງານ ແຕ່ຈະບໍ່ຕໍ່ອາຍຸ. ມັນຈະໃຊ້ໄດ້ຈົນເຖິງທ້າຍໄລຍະປັດຈຸບັນ.</string>
+    <string name="upgrade_screen_owned_both_warning">ທ່ານມີທັງການສະໝັກສະມາຊິກ ແລະ ການຊື້ແບບຄັ້ງດຽວ. ຍົກເລີກການສະໝັກສະມາຊິກໃນ Google Play ເພື່ອບໍ່ໃຫ້ຖືກຮຽກເກັບເງິນອີກ.</string>
+    <string name="upgrade_screen_manage_subscription">ຈັດການການສະໝັກສະມາຊິກ</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">ປ່ຽນໄປໃຊ້ການຊື້ແບບຄັ້ງດຽວ</string>
+    <string name="upgrade_screen_switch_purchase_note">ນີ້ແມ່ນການຊື້ແບບຄັ້ງດຽວທີ່ແຍກຕ່າງຫາກ. ມັນບໍ່ໄດ້ຍົກເລີກ ຫຼື ຄືນເງິນການສະໝັກສະມາຊິກຂອງທ່ານ, ສະນັ້ນໃຫ້ຍົກເລີກອັນນັ້ນໃນ Google Play ນຳ. ໃຊ້ບັນຊີ Google ດຽວກັນສຳລັບທັງສອງ.</string>
+    <string name="upgrade_screen_switch_locked_note">ໃຊ້ໄດ້ເມື່ອການສະໝັກສະມາຊິກຂອງທ່ານບໍ່ຕັ້ງໄວ້ໃຫ້ຕໍ່ອາຍຸອີກຕໍ່ໄປ. ຍົກເລີກມັນໃນ Google Play ເພື່ອປ່ຽນ — ທ່ານຈະຮັກສາ Pro ໄວ້ຈົນເຖິງທ້າຍໄລຍະປັດຈຸບັນ.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">ສະຖານະເບິ່ງຄືວ່າຜິດພາດບໍ?</string>
+    <string name="upgrade_screen_status_restore_body">ຖ້າການຊື້ຂອງທ່ານບໍ່ປາກົດຢູ່ບ່ອນນີ້, ລອງກູ້ຄືນມັນ.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">ກຳລັງຢືນຢັນການຊື້ຂອງທ່ານ</string>
+    <string name="upgrade_screen_grace_body_short">ລໍຖ້າບຶດໝຶ່ງ — ພວກເຮາກຳລັງກວດສອບການຊື້ຂອງທ່ານກັບ Google Play ອີກຄັ້ງ.</string>
+    <string name="upgrade_screen_grace_body">ພວກເຮາຍັງບໍ່ສາມາດຍືນຍັນການຊື້ຂອງທ່ານກັບ Google Play ໄດ້. ລອງກູ້ຄືນມັນ, ຫຼື ກວດເບິ່ງວ່າທ່ານໄດ້ເຂ້າສູ່ລະບົບດ້ວຍບັນຊີທີ່ຖືກຕ້ອງ.</string>
+    <string name="upgrade_screen_retry_action">ລອງໃໝ່</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">ການສະໝັກສະມາຊິກຍັງເປີດໃຊ້ງານຢູ່</string>
+    <string name="upgrade_screen_sub_still_renewing_message">ການສະໝັກສະມາຊິກຂອງທ່ານຍັງຕັ້ງໄວ້ໃຫ້ຕໍ່ອາຍຸຢູ່. ໃຫ້ຍົກເລີກມັນໃນ Google Play ກ່ອນ, ແລ້ວກັບມາຊື້ແບບຄັ້ງດຽວ — ວິທີນີ້ຈະບໍ່ໃຫ້ທ່ານຖືກຮຽກເກັບເງິນສອງເທື່ອ.</string>
+    <string name="upgrade_screen_sub_check_failed_message">ພວກເຮາບໍ່ສາມາດກວດສອບສະຖານະການສະໝັກສະມາຊິກຂອງທ່ານໄດ້. ກະລຸນາກວດເບິ່ງການເຊື່ອມຕໍ່ຂອງທ່ານແລ້ວລອງໃໝ່.</string>
+    <string name="upgrades_gplay_already_owned_error_title">ຊື້ແລ້ວ</string>
+    <string name="upgrades_gplay_already_owned_error_description">ໃຊ້ຕຽວເລືອກ \"ກູ້ຄືນການຊື້\" ເພື່ອກູ້ຄືນການຊື້ຂອງທ່ານ. ຖ້າບັນໝາຍັງເກີດຂຶ້ນຢູ່, ລອງລ້າງແຄດຊ Google Play ແລ້ວເປີດອຸປະກອນຂອງທ່ານໃໝ່.</string>
+    <string name="upgrades_gplay_internal_error_title">ຂໍ້ຜິດພາດ Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">ເກີດຂໍ້ຜິດພາດພາຍໃນ Google Play. ກະລຸນາລອງເຮັດຕາມນີ້:\n\n• ເປີດອຸປະກອນຂອງທ່ານໃໝ່\n• ລ້າງແຄດຊ Google Play Store\n• ລອງໃໝ່ພາຍຫຼັງ</string>
+    <string name="upgrades_gplay_network_error_title">ຂໍ້ຜິດພາດການເຊື່ອມຕໍ່</string>
+    <string name="upgrades_gplay_network_error_description">ບໍ່ສາມາດເຊື່ອມຕໍ່ກັບ Google Play ໄດ້. ກະລຸນາກວດເບິ່ງການເຊື່ອມຕໍ່ອິນຕີເນັດຂອງທ່ານແລ້ວລອງໃໝ່.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ບໍ່ພ້ອມໃຊ້ງານ</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ໂຊ່ມຕ່ອກັບ Google Play ໄດ້. ໂດຍຕິດຕັ້ງ Google Play ແລະອັດເດທໄດ້ບ່? ເຂົ້າລັອກ Google ໄດ້ບ່? ລອງລ້າງແຄຊແລະຊົກເລີ່ມອຸປກອນຂອງທ່ານໃຫມ່.</string>
     <string name="upgrades_no_purchases_found_check_account">ບໍ່ພົບການຊື້. ທ່ານກຳລັງໃຊ້ບັນຊີທີ່ຖືກຕ້ອງບໍ?</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Prenumerata kainuoja %s per metus.</string>
     <string name="upgrade_screen_iap_action">Vienkartinis pirkimas</string>
     <string name="upgrade_screen_iap_action_hint">Vienkartinis pirkimas kainuoja %s.</string>
+    <string name="upgrade_screen_offer_divider_or">arba</string>
+    <string name="upgrade_screen_offer_same_features">Tos pačios funkcijos, tik skirtingi kainodaros modeliai.</string>
     <string name="upgrade_screen_thanks_toast">Jūs geriausi! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Atkurti pirkimą</string>
+    <string name="upgrade_screen_restore_banner_title">Jau įsigijote BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Atrodo, kad šiame įrenginyje jau atlikote atnaujinimą anksčiau. Atkurkite pirkinį, kad vėl jį atrakintumėte.</string>
     <string name="upgrade_screen_restore_purchase_message">Jūsų naujinimas galioja įrenginiuose su ta pačia Google paskyra.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Trikčių šalinimo patarimai neatpažintiems naujinimams:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sinchronizacija gali užtrukti. Pabandykite paleisti iš naujo, išvalyti Google Play talpyklą arba tiesiog palaukti.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Kelios paskyros gali supainioti Google Play. Atsijunkite nuo kitų paskyrų arba įdiekite per Google Play svetainę, kuri priverčia susieti su konkrečia paskyra.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Peržiūrėkite savo Pro būseną</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Sveikiname!</string>
+    <string name="upgrade_screen_owned_congrats_body">Jūs turite BVM Pro — dėkojame, kad remiate kūrimą. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Vienkartinis pirkimas</string>
+    <string name="upgrade_screen_owned_iap_body">Jūs visam laikui esate BVM Pro savininkas. Dėkojame už paramą ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Prenumerata</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Jūsų BVM Pro prenumerata yra aktyvi ir bus atnaujinta.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Jūsų BVM Pro prenumerata yra aktyvi, tačiau nebus atnaujinta. Ji galios iki dabartinio laikotarpio pabaigos.</string>
+    <string name="upgrade_screen_owned_both_warning">Turite ir prenumeratą, ir vienkartinį pirkinį. Atšaukite prenumeratą „Google Play“, kad daugiau nebūtumėte apmokestinti.</string>
+    <string name="upgrade_screen_manage_subscription">Tvarkyti prenumeratą</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Pereiti prie vienkartinio pirkinio</string>
+    <string name="upgrade_screen_switch_purchase_note">Tai atskiras vienkartinis pirkinys. Jis neatšaukia ir negrąžina pinigų už jūsų prenumeratą, todėl ją taip pat atšaukite „Google Play“. Abiem atvejais naudokite tą pačią „Google“ paskyrą.</string>
+    <string name="upgrade_screen_switch_locked_note">Bus prieinama, kai jūsų prenumerata nebebus atnaujinama. Atšaukite ją „Google Play“, kad galėtumėte pereiti — Pro funkcijas išlaikysite iki dabartinio laikotarpio pabaigos.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Būsena atrodo klaidinga?</string>
+    <string name="upgrade_screen_status_restore_body">Jei jūsų pirkinys čia nerodomas, pabandykite jį atkurti.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Patvirtinamas jūsų pirkinys</string>
+    <string name="upgrade_screen_grace_body_short">Palaukite — dar kartą tikriname jūsų pirkinį per „Google Play“.</string>
+    <string name="upgrade_screen_grace_body">Vis dar negalime patvirtinti jūsų pirkinio per „Google Play“. Pabandykite jį atkurti arba patikrinkite, ar esate prisijungę su teisinga paskyra.</string>
+    <string name="upgrade_screen_retry_action">Bandyti dar kartą</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Prenumerata vis dar aktyvi</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Jūsų prenumerata vis dar bus atnaujinama. Pirmiausia atšaukite ją „Google Play“, tada grįžkite ir įsigykite vienkartinį pirkinį — taip nebūsite apmokestinti du kartus.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nepavyko patikrinti jūsų prenumeratos būsenos. Patikrinkite ryšį ir bandykite dar kartą.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Jau įsigyta</string>
+    <string name="upgrades_gplay_already_owned_error_description">Naudokite parinktį „Atkurti pirkinį“, kad atkurtumėte savo pirkinį. Jei problema kartojasi, pabandykite išvalyti „Google Play“ talpyklą ir iš naujo paleisti įrenginį.</string>
+    <string name="upgrades_gplay_internal_error_title">„Google Play“ klaida</string>
+    <string name="upgrades_gplay_internal_error_description">Įvyko vidinė „Google Play“ klaida. Pabandykite atlikti šiuos veiksmus:\n\n• Iš naujo paleiskite įrenginį\n• Išvalykite „Google Play Store“ talpyklą\n• Pabandykite vėliau dar kartą</string>
+    <string name="upgrades_gplay_network_error_title">Ryšio klaida</string>
+    <string name="upgrades_gplay_network_error_description">Nepavyko prisijungti prie „Google Play“. Patikrinkite interneto ryšį ir bandykite dar kartą.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nepasiekiamas</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager negali prisijungti prie Google Play. Ar įdiegta ir atnaujinta Google Play? Ar esate prisijungę prie Google paskyros? Pabandykite išvalyti Google Play programėlės talpyklą ir paleisti iš naujo įrenginį.</string>
     <string name="upgrades_no_purchases_found_check_account">Pirkimų nerasta. Ar naudojate tinkamą paskyrą?</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Abonements maksā %s gadā.</string>
     <string name="upgrade_screen_iap_action">Vienreizējs pirkums</string>
     <string name="upgrade_screen_iap_action_hint">Vienreizējais pirkums maksā %s.</string>
+    <string name="upgrade_screen_offer_divider_or">vai</string>
+    <string name="upgrade_screen_offer_same_features">Tādas pašas funkcijas, tikai atšķirīgi cenu modeļi.</string>
     <string name="upgrade_screen_thanks_toast">Jūs esat labākais! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Atjaunot pirkumu</string>
+    <string name="upgrade_screen_restore_banner_title">Jau iegādājies BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Šķiet, ka iepriekš esi jau uzlabojis šo ierīci. Atjauno savu pirkumu, lai to atkal atbloķētu.</string>
     <string name="upgrade_screen_restore_purchase_message">Jūsu uzlabojums ir derīgs ierīcēs ar to pašu Google kontu.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Problēmu risināšanas padomi neatpazītiem uzlabojumiem:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sinhronizācija var aizņemt laiku. Mēģiniet restartēt, notīrīt Google Play kešatmiņu vai vienkārši uzgaidīt.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Vairāki konti var sajaukt Google Play. Izejiet no citiem kontiem vai instalējiet caur Google Play tīmekļa vietni, kas piespiedu kārtā izveido asociācijas ar konkrētu kontu.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Skatīt savu Pro statusu</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Apsveicam!</string>
+    <string name="upgrade_screen_owned_congrats_body">Tev tagad ir BVM Pro — paldies, ka atbalsti izstrādi. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Vienreizējs pirkums</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro tev pieder uz visiem laikiem. Paldies par atbalstu ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abonements</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Tavs BVM Pro abonements ir aktīvs un iestatīts atjaunoties.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Tavs BVM Pro abonements ir aktīvs, bet netiks atjaunots. Tas paliks derīgs līdz pašreizējā perioda beigām.</string>
+    <string name="upgrade_screen_owned_both_warning">Tev ir gan abonements, gan vienreizējais pirkums. Atcel abonementu Google Play, lai tev atkārtoti neieturētu maksu.</string>
+    <string name="upgrade_screen_manage_subscription">Pārvaldīt abonementu</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Pāriet uz vienreizēju pirkumu</string>
+    <string name="upgrade_screen_switch_purchase_note">Šis ir atsevišķis vienreizējais pirkums. Tas neatcel un neatmaksā tavu abonementu, tāpēc atcel arī to Google Play. Abiem izmanto vienu un to pašu Google kontu.</string>
+    <string name="upgrade_screen_switch_locked_note">Pieejams, kad tavs abonements vairs nav iestatīts atjaunoties. Atcel to Google Play, lai pārietu — Pro statuss saglabāsies līdz pašreizējā perioda beigām.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Statuss izskatās nepareizs?</string>
+    <string name="upgrade_screen_status_restore_body">Ja tavs pirkums šeit nav redzams, mēģini to atjaunot.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Apstiprina tavu pirkumu</string>
+    <string name="upgrade_screen_grace_body_short">Uzgaidi — mēs vēlreiz pārbaudām tavu pirkumu Google Play.</string>
+    <string name="upgrade_screen_grace_body">Mēs joprojām nevaram apstiprināt tavu pirkumu Google Play. Mēģini to atjaunot vai pārbaudi, vai esi pierakstijies ar pareizo kontu.</string>
+    <string name="upgrade_screen_retry_action">Mēģināt vēlreiz</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonements joprojām aktīvs</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Tavs abonements joprojām ir iestatīts atjaunoties. Vispirms atcel to Google Play, pēc tam atgriezies, lai iegādātos vienreizējo pirkumu — tā tev netiks ieturēta maksa divreiz.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Mēs nevarējām pārbaudīt tava abonementa statusu. Lūdzu, pārbaudi savienojumu un mēģini vēlreiz.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Jau iegādāts</string>
+    <string name="upgrades_gplay_already_owned_error_description">Izmanto opciju \"Atjaunot pirkumu\", lai atjaunotu savu pirkumu. Ja problēma joprojām pastāv, mēģini notīrīt Google Play kešatmiņu un restartēt ierīci.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play kļūda</string>
+    <string name="upgrades_gplay_internal_error_description">Radās iekšēja Google Play kļūda. Lūdzu, izmēģini sekojošo:\n\n• Restartē ierīci\n• Notīri Google Play Store kešatmiņu\n• Mēģini vēlreiz vēlāk</string>
+    <string name="upgrades_gplay_network_error_title">Savienojuma kļūda</string>
+    <string name="upgrades_gplay_network_error_description">Neizdevās izveidot savienojumu ar Google Play. Lūdzu, pārbaudi interneta savienojumu un mēģini vēlreiz.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nav pieejams</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth skaļuma pārvaldnieks nevar izveidot savienojumu ar Google Play. Vai Google Play ir instalēts un atjaunināts? Vai Google konts ir piezēmošanās? Mēģiniet notīrīt Google Play lietotnes kešatmiņu un pārstārtout ierīci.</string>
     <string name="upgrades_no_purchases_found_check_account">Pirkumi nav atrasti. Vai izmantojat pareizo kontu?</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Претплатата чини %s годишно.</string>
     <string name="upgrade_screen_iap_action">Еднократна купувачка</string>
     <string name="upgrade_screen_iap_action_hint">Еднократната купувачка чини %s.</string>
+    <string name="upgrade_screen_offer_divider_or">или</string>
+    <string name="upgrade_screen_offer_same_features">Исти функции, само различни модели на цени.</string>
     <string name="upgrade_screen_thanks_toast">Вие сте најдобри! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Обнови купувачка</string>
+    <string name="upgrade_screen_restore_banner_title">Веќе го купивте BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Изгледа дека веќе сте надградиле на овој уред претходно. Обновете ја вашата куповина за да го отклучите повторно.</string>
     <string name="upgrade_screen_restore_purchase_message">Вашата надградба важи на сите уреди со иста Google сметка.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Совети за решавање проблеми за непрепознаени надградби:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизацијата на Play Store може да потрае. Обидете се да рестартирате, исчистете ја кеш меморијата на Google Play или едноставно почекајте.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Повеќе сметки можат да го збунат Google Play. Одјавете се од другите сметки или инсталирајте преку веб-страницата на Google Play, што принудува асоцијации со конкретна сметка.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Погледнете го вашиот Pro статус</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Честитки!</string>
+    <string name="upgrade_screen_owned_congrats_body">Го имате BVM Pro — благодариме што го поддржувате развојот. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Еднократна купувачка</string>
+    <string name="upgrade_screen_owned_iap_body">Го поседувате BVM Pro засекогаш. Благодариме за вашата поддршка ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Претплата</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Вашата BVM Pro претплата е активна и поставена да се обнови.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Вашата BVM Pro претплата е активна, но нема да се обнови. Останува валидна до крајот на тековниот период.</string>
+    <string name="upgrade_screen_owned_both_warning">Имате и претплата и еднократна куповина. Откажете ја претплатата во Google Play за да не бидете наплатени повторно.</string>
+    <string name="upgrade_screen_manage_subscription">Управување со претплата</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Префрлете се на еднократна куповина</string>
+    <string name="upgrade_screen_switch_purchase_note">Ова е одделна еднократна куповина. Таа не ја откажува или враќа вашата претплата, затоа откажете ја и таа во Google Play. Користете ја истата Google сметка за обете.</string>
+    <string name="upgrade_screen_switch_locked_note">Достапно откако вашата претплата повеќе не е поставена да се обнови. Откажете ја во Google Play за да се префрлите — останувате со Pro до крајот на тековниот период.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Статусот изгледа погрешен?</string>
+    <string name="upgrade_screen_status_restore_body">Ако вашата куповина не се појавува тука, обидете се да ја вратите.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Потврдување на вашата куповина</string>
+    <string name="upgrade_screen_grace_body_short">Чекајте — ја проверуваме вашата куповина со Google Play.</string>
+    <string name="upgrade_screen_grace_body">Сè уште не можеме да ја потврдиме вашата куповина со Google Play. Обидете се да ја обновите, или проверете дали сте најавени со вистинската сметка.</string>
+    <string name="upgrade_screen_retry_action">Пробајте повторно</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Претплатата е сè уште активна</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Вашата претплата е сè уште поставена да се обнови. Прво откажете ја во Google Play, потоа вратете се да ја купите еднократната куповина — на тој начин нема да бидете наплатени двапати.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Не можевме да го провериме вашиот статус на претплата. Ве молиме проверете ја вашата врска и обидете се повторно.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Веќе купено</string>
+    <string name="upgrades_gplay_already_owned_error_description">Користете ја опцијата „Обнови куповина\" за да ја обновите вашата куповина. Ако проблемот продолжува, обидете се да го исчистите кешот на Google Play Store и да го рестартирате уредот.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play грешка</string>
+    <string name="upgrades_gplay_internal_error_description">Се случи интерна грешка на Google Play. Ве молиме обидете се со следново:\n\n• Рестартирајте го вашиот уред\n• Исчистете го кешот на Google Play Store\n• Обидете се подоцна</string>
+    <string name="upgrades_gplay_network_error_title">Грешка при поврзување</string>
+    <string name="upgrades_gplay_network_error_description">Не успеавме да се поврземе со Google Play. Проверете ја вашата интернет врска и обидете се повторно.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play не е достапен</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може да се поврзе со Google Play. Дали Google Play е инсталиран и ажуриран? Дали вашата Google сметка е најавена? Обидете се да ја исчистите кеш меморијата на апликацијата Google Play и рестартирајте го вашиот уред.</string>
     <string name="upgrades_no_purchases_found_check_account">Не се пронајдени купувања. Дали користите вистинска сметка?</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">സബ്‌സ്‌ക്രിപ്‌ഷന്റെ വില പ്രതിവർഷം %s ആണ്.</string>
     <string name="upgrade_screen_iap_action">ഒറ്റത്തവണ വാങ്ങൽ</string>
     <string name="upgrade_screen_iap_action_hint">ഒറ്റത്തവണ വാങ്ങലിന്റെ വില %s ആണ്.</string>
+    <string name="upgrade_screen_offer_divider_or">അല്ലെങ്കിൽ</string>
+    <string name="upgrade_screen_offer_same_features">ഒരേ സവിശേഷതകൾ, വെറും വ്യത്യസ്ത വിലനിർണയ മാതൃകകൾ.</string>
     <string name="upgrade_screen_thanks_toast">നന്ദി❤️</string>
     <string name="upgrade_screen_restore_purchase_action">വാങ്ങൽ പുനഃസ്ഥാപിക്കുക</string>
+    <string name="upgrade_screen_restore_banner_title">ഇതിനകം BVM Pro വാങ്ങിയോ?</string>
+    <string name="upgrade_screen_restore_banner_body">നിങ്ങൾ ഈ ഡിവൈസിൽ മുമ്പ് അപ്ഗ്രേഡ് ചെയ്തതായി തോന്നുന്നു. വീണ്ടും അൺലോക്ക് ചെയ്യാൻ നിങ്ങളുടെ ക്രയം പുനഃസ്ഥാപിക്കുക.</string>
     <string name="upgrade_screen_restore_purchase_message">നിങ്ങളുടെ അപ്‌ഗ്രേഡ് ഒരേ Google അക്കൗണ്ടിലെ എല്ലാ ഉപകരണങ്ങളിലും സാധുവാണ്.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">തിരിച്ചറിയാത്ത അപ്‌ഗ്രേഡുകൾക്കുള്ള ട്രബിൾഷൂട്ടിംഗ് നുറുങ്ങുകൾ:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play സ്റ്റോർ സിൻക്രൊണൈസേഷൻ സമയമെടുത്തേക്കാം. റീബൂട്ട് ചെയ്യുക, Google Play കാഷെ മായ്‌ക്കുക അല്ലെങ്കിൽ കാത്തിരിക്കുക.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ഒന്നിലധികം അക്കൗണ്ടുകൾ Google Play-യെ ആശയക്കുഴപ്പത്തിലാക്കാം. മറ്റ് അക്കൗണ്ടുകളിൽ നിന്ന് ലോഗൗട്ട് ചെയ്യുക അല്ലെങ്കിൽ Google Play വെബ്‌സൈറ്റ് വഴി ഇൻസ്റ്റാൾ ചെയ്യുക, ഇത് ഒരു നിർദ്ദിഷ്ട അക്കൗണ്ടുമായുള്ള ബന്ധം നിർബന്ധമാക്കുന്നു.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">നിങ്ങളുടെ Pro സ്ഥിതി കാണുക</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">അഭിനന്ദനങ്ങൾ!</string>
+    <string name="upgrade_screen_owned_congrats_body">നിങ്ങൾക്ക് BVM Pro ലഭിച്ചു — വികസനത്തെ പിന്തുണയ്ക്കുന്നതിന് നന്ദി. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">ഒറ്റത്തവണ വാങ്ങൽ</string>
+    <string name="upgrade_screen_owned_iap_body">നിങ്ങൾ BVM Pro എന്നെന്നോളം സ്വന്തമാക്കിയിരിക്കുന്നു. നിങ്ങളുടെ പിന്തുണയ്ക്കുന്നതിന് നന്ദി ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">സബ്സ്ക്രിപ്ഷൻ</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">നിങ്ങളുടെ BVM Pro സബ്സ്ക്രിപ്ഷൻ സജീവമാണ് കൂടാതെ നവീകരണത്തിന് സെറ്റ് ചെയ്തിരിക്കുന്നു.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">നിങ്ങളുടെ BVM Pro സബ്സ്ക്രിപ്ഷൻ സജീവമാണ് എന്നാൽ നവീകരിക്കില്ല. നിലവിലെ കാലയളവിന്റെ അവസാനം വരെ ഇത് സാധുവായി നിലനിൽക്കുന്നു.</string>
+    <string name="upgrade_screen_owned_both_warning">നിങ്ങൾക്ക് സബ്സ്ക്രിപ്ഷനും ഒറിക്കലുളിറ്റ വാങ്ങലും ഉണ്ട്. Google Play ൽ സബ്സ്ക്രിപ്ഷൻ റദ്ദ് ചെയ്യുക അങ്ങനെ നിങ്ങൾ വീണ്ടും ചാർജ് ചെയ്യപ്പെടുകയില്ല.</string>
+    <string name="upgrade_screen_manage_subscription">സബ്സ്ക്രിപ്ഷൻ നിയന്ത്രിക്കുക</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">ഒറിക്കലുളള വാങ്ങലിലേക്ക് മാറുക</string>
+    <string name="upgrade_screen_switch_purchase_note">ഇത് ഒരു സ്വതന്ത്ര ഒറിക്കലുളള വാങ്ങൽ ആണ്. ഇത് നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ റദ്ദ് ചെയ്യുകയോ പണം തിരികെ നൽകുകയോ ചെയ്യില്ല, അതിനാൽ Google Play ൽ അതും റദ്ദ് ചെയ്യുക. രണ്ടിനും ഒറ്റെ Google അക്കൗണ്ട് ഉപയോഗിക്കുക.</string>
+    <string name="upgrade_screen_switch_locked_note">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ നവീകരണത്തിന് സെറ്റ് ചെയ്തിരിക്കാത്തിനുശേഷം ലഭ്യമാണ്. മാറാൻ Google Play ൽ അത് റദ്ദ് ചെയ്യുക — നിലവിലെ കാലയളവ് അവസാനിക്കുന്നത് വരെ നിങ്ങൾ Pro സൂക്ഷിക്കുന്നു.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">സ്ഥിതി തെറ്റായി കാണപ്പെടുന്നോ?</string>
+    <string name="upgrade_screen_status_restore_body">നിങ്ങളുടെ വാങ്ങൽ ഇവിടെ കാണിക്കുന്നില്ലെങ്കിൽ, അത് പുനഃസ്ഥാപിക്കാൻ ശ്രമിക്കുക.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">നിങ്ങളുടെ വാങ്ങൽ സ്ഥിരീകരിക്കുന്നു</string>
+    <string name="upgrade_screen_grace_body_short">കാത്തിരിക്കുക — നിങ്ങളുടെ Google Play വാങ്ങൽ ഞങ്ങൾ പരിശോധിച്ച് വരുകയാണ്.</string>
+    <string name="upgrade_screen_grace_body">നിങ്ങളുടെ Google Play വാങ്ങൽ കണ്ഫർം ചെയ്യാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. അത് പുനരുദ്ധരിക്കാൻ ശ്രമിക്കുക, അല്ലെങ്കിൽ നിങ്ങൾ ശരിയായ അക്കൗണ്ടിൽ സൈൻ ഇൻ ചെയ്തിരിക്കുന്നുണ്ടെന്ന് പരിശോധിക്കുക.</string>
+    <string name="upgrade_screen_retry_action">വീണ്ടും ശ്രമിക്കുക</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">സബ്സ്ക്രിപ്ഷൻ ഇപ്പോഴും സജീവമാണ്</string>
+    <string name="upgrade_screen_sub_still_renewing_message">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ പുതുക്കാൻ സജ്ജമായിരിക്കുന്നു. Google Play-ൽ ആദ്യം അത് റദ്ദ് ചെയ്യുക, പിന്നെ ഒറിക്കലുളള വാങ്ങലിനായി തിരികെ വരിക — ഈ വിധത്തിൽ നിങ്ങൾക്ക് രണ്ടുതവണ ചാർജ് ചെയ്യപ്പെടുകയില്ല.</string>
+    <string name="upgrade_screen_sub_check_failed_message">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ അവസ്ഥ പരിശോധിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. ദയവായി നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക.</string>
+    <string name="upgrades_gplay_already_owned_error_title">ഇതിനകം വാങ്ങിയിരിക്കുന്നു</string>
+    <string name="upgrades_gplay_already_owned_error_description">നിങ്ങളുടെ വാങ്ങൽ പുനരുദ്ധരിക്കാൻ \"വാങ്ങൽ പുനരുദ്ധരിക്കുക\" ഓപ്ഷൻ ഉപയോഗിക്കുക. പ്രശ്നം തുടരുന്നുണ്ടെങ്കിൽ, Google Play കാഷെ നീക്കം ചെയ്യുകയോ നിങ്ങളുടെ ഡിവൈസ് പുനരാരംഭിക്കുകയോ ചെയ്തു നോക്കുക.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play പിശക്</string>
+    <string name="upgrades_gplay_internal_error_description">ഒരു ആന്തരിക Google Play പിശക് സംഭവിച്ചു. ദയവായി താഴെ കാണിച്ച കാര്യങ്ങൾ ശ്രമിക്കുക:\n\n• നിങ്ങളുടെ ഡിവൈസ് പുനരാരംഭിക്കുക\n• Google Play Store കാഷെ നീക്കം ചെയ്യുക\n• പിന്നീട് പരിശ്രമിക്കുക</string>
+    <string name="upgrades_gplay_network_error_title">കണക്ഷൻ പിഴവ്</string>
+    <string name="upgrades_gplay_network_error_description">Google Play ൽ ബന്ധപ്പെടാൻ കഴിഞ്ഞില്ല. ദയവായി നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ പരിശോധിക്കുകയും വീണ്ടും ശ്രമിക്കുകയും ചെയ്യുക.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ലഭ്യമല്ല</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ക്ക് Google Play യുമായ് ബന്ധപ്പെടാൻ കഴിയുന്നില്ല. Google Play ഇൻസ്റ്റൽ ചെയ്ത് അപ്ഡേറ്റ് ചെയ്തിട്ടുണ്ടോ? നിങ്ങളുടെ Google അക്കൗൺട് ലോഗിൻ ചെയ്തിട്ടുണ്ടോ? Google Play ആപ്പിന്റെ ക്യാഷ് മാർജിക്കുകയും ഉപകരണം രീബൂട്ട് ചെയ്യുകയും ശ്രമിക്കുക.</string>
     <string name="upgrades_no_purchases_found_check_account">വാങ്ങലുകളൊന്നും കണ്ടെത്തിയില്ല. നിങ്ങൾ ശരിയായ അക്കൗണ്ട് തന്നെയാണോ ഉപയോഗിക്കുന്നത്?</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Захиалга жилд %s өртөгтэй.</string>
     <string name="upgrade_screen_iap_action">Нэг удаагийн худалдан авалт</string>
     <string name="upgrade_screen_iap_action_hint">Нэг удаагийн худалдан авалт %s өртөгтэй.</string>
+    <string name="upgrade_screen_offer_divider_or">эсвэл</string>
+    <string name="upgrade_screen_offer_same_features">Ижил функцууд, зөвхөн өөр өөр үнийн загварууд.</string>
     <string name="upgrade_screen_thanks_toast">Та хамгийн шилдэг нь! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Худалдан авалтыг сэргээх</string>
+    <string name="upgrade_screen_restore_banner_title">BVM Pro аль хэдийн авсан уу?</string>
+    <string name="upgrade_screen_restore_banner_body">Та энэ төхөөрөмжид өмнө нь шинэчилсэн бололтой. Үүнийг дахин нээхийн тулд худалдан авалтыг сэргээнэ үү.</string>
     <string name="upgrade_screen_restore_purchase_message">Таны шинэчлэлт ижил Google бүртгэл дээрх төхөөрөмжүүдэд хүчинтэй.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Танигдаагүй шинэчлэлтүүдийн асуудал шийдвэрлэх зөвлөмжүүд:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store синк хийхэд хугацаа шаардагдаж магадгүй. Дахин эхлүүлэх, Google Play кэшийг цэвэрлэх эсвэл зүгээр хүлээхийг оролдоно уу.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Олон бүртгэл Google Play-г төөрөгдүүлж болно. Бусад бүртгэлээс гарах эсвэл Google Play вэбсайтаар дамжуулан суулгах нь тодорхой бүртгэлтэй холбоосыг албадаж өгдөг.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Таны Pro статусыг үзэх</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Баяр хүргэе!</string>
+    <string name="upgrade_screen_owned_congrats_body">Та BVM Pro авсан — хөгжүүлэлтийг дэмжсэнд баярлалаа. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Нэг удаагийн худалдан авалт</string>
+    <string name="upgrade_screen_owned_iap_body">Та BVM Pro-г үүрд эзэмшиж байна. Таны дэмжлэгэнд баярлалаа ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Захиалга</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Таны BVM Pro подписк идэвхтэй бөгөөд сэргээгдэхээр тохируулагдсан.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Таны BVM Pro подписк идэвхтэй боловч сэргээгдэхгүй. Энэ нь одоогийн үе төгсгөл хүртэл хүчинтэй хэвээр байна.</string>
+    <string name="upgrade_screen_owned_both_warning">Та подписк болон нэг удаагийн худалдан авалтын хоёуланг эзэмшээд байна. Google Play-д подпискийг цуцлаарай. Ингэснээр та дахин төлөхгүй болно.</string>
+    <string name="upgrade_screen_manage_subscription">Подпискийг удирдах</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Нэг удаагийн худалдан авалт руу шилжүүлэх</string>
+    <string name="upgrade_screen_switch_purchase_note">Энэ нь тусдаа нэг удаагийн худалдан авалт юм. Энэ нь таны подпискийг цуцлахгүй эсвэл буцаан төлөлөлт өгөхгүй тул Google Play-д түүнийг бас цуцлаарай. Хоёулангийн хувьд ижил Google данстай ашиглаарай.</string>
+    <string name="upgrade_screen_switch_locked_note">Таны подпискийг сэргээгдэхээр тохируулахыг болиулсаны дараа боломжтой байна. Google Play-д түүнийг цуцлаарай солихын тулд. Та одоогийн үе төгсгөл хүртэл хүчинтэй Pro-г хадгалах болно.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Статус буруу харагдаж байна уу?</string>
+    <string name="upgrade_screen_status_restore_body">Хэрвэг таны худалдан авалт энд харагдахгүй байвал сэргэхийг оролдоорой.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Таны худалдан авалтыг баталгаажуулж байна</string>
+    <string name="upgrade_screen_grace_body_short">Зүгээр байгаарай — бид таны худалдан авалтыг Google Play-тай дахин шалгаж байна.</string>
+    <string name="upgrade_screen_grace_body">Бид таны худалдан авалтыг Google Play-тай баталгаажуулж чадаагүй байна. Үүнийг сэргэхийг оролдоно уу эсвэл зөв бүртгэлээр нэвтэрсэн эсэхийг шалгана уу.</string>
+    <string name="upgrade_screen_retry_action">Дахин оролдох</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Захиалга идэвхтэй байна</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Таны захиалга сэргээгдэхээр тохируулагдсан байна. Эхлээд Google Play-д цуцлана уу, дараа нь нэг удаагийн худалдан авалт хийхээр буцаж ирнэ үү — ингэснээр та хоёр удаа суллагдахгүй.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Бид таны захиалгын статусыг шалгаж чадаагүй. Интернэт холболт шалгаж дахин оролдоно уу.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Аль хэдийн худалдан авсан</string>
+    <string name="upgrades_gplay_already_owned_error_description">\"Худалдан авалтыг сэргэх\" сонголтыг ашиглан таны худалдан авалтыг сэргээнэ үү. Хэрвээ асуудал үргэлжвэл Google Play-ийн кеш цэвэрлэж, төхөөрөмжөө дахин эхлүүлэхийг оролдоно уу.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play алдаа</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play-ийн дотоод алдаа гарсан. Дараахийг оролдоно уу:\n\n• Төхөөрөмжөө дахин эхлүүлнэ үү\n• Google Play Store-ийн кеш цэвэрлнэ үү\n• Дараа нь дахин оролдоно уу</string>
+    <string name="upgrades_gplay_network_error_title">Холболтын алдаа</string>
+    <string name="upgrades_gplay_network_error_description">Google Play-д холбогдох боломжгүй. Интернет холболтоо шалгаж, дахин оролдоно уу.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play боломжгүй байна</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play-тай холбогдож чадахгүй байна. Google Play суулгагдсан бөгөөд шинэчлэлтсэн уу? Google хаднаа нэвтрээсэн байна уу? Google Play аппын кэшийг арилгаад төхөөрөмжийгеэ дахин ньюцлаарай.</string>
     <string name="upgrades_no_purchases_found_check_account">Худалдан авалт олдсонгүй. Та зөв бүртгэл ашиглаж байна уу?</string>

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">सदस्यत्वाची किंमत वर्षाला %s आहे.</string>
     <string name="upgrade_screen_iap_action">एकवेळ खरेदी</string>
     <string name="upgrade_screen_iap_action_hint">एकवेळ खरेदीची किंमत %s आहे.</string>
+    <string name="upgrade_screen_offer_divider_or">किंवा</string>
+    <string name="upgrade_screen_offer_same_features">समान वैशिष्ट्ये, फक्त भिन्न मूल्य निर्धारण मॉडेल.</string>
     <string name="upgrade_screen_thanks_toast">तुम्ही सर्वोत्तम आहात! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">खरेदी पुनस्थापित करा</string>
+    <string name="upgrade_screen_restore_banner_title">आधीच BVM Pro खरेदी केले?</string>
+    <string name="upgrade_screen_restore_banner_body">असे दिसते की तुम्ही या डिव्हाइसवर आधी अपग्रेड केले होते. हे पुन्हा अनलॉक करण्यासाठी आपल्या खरेदी पुनर्संचयित करा.</string>
     <string name="upgrade_screen_restore_purchase_message">तुमचे अपग्रेड एकाच गूगल खात्यावरील सर्व डिव्हाइसेसवर वैध आहे.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">नॉन-रिकॉग्नाइझ्ड अपग्रेड्ससाठी समस्यानिवारण टिप्स:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store सिंक्रोनायझेशनला वेळ लागू शकतो. रीबूट करण्याचा, Google Play कॅश साफ करण्याचा प्रयत्न करा किंवा फक्त थांबा.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">अनेक खाती Google Play ला गोंधळात टाकू शकतात. इतर खात्यांतून लॉग आउट व्हा किंवा Google Play वेबसाइटवरून इन्स्टॉल करा, जे विशिष्ट खात्याशी संबंध जोडण्यास भाग पाडते.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">आपली Pro स्थिती पहा</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">अभिनंदन!</string>
+    <string name="upgrade_screen_owned_congrats_body">तुम्हाला BVM Pro मिळाले — विकास समर्थन केल्याबद्दल धन्यवाद. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">एकवेळी खरेदी</string>
+    <string name="upgrade_screen_owned_iap_body">तुम्ही BVM Pro सर्वदा मालक आहात. आपल्या समर्थनाबद्दल धन्यवाद ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">सदस्यता</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">तुमची BVM Pro सदस्यता सक्रिय आहे आणि नवीकरणासाठी सेट केली आहे.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">तुमची BVM Pro सदस्यता सक्रिय आहे परंतु नवीकरण होणार नाही. हे वर्तमान कालावधीच्या शेवटपर्यंत वैध राहील.</string>
+    <string name="upgrade_screen_owned_both_warning">तुमच्याकडे सदस्यता आणि एकेरी खरेदी दोन्ही आहेत. Google Play मध्ये सदस्यता रद्द करा जेणेकरून तुमच्यावर पुन्हा शुल्क लागू होणार नाही.</string>
+    <string name="upgrade_screen_manage_subscription">सदस्यता व्यवस्थापित करा</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">एकेरी खरेदीवर स्विच करा</string>
+    <string name="upgrade_screen_switch_purchase_note">हे एक वेगळी एकेरी खरेदी आहे. हे तुमची सदस्यता रद्द किंवा परत करत नाही, म्हणून ते Google Play मध्ये देखील रद्द करा. दोन्हीसाठी समान Google खाते वापरा.</string>
+    <string name="upgrade_screen_switch_locked_note">एकदा तुमची सदस्यता नवीकरणासाठी सेट केली जाणार नाही तेव्हा उपलब्ध. स्विच करण्यासाठी ते Google Play मध्ये रद्द करा — तुम्ही वर्तमान कालावधीच्या शेवटपर्यंत Pro ठेवा.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">स्थिती चुकीची दिसते?</string>
+    <string name="upgrade_screen_status_restore_body">जर तुमची खरेदी येथे दिसत नसेल तर ते पुनर्संचयित करण्याचा प्रयत्न करा.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">आपली खरेदी पुष्टी करत आहे</string>
+    <string name="upgrade_screen_grace_body_short">थांबा — आम्ही Google Play सह आपल्या खरेदीची दुहेरी तपासणी करत आहोत.</string>
+    <string name="upgrade_screen_grace_body">आम्ही अजूनही Google Play सह आपल्या खरेदीची पुष्टी करू शकत नाही. ते पुनर्संचयित करण्याचा प्रयत्न करा, किंवा आपण योग्य खात्यासह साइन इन आहात हे तपासा.</string>
+    <string name="upgrade_screen_retry_action">पुन्हा प्रयत्न करा</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">सदस्यता अजूनही सक्रिय आहे</string>
+    <string name="upgrade_screen_sub_still_renewing_message">आपली सदस्यता अजूनही नवीन करण्यासाठी सेट आहे. प्रथम ते Google Play मध्ये रद्द करा, नंतर एकवेळी खरेदी खरेदी करण्यासाठी परत या — अशा प्रकारे आपल्याला दोनदा शुल्क लागणार नाही.</string>
+    <string name="upgrade_screen_sub_check_failed_message">आम्ही आपल्या सदस्यता स्थिती तपासू शकत नाही. कृपया आपले कनेक्शन तपासा आणि पुन्हा प्रयत्न करा.</string>
+    <string name="upgrades_gplay_already_owned_error_title">आधीच खरेदी केली</string>
+    <string name="upgrades_gplay_already_owned_error_description">आपली खरेदी पुनर्संचयित करण्यासाठी \"खरेदी पुनर्संचयित करा\" पर्याय वापरा. समस्या कायम राहिल्यास, Google Play कॅश साफ करण्याचा प्रयत्न करा आणि आपले डिव्हाइस पुनरारंभ करा.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play त्रुटी</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play मध्ये एक अंतर्गत त्रुटी उद्भवली. कृपया खालील प्रयत्न करा:\n\n• आपले डिव्हाइस पुनः सुरू करा\n• Google Play स्टोर कॅश साफ करा\n• नंतर पुन्हा प्रयत्न करा</string>
+    <string name="upgrades_gplay_network_error_title">कनेक्शन त्रुटी</string>
+    <string name="upgrades_gplay_network_error_description">Google Play शी जोडणे अशक्य. कृपया आपले इंटरनेट कनेक्शन तपासा आणि पुन्हा प्रयत्न करा.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play उपलब्ध नाही</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play शी कनेक्ट करू शकत नाही. Google Play इन्स्टॉल आणि अपडेट आहे का? तुमचे Google खाते लॉग इन आहे का? Google Play अॅपचा कॅश साफ करण्याचा आणि डिव्हाइस रीबूट करण्याचा प्रयत्न करा.</string>
     <string name="upgrades_no_purchases_found_check_account">कोणतीही खरेदी आढळली नाही. तुम्ही योग्य खाते वापरत आहात का?</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Kos langganan %s setahun.</string>
     <string name="upgrade_screen_iap_action">Belian sekali</string>
     <string name="upgrade_screen_iap_action_hint">Kos pembelian sekali ialah %s.</string>
+    <string name="upgrade_screen_offer_divider_or">atau</string>
+    <string name="upgrade_screen_offer_same_features">Ciri-ciri yang sama, hanya model harga yang berbeza.</string>
     <string name="upgrade_screen_thanks_toast">Anda lah yang terbaik! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Pulihkan pembelian</string>
+    <string name="upgrade_screen_restore_banner_title">Sudah membeli BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Nampaknya anda telah menaik taraf pada peranti ini sebelumnya. Pulihkan pembelian anda untuk membukanya semula.</string>
     <string name="upgrade_screen_restore_purchase_message">Naik taraf anda sah merentasi peranti pada akaun Google yang sama.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Petua penyelesaian masalah untuk naik taraf yang tidak diiktiraf:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Penyegerakan Play Store mungkin mengambil masa. Cuba but semula, kosongkan cache Google Play atau tunggu sahaja.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Pelbagai akaun boleh mengelirukan Google Play. Log keluar dari akaun lain atau pasang melalui laman web Google Play, yang memaksa perkaitan dengan akaun tertentu.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Lihat status Pro anda</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Tahniah!</string>
+    <string name="upgrade_screen_owned_congrats_body">Anda telah mendapatkan BVM Pro — terima kasih atas sokongan pembangunan. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Belian sekali</string>
+    <string name="upgrade_screen_owned_iap_body">Anda memiliki BVM Pro selamanya. Terima kasih atas sokongan anda ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Langganan</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Langganan BVM Pro anda sedang aktif dan ditetapkan untuk diperbaharui.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Langganan BVM Pro anda sedang aktif tetapi tidak akan diperbaharui. Ia tetap sah hingga akhir tempoh semasa.</string>
+    <string name="upgrade_screen_owned_both_warning">Anda mempunyai kedua-dua langganan dan pembelian sekali jalan. Batalkan langganan di Google Play supaya anda tidak dicaj semula.</string>
+    <string name="upgrade_screen_manage_subscription">Urus langganan</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Tukar kepada pembelian sekali jalan</string>
+    <string name="upgrade_screen_switch_purchase_note">Ini adalah pembelian sekali jalan yang berasingan. Ia tidak membatalkan atau membayar balik langganan anda, jadi batalkan itu di Google Play juga. Gunakan akaun Google yang sama untuk kedua-duanya.</string>
+    <string name="upgrade_screen_switch_locked_note">Tersedia selepas langganan anda tidak lagi ditetapkan untuk diperbaharui. Batalkan di Google Play untuk menukar — anda mengekalkan Pro sehingga akhir tempoh semasa.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Status kelihatan salah?</string>
+    <string name="upgrade_screen_status_restore_body">Jika pembelian anda tidak muncul di sini, cuba memulihkannya.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Mengesahkan pembelian anda</string>
+    <string name="upgrade_screen_grace_body_short">Tunggu sebentar — kami sedang mengesahkan semula pembelian anda dengan Google Play.</string>
+    <string name="upgrade_screen_grace_body">Kami masih tidak dapat mengesahkan pembelian anda dengan Google Play. Cuba pulihkan ia, atau periksa bahawa anda telah log masuk dengan akaun yang betul.</string>
+    <string name="upgrade_screen_retry_action">Cuba Lagi</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Langganan masih aktif</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Langganan anda masih ditetapkan untuk diperbaharui. Batalkan ia di Google Play terlebih dahulu, kemudian kembali untuk membeli pembelian satu kali — dengan cara itu anda tidak akan dikenakan bayaran dua kali.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Kami tidak dapat memeriksa status langganan anda. Sila periksa sambungan anda dan cuba lagi.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Sudah dibeli</string>
+    <string name="upgrades_gplay_already_owned_error_description">Gunakan pilihan \"Pulih pembelian\" untuk memulihkan pembelian anda. Jika masalah berterusan, cuba hapuskan cache Google Play dan mulai semula peranti anda.</string>
+    <string name="upgrades_gplay_internal_error_title">Ralat Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Ralat dalaman Google Play telah berlaku. Sila cuba yang berikut:\n\n• Mulai semula peranti anda\n• Hapuskan cache Google Play Store\n• Cuba lagi kemudian</string>
+    <string name="upgrades_gplay_network_error_title">Ralat sambungan</string>
+    <string name="upgrades_gplay_network_error_description">Tidak dapat menyambung ke Google Play. Sila periksa sambungan internet anda dan cuba semula.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play tidak tersedia</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager tidak dapat menyambung ke Google Play. Adakah Google Play dipasang dan dikemaskini? Adakah Akaun Google anda log masuk? Cuba kosongkan cache aplikasi Google Play dan but semula peranti anda.</string>
     <string name="upgrades_no_purchases_found_check_account">Tiada pembelian ditemui. Adakah anda menggunakan akaun yang betul?</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Subscription သည် နှစ်စဉ် %s ကျသင့်သည်။</string>
     <string name="upgrade_screen_iap_action">တစ်ကြိမ်တည်း ဝယ်ယူမှု</string>
     <string name="upgrade_screen_iap_action_hint">တစ်ကြိမ်တည်း ဝယ်ယူမှုသည် %s ကျသင့်သည်။</string>
+    <string name="upgrade_screen_offer_divider_or">သို့မဟုတ်</string>
+    <string name="upgrade_screen_offer_same_features">အလားတူလုပ်ဆောင်ချက်များ၊ဈေးနှုန်းမော်ဒယ်များသာကွဲပြားသည်။</string>
     <string name="upgrade_screen_thanks_toast">သင်သည် အကောင်းဆုံးပါ! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">ဝယ်ယူမှုကို ပြန်လည်ရယူမည်</string>
+    <string name="upgrade_screen_restore_banner_title">ရှေ့ဦးစွာ BVM Pro ကိုဝယ်ယူထားပြီးလား?</string>
+    <string name="upgrade_screen_restore_banner_body">ယခင်ကတွင်ဤစက်ပစ္စည်းတွင်အဆင့်မြှင့်တင်ထားခြင်းရှိသည်။သင်၏ဝယ်ယူမှုကိုပြန်လည်ရယူသုံးခွင့်ပွင့်လင်းပါ။</string>
     <string name="upgrade_screen_restore_purchase_message">သင်၏အဆင့်မြှင့်မှုသည် တူညီသော Google အကောင့်ရှိ စက်များတွင် အသုံးပြုနိုင်ပါသည်။</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">အသိအမှတ်မပြုသော အဆင့်မြှင့်မှုများအတွက် ပြဿနာဖြေရှင်းခြင်း အကြံပြုချက်များ-</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sync လုပ်ရန် အချိန်ယူနိုင်ပါသည်။ ပြန်လည်စတင်ခြင်း၊ Google Play cache ရှင်းလင်းခြင်း သို့မဟုတ် ရိုးရိုးစောင့်ဆိုင်းခြင်း ပြုလုပ်ကြည့်ပါ။</string>
     <string name="upgrade_screen_restore_multiaccount_hint">အကောင့်များစွာသည် Google Play ကို ရှုပ်ထွေးစေနိုင်သည်။ အခြားအကောင့်များမှ ထွက်ပါ သို့မဟုတ် Google Play ဝဘ်ဆိုဒ်မှတစ်ဆင့် ထည့်သွင်းပါ၊ ၎င်းသည် သတ်မှတ်ထားသော အကောင့်နှင့် ချိတ်ဆက်မှုကို တွန်းအားပေးသည်။</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">သင်၏Pro အခြေအနေကိုကြည့်ရှုပါ</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">ကောင်းကျိုးတွေ!</string>
+    <string name="upgrade_screen_owned_congrats_body">သင့်ထံ BVM Pro ရှိသည် — ဖန်တီးမှုအတွက် အထောက်အပံ့ ပေးသည့်အတွက် ကျေးဇူးတင်ပါသည်။ ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">တစ်ကြိမ်တည်း ဝယ်ယူမှု</string>
+    <string name="upgrade_screen_owned_iap_body">သင်သည် BVM Pro ကို အစဉ်အမြဲ ပိုင်ဆိုင်သည်။ သင်၏ အထောက်အပံ့အတွက် ကျေးဇူးတင်ပါသည် ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">စာရင်းသွင်းမှု</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">သင်၏ BVM Pro စာရင်းသွင်းမှု အလုပ်ဆောင်နေပြီး အလိုအလျောက်အသစ်ဖြစ်စေရန်သတ်မှတ်ထားသည်။</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">သင်၏ BVM Pro စာရင်းသွင်းမှု အလုပ်ဆောင်နေသော်လည်း အသစ်မဖြစ်စေပါ။ ယခုအခါ ကာလ အဆုံးအထိ အသုံးပြုနိုင်သည်။</string>
+    <string name="upgrade_screen_owned_both_warning">သင်သည် စာရင်းသွင်းမှု နှင့် တစ်ကြိမ်တည်းသည့် ဝယ်ယူမှု နှစ်ခုလုံးကို ပိုင်ဆိုင်သည်။ Google Play တွင် စာရင်းသွင်းမှုကို ပယ်ဖျက်ပါ။ သို့မှ သင် ထပ်မံ ငွေချေမည်မဟုတ်ပါ။</string>
+    <string name="upgrade_screen_manage_subscription">စာရင်းသွင်းမှု စီမံခြင်း</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">တစ်ကြိမ်တည်းသည့် ဝယ်ယူမှုသို့ ပြောင်းလဲခြင်း</string>
+    <string name="upgrade_screen_switch_purchase_note">ဤသည်မှာ သီးခြား တစ်ကြိမ်တည်းသည့် ဝယ်ယူမှု ဖြစ်သည်။ သင်၏ စာရင်းသွင်းမှုကို ဖျက်လည်း မည်သည့်နည်း မည်သည့်ပုံစံ မျှ နေမည်မဟုတ်ပါ။ ထို့ကြောင့် Google Play တွင်လည်း ပယ်ဖျက်ပါ။ နှစ်ခုလုံးအတွက် တူညီသည့် Google အကောင့်ကို အသုံးပြုပါ။</string>
+    <string name="upgrade_screen_switch_locked_note">သင်၏ စာရင်းသွင်းမှု အလိုအလျောက်အသစ်မဖြစ်စေတော့သည့အခါ ရရှိနိုင်သည်။ ပြောင်းလဲရန် Google Play တွင် ပယ်ဖျက်ပါ — သင်သည် ယခုအခါ ကာလ အဆုံးအထိ Pro ကိုကိုင်ဆောင်သည်။</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">အခြေအနေ မှားတွဲသလား?</string>
+    <string name="upgrade_screen_status_restore_body">အကယ်၏ သင်၏ ဝယ်ယူမှုကို ဤတွင် မတွဲရှိပါက ၊ ဩင်းကို ပြန်လည်ရယူကြိုးစားပါ။</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">သင်၏ ဝယ်ယူမှုအား အတဝ်ပြုနေသည်</string>
+    <string name="upgrade_screen_grace_body_short">စိုက်ခိုင်နေပါ — ကျွန်ုပ်တို့သည် Google Play နှင့် သင်၏ ဝယ်ယူမှုအား ထပ်မံစိစစေနေသည်။</string>
+    <string name="upgrade_screen_grace_body">ကျွန်ုပ်တို့သည် Google Play နှင့် သင်၏ ဝယ်ယူမှုအား အတဝ်မပြုနိုင်တေဲပါ။ ဩင်းကို ပြန်လည်ရယူကြိုးစားပါ၊ သို့မဟုတ် သင်သည် မှန်ကန်သောအကောင့်ဖြင့် ဆိုင်းဝင်ထားသည်ကို စစ်ဆေပါ။</string>
+    <string name="upgrade_screen_retry_action">ထပ်မံကြိုးစားပါ</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">စာရင်းသွင်းမှု ပြဲး အလုပ်ဆောင်နေသည်</string>
+    <string name="upgrade_screen_sub_still_renewing_message">သင်၏ စာရင်းသွင်းမှုစိ ယခုအခါ အလိုအလျောက်အသစ်ဖြစ်စေရန် သတ်မှတ်ထားသည်။ Google Play တွင် ပထမဆုံ ပယ်ဖျက်ပါ။ ထို့နောက် တစ်ကြိမ်တည်းသည့် ဝယ်ယူမှုကို ဝယ်ယူပါ — သို့မှ သင်သည် အကြိမ်နှစ်ကြိမ် အခြေခြံရီမည်မဟုတ်ပါ။</string>
+    <string name="upgrade_screen_sub_check_failed_message">ကျွန်ုပ်တို့သည် သင်၏ စာရင်းသွင်းမှု အခြေအနေကို မစိစစနိုင်ခဲပါ။ သင်၏ အင်တာနက်ချိတ်ဆက်မှုကို ကျေးဇူးပြီး စစ်ဆပါ၊ ထို့နောက် ထပ်မံကြိုးစားပါ။</string>
+    <string name="upgrades_gplay_already_owned_error_title">ယခင်က ဝယ်ယူပြီးပြီ</string>
+    <string name="upgrades_gplay_already_owned_error_description">သင်၏ဝယ်ယူမှုကိုပြန်လည်ရယူရန် \"ဝယ်ယူမှုပြန်လည်ရယူ\" ရွေးချယ်မှုကိုအသုံးပြုပါ။ အကယ်၏ပြဲဆနာအဆက်အလက်ရှိပါက Google Play ကက်ရှ်ကိုရှင်လင်းပြီးသင်၏ကိရိယာကိုပြန်စတင်ကြည့်ပါ။</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play အမှားအယွင်း</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play အတွင်းပိုင်းအမှားအယွင်း ပော့ပောက်ခဲျသည်။ အောက်ပာတွေကိုစမ်းသပ်ကြည့်ပါ:\n\n• သင်၏ကိရိယာကိုပြန်စတင်ပါ\n• Google Play Store ကက်ရှ်ကိုရှင်လင်းပါ\n• နောက်မှထပ်မံစမ်းသပ်ကြည့်ပါ</string>
+    <string name="upgrades_gplay_network_error_title">ချိတ်ဆက်မှုအမှားအယွင်း</string>
+    <string name="upgrades_gplay_network_error_description">Google Play သို့ချိတ်ဆက်၏မရနိုင်ပါ။ သင်၏အင််ဂာရပ်ချိတ်ဆက်မှုကိုစုံစမ်းပြီးထပ်မံစမ်းသပ်ကြည့်ပါ။</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play မရရှိနိုင်ပါ</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager မှ Google Play သို့ ချိတ်ဆက်၍မရပါ။ Google Play ထည့်သွင်းပြီး နောက်ဆုံးဗားရှင်းဖြစ်ပါသလား? သင်၏ Google အကောင့် ဝင်ရောက်ထားပါသလား? Google Play အက်ပ်၏ cache ကိုရှင်းလင်းပြီး ကိရိယာကိုပြန်လည်စတင်ကြည့်ပါ။</string>
     <string name="upgrades_no_purchases_found_check_account">ဝယ်ယူမှုများ ရှာမတွေ့ပါ။ မှန်ကန်သော အကောင့်ကို အသုံးပြုနေပါသလား။</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">सदस्यता प्रति वर्ष %s लाग्छ।</string>
     <string name="upgrade_screen_iap_action">एक-पटक खरिद</string>
     <string name="upgrade_screen_iap_action_hint">एक-पटक खरिद %s लाग्छ।</string>
+    <string name="upgrade_screen_offer_divider_or">वा</string>
+    <string name="upgrade_screen_offer_same_features">एकै सुविधा, केवल फरक मूल्य निर्धारण मोडल।</string>
     <string name="upgrade_screen_thanks_toast">तपाईं उत्कृष्ट हुनुहुन्छ! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">खरिद पुनर्स्थापना गर्नुहोस्</string>
+    <string name="upgrade_screen_restore_banner_title">पहिले नै BVM Pro किन्नुभएको छ?</string>
+    <string name="upgrade_screen_restore_banner_body">यस्तो लाग्छ कि तपाईंले यो उपकरणमा पहिले अपग्रेड गर्नुभएको छ। यसलाई फेरि अनलक गर्न आफ्नो खरिद पुनर्स्थापन गर्नुहोस्।</string>
     <string name="upgrade_screen_restore_purchase_message">तपाईंको अपग्रेड उही Google खातामा भएका उपकरणहरूमा मान्य छ।</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">अपरिचित अपग्रेडहरूका लागि समस्या निवारण सुझावहरू:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store सिङ्कमा समय लाग्न सक्छ। रिबुट गर्ने, Google Play क्यास खाली गर्ने वा केवल पर्खने प्रयास गर्नुहोस्।</string>
     <string name="upgrade_screen_restore_multiaccount_hint">धेरै खाताहरूले Google Play लाई भ्रमित गर्न सक्छ। अन्य खाताहरूबाट लग आउट गर्नुहोस् वा Google Play वेबसाइट मार्फत स्थापना गर्नुहोस्, जसले विशिष्ट खातासँग सम्बन्धहरू बल गर्दछ।</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">आफ्नो Pro स्थिति हेर्नुहोस्</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">बधाई छ!</string>
+    <string name="upgrade_screen_owned_congrats_body">तपाईंसँग BVM Pro छ — विकास समर्थन गरेकोको लागि धन्यवाद। ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">एक-पटक खरिद</string>
+    <string name="upgrade_screen_owned_iap_body">तपाईंसँग सदैको लागि BVM Pro छ। आफ्नो समर्थनको लागि धन्यवाद ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">सदस्यता</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">तपाइँको BVM Pro सदस्यता सक्रिय छ र नवीकरण हुन सेट गरिएको छ।</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">तपाइँको BVM Pro सदस्यता सक्रिय छ तर नवीकरण हुने छैन। यो हालको अवधिको अन्तसम्म वैध रहनेछ।</string>
+    <string name="upgrade_screen_owned_both_warning">तपाइँसँग सदस्यता र एकै पटकको खरिद दुवै छन्। Google Play मा सदस्यता रद्द गर्नुहोस् ताकि तपाइँलाई फेरि चार्ज नगरिओस्।</string>
+    <string name="upgrade_screen_manage_subscription">सदस्यता व्यवस्थापन गर्नुहोस्</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">एकै पटकको खरिदमा स्विच गर्नुहोस्</string>
+    <string name="upgrade_screen_switch_purchase_note">यो अलग एकै पटकको खरिद हो। यसले तपाइँको सदस्यता रद्द वा फिर्ता गर्दैन, त्यसैले यसलाई Google Play मा पनि रद्द गर्नुहोस्। दुवैको लागि एउटै Google खाता प्रयोग गर्नुहोस्।</string>
+    <string name="upgrade_screen_switch_locked_note">तपाइँको सदस्यता नवीकरण हुन सेट नभएपछि उपलब्ध हुनेछ। स्विच गर्न Google Play मा यसलाई रद्द गर्नुहोस् — तपाइँ हालको अवधि समाप्त नभएसम्म Pro राख्नुहुन्छ।</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">स्थिति गलत लाग्छ?</string>
+    <string name="upgrade_screen_status_restore_body">यदि तपाइँको खरिद यहाँ देखिइरहेको छैन भने, यसलाई पुनः प्राप्त गर्ने प्रयास गर्नुहोस्।</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">तपाइँको खरिद पुष्टि गरिँदैछ</string>
+    <string name="upgrade_screen_grace_body_short">धैर्य राख्नुहोस् — हामी तपाईंको ख्रिद Google Play सँग पुनः जाँच गरिरहेका छौँ।</string>
+    <string name="upgrade_screen_grace_body">हामी अझै पनि Google Play सँग तपाईंको ख्रिद पुष्टि गर्न सक्दिनौँ। यसलाई पुनर्स्थापन गर्ने प्रयास गर्नुहोस्, वा तपाईं सही खाताको साथ साइन इन गरेको छ भनी जाँच गर्नुहोस्।</string>
+    <string name="upgrade_screen_retry_action">फेरी प्रयास गर्नुहोस्</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">सदस्यता अझै सक्रिय छ</string>
+    <string name="upgrade_screen_sub_still_renewing_message">तपाईंको सदस्यता अझै नवीकरण गर्न सेट गरिएको छ। यसलाई पहिले Google Play मा रद्द गर्नुहोस्, त्यसपछि एकबार खरिद गर्न फिर्ता आउनुहोस् — त्यसरी तपाईंलाई दुबै पटक शुल्क लिइने छैन।</string>
+    <string name="upgrade_screen_sub_check_failed_message">हामी तपाईंको सदस्यता स्थिति जाँच गर्न सकेनौँ। कृपया तपाईंको जडान जाँच गर्नुहोस् र फेरी प्रयास गर्नुहोस्।</string>
+    <string name="upgrades_gplay_already_owned_error_title">पहिले नै खरिद गरिएको</string>
+    <string name="upgrades_gplay_already_owned_error_description">तपाईंको खरिद पुनर्स्थापन गर्न \"खरिद पुनर्स्थापन गर्नुहोस्\" विकल्पको प्रयोग गर्नुहोस्। यदि समस्या कायम रहन्छ भने, Google Play क्यास साफ गर्ने र आफ्नो डिभाइस पुनः सुरु गर्ने प्रयास गर्नुहोस्।</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play त्रुटि</string>
+    <string name="upgrades_gplay_internal_error_description">एक आन्तरिक Google Play त्रुटि भयो। कृपया निम्न प्रयास गर्नुहोस्:\n\n• तपाईंको डिभाइस पुनः सुरु गर्नुहोस्\n• Google Play Store क्यास साफ गर्नुहोस्\n• पछि प्रयास गर्नुहोस्</string>
+    <string name="upgrades_gplay_network_error_title">जडान त्रुटि</string>
+    <string name="upgrades_gplay_network_error_description">Google Play मा जडान गर्न सक्नु भएन। कृपया आफ्नो इन्टरनेट जडान जाँच गर्नुहोस् र फेरि प्रयास गर्नुहोस्।</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play उपलब्ध छैन</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play मा जोडिन सक्दैन। क्षमा गर्नुहोस्, Google Play स्थापित र अद्यतन छ? तपाईंको Google खाता लग इन गरिएको छ? Google Play अ्यापको क्यास साफ गर्नुहोस् र आफ्नो यन्त्र पुनःसुरू गर्नुहोस्।</string>
     <string name="upgrades_no_purchases_found_check_account">कुनै खरिदहरू फेला परेनन्। के तपाईं सही खाता प्रयोग गर्दै हुनुहुन्छ?</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Het abonnement kost %s per jaar.</string>
     <string name="upgrade_screen_iap_action">Eenmalige aankoop</string>
     <string name="upgrade_screen_iap_action_hint">De eenmalige aankoop kost %s.</string>
+    <string name="upgrade_screen_offer_divider_or">of</string>
+    <string name="upgrade_screen_offer_same_features">Dezelfde functies, alleen verschillende prijsmodellen.</string>
     <string name="upgrade_screen_thanks_toast">Jij bent de beste! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Herstel aankoop</string>
+    <string name="upgrade_screen_restore_banner_title">Heb je BVM Pro al gekocht?</string>
+    <string name="upgrade_screen_restore_banner_body">Het lijkt erop dat je eerder op dit apparaat een upgrade hebt gedaan. Herstel je aankoop om het opnieuw te ontgrendelen.</string>
     <string name="upgrade_screen_restore_purchase_message">Je upgrade is geldig op alle apparaten met hetzelfde Google-account.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Tips voor het oplossen van problemen met niet herkende upgrades:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Synchronisatie via de Play Store kan enige tijd duren. Probeer opnieuw op te starten, de Google Play cache te wissen of wacht gewoon.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Meerdere accounts kunnen Google Play in verwarring brengen. Meld je af bij andere accounts of installeer deze via de website van Google Play, waardoor koppelingen met een specifiek account worden afgedwongen.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Bekijk je Pro-status</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Gefeliciteerd!</string>
+    <string name="upgrade_screen_owned_congrats_body">Je hebt BVM Pro — bedankt voor je steun voor de ontwikkeling. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Eenmalige aankoop</string>
+    <string name="upgrade_screen_owned_iap_body">Je bezit BVM Pro voor altijd. Bedankt voor je steun ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abonnement</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Je BVM Pro-abonnement is actief en ingesteld om te verlengen.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Je BVM Pro-abonnement is actief maar verlengt niet. Het blijft geldig tot het einde van de huidige periode.</string>
+    <string name="upgrade_screen_owned_both_warning">Je hebt zowel een abonnement als een eenmalige aankoop. Zeg het abonnement op in Google Play zodat je niet opnieuw wordt gefactureerd.</string>
+    <string name="upgrade_screen_manage_subscription">Abonnement beheren</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Overstappen naar een eenmalige aankoop</string>
+    <string name="upgrade_screen_switch_purchase_note">Dit is een aparte eenmalige aankoop. Hiermee wordt je abonnement niet geannuleerd en het aankoopbedrag wordt niet terugbetaald. Zeg het abonnement ook op in Google Play. Gebruik voor beide aankopen hetzelfde Google-account.</string>
+    <string name="upgrade_screen_switch_locked_note">Beschikbaar wanneer je abonnement niet meer is ingesteld om te verlengen. Zeg het op in Google Play om over te schakelen — je behoudt Pro tot het einde van de huidige periode.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">De status lijkt onjuist?</string>
+    <string name="upgrade_screen_status_restore_body">Als je aankoop hier niet wordt weergegeven, probeer deze te herstellen.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Je aankoop bevestigen</string>
+    <string name="upgrade_screen_grace_body_short">Even geduld — we controleren je aankoop met Google Play.</string>
+    <string name="upgrade_screen_grace_body">We kunnen je aankoop nog steeds niet bevestigen met Google Play. Probeer het te herstellen, of controleer dat je bent ingelogd met het juiste account.</string>
+    <string name="upgrade_screen_retry_action">Opnieuw proberen</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonnement nog steeds actief</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Je abonnement is nog steeds ingesteld om te vernieuwen. Annuleer dit eerst in Google Play, kom dan terug om de eenmalige aankoop te doen — zo word je niet twee keer in rekening gebracht.</string>
+    <string name="upgrade_screen_sub_check_failed_message">We konden je abonnementsstatus niet controleren. Controleer je verbinding en probeer het opnieuw.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Reeds gekocht</string>
+    <string name="upgrades_gplay_already_owned_error_description">Gebruik de optie \'Aankoop herstellen\' om uw aankoop te herstellen. Als het probleem aanhoudt, probeer dan de cache van Google Play te wissen en uw apparaat opnieuw op te starten.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-fout</string>
+    <string name="upgrades_gplay_internal_error_description">Er is een interne Google Play-fout opgetreden. Probeer het volgende:\n\n• Herstart je apparaat\n• Wis de cache van de Google Play Store\n• Probeer het later opnieuw</string>
+    <string name="upgrades_gplay_network_error_title">Verbindingsfout</string>
+    <string name="upgrades_gplay_network_error_description">Kan geen verbinding maken met Google Play. Controleer je internetverbinding en probeer het opnieuw.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play is niet beschikbaar</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan geen verbinding maken met Google Play. Is Google Play geïnstalleerd en up-to-date? Is je Google-account ingelogd? Probeer de cache van de Google Play-app te wissen en je apparaat opnieuw op te starten.</string>
     <string name="upgrades_no_purchases_found_check_account">Geen aankopen gevonden. Gebruik je de juiste rekening?</string>

--- a/app/src/gplay/res/values-no/strings.xml
+++ b/app/src/gplay/res/values-no/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Abonnementet koster %s per år.</string>
     <string name="upgrade_screen_iap_action">Engangskjøp</string>
     <string name="upgrade_screen_iap_action_hint">Engangskjøpet koster %s.</string>
+    <string name="upgrade_screen_offer_divider_or">eller</string>
+    <string name="upgrade_screen_offer_same_features">De samme funksjonene, bare ulike prismodeller.</string>
     <string name="upgrade_screen_thanks_toast">Du er den beste! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Gjenopprett kjøp</string>
+    <string name="upgrade_screen_restore_banner_title">Allerede kjøpt BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Det ser ut til at du har oppgradert på denne enheten før. Gjenopprett kjøpet ditt for å låse det opp igjen.</string>
     <string name="upgrade_screen_restore_purchase_message">Oppgraderingen er gyldig på tvers av enheter med samme Google-konto.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Feilsøkingstips for ukjente oppgraderinger:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Synkronisering med Play Butikk kan ta tid. Prøv å starte på nytt, tømme Google Play bufferen, eller bare vent.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Flere kontoer kan forvirre Google Play. Logg ut av andre kontoer eller installer via Google Play-nettstedet, som tvinger assosiasjoner til en spesifikk konto.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Vis Pro-status</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Gratulerer!</string>
+    <string name="upgrade_screen_owned_congrats_body">Du har BVM Pro — takk for at du støtter utviklingen. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Engangskjøp</string>
+    <string name="upgrade_screen_owned_iap_body">Du eier BVM Pro for alltid. Takk for din støtte ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abonnement</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">BVM Pro-abonnementet ditt er aktivt og skal fornyes.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">BVM Pro-abonnementet ditt er aktivt, men vil ikke fornyes. Det forblir gyldig til slutten av gjeldende periode.</string>
+    <string name="upgrade_screen_owned_both_warning">Du har både et abonnement og et engangsinnkjøp. Avbryt abonnementet i Google Play slik at du ikke blir belastet igjen.</string>
+    <string name="upgrade_screen_manage_subscription">Administrer abonnement</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Bytt til engangsinnkjøp</string>
+    <string name="upgrade_screen_switch_purchase_note">Dette er et separat engangsinnkjøp. Det kansellerer eller refunderer ikke abonnementet ditt, så avbryt det også i Google Play. Bruk samme Google-konto for begge.</string>
+    <string name="upgrade_screen_switch_locked_note">Tilgjengelig når abonnementet ditt ikke lenger er satt til å fornyes. Avbryt det i Google Play for å bytte — du beholder Pro til slutten av gjeldende periode.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Statusen ser feil ut?</string>
+    <string name="upgrade_screen_status_restore_body">Hvis innkjøpet ditt ikke vises her, prøv å gjenopprette det.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Bekrefter innkjøpet ditt</string>
+    <string name="upgrade_screen_grace_body_short">Hold på — vi dobbeltsjekker kjøpet ditt med Google Play.</string>
+    <string name="upgrade_screen_grace_body">Vi kan fortsatt ikke bekrefte kjøpet ditt med Google Play. Prøv å gjenopprette det, eller sjekk at du er pålogget med riktig konto.</string>
+    <string name="upgrade_screen_retry_action">Prøv igjen</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonnement fortsatt aktivt</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Abonnementet ditt er fortsatt satt til å fornyes. Avbryt det i Google Play først, så kom tilbake for å kjøpe engangskjøp — på den måten blir du ikke belastet to ganger.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Vi kunne ikke sjekke abonnementstatusen din. Vennligst sjekk tilkoblingen din og prøv igjen.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Allerede kjøpt</string>
+    <string name="upgrades_gplay_already_owned_error_description">Bruk alternativet «Gjenopprette kjøp» for å gjenopprette kjøpet ditt. Hvis problemet vedvarer, prøv å fjerne Google Play-hurtiglagre og start enheten på nytt.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-feil</string>
+    <string name="upgrades_gplay_internal_error_description">En intern Google Play-feil oppstod. Vennligst prøv følgende:\n\n• Start enheten på nytt\n• Fjern Google Play Store-hurtiglagre\n• Prøv igjen senere</string>
+    <string name="upgrades_gplay_network_error_title">Tilkoblingsfeil</string>
+    <string name="upgrades_gplay_network_error_description">Kunne ikke koble til Google Play. Kontroller internettforbindelsen din og prøv igjen.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play er utilgjengelig</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan ikke koble til Google Play. Er Google Play installert og oppdatert? Er Google-kontoen din logget inn? Prøv å tømme hurtigbufferen til Google Play-appen og starte enheten på nytt.</string>
     <string name="upgrades_no_purchases_found_check_account">Ingen kjøp funnet. Bruker du riktig konto?</string>

--- a/app/src/gplay/res/values-pcm-rNG/strings.xml
+++ b/app/src/gplay/res/values-pcm-rNG/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Di subscription cost %s per year.</string>
     <string name="upgrade_screen_iap_action">One-time purchase</string>
     <string name="upgrade_screen_iap_action_hint">Di one-time purchase cost %s.</string>
+    <string name="upgrade_screen_offer_divider_or">abi</string>
+    <string name="upgrade_screen_offer_same_features">Same features, just different prices.</string>
     <string name="upgrade_screen_thanks_toast">You be di best!</string>
     <string name="upgrade_screen_restore_purchase_action">Restore purchase</string>
+    <string name="upgrade_screen_restore_banner_title">You don buy BVM Pro before?</string>
+    <string name="upgrade_screen_restore_banner_body">E look like you don upgrade this device before. Restore your purchase to unlock am again.</string>
     <string name="upgrade_screen_restore_purchase_message">Your upgrade dey valid across devices on di same Google account.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Troubleshooting tips for unrecognized upgrades:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store synchronization fit take time. Try reboot, clear Google Play cache or just wait.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Multiple accounts fit confuse Google Play. Log out of other accounts or install through di Google Play website, wey go force association with specific account.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">See your Pro status</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Congratulations!</string>
+    <string name="upgrade_screen_owned_congrats_body">You don get BVM Pro — thank you for supporting development. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">One-time purchase</string>
+    <string name="upgrade_screen_owned_iap_body">You own BVM Pro forever. Thank you for your support ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Subscription</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Your BVM Pro subscription don active and e go renew.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Your BVM Pro subscription don active but e no go renew. E go stay valid till the end of this period.</string>
+    <string name="upgrade_screen_owned_both_warning">You get both subscription and one-time purchase. Cancel the subscription for Google Play so dem no go charge you again.</string>
+    <string name="upgrade_screen_manage_subscription">Manage your subscription</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Switch to one-time purchase</string>
+    <string name="upgrade_screen_switch_purchase_note">This na separate one-time purchase. E no go cancel or refund your subscription, so cancel that one for Google Play too. Use the same Google account for both.</string>
+    <string name="upgrade_screen_switch_locked_note">E go dey available once your subscription no longer dey set to renew. Cancel am for Google Play to switch — you go still get Pro until the current period end.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Status look wrong?</string>
+    <string name="upgrade_screen_status_restore_body">If your purchase no show here, try restore am.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">We dey confirm your purchase</string>
+    <string name="upgrade_screen_grace_body_short">Wait small — we dey double-check your purchase with Google Play.</string>
+    <string name="upgrade_screen_grace_body">We still no fit confirm your purchase with Google Play. Try restore am, or check say you don sign in with the right account.</string>
+    <string name="upgrade_screen_retry_action">Try again</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Subscription still active</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Your subscription still dey set to renew. Cancel am for Google Play first, then come back buy the one-time purchase — that way dem no go charge you twice.</string>
+    <string name="upgrade_screen_sub_check_failed_message">We no fit check your subscription status. Check your connection and try again.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Already purchased</string>
+    <string name="upgrades_gplay_already_owned_error_description">Use the \"Restore purchase\" option to restore your purchase. If the problem still dey, try clear Google Play cache and restart your device.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play error</string>
+    <string name="upgrades_gplay_internal_error_description">Error don happen for inside Google Play. Abeg try dis dem:\n\n• Restart your device\n• Clear Google Play Store cache\n• Try again later</string>
+    <string name="upgrades_gplay_network_error_title">Connection error</string>
+    <string name="upgrades_gplay_network_error_description">You no fit connect to Google Play. Abeg check your internet connection and try again.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no dey available</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no fit connect to Google Play. Google Play don install and up to date? Your Google Account don log in? Try clear di cache of Google Play app and reboot your device.</string>
     <string name="upgrades_no_purchases_found_check_account">No purchases found. You dey use di right account?</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Subskrypcja kosztuje %s rocznie.</string>
     <string name="upgrade_screen_iap_action">Jednorazowy zakup</string>
     <string name="upgrade_screen_iap_action_hint">Jednorazowy zakup kosztuje %s.</string>
+    <string name="upgrade_screen_offer_divider_or">lub</string>
+    <string name="upgrade_screen_offer_same_features">Te same funkcje, tylko różne modele cenowe.</string>
     <string name="upgrade_screen_thanks_toast">Jesteś najlepszy! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Przywróć zakup</string>
+    <string name="upgrade_screen_restore_banner_title">Już kupiłeś BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Wygląda na to, że na tym urządzeniu dokonano już wcześniej uaktualnienia do BVM Pro. Przywróć zakup, aby odblokować je ponownie.</string>
     <string name="upgrade_screen_restore_purchase_message">Twoje uaktualnienie jest ważne na wszystkich urządzeniach korzystających z tego samego konta Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Wskazówki dotyczące rozwiązywania problemów w przypadku nierozpoznanych uaktualnień:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Synchronizacja Sklepu Play może zająć trochę czasu. Spróbuj uruchomić ponownie, wyczyścić pamięć podręczną Google Play lub po prostu poczekać.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Wiele kont może powodować problemy z Google Play. Wyloguj się z innych kont lub zainstaluj aplikację przez stronę Google Play, co wymusi powiązanie z konkretnym kontem.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Zobacz swój status Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Gratulacje!</string>
+    <string name="upgrade_screen_owned_congrats_body">Masz już BVM Pro — dzięki za wsparcie rozwoju aplikacji. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Jednorazowy zakup</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro jest twoje na zawsze. Dziękujemy za wsparcie ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Subskrypcja</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Twoja subskrypcja BVM Pro jest aktywna i zostanie odnowiona.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Twoja subskrypcja BVM Pro jest aktywna, ale nie zostanie odnowiona. Pozostanie ważna do końca bieżącego okresu rozliczeniowego.</string>
+    <string name="upgrade_screen_owned_both_warning">Masz zarówno subskrypcję, jak i zakup jednorazowy. Anuluj subskrypcję w Google Play, aby uniknąć ponownego naliczenia opłaty.</string>
+    <string name="upgrade_screen_manage_subscription">Zarządzaj subskrypcją</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Przejdź na jednorazowy zakup</string>
+    <string name="upgrade_screen_switch_purchase_note">To osobny, jednorazowy zakup. Nie anuluje ani nie zwraca kosztów subskrypcji, więc musisz anulować ją osobno w Google Play. Użyj tego samego konta Google do obu zakupów.</string>
+    <string name="upgrade_screen_switch_locked_note">Dostępne, gdy Twoja subskrypcja nie będzie już ustawiona na odnawianie. Anuluj ją w Google Play, aby przełączyć — zachowasz Pro do końca bieżącego okresu.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Status wygląda źle?</string>
+    <string name="upgrade_screen_status_restore_body">Jeśli Twój zakup się tu nie pojawia, spróbuj go przywrócić.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Potwierdzanie twojego zakupu</string>
+    <string name="upgrade_screen_grace_body_short">Chwila cierpliwości — sprawdzamy jeszcze raz Twój zakup w Google Play.</string>
+    <string name="upgrade_screen_grace_body">Nadal nie możemy potwierdzić Twojego zakupu w Google Play. Spróbuj go przywrócić lub sprawdź, czy używasz właściwego konta.</string>
+    <string name="upgrade_screen_retry_action">Ponów</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Subskrypcja nadal aktywna</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Twoja subskrypcja nadal jest ustawiona na odnawianie. Najpierw anuluj ją w Google Play, a potem wróć, aby kupić wersję jednorazową — dzięki temu unikniesz podwójnej opłaty.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nie udało się sprawdzić statusu Twojej subskrypcji. Sprawdź połączenie internetowe i spróbuj ponownie.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Już zakupiono</string>
+    <string name="upgrades_gplay_already_owned_error_description">Użyj opcji \"Przywróć zakup\", aby przywrócić zakup. Jeśli problem będzie się powtarzał, spróbuj wyczyścić pamięć podręczną Google Play i ponownie uruchomić urządzenie.</string>
+    <string name="upgrades_gplay_internal_error_title">Błąd Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Wystąpił wewnętrzny błąd Google Play. Spróbuj najpierw:\n\n• Uruchomić ponownie urządzenie\n• Wyczyść pamięć podręczną sklepu Google Play\n• Spróbuj ponownie później</string>
+    <string name="upgrades_gplay_network_error_title">Błąd połączenia</string>
+    <string name="upgrades_gplay_network_error_description">Nie udało się połączyć się z Google Play. Sprawdź swoje połączenie internetowe i spróbuj ponownie.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play jest niedostępne</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nie może połączyć się z Google Play. Czy Google Play jest zainstalowany i aktualny? Czy jesteś zalogowany na swoim koncie Google? Spróbuj wyczyścić pamięć podręczną aplikacji Google Play i zrestartować urządzenie.</string>
     <string name="upgrades_no_purchases_found_check_account">Nie znaleziono zakupów. Czy używasz właściwego konta?</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">A assinatura custa %s por ano.</string>
     <string name="upgrade_screen_iap_action">Compra de uma só vez</string>
     <string name="upgrade_screen_iap_action_hint">A compra única custa %s.</string>
+    <string name="upgrade_screen_offer_divider_or">ou</string>
+    <string name="upgrade_screen_offer_same_features">Os mesmos recursos, apenas com modelos de preço diferentes.</string>
     <string name="upgrade_screen_thanks_toast">Você é o melhor! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar a compra</string>
+    <string name="upgrade_screen_restore_banner_title">Já comprou BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Parece que você já fez upgrade neste dispositivo antes. Restaure sua compra para desbloqueá-lo novamente.</string>
     <string name="upgrade_screen_restore_purchase_message">A sua atualização é válida entre os dispositivos da mesma conta do Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Dicas de solução de problemas para atualizações não reconhecidas:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">A sincronização da Play Store pode demorar bastante. Tente reiniciar, limpar o cache do Google Play ou simplesmente aguarde.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Várias contas podem confundir o Google Play. Saia de outras contas ou instale através do site do Google Play, o que força associações com uma conta específica.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Ver seu status Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Parabéns!</string>
+    <string name="upgrade_screen_owned_congrats_body">Você tem BVM Pro — obrigado por apoiar o desenvolvimento. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Compra de uma só vez</string>
+    <string name="upgrade_screen_owned_iap_body">Você possui BVM Pro para sempre. Obrigado pelo seu apoio ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Assinatura</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Sua assinatura BVM Pro está ativa e configurada para renovar.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Sua assinatura BVM Pro está ativa, mas não será renovada. Permanece válida até o final do período atual.</string>
+    <string name="upgrade_screen_owned_both_warning">Você tem tanto uma assinatura quanto uma compra única. Cancele a assinatura no Google Play para não ser cobrado novamente.</string>
+    <string name="upgrade_screen_manage_subscription">Gerenciar assinatura</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Mudar para uma compra única</string>
+    <string name="upgrade_screen_switch_purchase_note">Esta é uma compra única separada. Ela não cancela ou reembolsa sua assinatura, então cancele também no Google Play. Use a mesma conta do Google para ambas.</string>
+    <string name="upgrade_screen_switch_locked_note">Disponível quando sua assinatura não estiver mais configurada para renovar. Cancele no Google Play para mudar — você mantém Pro até o final do período atual.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">O status parece errado?</string>
+    <string name="upgrade_screen_status_restore_body">Se sua compra não aparecer aqui, tente restaurá-la.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Confirmando sua compra</string>
+    <string name="upgrade_screen_grace_body_short">Aguarde — estamos verificando sua compra com o Google Play.</string>
+    <string name="upgrade_screen_grace_body">Ainda não conseguimos confirmar sua compra no Google Play. Tente restaurá-la ou verifique se você está conectado com a conta correta.</string>
+    <string name="upgrade_screen_retry_action">Tentar novamente</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Assinatura ainda ativa</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Sua assinatura ainda está configurada para renovar. Cancele-a no Google Play primeiro, depois volte para comprar a licença única — assim você não será cobrado duas vezes.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Não conseguimos verificar o status de sua assinatura. Verifique sua conexão e tente novamente.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Já comprado</string>
+    <string name="upgrades_gplay_already_owned_error_description">Use a opção \"Restaurar compra\" para restaurar sua compra. Se o problema persistir, tente limpar o cache do Google Play e reiniciar seu dispositivo.</string>
+    <string name="upgrades_gplay_internal_error_title">Erro do Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Ocorreu um erro interno do Google Play. Tente o seguinte:\n\n• Reinicie seu dispositivo\n• Limpe o cache do Google Play Store\n• Tente novamente mais tarde</string>
+    <string name="upgrades_gplay_network_error_title">Erro de conexão</string>
+    <string name="upgrades_gplay_network_error_description">Não foi possível conectar ao Google Play. Verifique sua conexão com a internet e tente novamente.</string>
     <string name="upgrades_gplay_unavailable_error_title">O Google Play está indisponível</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager não consegue se conectar ao Google Play. O Google Play está instalado e atualizado? Sua Conta do Google está conectada? Tente limpar o cache do app Google Play e reiniciar o dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Você está usando a conta certa?</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">A assinatura custa %s por ano.</string>
     <string name="upgrade_screen_iap_action">Compra única</string>
     <string name="upgrade_screen_iap_action_hint">A compra única custa %s.</string>
+    <string name="upgrade_screen_offer_divider_or">ou</string>
+    <string name="upgrade_screen_offer_same_features">As mesmas funcionalidades, apenas com modelos de preço diferentes.</string>
     <string name="upgrade_screen_thanks_toast">Você é o/a maior! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restaurar compra</string>
+    <string name="upgrade_screen_restore_banner_title">Já comprou o BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Parece que já atualizou neste dispositivo anteriormente. Restaure a sua compra para o desbloquear novamente.</string>
     <string name="upgrade_screen_restore_purchase_message">A sua atualização é válida entre dispositivos da mesma conta do Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Dicas de solução de problemas para upgrades:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">A sincronização com Play Store pode demorar. Tente reiniciar, limpar a cache do Google Play ou simplesmente aguarde.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Várias contas podem confundir o Google Play. Sair das outras contas ou instalar através do site do Google Play, forçando associações com uma conta específica.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Ver o estado do teu Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Parabéns!</string>
+    <string name="upgrade_screen_owned_congrats_body">Tens o BVM Pro — obrigado por apoiares o desenvolvimento. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Compra única</string>
+    <string name="upgrade_screen_owned_iap_body">Tens o BVM Pro para sempre. Obrigado pelo teu apoio ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Subscrição</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">A tua subscrição do BVM Pro está ativa e configurada para renovar.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">A tua subscrição do BVM Pro está ativa, mas não vai renovar. Mantém-se válida até ao final do período atual.</string>
+    <string name="upgrade_screen_owned_both_warning">Tens tanto uma subscrição como a compra única. Cancela a subscrição no Google Play para não seres cobrado novamente.</string>
+    <string name="upgrade_screen_manage_subscription">Gerir subscrição</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Mudar para uma compra única</string>
+    <string name="upgrade_screen_switch_purchase_note">Esta é uma compra única separada. Não cancela nem reembolsa a tua subscrição, por isso cancela-a também no Google Play. Usa a mesma conta Google para ambas.</string>
+    <string name="upgrade_screen_switch_locked_note">Disponível assim que a tua subscrição deixar de estar configurada para renovar. Cancela-a no Google Play para mudar — manténs o Pro até ao fim do período atual.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">O estado parece incorreto?</string>
+    <string name="upgrade_screen_status_restore_body">Se a tua compra não aparecer aqui, tenta restaurá-la.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">A confirmar a compra</string>
+    <string name="upgrade_screen_grace_body_short">Aguenta aí — estamos a verificar novamente a tua compra junto do Google Play.</string>
+    <string name="upgrade_screen_grace_body">Ainda não conseguimos confirmar a tua compra junto do Google Play. Tenta restaurá-la, ou verifica se tens sessão iniciada com a conta certa.</string>
+    <string name="upgrade_screen_retry_action">Tentar novamente</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Subscrição ainda ativa</string>
+    <string name="upgrade_screen_sub_still_renewing_message">A tua subscrição ainda está configurada para renovar. Cancela-a primeiro no Google Play e depois volta para comprar a compra única — assim não serás cobrado duas vezes.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar o estado da tua subscrição. Verifica a tua ligação e tenta novamente.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Já comprado</string>
+    <string name="upgrades_gplay_already_owned_error_description">Utilize a opção \"Restaurar compra\" para restaurar a sua compra. Se o problema persistir, tente limpar a cache do Google Play e reiniciar o dispositivo.</string>
+    <string name="upgrades_gplay_internal_error_title">Erro no Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Ocorreu um erro interno do Google Play. Tente o seguinte:\n\n• Reinicie o dispositivo\n• Limpe a cache da Google Play Store\n• Tente novamente mais tarde</string>
+    <string name="upgrades_gplay_network_error_title">Erro de ligação</string>
+    <string name="upgrades_gplay_network_error_description">Não foi possível estabelecer ligação ao Google Play. Verifique a ligação à Internet e tente novamente.</string>
     <string name="upgrades_gplay_unavailable_error_title">O Google Play está indisponível</string>
     <string name="upgrades_gplay_unavailable_error_description">O Bluetooth Volume Manager não se consegue conectar ao Google Play. O Google Play está instalado e atualizado? A sua conta Google está conectada? Tente limpar a cache da aplicação Google Play e reinicie o seu dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Está a usar a conta certa?</string>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">L\'abunament custa %s per onn.</string>
     <string name="upgrade_screen_iap_action">Cumprenda singula</string>
     <string name="upgrade_screen_iap_action_hint">La cumprenda singula custa %s.</string>
+    <string name="upgrade_screen_offer_divider_or">u</string>
+    <string name="upgrade_screen_offer_same_features">Mateunas funcziuns, nussas models da prezia differents.</string>
     <string name="upgrade_screen_thanks_toast">Ti es il meglier! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Recuperar cumprenda</string>
+    <string name="upgrade_screen_restore_banner_title">Hai gia cumprau BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Sembia che ti aias gia actualisau sin quel apparat. Restituir tia cumpaira per sblochir quella ancora ina giada.</string>
     <string name="upgrade_screen_restore_purchase_message">Tia actualisaziun è valaivla sin tuts ils apparat sul medem conto Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Tips per la soluziun da problems per actualisaziuns betg agnoschidas:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronisaziun cun il Play Store po prender temp. Emprova da ristar l\'apparat, da stgular il cache da Google Play u simplamain spetga.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Divers contos pon cunfunder Google Play. Sorta dad autri contos u installa via il website da Google Play, che forza l\'assoziaziun cun in conto specific.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Vesair tiu status Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Felicitaziuns!</string>
+    <string name="upgrade_screen_owned_congrats_body">Hai BVM Pro — grazia per sustenir il svilup. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Cumpaira ina giada</string>
+    <string name="upgrade_screen_owned_iap_body">Ti es proprietari da BVM Pro eternamain. Grazia per tia sustegna ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abunament</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Vossa abunament BVM Pro è activa e configurada per renovar se.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Vossa abunament BVM Pro è activa, ma na vegn betg renovada. Ella resta valida fina al fin dal perioda actual.</string>
+    <string name="upgrade_screen_owned_both_warning">Vus avais ina abunament e ina aquista ina metta. Annulai l\'abunament en Google Play che na vegniais betg chargiais pli.</string>
+    <string name="upgrade_screen_manage_subscription">Administrar l\'abunament</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Midar ad ina aquista ina metta</string>
+    <string name="upgrade_screen_switch_purchase_note">Questa è ina autra aquista ina metta. Ella na annulescha betg e na rumburscha betg vossa abunament, perquai annulai quella en Google Play er. Utilisai il medem cunt Google per l\'ina sco per l\'autra.</string>
+    <string name="upgrade_screen_switch_locked_note">Disponibla sch\'il voss abunament na vegn betg pli configurada per renovar. Annulai l\'abunament en Google Play per midar — vus tegnais Pro fina al fin dal perioda actual.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Statisa è chatta?</string>
+    <string name="upgrade_screen_status_restore_body">Sch\'il voss aquista na vegn betg mussau chi, empruvai da restaurar.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Confirmonda da tia commanda</string>
+    <string name="upgrade_screen_grace_body_short">Spetga - nus controllain tia commanda cun Google Play.</string>
+    <string name="upgrade_screen_grace_body">Nus n\'empruvain anc a confirmar tia commanda cun Google Play. Prouva da restituir, u controllescha che tu es logieu cun il cunt correct.</string>
+    <string name="upgrade_screen_retry_action">Emprouva uss</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">L\'abunament è anc activ</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Tia abunament è anc sa da renovar. Annulla la avant-maun en Google Play, lura vegn uss a cumprar la commanda unica - uschia na vegn ti na chargiau duas vias.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nus n\'empruvain a controlleschar il status da tia abunament. Controllescha per plaschair tia connexiun e prouva uss.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Gia cumpra</string>
+    <string name="upgrades_gplay_already_owned_error_description">Utilisescha l\'opziun \"Restituir la commanda\" per restituir tia commanda. Sche il problem persista, emprouva a stritgar il cache da Google Play e da restartar tia apparat.</string>
+    <string name="upgrades_gplay_internal_error_title">Errur da Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Igl ha dà in sbagl intern da Google Play. Prova las suandantas mesiras:\n\n• Reavair tia apparat\n• Svida la cache da Google Play Store\n• Prova pli tard</string>
+    <string name="upgrades_gplay_network_error_title">Sbagl da connexiun</string>
+    <string name="upgrades_gplay_network_error_description">Impussibel da connectar a Google Play. Controllescha tia connexiun d\'internet e prova anc ina volta.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play n\'è betg disponibel</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager na po betg sa connectar cun Google Play. Es Google Play installar ed actualisà? Es tiu conto Google s\'annunzià? Emprova da stgular il cache da l\'applicaziun Google Play e da ristar tiu apparat.</string>
     <string name="upgrades_no_purchases_found_check_account">Nagins acquists chattads. Utiliseschas ti il conto gist?</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Abonamentul costă %s pe an.</string>
     <string name="upgrade_screen_iap_action">Achiziție unică</string>
     <string name="upgrade_screen_iap_action_hint">Achiziția unică costă %s.</string>
+    <string name="upgrade_screen_offer_divider_or">sau</string>
+    <string name="upgrade_screen_offer_same_features">Aceleași funcții, doar cu modele de preț diferite.</string>
     <string name="upgrade_screen_thanks_toast">Ești cel mai bun! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Restabiliți achiziția</string>
+    <string name="upgrade_screen_restore_banner_title">Ai cumpărat deja BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Se pare că ai mai făcut upgrade pe acest dispozitiv. Restabilește achiziția pentru a o debloca din nou.</string>
     <string name="upgrade_screen_restore_purchase_message">Actualizarea dvs. este valabilă pe toate dispozitivele dvs. pe același cont Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Sfaturi depanare pentru upgrade-uri nerecunoscute:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Sincronizarea Magazinului Play poate dura timp. Încercați repornirea, ștergeți memoria cache Google Play sau doar așteptați.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Conturile multiple pot deruta Google Play. Deconectați-vă din alte conturi sau instalați prin site-ul Google Play, care forțează asociațiile cu un anumit cont.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Vizualizează-ți statusul Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Felicitări!</string>
+    <string name="upgrade_screen_owned_congrats_body">Ai BVM Pro — mulțumesc că susții dezvoltarea. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Achiziție unică</string>
+    <string name="upgrade_screen_owned_iap_body">Deții BVM Pro pentru totdeauna. Mulțumesc pentru suportul tău ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abonament</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Abonamentul tău BVM Pro este activ și setat să se reînnoiască.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Abonamentul tău BVM Pro este activ, dar nu se va reînnoi. Rămâne valabil până la sfârșitul perioadei curente.</string>
+    <string name="upgrade_screen_owned_both_warning">Ai atât un abonament, cât și o achiziție unică. Anulează abonamentul din Google Play ca să nu fii taxat din nou.</string>
+    <string name="upgrade_screen_manage_subscription">Gestionează abonamentul</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Treci la o achiziție unică</string>
+    <string name="upgrade_screen_switch_purchase_note">Aceasta este o achiziție unică separată. Nu anulează și nu rambursează abonamentul, așa că anulează-l și pe acela în Google Play. Folosește același cont Google pentru ambele.</string>
+    <string name="upgrade_screen_switch_locked_note">Disponibil când abonamentul tău nu mai e setat să se reînnoiască. Anulează-l în Google Play ca să treci la achiziția unică — păstrezi Pro până la sfârșitul perioadei curente.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Starea pare greșită?</string>
+    <string name="upgrade_screen_status_restore_body">Dacă achiziția ta nu apare aici, încearcă să o restabilești.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Confirmăm achiziția ta</string>
+    <string name="upgrade_screen_grace_body_short">Stai ușor — verificăm din nou achiziția ta cu Google Play.</string>
+    <string name="upgrade_screen_grace_body">Încă nu reușim să confirmăm achiziția ta cu Google Play. Încearcă să o restaurezi, sau verifică dacă ești logat cu contul corect.</string>
+    <string name="upgrade_screen_retry_action">Reîncearcă</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonament încă activ</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Abonamentul tău este încă setat să se reînnoiască. Anulează-l mai întâi în Google Play, apoi revino să cumperi achiziția unică — așa nu vei fi taxat de două ori.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nu am putut verifica statusul abonamentului tău. Te rog, verifică conexiunea și încearcă din nou.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Deja cumpărat</string>
+    <string name="upgrades_gplay_already_owned_error_description">Folosește opțiunea \"Restaurează achiziția\" pentru a restaura achiziția ta. Dacă problema persistă, încearcă să ștergi cache-ul Google Play și să restartezi dispozitivul.</string>
+    <string name="upgrades_gplay_internal_error_title">Eroare Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">A apărut o eroare internă a Google Play. Te rog, încearcă următoarele:\n\n• Restartează-ți dispozitivul\n• Șterge cache-ul Google Play Store\n• Încearcă din nou mai târziu</string>
+    <string name="upgrades_gplay_network_error_title">Eroare de conexiune</string>
+    <string name="upgrades_gplay_network_error_description">Nu se poate conecta la Google Play. Verifică conexiunea ta la internet și încearcă din nou.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nu este disponibil</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nu se poate conecta la Google Play. Este Google Play instalat şi actualizat? Eşti conectat cu contul Google? Încearcă să ștergă cache-ul aplicației Google Play şi reporneşte dispozitivul.</string>
     <string name="upgrades_no_purchases_found_check_account">Nu s-a găsit nicio achiziție. Ești sigur că folosești contul corect?</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Подписка стоит %s в год.</string>
     <string name="upgrade_screen_iap_action">Разовая покупка</string>
     <string name="upgrade_screen_iap_action_hint">Разовая покупка стоит %s.</string>
+    <string name="upgrade_screen_offer_divider_or">или</string>
+    <string name="upgrade_screen_offer_same_features">Те же функции, просто разные модели ценообразования.</string>
     <string name="upgrade_screen_thanks_toast">Вы лучший! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Восстановить покупку</string>
+    <string name="upgrade_screen_restore_banner_title">Уже купили BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Похоже, вы уже покупали BVM Pro на этом устройстве. Восстановите покупку, чтобы снова её разблокировать.</string>
     <string name="upgrade_screen_restore_purchase_message">Ваше обновление действительно на всех устройствах с одной учетной записи Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Советы по устранению неполадок для неизвестных обновлений:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизация Play Store может занять некоторое время. Попробуйте перезагрузиться, очистить кэш Google Play или просто подождать.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Множественные аккаунты могут путать Google Play. Выйдите из других аккаунтов или установите через веб-сайт Google Play, который определяет связь с определенной учетной записью.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Посмотреть статус Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Поздравляем!</string>
+    <string name="upgrade_screen_owned_congrats_body">У вас есть BVM Pro — спасибо за поддержку разработки. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Единовременная покупка</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro теперь навсегда ваш. Спасибо за поддержку ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Подписка</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Ваша подписка BVM Pro активна и будет продлена.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша подписка BVM Pro активна, но не будет продлена. Она остаётся действительной до конца текущего периода.</string>
+    <string name="upgrade_screen_owned_both_warning">У вас есть и подписка, и разовая покупка. Отмените подписку в Google Play, чтобы с вас больше не списывали деньги.</string>
+    <string name="upgrade_screen_manage_subscription">Управлять подпиской</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Перейти на разовую покупку</string>
+    <string name="upgrade_screen_switch_purchase_note">Это отдельная разовая покупка. Она не отменяет подписку и не возвращает за неё деньги, поэтому отмените её отдельно в Google Play. Используйте один и тот же аккаунт Google для обеих покупок.</string>
+    <string name="upgrade_screen_switch_locked_note">Станет доступно, когда подписка перестанет продлеваться. Отмените её в Google Play, чтобы переключиться — Pro останется у вас до конца текущего периода.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Статус выглядит неправильно?</string>
+    <string name="upgrade_screen_status_restore_body">Если ваша покупка не отображается здесь, попробуйте восстановить её.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Подтверждение покупки</string>
+    <string name="upgrade_screen_grace_body_short">Подождите немного — мы проверяем вашу покупку в Google Play.</string>
+    <string name="upgrade_screen_grace_body">Нам всё ещё не удаётся подтвердить вашу покупку в Google Play. Попробуйте восстановить её или проверьте, что вы вошли в нужный аккаунт.</string>
+    <string name="upgrade_screen_retry_action">Повторить</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Подписка всё ещё активна</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Ваша подписка всё ещё продлевается. Сначала отмените её в Google Play, а потом вернитесь, чтобы купить разовую покупку — так вы не заплатите дважды.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Не удалось проверить статус вашей подписки. Проверьте подключение и попробуйте снова.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Уже приобретено</string>
+    <string name="upgrades_gplay_already_owned_error_description">Используйте опцию \"Восстановить покупку\" для восстановления. Если проблема не устранена, попробуйте очистить кэш Google Play и перезагрузить устройство.</string>
+    <string name="upgrades_gplay_internal_error_title">Ошибка Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Произошла внутренняя ошибка Google Play. Пожалуйста, попробуйте следующее:\n\n• Перезапустите устройство\n• Очистите кэш Google Play Store\n• Повторите попытку позже</string>
+    <string name="upgrades_gplay_network_error_title">Ошибка соединения</string>
+    <string name="upgrades_gplay_network_error_description">Не удалось подключиться к Google Play. Пожалуйста, проверьте подключение к интернету и повторите попытку.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play недоступен</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не может подключиться к Google Play. Проверьте, установлен ли Google Play и обновлён ли до последней версии? Выполнен ли вход с Вашей учётной записью Google? Попробуйте очистить кэш Google Play и перезагрузить устройство.</string>
     <string name="upgrades_no_purchases_found_check_account">Покупки не найдены. Используете ли Вы правильный аккаунт?</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">S\'abbonamentu costat %s a s\'annu.</string>
     <string name="upgrade_screen_iap_action">Cùmperu de una borta</string>
     <string name="upgrade_screen_iap_action_hint">Su cùmperu de una borta costat %s.</string>
+    <string name="upgrade_screen_offer_divider_or">o</string>
+    <string name="upgrade_screen_offer_same_features">Istessas funtzionalitatzes, solu modelos de prezos differentes.</string>
     <string name="upgrade_screen_thanks_toast">Ses su mègius! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Recùpera su cùmperu</string>
+    <string name="upgrade_screen_restore_banner_title">Giai abbadu BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Sembriat chi ti sias aggiornadu in custu dispositivu inantis. Recupera sa cumpra tua pro ischida ancora.</string>
     <string name="upgrade_screen_restore_purchase_message">S\'agiornamentu tuo est vàlidu in dispositivos diferentes cun su matèssiu contu Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Cunsigiàdos pro risòlvere problemas cun agiornamentos non reconnotos:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Sa sincronizatzione de Play Store podet leare tempus. Proa a torrare a allùghere, limpiare sa cache de Google Play o simplesmente iseta.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Contos mùltiplos podent cunfùndere Google Play. Essi dae àteros contos o installa dae su situ web de Google Play, chi fortza assotziatziones cun unu contu ispetzìficu.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Controlla sa tua situatzione Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Congratulatziones!</string>
+    <string name="upgrade_screen_owned_congrats_body">Tenes BVM Pro — gràtzias pro su suportu a su sviluppu. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Cùmperu de una borta</string>
+    <string name="upgrade_screen_owned_iap_body">Tenes BVM Pro pro semper. Gràtzias pro su suportu tuyu ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Subscritzione</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Sa tua subscritzione BVM Pro est ativa e istada a s\'annovu.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Sa tua subscritzione BVM Pro est ativa pero no s\'annovat. Rimànghet valida fintzas a sa fine de su periddu atuale.</string>
+    <string name="upgrade_screen_owned_both_warning">Tenes una subscritzione e un\'acquistu unica. Annulla sa subscritzione in Google Play po no si ti cariegas de nou.</string>
+    <string name="upgrade_screen_manage_subscription">Gestione sa subscritzione</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Passa a un\'acquistu unica</string>
+    <string name="upgrade_screen_switch_purchase_note">Custu est un\'acquistu unica separadu. No anulla ne refrundida sa tua subscritzione, potzo annulla mancamente sa cussa in Google Play. Imprea sa matessi contu Google pro ambentu.</string>
+    <string name="upgrade_screen_switch_locked_note">Disponibele una borta ca sa tua subscritzione no est prus istada a s\'annovu. Annulla in Google Play pro commutare — tenes Pro fintzas a sa fine de su periddu atuale.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">S\'istadu at bidu mali?</string>
+    <string name="upgrade_screen_status_restore_body">Si s\'acquistu tuvu no at bidu issu, tenta a s\'istorare.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Confirmande s\'acquistu tuvu</string>
+    <string name="upgrade_screen_grace_body_short">Tene firmu — simus verificande sa compra tua cun Google Play.</string>
+    <string name="upgrade_screen_grace_body">No podimus ancora confirmàla sa compra tua cun Google Play. Tenta de isculàla, o cuntulla chi sias intradu cun s\'akuntu giustu.</string>
+    <string name="upgrade_screen_retry_action">Retenta</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">S\'iscritzione est sempre attiva</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Sa subscriptione tua est sempre impostada a isrenoare. Cancellàla in Google Play prima, dessos conpora sa compra de unu cunta — asa manera no ti carregant duas bilas.</string>
+    <string name="upgrade_screen_sub_check_failed_message">No podimus cuntullare s\'istadu de sa subscriptione tua. Cuntulla sa connessione tua e tenta anzis.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Già conporada</string>
+    <string name="upgrades_gplay_already_owned_error_description">Imprea s\'optzione \'Isculà sa compra\' a isculàla. Si su problema perdurat, tenta de scancellare sa cache de Google Play e de ristartare s\'apparatu.</string>
+    <string name="upgrades_gplay_internal_error_title">Errore de Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Hest acapattu un\'errore interu de Google Play. Tenta de eseguire sos seguentes passos:\n\n• Ristarta s\'apparatu\n• Scancella sa cache de Google Play Store\n• Tenta sa sera</string>
+    <string name="upgrades_gplay_network_error_title">Errore de connessione</string>
+    <string name="upgrades_gplay_network_error_description">No podo connetimi a Google Play. Controlla sa connessione de internet e tenta de novu.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no est disponìbile</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager non podet si connètere a Google Play. Google Play est installadu e agiornadu? Su contu Google tuo est intradu? Proa a limpiare sa cache de s\'aplicatzione Google Play e a torrare a allùghere su dispositivu tuo.</string>
     <string name="upgrades_no_purchases_found_check_account">Perunu cùmperu agatadu. Ses impreande su contu giustu?</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">දායකත්වය වසරකට %s වැය වේ.</string>
     <string name="upgrade_screen_iap_action">එක් වරක් මිලදී ගැනීම</string>
     <string name="upgrade_screen_iap_action_hint">එක් වරක් මිලදී ගැනීම %s වැය වේ.</string>
+    <string name="upgrade_screen_offer_divider_or">හෝ</string>
+    <string name="upgrade_screen_offer_same_features">එකම විශේෂාංග, විවිධ මිල ගණන් ආකෘති පමණි.</string>
     <string name="upgrade_screen_thanks_toast">ඔබ හොඳම කෙනා! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">මිලදී ගැනීම ප්‍රතිසාධනය කරන්න</string>
+    <string name="upgrade_screen_restore_banner_title">දැනටමත් BVM Pro ගෙන ඇත?</string>
+    <string name="upgrade_screen_restore_banner_body">පෙනෙන විට ඔබ මෙම උපකරණයේදී පෙර උසස් කර ඇත. එය නැවතත් අගුලු ඉවත් කිරීමට ඔබේ මිලදී ගැනීම ප්‍රතිස්ථාපනය කරන්න.</string>
     <string name="upgrade_screen_restore_purchase_message">ඔබගේ උත්ශ්‍රේණිය එකම Google ගිණුමේ උපාංග හරහා වලංගු වේ.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">හඳුනා නොගත් උත්ශ්‍රේණි සඳහා දෝෂ නිරාකරණ ඉඟි:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store සමමුහුර්ත කිරීමට කාලය ගත විය හැක. නැවත ආරම්භ කිරීම, Google Play හැඹිලිය මැකීම හෝ සරලව රැඳී සිටීමට උත්සාහ කරන්න.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">බහු ගිණුම් Google Play ව්‍යාකූල කළ හැක. වෙනත් ගිණුම් වලින් පිටවන්න හෝ Google Play වෙබ් අඩවිය හරහා ස්ථාපනය කරන්න, එය නිශ්චිත ගිණුමක් සමඟ සම්බන්ධතා බල කරයි.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">ඔබේ Pro තත්වය බලන්න</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">සුභ පැතුම්!</string>
+    <string name="upgrade_screen_owned_congrats_body">ඔබ BVM Pro ලබා ගෙන ඇත — සංවර්ධනයට සහාය දීම ගැන ස්තුතියි. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">එක් වරක් මිලදී ගැනීම</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro සදහටම ඔබගේයි. ඔබගේ සහයොගය සඳහා ස්තුතියි ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">දිගටි ගිණුම</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">ඔබගේ BVM Pro දිගටි ගිණුම සක්‍රිය වී ඇති අතර නැවුම් කිරීමට සැකසී ඇත.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">ඔබගේ BVM Pro දිගටි ගිණුම සක්‍රිය වී ඇත නමුත් නැවුම් නොකරනු ඇත. එය වත්මන් කාලපරිච්छේදයේ අවසානය දක්වා වලංගු පවතී.</string>
+    <string name="upgrade_screen_owned_both_warning">ඔබට දිගටි ගිණුම සහ එක්‍රමයෙන් ගිණුම ඇත. ඔබ නැවතත් අයකරතු නොලබීමට Google Play එකේහි දිගටි ගිණුම අවලංගු කරන්න.</string>
+    <string name="upgrade_screen_manage_subscription">දිගටි ගිණුම කළමනාකරණය</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">එක්‍රමයෙන් ගිණුමට මාරු වන්න</string>
+    <string name="upgrade_screen_switch_purchase_note">මෙය වෙනම් එක්‍රමයෙන් ගිණුමකි. එය ඔබගේ දිගටි ගිණුම අවලංගු නොකර ගුණය ද ආපසු නොදේ, එබැවින් එය Google Play එකේහි ද අවලංගු කරන්න. දෙකටම එකම Google ගිණුම භාවිතා කරන්න.</string>
+    <string name="upgrade_screen_switch_locked_note">ඔබගේ දිගටි ගිණුම නැවුම් කිරීමට සැකසී නැතිවිට මෙම විකල්පය ලබා ගත හැකි. Google Play එකේහි එය අවලංගු කරන්න එවිට මාරු වන්න — ඔබ වත්මන් කාලපරිච්छේදයේ අවසානය දක්වා Pro තබා ගනිනු ඇත.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">තත්වය වැරදිව පෙනේනවාද?</string>
+    <string name="upgrade_screen_status_restore_body">ඔබේ මිලදී ගැනීම මෙහි පෙනුණු නොමැත්තේ නම්, එය පුනස් ස්ථාපනය කිරීමට උත්සාහ කරන්න.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">ඔබේ මිලදී ගැනීම තහවුරු කරමින්</string>
+    <string name="upgrade_screen_grace_body_short">ඉඩ දෙන්න — අපි ඔබේ මිලදී ගැනීම Google Play සමඟ දෙවරක් තහවුරු කරමින් ඉන්නෙමු.</string>
+    <string name="upgrade_screen_grace_body">අපි තවමත් Google Play සමඟ ඔබේ මිලදී ගැනීම තහවුරු කිරීමට නොහැක. තවම් එය පුනෳ ස්ථාපනය කිරීමට උත්සාහ කරන්න, හෝ නිවැරදි ගිණුමෙන් ඔබ පිවිසුන් කර ඇතිවද පරීක්ෂා කරන්න.</string>
+    <string name="upgrade_screen_retry_action">නැවත උත්සාහ කරන්න</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">දායකත්ව තවමත් ක්‍රියාකාරී</string>
+    <string name="upgrade_screen_sub_still_renewing_message">ඔබේ දායකත්ව තවමත් නැවුම් කිරීමට සකසා ඉන්න. එය ප්‍රථමයෙන් Google Play වලින් අවලංගු කරන්න, ඉන්පසු එක් වතාවක මිලදී ගැනීමට ආපසු එන්න — එසේ ඔබ දෙවරක් අයකර නොමැතිවනු ඇත.</string>
+    <string name="upgrade_screen_sub_check_failed_message">අපි ඔබේ දායකත්ව තත්වය පරීක්ෂා කිරීමට නොහැකි විය. කරුණාකර ඔබේ සම්බන්ධතාවය පරීක්ෂා කරන්න සහ නැවත උත්සාහ කරන්න.</string>
+    <string name="upgrades_gplay_already_owned_error_title">දැනටමත් මිලදී ගන්නා ඇත</string>
+    <string name="upgrades_gplay_already_owned_error_description">ඔබේ මිලදී ගැනීම පුනෳ ස්ථාපනය කිරීමට \"මිලදී ගැනීම පුනෳ ස්ථාපනය\" විකල්පය භාවිතා කරන්න. ගටළුව නොතීරුවෙන් තිබේ නම්, Google Play කැෂ් ඉවත් කිරීමට සහ ඔබේ ගිණුමිය නැවත ආරම්භ කිරීමට උත්සාහ කරන්න.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play දොෂයක්</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play හි අභ්‍යන්තර දොෂයක් ඇතිවිය. කරුණාකර පහත් උත්සාහ කරන්න:\n\n• ඔබගේ උපාංගය නැවත ආරම්භ කරන්න\n• Google Play Store හි ස්මෘතිය හිස් කරන්න\n• පසුව නැවත උත්සාහ කරන්න</string>
+    <string name="upgrades_gplay_network_error_title">සම්බන්ධතා දොෂයක්</string>
+    <string name="upgrades_gplay_network_error_description">Google Play සමඟ සම්බන්ධ වීමට නොහැකි විය. කරුණාකර ඔබගේ අන්තර්ජාල සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ලබා ගත නොහැක</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager හට Google Play වෙත සම්බන්ධ වීමට නොහැකිය. Google Play ස්ථාපිත කර යාවත්කාලීන ද? ඔබේ Google ගිණුම පිවිසී ද? Google Play යෙදුමේ හැඹිලිය ඉවත් කර ඔබේ උපාංගය නැවත ආරම්භ කිරීමට උත්සාහ කරන්න.</string>
     <string name="upgrades_no_purchases_found_check_account">කිසිදු මිලදී ගැනීමක් හමු නොවිණි. ඔබ නිවැරදි ගිණුම භාවිතා කරන්නේද?</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Predplatné stojí %s ročne.</string>
     <string name="upgrade_screen_iap_action">Jednorazový nákup</string>
     <string name="upgrade_screen_iap_action_hint">Jednorazový nákup stojí %s.</string>
+    <string name="upgrade_screen_offer_divider_or">alebo</string>
+    <string name="upgrade_screen_offer_same_features">Rovnaké funkcie, len s rôznymi cenovými modelmi.</string>
     <string name="upgrade_screen_thanks_toast">Ste najlepší! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Obnoviť nákup</string>
+    <string name="upgrade_screen_restore_banner_title">Už ste si kúpili BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Vyzerá to tak, že ste si ho na tomto zariadení už niekedy kúpili. Obnovte si kúpu, aby ste ho opäť odomkli.</string>
     <string name="upgrade_screen_restore_purchase_message">Vaša licencia je platná pre všetky zariadenia s tým istým účtom Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Tipy na riešenie problémov s licenciou:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Synchronizácia Obchodu Play môže chvíľu trvať. Skúste reštartovať, vymazať vyrovnávaciu pamäť Google Play alebo jednoducho počkajte.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Viaceré účty môžu zmiasť Google Play. Odhláste sa z iných účtov alebo nainštalujte prostredníctvom webovej stránky Google Play, čo si vynúti priradenie ku konkrétnemu účtu.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Zobraziť stav vášho Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Gratulujeme!</string>
+    <string name="upgrade_screen_owned_congrats_body">Máte BVM Pro — ďakujeme za podporu vývoja. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Jednorazový nákup</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro je váš navždy. Ďakujeme za vašu podporu ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Predplatné</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Vaše BVM Pro predplatné je aktívne a je nastavené na obnovenie.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Vaše BVM Pro predplatné je aktívne, ale nebude sa obnovovať. Zostáva platné až do konca aktuálneho obdobia.</string>
+    <string name="upgrade_screen_owned_both_warning">Máte aj predplatné, aj jednorazový nákup. Zrušte predplatné v Google Play, aby ste neboli znova naúčtovaní.</string>
+    <string name="upgrade_screen_manage_subscription">Spravovať predplatné</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Prejsť na jednorazový nákup</string>
+    <string name="upgrade_screen_switch_purchase_note">Toto je samostatný jednorazový nákup. Nezrušuje ani nevracia vaše predplatné, preto ho tiež zrušte v Google Play. Pre oboje použite rovnaký účet Google.</string>
+    <string name="upgrade_screen_switch_locked_note">Dostupné, keď vaše predplatné už nie je nastavené na obnovenie. Zrušte ho v Google Play na prepnutie — budete mať Pro až do konca aktuálneho obdobia.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Stav vyzerá zle?</string>
+    <string name="upgrade_screen_status_restore_body">Ak sa vám váš nákup neukazuje tu, skúste ho obnoviť.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Potvrdzovanie vášho nákupu</string>
+    <string name="upgrade_screen_grace_body_short">Vydržte — overujeme vašu kúpu v službe Google Play.</string>
+    <string name="upgrade_screen_grace_body">Stále nemôžeme potvrdiť vašu kúpu v službe Google Play. Skúste ju obnoviť alebo skontrolujte, či ste prihlásení s tým správnym účtom.</string>
+    <string name="upgrade_screen_retry_action">Skúsiť znova</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Predplatné je stále aktívne</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Vaše predplatné je stále nastavené na obnovenie. Najprv ho zrušte v službe Google Play, potom sa vráťte a kúpte si jednorazový nákup – tak vás nebudeme účtovať dvakrát.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nemohli sme skontrolovať stav vášho predplatného. Skontrolujte vaše pripojenie a skúste znova.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Už zakúpené</string>
+    <string name="upgrades_gplay_already_owned_error_description">Použite možnosť „Obnoviť nákup“ na obnovenie vašej kúpy. Ak problém pretrváva, skúste vyčistiť vyrovnávaciu pamäť služby Google Play a reštartujte zariadenie.</string>
+    <string name="upgrades_gplay_internal_error_title">Chyba Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Vyskytla sa interná chyba služby Google Play. Skúste nasledujúce:\n\n• Reštartujte zariadenie\n• Vyčistite vyrovnávaciu pamäť služby Google Play\n• Skúste neskôr</string>
+    <string name="upgrades_gplay_network_error_title">Chyba pripojenia</string>
+    <string name="upgrades_gplay_network_error_description">Nie je možné pripojiť sa k Obchodu Play. Skontrolujte internetové pripojenie a skúste znova.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nie je k dispozícii</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager sa nemôže pripojiť k Google Play. Je Google Play nainštalovaný a aktuálny? Je vaše konto Google prihlásené? Skúste vymazalť vyrovnávaciu pamäť aplikácie Google Play a reštartovať zariadenie.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenašli sa žiadne nákupy. Používate správny účet?</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Naročnina stane %s na leto.</string>
     <string name="upgrade_screen_iap_action">Enkratni nakup</string>
     <string name="upgrade_screen_iap_action_hint">Enkratni nakup stane %s.</string>
+    <string name="upgrade_screen_offer_divider_or">ali</string>
+    <string name="upgrade_screen_offer_same_features">Iste lastnosti, le drugačni modeli cenovanja.</string>
     <string name="upgrade_screen_thanks_toast">Hvala! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Obnovi nakup</string>
+    <string name="upgrade_screen_restore_banner_title">Ste že kupili BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Izgleda, da ste to napravo že nadgradili. Obnovite nakup, da ga znova odklenete.</string>
     <string name="upgrade_screen_restore_purchase_message">Nadgradnja je veljavna v vseh napravah, kjer ste prijavljeni z istim Googlovim računom.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Nasveti za odpravljanje težav pri neprepoznanih nadgradnjah:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Sinhronizacija s Trgovino Play bo morda trajala nekaj časa.  Poizkusite s ponovnim zagnom naprave, čiščenjem predpomnilnika Googla Play ali preprosto počakajte.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Več računov lahko zmede Google Play.  Odjavite se iz drugih računov ali namestite preko spletne strani Google Play, ki vsili povezavo z določenim računom.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Preglejte svoj status Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Čestitke!</string>
+    <string name="upgrade_screen_owned_congrats_body">Imate BVM Pro — hvala, da podpirate razvoj. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Enkratni nakup</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro je vaš za vedno. Hvala za vašo podporo ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Naročnina</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Vaša BVM Pro naročnina je aktivna in je nastavljena na obnavljanje.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Vaša BVM Pro naročnina je aktivna, vendar se ne bo obnovila. Ostane veljavna do konca trenutnega obdobja.</string>
+    <string name="upgrade_screen_owned_both_warning">Imate tako naročnino kot tudi enkratni nakup. Prekličite naročnino v Google Play, da vas ne bi ponovno zaračunali.</string>
+    <string name="upgrade_screen_manage_subscription">Upravljanje naročnine</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Preklopi na enkratni nakup</string>
+    <string name="upgrade_screen_switch_purchase_note">To je ločen enkratni nakup. Ne prekliče in ne vrne vaše naročnine, zato to prekličite tudi v Google Play. Uporabite isti račun Google za oba.</string>
+    <string name="upgrade_screen_switch_locked_note">Dostopno, ko vaša naročnina ne bo več nastavljena na obnavljanje. Prekličite jo v Google Play za prestop — Pro obdržite do konca trenutnega obdobja.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Ali status izgleda napačen?</string>
+    <string name="upgrade_screen_status_restore_body">Če se vaš nakup tukaj ne prikazuje, poskusite ga obnoviti.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Potrditev vašega nakupa</string>
+    <string name="upgrade_screen_grace_body_short">Počakaj — ponovno preverjamo tvoj nakup pri Google Play.</string>
+    <string name="upgrade_screen_grace_body">Še vedno ne moremo potrditi tvojega nakupa pri Google Play. Poskusi ga obnoviti ali preveri, da si prijavljen s pravim računom.</string>
+    <string name="upgrade_screen_retry_action">Poskusi ponovno</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Naročnina je še vedno aktivna</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Tvoja naročnina je še vedno nastavljena za obnovitev. Najprej jo prekliči v Google Play, nato se vrni in kupi enkratni nakup — na ta način ne boš zaračunan dvakrat.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nismo mogli preveriti stanja tvoje naročnine. Prosimo, preveri svojo povezavo in poskusi ponovno.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Že kupljeno</string>
+    <string name="upgrades_gplay_already_owned_error_description">Uporabi možnost »Obnovi nakup«, da obnoviš svoj nakup. Če se težava nadaljuje, poskusi počistiti predpomnilnik Google Play in ponovno zagnati napravo.</string>
+    <string name="upgrades_gplay_internal_error_title">Napaka Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Prišlo je do notranje napake Google Play. Prosimo, poskusi naslednje:\n\n• Ponovno zagnani napravo\n• Počisti predpomnilnik Google Play Store\n• Poskusi ponovno kasneje</string>
+    <string name="upgrades_gplay_network_error_title">Napaka pri povezavi</string>
+    <string name="upgrades_gplay_network_error_description">Ni mogoče se povezati s Google Play. Preverite svojo internetno povezavo in poskusite znova.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ni na voljo.</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager se ne more povezati z Google Play. Ali je Google Play nameščen in posodobljen? Ali ste prijavljeni v Google Račun? Poskusite počistiti predpomnilnik aplikacije Google Play in znova zagnati napravo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nakup ni bil najden.  Ali uporabljate pravi račun?</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Abonimi kushton %s në vit.</string>
     <string name="upgrade_screen_iap_action">Blerje një herë</string>
     <string name="upgrade_screen_iap_action_hint">Blerja një herë kushton %s.</string>
+    <string name="upgrade_screen_offer_divider_or">ose</string>
+    <string name="upgrade_screen_offer_same_features">Të njëjtat karakteristika, thjesht modele të ndryshme të çmimeve.</string>
     <string name="upgrade_screen_thanks_toast">Ti je më i miri! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Rivendos blerjen</string>
+    <string name="upgrade_screen_restore_banner_title">E keni blerë tashmë BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Duket se e keni përmirësuar më parë në këtë pajisje. Rikthejeni blerjen tuaj për ta shkyçur atë përsëri.</string>
     <string name="upgrade_screen_restore_purchase_message">Përmirësimi yt(blerja) është i vlefshëm në të gjitha pajisjet në të njëjtën llogari të Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Këshilla për zgjidhjen e problemeve për përmirësimet e panjohura:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Sinkronizimi i Play Store-it mund të marrë kohë. Provoni të rindizni, pastroni cache-in e Google Play ose thjesht prisni.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Llogaritë e shumta mund të habisin Google Play. Dilni nga llogaritë e tjera ose instaloni përmes faqes së internetit të Google Play, gjë që detyron lidhjet me një llogari specifike.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Shikoni statusin tuaj Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Urime!</string>
+    <string name="upgrade_screen_owned_congrats_body">Keni marrë BVM Pro — faleminderit për mbështetjen e zhvillimit. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Blerje një herë</string>
+    <string name="upgrade_screen_owned_iap_body">Jeni zotëruesi i BVM Pro përgjithmonë. Faleminderit për mbështetjen tuaj ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abonim</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Abonimi juaj BVM Pro është aktiv dhe do të rinovohet.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Abonimi juaj BVM Pro është aktiv, por nuk do të rinovohet. Mbetet i vlefshëm deri në fund të periudhës aktuale.</string>
+    <string name="upgrade_screen_owned_both_warning">Ju keni njëkohësisht një abonim dhe blerjen njëherësh. Anulojeni abonimin në Google Play që të mos ngarkoheni përsëri.</string>
+    <string name="upgrade_screen_manage_subscription">Menaxho abonimin</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Kaloni në një blerje njëherësh</string>
+    <string name="upgrade_screen_switch_purchase_note">Kjo është një blerje njëherësh e veçantë. Ajo nuk anulon apo rimburson abonimin tuaj, prandaj anulojeni atë edhe në Google Play. Përdorni të njëjtën llogari Google për të dyja.</string>
+    <string name="upgrade_screen_switch_locked_note">I disponueshëm pasi abonimi juaj të mos jetë më i caktuar për rinovim. Anulojeni në Google Play për të kaluar — mbani Pro deri në fund të periudhës aktuale.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Statusi duket i gabuar?</string>
+    <string name="upgrade_screen_status_restore_body">Nëse blerja juaj nuk shfaqet këtu, provoni ta riktheni.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Konfirmimi i blerjes suaj</string>
+    <string name="upgrade_screen_grace_body_short">Duroni — po e kontrollojmë blerjen tuaj në Google Play.</string>
+    <string name="upgrade_screen_grace_body">Ende nuk mund ta konfirmojmë blerjen tuaj në Google Play. Provoni ta riktheni atë, ose kontrolloni që jeni kyçur me llogarinë e duhur.</string>
+    <string name="upgrade_screen_retry_action">Provo përsëri</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonimi ende aktiv</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Abonimi juaj është ende i caktuar për t\'u rinovuar. Anulojeni atë në Google Play fillimisht, pastaj kthehuni për të blerë blerjen njëherë — kështu nuk do të ngarkoheni dy herë.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Nuk mundëm të kontrollojmë statusin e abonimit tuaj. Ju lutemi kontrolloni lidhjen tuaj dhe provoni përsëri.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Tashmë i blerë</string>
+    <string name="upgrades_gplay_already_owned_error_description">Përdorni opsionin \"Rikthe blerjen\" për të rikthyer blerjen tuaj. Nëse problemi vazhdon, provoni të fshini memorjen cache të Google Play dhe të ristartoni pajisjen tuaj.</string>
+    <string name="upgrades_gplay_internal_error_title">Gabim i Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Ndodhi një gabim i brendshëm i Google Play. Ju lutemi provoni sa vijon:\n\n• Ristartoni pajisjen tuaj\n• Fshini memorjen cache të Google Play Store\n• Provoni më vonë</string>
+    <string name="upgrades_gplay_network_error_title">Gabim lidhjeje</string>
+    <string name="upgrades_gplay_network_error_description">Nuk mund të lidhet me Google Play. Ju lutemi kontrolloni lidhjen tuaj të internetit dhe provoni përsëri.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play dyqani është i padisponueshëm</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nuk mund të lidhet me Google Play. A është Google Play i instaluar dhe i përditësuar? A jeni kyçur me llogarinë tuaj Google? Provoni të pastroni memorien e Google Play dhe të rinisni pajisjen tuaj.</string>
     <string name="upgrades_no_purchases_found_check_account">Nuk u gjet asnjë blerje. A po përdorni llogarinë e duhur?</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Претплата кошта %s годишње.</string>
     <string name="upgrade_screen_iap_action">Једнократна куповина</string>
     <string name="upgrade_screen_iap_action_hint">Једнократна куповина кошта %s.</string>
+    <string name="upgrade_screen_offer_divider_or">или</string>
+    <string name="upgrade_screen_offer_same_features">Исте функције, само другачији модели плаћања.</string>
     <string name="upgrade_screen_thanks_toast">Ви сте најбољи! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Врати куповину</string>
+    <string name="upgrade_screen_restore_banner_title">Већ сте купили BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Чини се да сте раније куповали BVM Pro на овом уређају. Вратите своју куповину да је поново откључите.</string>
     <string name="upgrade_screen_restore_purchase_message">Ваше надоградње важе на уређајима са истим Google налогом.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Савети за решавање проблема за непрепознате надоградње:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизација Play Store може потрајати. Покушајте поново покретање, брисање Google Play кеша или једноставно сачекајте.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Више налога може збунити Google Play. Одјавите се са других налога или инсталирајте преко Google Play веб сајта, што приморава везе са одређеним налогом.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Погледајте свој Pro статус</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Честитамо!</string>
+    <string name="upgrade_screen_owned_congrats_body">Добили сте BVM Pro — хвала за подршку развоју. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Једнократна куповина</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro је ваш заувек. Хвала на подршци ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Претплата</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Ваша BVM Pro претплата је активна и подешена да се обнови.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша BVM Pro претплата је активна али се неће обновити. Остаје важећа до краја тренутног периода.</string>
+    <string name="upgrade_screen_owned_both_warning">Имате и претплату и једнократну куповину. Откажите претплату у Google Play-у да не будете наплаћени поново.</string>
+    <string name="upgrade_screen_manage_subscription">Управљајте претплатом</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Пређите на једнократну куповину</string>
+    <string name="upgrade_screen_switch_purchase_note">Ово је одвојена једнократна куповина. Не отказује или не враћа вашу претплату, па откажите и то у Google Play-у. Користите исти Google налог за оба.</string>
+    <string name="upgrade_screen_switch_locked_note">Доступно када ваша претплата више није подешена да се обнови. Откажите је у Google Play-у да пређете — задржавате Pro док се текући период не заврши.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Статус изгледа погрешно?</string>
+    <string name="upgrade_screen_status_restore_body">Ако се ваша куповина не приказује овде, покушајте да је вратите.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Потврђивање куповине</string>
+    <string name="upgrade_screen_grace_body_short">Издржите — двоструко проверавамо вашу куповину са Google Play.</string>
+    <string name="upgrade_screen_grace_body">И даље не можемо потврдити вашу куповину са Google Play. Покушајте да је вратите, или проверите да сте пријављени са правим налогом.</string>
+    <string name="upgrade_screen_retry_action">Покушај поново</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Претплата је још увек активна</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Ваша претплата је још увек подешена да се обнови. Прво је откажите у Google Play, а затим се вратите да купите једнократну куповину — на тај начин вам неће бити наплаћено два пута.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Нисмо могли проверити статус ваше претплате. Молимо проверите везу и покушајте поново.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Већ купљено</string>
+    <string name="upgrades_gplay_already_owned_error_description">Користите опцију „Врати куповину” да вратите вашу куповину. Ако проблем настави, покушајте да очистите кеш Google Play-а и поново покренете уређај.</string>
+    <string name="upgrades_gplay_internal_error_title">Грешка Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Дошло је до унутарње грешке у Google Play. Молимо покушајте следеће:\n\n• Рестартујте уређај\n• Очистите кеш Google Play Store\n• Покушајте касније</string>
+    <string name="upgrades_gplay_network_error_title">Грешка при повезивању</string>
+    <string name="upgrades_gplay_network_error_description">Није могуће повезати се на Google Play. Молимо проверите вашу интернет везу и покушајте поново.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play није доступан</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може да се повеже на Google Play. Да ли је Google Play инсталиран и ажуриран? Да ли си пријављен на свој Google налог? Покушај очистити кеш Google Play апликације и поново покрени уређај.</string>
     <string name="upgrades_no_purchases_found_check_account">Нису пронађене куповине. Користите ли прави налог?</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Prenumerationen kostar %s per år.</string>
     <string name="upgrade_screen_iap_action">Engångsköp</string>
     <string name="upgrade_screen_iap_action_hint">Engångsköpet kostar %s.</string>
+    <string name="upgrade_screen_offer_divider_or">eller</string>
+    <string name="upgrade_screen_offer_same_features">Samma funktioner, bara olika prismodeller.</string>
     <string name="upgrade_screen_thanks_toast">Du är bäst! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Återställ köp</string>
+    <string name="upgrade_screen_restore_banner_title">Redan köpt BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Det verkar som att du redan har uppgraderat denna enhet. Återställ ditt köp för att låsa upp det igen.</string>
     <string name="upgrade_screen_restore_purchase_message">Din uppgradering gäller för enheter på samma Google-konto.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Felsökningstips för okända uppgraderingar:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store-synkronisering kan ta tid. Försök starta om, rensa Google Play-cache eller bara vänta.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Flera konton kan förvirra Google Play. Logga ut från andra konton eller installera via Google Play-webbplatsen, vilket tvingar associationer med ett specifikt konto.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Visa din Pro-status</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Grattis!</string>
+    <string name="upgrade_screen_owned_congrats_body">Du har BVM Pro — tack för att du stöder utvecklingen. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Engångsköp</string>
+    <string name="upgrade_screen_owned_iap_body">Du äger BVM Pro för alltid. Tack för ditt stöd ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Prenumeration</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Din BVM Pro-prenumeration är aktiv och inställd på att förnyas.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Din BVM Pro-prenumeration är aktiv men kommer inte att förnyas. Den gäller fram till slutet av den aktuella perioden.</string>
+    <string name="upgrade_screen_owned_both_warning">Du har både en prenumeration och ett engångsköp. Avbryt prenumerationen i Google Play så du inte debiteras igen.</string>
+    <string name="upgrade_screen_manage_subscription">Hantera prenumeration</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Byt till ett engångsköp</string>
+    <string name="upgrade_screen_switch_purchase_note">Det här är ett separat engångsköp. Det avbryter eller återbetalar inte din prenumeration, så avbryt även den i Google Play. Använd samma Google-konto för båda.</string>
+    <string name="upgrade_screen_switch_locked_note">Tillgänglig när din prenumeration inte längre är inställd på att förnyas. Avbryt den i Google Play för att byta — du behåller Pro fram till slutet av den aktuella perioden.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Verkar statusen vara fel?</string>
+    <string name="upgrade_screen_status_restore_body">Om ditt köp inte visas här kan du försöka återställa det.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Bekräftar ditt köp</string>
+    <string name="upgrade_screen_grace_body_short">Vänta — vi dubbelkontrollerar ditt köp med Google Play.</string>
+    <string name="upgrade_screen_grace_body">Vi kan fortfarande inte bekräfta ditt köp med Google Play. Försök att återställa det, eller kontrollera att du är inloggad med rätt konto.</string>
+    <string name="upgrade_screen_retry_action">Försök igen</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Prenumeration fortfarande aktiv</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Din prenumeration är fortfarande inställd på att förnya. Avbryt den i Google Play först, kom sedan tillbaka för att köpa engångsköpet — så blir du inte debiterad två gånger.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Vi kunde inte kontrollera din prenumerationsstatus. Kontrollera din anslutning och försök igen.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Redan köpt</string>
+    <string name="upgrades_gplay_already_owned_error_description">Använd alternativet ”Återställ köp” för att återställa ditt köp. Om problemet kvarstår, försök att rensa Google Play-cacheminnet och starta om enheten.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play-fel</string>
+    <string name="upgrades_gplay_internal_error_description">Ett internt Google Play-fel inträffade. Försök med följande:\n\n• Starta om enheten\n• Rensa Google Play Store-cache\n• Försök igen senare</string>
+    <string name="upgrades_gplay_network_error_title">Anslutningsfel</string>
+    <string name="upgrades_gplay_network_error_description">Det gick inte att ansluta till Google Play. Kontrollera din internetanslutning och försök igen.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play är inte tillgängligt</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan inte ansluta till Google Play. Är Google Play installerat och uppdaterat? Är ditt Google-konto inloggat? Försök rensa cachen för Google Play-appen och starta om enheten.</string>
     <string name="upgrades_no_purchases_found_check_account">Inga köp hittades. Använder du rätt konto?</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Usajili ungharimu %s kwa mwaka.</string>
     <string name="upgrade_screen_iap_action">Ununuzi wa mara moja</string>
     <string name="upgrade_screen_iap_action_hint">Ununuzi wa mara moja ungharimu %s.</string>
+    <string name="upgrade_screen_offer_divider_or">au</string>
+    <string name="upgrade_screen_offer_same_features">Vipengele vile, tu mifumo tofauti ya bei.</string>
     <string name="upgrade_screen_thanks_toast">Wewe ni bora zaidi! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Rejesha ununuzi</string>
+    <string name="upgrade_screen_restore_banner_title">Umekwisha kununua BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Inaonekana umefanya upgrade kwenye kifaa hiki hapo awali. Rejesha kununuzi wako ili kulifungua tena.</string>
     <string name="upgrade_screen_restore_purchase_message">Uboreshaji wako ni halali kwenye vifaa vya akaunti ile ile ya Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Vidokezo vya kutatua matatizo kwa uboreshaji usiotambuliwa:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Ulandanishi wa Play Store unaweza kuchukua muda. Jaribu kuanzisha upya, kusafisha akiba ya Google Play au tu subiri.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Akaunti nyingi zinaweza kuchanganya Google Play. Toka kwenye akaunti zingine au sakinisha kupitia tovuti ya Google Play, ambayo inalazimisha uhusiano na akaunti maalum.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Tazama hali ya Pro yako</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Hongera!</string>
+    <string name="upgrade_screen_owned_congrats_body">Umepata BVM Pro — asante kwa kusaidia maendeleo. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Ununuzi wa mara moja</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro ni yako milele. Asante kwa usaidizi wako ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Usajili</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Usajili wako wa BVM Pro unatumika na umewekwa kurejea.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Usajili wako wa BVM Pro unatumika lakini hautarejea. Utabaki kuwa halali hadi mwisho wa kipindi cha sasa.</string>
+    <string name="upgrade_screen_owned_both_warning">Una usajili na ununuzi wa mara moja. Ghairi usajili katika Google Play ili usitozwe tena.</string>
+    <string name="upgrade_screen_manage_subscription">Dhibiti usajili</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Badili kuwa ununuzi wa mara moja</string>
+    <string name="upgrade_screen_switch_purchase_note">Hii ni ununuzi wa mara moja tofauti. Haifuti au kurudisha usajili wako, kwa hiyo ghairi hiyo pia katika Google Play. Tumia akaunti sawa ya Google kwa zote.</string>
+    <string name="upgrade_screen_switch_locked_note">Itapatikana baada ya usajili wako kutorejea tena. Ghairi katika Google Play kubadilisha — unabaki na Pro hadi kipindi cha sasa kinapoisha.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Hali inaonekana si sahihi?</string>
+    <string name="upgrade_screen_status_restore_body">Ikiwa ununuzi wako hauonekani hapa, jaribu kuurejesha.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Inathibitisha ununuzi wako</string>
+    <string name="upgrade_screen_grace_body_short">Subiri kidogo — tunakagua tena ununuzi wako kwa Google Play.</string>
+    <string name="upgrade_screen_grace_body">Bado hatuwezi kuthibitisha ununuzi wako kwa Google Play. Jaribu kuurejesha, au angalia kuwa umeingia kwa akaunti sahihi.</string>
+    <string name="upgrade_screen_retry_action">Jaribu tena</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Usajili bado ni hai</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Usajili wako bado umewekwa kurejea. Ghairi katika Google Play kwanza, kisha rudi kununua kwa mara moja — kwa hiyo hutatozwa mara mbili.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Hatukuweza kuangalia hali ya usajili wako. Tafadhali angalia muunganisho wako na jaribu tena.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Tayari umeshanunua</string>
+    <string name="upgrades_gplay_already_owned_error_description">Tumia chaguo la \"Rejesha ununuzi\" kurejesha ununuzi wako. Ikiwa tatizo linaendelea, jaribu kuondoa akache ya Google Play na kuanzisha upya kifaa chako.</string>
+    <string name="upgrades_gplay_internal_error_title">Hitilafu ya Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Hitilafu ya ndani ya Google Play ilitokea. Tafadhali jaribu zifuatazo:\n\n• Anzisha upya kifaa chako\n• Ondoa akache ya Google Play Store\n• Jaribu baadaye</string>
+    <string name="upgrades_gplay_network_error_title">Hitilafu ya muunganisho</string>
+    <string name="upgrades_gplay_network_error_description">Haiwezi kuungana na Google Play. Tafadhali angalia muunganisho wako wa mtandao na jaribu tena.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play haipo</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager haiwezi kuunganika na Google Play. Je, Google Play imewekwa na iko ya kisasa? Je, akaunti yako ya Google imeingia? Jaribu kufuta kashe ya programu ya Google Play na kuanzisha upya kifaa chako.</string>
     <string name="upgrades_no_purchases_found_check_account">Hakuna ununuzi uliopatikana. Je, unatumia akaunti sahihi?</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">சந்தா வருடத்திற்கு %s செலவாகும்.</string>
     <string name="upgrade_screen_iap_action">ஒரு முறை வாங்குதல்</string>
     <string name="upgrade_screen_iap_action_hint">ஒரு முறை வாங்குதல் %s செலவாகும்.</string>
+    <string name="upgrade_screen_offer_divider_or">அல்லது</string>
+    <string name="upgrade_screen_offer_same_features">ஒரே அம்சங்கள், வெவ்வேறு விலை திட்டங்கள் மட்டுமே.</string>
     <string name="upgrade_screen_thanks_toast">நீங்கள் சிறந்தவர்! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">வாங்குதலை மீட்டமை</string>
+    <string name="upgrade_screen_restore_banner_title">ஏற்கனவே BVM Pro வாங்கியிருக்கிறீர்களா?</string>
+    <string name="upgrade_screen_restore_banner_body">இந்த சாதனத்தில் நீங்கள் முன்பு அப்‌கிரேட் செய்திருக்கிறீர்கள் போல் தெரிகிறது. உங்கள் கொள்முதலை மீட்டெடுத்து மீண்டும் திறக்கவும்.</string>
     <string name="upgrade_screen_restore_purchase_message">உங்கள் மேம்படுத்தல் அதே Google கணக்கில் உள்ள அனைத்து சாதனங்களிலும் செல்லுபடியாகும்.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">அங்கீகரிக்கப்படாத மேம்படுத்தல்களுக்கான சிக்கல் தீர்க்கும் குறிப்புகள்:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store ஒத்திசைவு நேரம் எடுக்கலாம். மறுதொடக்கம் செய்ய, Google Play தற்காலிக சேமிப்பை அழிக்க அல்லது காத்திருக்க முயற்சிக்கவும்.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">பல கணக்குகள் Google Playஐ குழப்பலாம். மற்ற கணக்குகளிலிருந்து வெளியேறவும் அல்லது Google Play வலைத்தளம் வழியாக நிறுவவும், இது குறிப்பிட்ட கணக்குடன் தொடர்புகளை கட்டாயப்படுத்துகிறது.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">உங்கள் Pro நிலையைப் பார்க்கவும்</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">வாழ்த்துக்கள்!</string>
+    <string name="upgrade_screen_owned_congrats_body">நீங்கள் BVM Pro பெற்றுவிட்டீர்கள் — வளர்ச்சிக்கு ஆதரவளிப்பதற்கு நன்றி. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">ஒரு முறை வாங்குதல்</string>
+    <string name="upgrade_screen_owned_iap_body">நீங்கள் BVM Pro ஐ என்றென்றும் சொந்தமாக வைத்துள்ளீர்கள். உங்கள் ஆதரவுக்கு நன்றி ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">சந்தா</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">உங்கள் BVM Pro சந்தாவு செயல்படுகிறது மற்றும் புதுப்பிக்க அமைக்கப்பட்டுள்ளது.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">உங்கள் BVM Pro சந்தாவு செயல்படுகிறது ஆனால் புதுப்பிக்கப்பட மாட்டாது. இது தற்போதைய காலத்தின் முடிவு வரை செல்லுபடியாக இருக்கும்.</string>
+    <string name="upgrade_screen_owned_both_warning">உங்களிடம் சந்தாவும் ஒரு முறை வாங்குதலும் உள்ளன. Google Play இல் சந்தாவை ரத்து செய்யவும், இல்லையெனில் மீண்டும் வசூல் செய்யப்படுவீர்கள்.</string>
+    <string name="upgrade_screen_manage_subscription">சந்தாவை நிர்வகி</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">ஒரு முறை வாங்குதலுக்கு மாறவும்</string>
+    <string name="upgrade_screen_switch_purchase_note">இது ஒரு தனிப்பட்ட ஒரு முறை வாங்குதல் ஆகும். இது உங்கள் சந்தாவை ரத்து செய்யாது அல்லது திரும்பப் பணம் தரவும் இல்லை, எனவே Google Play இலும் அதை ரத்து செய்யவும். இரண்டிற்கும் ஒரே Google கணக்கைப் பயன்படுத்தவும்.</string>
+    <string name="upgrade_screen_switch_locked_note">உங்கள் சந்தாவு இனி புதுப்பிக்க அமைக்கப்பட்டிராமல் இருக்கும் போது கிடைக்கிறது. மாற்ற Google Play இல் அதை ரத்து செய்யவும் — தற்போதைய காலம் முடிய வரை நீங்கள் Pro ஐ வைத்திருப்பீர்கள்.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">நிலை தவறாக தெரிகிறதா?</string>
+    <string name="upgrade_screen_status_restore_body">உங்கள் வாங்குதல் இங்கே தெரியவில்லையெனில், அதை மீட்டெடுக்க முயற்சிக்கவும்.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">உங்கள் வாங்குதலை உறுதிப்படுத்துகிறது</string>
+    <string name="upgrade_screen_grace_body_short">கொஞ்சம் நேரம் பொறுங்கள் — Google Play உடன் உங்கள் வாங்குதலை நாங்கள் மீண்டும் சரிபார்க்கிறோம்.</string>
+    <string name="upgrade_screen_grace_body">Google Play உடன் உங்கள் வாங்குதலை நாங்கள் இன்னும் உறுதிசெய்ய முடியவில்லை. அதை மீட்டெடுக்க முயற்சி செய்யவும் அல்லது சரியான கணக்கில் உள்நுழைந்துள்ளதா என்பதை சரிபார்க்கவும்.</string>
+    <string name="upgrade_screen_retry_action">மீண்டும் முயற்சி செய்க</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">சந்தா இன்னும் செயலில் உள்ளது</string>
+    <string name="upgrade_screen_sub_still_renewing_message">உங்கள் சந்தா இன்னும் புதுப்பிக்க வைக்கப்பட்டுள்ளது. முதலில் Google Play இல் அதை ரத்து செய்யவும், பிறகு திரும்பி வந்து ஒரு முறை வாங்குவனை வாங்கவும் — அப்படி செய்தால் உங்களிடம் இரண்டு முறை பணம் வசூல் செய்யப்பட மாட்டாது.</string>
+    <string name="upgrade_screen_sub_check_failed_message">உங்கள் சந்தா நிலைமையை நாங்கள் சரிபார்க்க முடியவில்லை. தயவுசெய்து உங்கள் இணைப்பைச் சரிபார்த்து மீண்டும் முயற்சி செய்யவும்.</string>
+    <string name="upgrades_gplay_already_owned_error_title">ஏற்கனவே வாங்கப்பட்டது</string>
+    <string name="upgrades_gplay_already_owned_error_description">உங்கள் வாங்குதலை மீட்டெடுக்க \"வாங்குதலை மீட்டெடு\" விருப்பத்தைப் பயன்படுத்தவும். சிக்கல் தொடர்ந்திருந்தால், Google Play சேமிப்பை அழிக்க முயற்சி செய்து உங்கள் சாதனத்தை மீண்டும் தொடங்கவும்.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play பிழை</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play வில் ஒரு உள்ளக பிழை ஏற்பட்டுள்ளது. தயவுசெய்து பின்வருவனவற்றை முயற்சி செய்யவும்:\n\n• உங்கள் சாதனத்தை மீண்டும் தொடங்கவும்\n• Google Play Store சேமிப்பை அழிக்கவும்\n• பிறகு மீண்டும் முயற்சி செய்யவும்</string>
+    <string name="upgrades_gplay_network_error_title">இணைப்பு பிழை</string>
+    <string name="upgrades_gplay_network_error_description">Google Play கு இணைய முடியவில்லை. தயவு செய்து உங்கள் இணைய இணைப்பை சரிபார்த்து மீண்டும் முயற்சி செய்யவும்.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play கிடைக்கவில்லை</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Playஆல் இணையமுடியவில்லை. Google Play நிறுவப்பட்டு புதுப்பிக்கப்பட்டதா? உங்கள் Google கணக்கு உள்நுழைகிறீர்களா? Google Play பயன்பாட்டுகள் தீளிப்பை அழித்து சாதனத்தை மறுதொடக்கம் செய்து முயற்சிக்கவும்.</string>
     <string name="upgrades_no_purchases_found_check_account">கொள்முதல்கள் எதுவும் இல்லை. நீங்கள் சரியான கணக்கைப் பயன்படுத்துகிறீர்களா?</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">ఏడాదికి చందా %s అవుతుంది.</string>
     <string name="upgrade_screen_iap_action">ఒకేసారి కొనేయి</string>
     <string name="upgrade_screen_iap_action_hint">ఒకేసారి కొనేయడానికి %s అవుతుంది.</string>
+    <string name="upgrade_screen_offer_divider_or">లేదా</string>
+    <string name="upgrade_screen_offer_same_features">అదే ఫీచర్‌లు, వేరు ధర నిర్ణయ విధానాలు.</string>
     <string name="upgrade_screen_thanks_toast">మీరు అత్యుత్తమం❤️</string>
     <string name="upgrade_screen_restore_purchase_action">కొనుగోలును పునరుద్ధరించండి</string>
+    <string name="upgrade_screen_restore_banner_title">ఇప్పటికే BVM Pro కొన్నారా?</string>
+    <string name="upgrade_screen_restore_banner_body">ఈ పరికరంలో మీరు ఇప్పటికే అప్‌గ్రేడ్ చేసినట్లుంది. దీన్ని మళ్లీ అన్‌లాక్ చేయడానికి మీ కొనుగోలు పునరుద్ధరించండి.</string>
     <string name="upgrade_screen_restore_purchase_message">మీ అప్‌గ్రేడ్ అదే Google ఖాతాలోని అన్ని పరికరాలలో చెల్లుబాటు అవుతుంది.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">గుర్తించబడని అప్‌గ్రేడ్‌ల కోసం ట్రబుల్‌షూటింగ్ చిట్కాలు:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store సమకాలీకరణ సమయం పట్టవచ్చు. రీబూట్ చేయడానికి, Google Play కాష్‌ని క్లియర్ చేయడానికి లేదా కేవలం వేచి ఉండటానికి ప్రయత్నించండి.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">బహుళ ఖాతాలు Google Playని గందరగోళానికి గురి చేయవచ్చు. ఇతర ఖాతాల నుండి లాగ్ అవుట్ చేయండి లేదా Google Play వెబ్‌సైట్ ద్వారా ఇన్‌స్టాల్ చేయండి, ఇది నిర్దిష్ట ఖాతాతో అనుబంధాలను బలవంతం చేస్తుంది.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">మీ ప్రో స్థితిని చూడండి</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">అభినందనలు!</string>
+    <string name="upgrade_screen_owned_congrats_body">మీకు BVM Pro ఉంది — అభివృద్ధిని సమర్థించినందుకు ధన్యవాదాలు। ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">ఒకేసారి కొనేయి</string>
+    <string name="upgrade_screen_owned_iap_body">మీరు BVM Pro ను శాశ్వతంగా సొంతం చేసుకున్నారు। మీ సమర్థనకు ధన్యవాదాలు ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">సభ్యత్వం</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">మీ BVM Pro సబ్‌స్క్రిప్షన్ క్రియాశీలంగా ఉంది మరియు పునరావృత్తి చేయడానికి సెట్ చేయబడింది.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">మీ BVM Pro సబ్‌స్క్రిప్షన్ క్రియాశీలంగా ఉంది కానీ పునరావృత్తి కాదు. ఇది ప్రస్తుత కాలం చివరి వరకు చెల్లుబాటుగా ఉంటుంది.</string>
+    <string name="upgrade_screen_owned_both_warning">మీరు సబ్‌స్క్రిప్షన్ మరియు ఒక్కసారి కొనుగోలు రెండూ కలిగి ఉన్నారు. Google Play లో సబ్‌స్క్రిప్షన్ను రద్దు చేయండి కాబట్టి మీకు మళ్ళీ చార్జ్ చేయబడదు.</string>
+    <string name="upgrade_screen_manage_subscription">సబ్‌స్క్రిప్షన్‌ను నిర్వహించండి</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">ఒక్కసారి కొనుగోలుకు మారండి</string>
+    <string name="upgrade_screen_switch_purchase_note">ఇది ఒక ప్రత్యేక ఒక్కసారి కొనుగోలు. ఇది మీ సబ్‌స్క్రిప్షన్‌ను రద్దు చేయదు లేదా తిరిగి ఇవ్వదు, కాబట్టి దానిని Google Play లో కూడా రద్దు చేయండి. రెండింటికీ ఒకే Google ఖాతాను ఉపయోగించండి.</string>
+    <string name="upgrade_screen_switch_locked_note">మీ సబ్‌స్క్రిప్షన్ ఇకపై పునరావృత్తి కానికి సెట్ చేయబడనప్పుడు అందుబాటులో ఉంటుంది. మారడానికి Google Play లో దానిని రద్దు చేయండి — ప్రస్తుత కాలం ముగిసే వరకు మీరు Pro ను ఉంచుకోగలరు.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">స్థితి తప్పుగా కనిపిస్తుందా?</string>
+    <string name="upgrade_screen_status_restore_body">మీ కొనుగోలు ఇక్కడ కనిపించకపోతే, దానిని పునరుద్ధరించడానికి ప్రయత్నించండి.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">మీ కొనుగోలును నిర్ధారిస్తోంది</string>
+    <string name="upgrade_screen_grace_body_short">వేచిఉండండి — మీ కొనుక్కోలను Google Play తనిఖీ చేస్తోంది.</string>
+    <string name="upgrade_screen_grace_body">మేము ఇప్పటికీ Google Play తో మీ కొనుక్కోలను నిర్ధారించలేకపోయాము. దీన్ని పునరుద్ధరించటానికి ప్రయత్నించండి, లేదా సరైన ఖాతాతో సైన్ ఇన్ చేసిఉన్నారో తనిఖీ చేయండి.</string>
+    <string name="upgrade_screen_retry_action">మళ్లీ ప్రయత్నించండి</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">సబ్‌స్క్రిప్షన్ ఇప్పటికీ క్రియాశీలంగా ఉంది</string>
+    <string name="upgrade_screen_sub_still_renewing_message">మీ సబ్‌స్క్రిప్షన్ ఇప్పటికీ పునరావృత్తికి సెట్ చేయబడి ఉంది. Google Play లో దీన్ని ముందుగా రద్దు చేసి, తర్వాత ఒక్కసారి కొనుగోలు కొరకు తిరిగి రండి — ఆ విధంగా మీరు రెండుసార్లు ఛార్జ్ చేయబడరు.</string>
+    <string name="upgrade_screen_sub_check_failed_message">మీ సబ్‌స్క్రిప్షన్ స్థితిని తనిఖీ చేయలేకపోయాము. దయచేసి మీ కనెక్షన్‌ను తనిఖీ చేసి, మళ్లీ ప్రయత్నించండి.</string>
+    <string name="upgrades_gplay_already_owned_error_title">ఇప్పటికే కొనుగోలు చేయబడింది</string>
+    <string name="upgrades_gplay_already_owned_error_description">మీ కొనుగోలును పునరుద్ధరించడానికి \"కొనుగోలును పునరుద్ధరించండి\" ఎంపికను ఉపయోగించండి. సమస్య కొనసాగితే, Google Play క్యాష్‌ను క్లిఅర్ చేసి మీ పరికరాన్ని పునరారంభించడానికి ప్రయత్నించండి.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play లోపం</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play లో అంతర్గత లోపం సంభవించింది. దయచేసి కిందివాటిని ప్రయత్నించండి:\n\n• మీ పరికరాన్ని పునరారంభించండి\n• Google Play Store క్యాష్‌ను క్లిఅర్ చేయండి\n• తర్వాత మళ్లీ ప్రయత్నించండి</string>
+    <string name="upgrades_gplay_network_error_title">కనెక్షన్ లోపం</string>
+    <string name="upgrades_gplay_network_error_description">Google Playకు కనెక్ట్ చేయలేకపోయాను. దయచేసి మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేసి మళ్ళీ ప్రయత్నించండి.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play అందుబాటులో లేదు</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play కి కనెక్ట్ కాలేకపోతోంది. Google Play ఇన్‌స్టాల్ చేయబడి అప్-టు-డేట్‌గా ఉందా? మీ Google అకౌంట్ లాగిన్ అయి ఉందా? Google Play యాప్ యొక్క కాష్‌ని క్లియర్ చేసి మీ పరికరాన్ని రీబూట్ చేయడానికి ప్రయత్నించండి.</string>
     <string name="upgrades_no_purchases_found_check_account">కొనుగోళ్లు కనుగొనబడలేదు. మీరు సరైన ఖాతాను ఉపయోగిస్తున్నారా?</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">การสมัครสมาชิกค่าใช้จ่าย %s ต่อปี</string>
     <string name="upgrade_screen_iap_action">ซื้อครั้งเดียว</string>
     <string name="upgrade_screen_iap_action_hint">การซื้อครั้งเดียวค่าใช้จ่าย %s</string>
+    <string name="upgrade_screen_offer_divider_or">หรือ</string>
+    <string name="upgrade_screen_offer_same_features">คุณสมบัติเดียวกัน แต่มีรูปแบบการจ่ายเงินที่แตกต่างกัน</string>
     <string name="upgrade_screen_thanks_toast">คุณเป็นคนที่ดีที่สุด! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">กู้คืนการซื้อ</string>
+    <string name="upgrade_screen_restore_banner_title">ซื้อ BVM Pro แล้วหรือ</string>
+    <string name="upgrade_screen_restore_banner_body">ดูเหมือนว่าคุณได้อัปเกรดบนอุปกรณ์นี้มาแล้ว คืนค่าการซื้อของคุณเพื่อปลดล็อกอีกครั้ง</string>
     <string name="upgrade_screen_restore_purchase_message">การอัปเกรดของคุณใช้ได้กับอุปกรณ์ต่างๆ ในบัญชี Google เดียวกัน</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">เคล็ดลับการแก้ไขปัญหาสำหรับการอัปเกรดที่ไม่ได้รับการยอมรับ:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">การซิงค์ Play Store อาจใช้เวลา ลองรีบูต ล้างแคช Google Play หรือรอสักครู่</string>
     <string name="upgrade_screen_restore_multiaccount_hint">บัญชีหลายบัญชีอาจทำให้ Google Play สับสน ออกจากบัญชีอื่นหรือติดตั้งผ่านเว็บไซต์ Google Play ซึ่งบังคับให้เชื่อมโยงกับบัญชีเฉพาะ</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">ดูสถานะ Pro ของคุณ</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">ยินดีด้วย</string>
+    <string name="upgrade_screen_owned_congrats_body">คุณได้ BVM Pro แล้ว — ขอบคุณที่สนับสนุนการพัฒนา ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">ซื้อครั้งเดียว</string>
+    <string name="upgrade_screen_owned_iap_body">คุณเป็นเจ้าของ BVM Pro ตลอดไป ขอบคุณสำหรับการสนับสนุนของคุณ ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">สมัครสมาชิก</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">การสมัครสมาชิก BVM Pro ของคุณใช้งานอยู่และจะต่ออายุโดยอัตโนมัติ</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">การสมัครสมาชิก BVM Pro ของคุณใช้งานอยู่แต่จะไม่ต่ออายุ ยังใช้ได้จนสิ้นสุดช่วงเวลาปัจจุบัน</string>
+    <string name="upgrade_screen_owned_both_warning">คุณมีทั้งการสมัครสมาชิกและการซื้อครั้งเดียว ยกเลิกการสมัครสมาชิกใน Google Play เพื่อไม่ให้ถูกเรียกเก็บเงินอีกครั้ง</string>
+    <string name="upgrade_screen_manage_subscription">จัดการการสมัครสมาชิก</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">เปลี่ยนไปใช้การซื้อครั้งเดียว</string>
+    <string name="upgrade_screen_switch_purchase_note">นี่คือการซื้อครั้งเดียวแยกต่างหาก ไม่ได้ยกเลิกหรือคืนเงินการสมัครสมาชิกของคุณ ต้องยกเลิกใน Google Play ด้วย ใช้บัญชี Google เดียวกันสำหรับทั้งสอง</string>
+    <string name="upgrade_screen_switch_locked_note">พร้อมใช้งานเมื่อการสมัครสมาชิกของคุณไม่ได้ตั้งค่าให้ต่ออายุอัตโนมัติอีกต่อไป ยกเลิกใน Google Play เพื่อเปลี่ยน — คุณจะเก็บ Pro ไว้จนกว่าช่วงเวลาปัจจุบันจะสิ้นสุด</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">สถานะดูเหมือนผิดหรือ</string>
+    <string name="upgrade_screen_status_restore_body">หากการซื้อของคุณไม่ปรากฏที่นี่ ลองคืนค่าเดิม</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">กำลังยืนยันการซื้อของคุณ</string>
+    <string name="upgrade_screen_grace_body_short">กรุณารอสักครู่ — เรากำลังตรวจสอบการซื้อของคุณกับ Google Play</string>
+    <string name="upgrade_screen_grace_body">เราไม่สามารถยืนยันการซื้อของคุณกับ Google Play ได้ ลองกู้คืนการซื้อ หรือตรวจสอบว่าคุณลงชื่อเข้าใช้ด้วยบัญชีที่ถูกต้อง</string>
+    <string name="upgrade_screen_retry_action">ลองใหม่</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">การสมัครสมาชิกยังใช้งานอยู่</string>
+    <string name="upgrade_screen_sub_still_renewing_message">การสมัครสมาชิกของคุณยังตั้งค่าให้ต่ออายุ ยกเลิกการสมัครใน Google Play ก่อน จากนั้นกลับมาซื้อแบบครั้งเดียว — ด้วยวิธีนี้คุณจะไม่ถูกเรียกเก็บเงินสองครั้ง</string>
+    <string name="upgrade_screen_sub_check_failed_message">เราไม่สามารถตรวจสอบสถานะการสมัครสมาชิกของคุณได้ โปรดตรวจสอบการเชื่อมต่อและลองใหม่</string>
+    <string name="upgrades_gplay_already_owned_error_title">ซื้อไปแล้ว</string>
+    <string name="upgrades_gplay_already_owned_error_description">ใช้ตัวเลือก \"กู้คืนการซื้อ\" เพื่อกู้คืนการซื้อของคุณ หากปัญหายังคงเกิดขึ้น ให้ลองล้างแคชของ Google Play และรีสตาร์ตอุปกรณ์ของคุณ</string>
+    <string name="upgrades_gplay_internal_error_title">ข้อผิดพลาด Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">เกิดข้อผิดพลาดภายในของ Google Play โปรดลองดำเนินการต่อไปนี้:\n\n• รีสตาร์ตอุปกรณ์ของคุณ\n• ล้างแคช Google Play Store\n• ลองใหม่ในภายหลัง</string>
+    <string name="upgrades_gplay_network_error_title">ข้อผิดพลาดในการเชื่อมต่อ</string>
+    <string name="upgrades_gplay_network_error_description">ไม่สามารถเชื่อมต่อกับ Google Play โปรดตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ไม่พร้อมใช้งาน</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ไม่สามารถเชื่อมต่อกับ Google Play ได้ Google Play ได้รับการติดตั้งและอัปเดตแล้วหรือไม่? บัญชี Google ของคุณเข้าสู่ระบบแล้วหรือไม่? ลองล้างแคชของแอป Google Play และรีบูตอุปกรณ์ของคุณ</string>
     <string name="upgrades_no_purchases_found_check_account">ไม่พบการซื้อ คุณใช้บัญชีที่ถูกต้องหรือไม่?</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Abonelik ücreti yıllık %s\'dir.</string>
     <string name="upgrade_screen_iap_action">Tek seferlik satın alma</string>
     <string name="upgrade_screen_iap_action_hint">Tek seferlik satın alma ücreti %s.</string>
+    <string name="upgrade_screen_offer_divider_or">veya</string>
+    <string name="upgrade_screen_offer_same_features">Aynı özellikler, sadece farklı fiyatlandırma modelleri.</string>
     <string name="upgrade_screen_thanks_toast">Çok teşekkürler! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Satın almayı geri yükle</string>
+    <string name="upgrade_screen_restore_banner_title">BVM Pro\'yu zaten satın aldınız mı?</string>
+    <string name="upgrade_screen_restore_banner_body">Bu cihazda daha önce yükseltme yaptığınız görülüyor. Bunu tekrar açmak için satın almayı geri yükleyin.</string>
     <string name="upgrade_screen_restore_purchase_message">Yükseltmeniz aynı Google hesabındaki cihazlar arasında geçerlidir.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Tanınmayan yükseltmeler için sorun giderme ipuçları:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store senkronizasyonu zaman alabilir. Yeniden başlatmayı, Google Play önbelleğini temizlemeyi deneyin veya sadece bekleyin.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Birden fazla hesap Google Play\'i karıştırabilir. Diğer hesaplardan çıkış yapın veya belirli bir hesapla ilişkilendirmeye zorlayan Google Play web sitesi üzerinden yükleyin.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Pro durumunuzu görüntüleyin</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Tebrikler!</string>
+    <string name="upgrade_screen_owned_congrats_body">BVM Pro\'ya sahipsiniz — geliştirmeyi desteklediğiniz için teşekkür ederiz. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Tek seferlik satın alma</string>
+    <string name="upgrade_screen_owned_iap_body">BVM Pro\'ya sonsuza dek sahipsiniz. Desteğiniz için teşekkür ederiz ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Abonelik</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">BVM Pro aboneliğiniz aktif ve yenilenecek şekilde ayarlanmış.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">BVM Pro aboneliğiniz aktif ama yenilenmeyecek. Mevcut dönemin sonuna kadar geçerli kalacak.</string>
+    <string name="upgrade_screen_owned_both_warning">Hem bir aboneliğiniz hem de tek seferlik bir satın almış durumdasınız. Tekrar ücretlendirilmemek için Google Play\'de aboneliği iptal edin.</string>
+    <string name="upgrade_screen_manage_subscription">Aboneliği yönet</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Tek seferlik satın almaya geç</string>
+    <string name="upgrade_screen_switch_purchase_note">Bu, ayrı bir tek seferlik satın almadır. Aboneliğinizi iptal etmez veya geri ödemez, bu yüzden bunu Google Play\'de de iptal edin. Her ikisi için aynı Google hesabını kullanın.</string>
+    <string name="upgrade_screen_switch_locked_note">Aboneliğiniz artık yenilenecek şekilde ayarlanmadığında kullanılabilir. Geçiş yapmak için Google Play\'de iptal edin — mevcut dönem sonuna kadar Pro\'ya sahip kalırsınız.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Durum yanlış mı görünüyor?</string>
+    <string name="upgrade_screen_status_restore_body">Satın almayı burada görmüyorsanız, geri yüklemeyi deneyin.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Satın alma onaylanıyor</string>
+    <string name="upgrade_screen_grace_body_short">Biraz bekleyin — satın alımınızı Google Play ile tekrar kontrol ediyoruz.</string>
+    <string name="upgrade_screen_grace_body">Satın alımınızı Google Play ile hâlâ doğrulayamıyoruz. Geri yüklemeyi deneyin veya doğru hesapla oturum açtığınızdan emin olun.</string>
+    <string name="upgrade_screen_retry_action">Yeniden dene</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Abonelik hâlâ aktif</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Aboneliğiniz hâlâ yenilenecek şekilde ayarlı. Önce Google Play\'de iptal edin, ardından tek seferlik satın almayı yapmak için geri dönün — böylece iki kez ücretlendirilmezsiniz.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Abonelik durumunuzu kontrol edemedik. Lütfen bağlantınızı kontrol edin ve tekrar deneyin.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Zaten satın alındı</string>
+    <string name="upgrades_gplay_already_owned_error_description">\"Satın almayı geri yükle\" seçeneğini kullanarak satın alımınızı geri yükleyin. Sorun devam ederse, Google Play Store önbelleğini temizleyin ve cihazınızı yeniden başlatın.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play hatası</string>
+    <string name="upgrades_gplay_internal_error_description">Bir iç Google Play hatası oluştu. Lütfen şunları deneyin:\n\n• Cihazınızı yeniden başlatın\n• Google Play Store önbelleğini temizleyin\n• Daha sonra tekrar deneyin</string>
+    <string name="upgrades_gplay_network_error_title">Bağlantı hatası</string>
+    <string name="upgrades_gplay_network_error_description">Google Play\'e bağlanılamıyor. Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play kullanılamıyor</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play\'e bağlanamıyor. Google Play yüklü ve güncel mi? Google Hesabınız ile oturum açtınız mı? Google Play uygulamasının önbelleğini temizlemeyi ve cihazınızı yeniden başlatmayı deneyin.</string>
     <string name="upgrades_no_purchases_found_check_account">Satın alma bulunamadı. Doğru hesabı mı kullanıyorsunuz?</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Вартість підписки становить %s на рік.</string>
     <string name="upgrade_screen_iap_action">Одноразова покупка</string>
     <string name="upgrade_screen_iap_action_hint">Вартість одноразової покупки становить %s.</string>
+    <string name="upgrade_screen_offer_divider_or">або</string>
+    <string name="upgrade_screen_offer_same_features">Ті ж самі функції, просто інші моделі ціноутворення.</string>
     <string name="upgrade_screen_thanks_toast">Ви найкращі! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Відновити покупку</string>
+    <string name="upgrade_screen_restore_banner_title">Вже придбали BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Схоже, ви вже оновлювалися на цьому пристрої раніше. Відновіть покупку, щоб розблокувати її знову.</string>
     <string name="upgrade_screen_restore_purchase_message">Ваше оновлення дійсне для всіх пристроїв, зареєстрованих в одному обліковому записі Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Поради щодо усунення несправностей у разі нерозпізнаних оновлень:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронізація Play Store може зайняти деякий час. Спробуйте перезавантажити, очистити кеш Google Play або просто почекати.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Кілька облікових записів можуть заплутати Google Play. Вийдіть з інших облікових записів або встановлюйте через вебсайт Google Play, який примушує асоціювати їх з певним обліковим записом.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Переглянути свій статус Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Вітаємо!</string>
+    <string name="upgrade_screen_owned_congrats_body">Ви отримали BVM Pro — дякуємо за підтримку розробки. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Одноразова покупка</string>
+    <string name="upgrade_screen_owned_iap_body">Ви володієте BVM Pro назавжди. Дякуємо за вашу підтримку ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Підписка</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Ваша підписка BVM Pro активна і буде автоматично поновлена.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Ваша підписка BVM Pro активна, але не буде поновлена. Вона діятиме до кінця поточного періоду.</string>
+    <string name="upgrade_screen_owned_both_warning">У вас є і підписка, і одноразова покупка. Скасуйте підписку в Google Play, щоб з вас більше не стягували плату.</string>
+    <string name="upgrade_screen_manage_subscription">Керувати підпискою</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Перейти на одноразову покупку</string>
+    <string name="upgrade_screen_switch_purchase_note">Це окрема одноразова покупка. Вона не скасовує підписку і не повертає за неї кошти, тому скасуйте підписку в Google Play окремо. Використовуйте той самий обліковий запис Google для обох.</string>
+    <string name="upgrade_screen_switch_locked_note">Доступно, коли ваша підписка більше не буде поновлюватися автоматично. Скасуйте її в Google Play, щоб перейти — ви збережете Pro до кінця поточного періоду.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Статус виглядає неправильно?</string>
+    <string name="upgrade_screen_status_restore_body">Якщо ваша покупка тут не відображається, спробуйте відновити її.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Підтвердження покупки</string>
+    <string name="upgrade_screen_grace_body_short">Зачекайте — ми перевіряємо вашу покупку в Google Play.</string>
+    <string name="upgrade_screen_grace_body">Ми все ще не можемо підтвердити вашу покупку в Google Play. Спробуйте відновити її або перевірте, чи ви ввійшли під правильним обліковим записом.</string>
+    <string name="upgrade_screen_retry_action">Повторити</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Підписка все ще активна</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Ваша підписка все ще налаштована на автоматичне поновлення. Спочатку скасуйте її в Google Play, а потім поверніться, щоб придбати одноразову покупку — так з вас не стягнуть плату двічі.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Не вдалося перевірити статус вашої підписки. Перевірте з\'єднання і спробуйте ще раз.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Вже придбано</string>
+    <string name="upgrades_gplay_already_owned_error_description">Скористайтеся опцією «Відновити покупку», щоб відновити свою покупку. Якщо проблема не зникає, спробуйте очистити кеш Google Play і перезавантажити пристрій.</string>
+    <string name="upgrades_gplay_internal_error_title">Помилка Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Сталася внутрішня помилка Google Play. Спробуйте виконати наступні дії:\n\n• Перезапустіть пристрій\n• Очистіть кеш Google Play Store\n• Спробуйте пізніше</string>
+    <string name="upgrades_gplay_network_error_title">Помилка підключення</string>
+    <string name="upgrades_gplay_network_error_description">Неможливо підключитися до Google Play. Перевірте підключення до Інтернету та спробуйте ще раз.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play недоступний</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може підключитися до Google Play. Google Play встановлений та оновлений? Ви увійшли до облікового запису Google? Спробуйте очистити кеш Google Play та перезавантажити пристрій.</string>
     <string name="upgrades_no_purchases_found_check_account">Покупки не знайдено. Ви використовуєте правильний обліковий запис?</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">سبسکرپشن کی قیمت %s سالانہ ہے۔</string>
     <string name="upgrade_screen_iap_action">ایک بار کی خریداری</string>
     <string name="upgrade_screen_iap_action_hint">ایک بار کی خریداری کی قیمت %s ہے۔</string>
+    <string name="upgrade_screen_offer_divider_or">یا</string>
+    <string name="upgrade_screen_offer_same_features">ایک جیسی خصوصیات، بس مختلف قیمت کے منصوبے۔</string>
     <string name="upgrade_screen_thanks_toast">آپ بہترین ہیں! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">خریداری بحال کریں</string>
+    <string name="upgrade_screen_restore_banner_title">پہلے سے BVM Pro خریدا ہے؟</string>
+    <string name="upgrade_screen_restore_banner_body">ایسا لگتا ہے کہ آپ نے اس ڈیوائس پر پہلے اپ گریڈ کیا تھا۔ اسے دوبارہ آن لاک کرنے کے لیے اپنی خریداری بحال کریں۔</string>
     <string name="upgrade_screen_restore_purchase_message">آپ کی اپ گریڈ ایک ہی Google اکاؤنٹ پر ڈیوائسز پر درست ہے۔</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">غیر تسلیم شدہ اپ گریڈز کے لیے ٹربل شوٹنگ ٹپس:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store سنک میں وقت لگ سکتا ہے۔ ری بوٹ کرنے، Google Play کیش صاف کرنے یا صرف انتظار کرنے کی کوشش کریں۔</string>
     <string name="upgrade_screen_restore_multiaccount_hint">متعدد اکاؤنٹس Google Play کو الجھا سکتے ہیں۔ دیگر اکاؤنٹس سے لاگ آوٹ کریں یا Google Play ویب سائٹ کے ذریعے انسٹال کریں، جو مخصوص اکاؤنٹ کے ساتھ ایسوسی ایشن کو مجبور کرتا ہے۔</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">اپنی Pro حالت دیکھیں</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">مبارک ہو!</string>
+    <string name="upgrade_screen_owned_congrats_body">آپ کے پاس BVM Pro ہے — ترقی میں معاونت کے لیے شکریہ۔ ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">ایک بار کی خریداری</string>
+    <string name="upgrade_screen_owned_iap_body">آپ BVM Pro کو ہمیشہ کے لیے رکھتے ہیں۔ آپ کی معاونت کے لیے شکریہ ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">رکنیت</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">آپ کی BVM Pro رکنیت فعال ہے اور تجدید کے لیے مقرر ہے۔</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">آپ کی BVM Pro رکنیت فعال ہے لیکن تجدید نہیں ہوگی۔ یہ موجودہ مدت کے اختتام تک درست رہے گی۔</string>
+    <string name="upgrade_screen_owned_both_warning">آپ کے پاس رکنیت اور ایک بار خریداری دونوں ہیں۔ Google Play میں رکنیت منسوخ کریں تاکہ آپ سے دوبارہ چارج نہ کیا جائے۔</string>
+    <string name="upgrade_screen_manage_subscription">رکنیت کا نظم کریں</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">ایک بار خریداری پر تبدیل کریں</string>
+    <string name="upgrade_screen_switch_purchase_note">یہ الگ ایک بار خریداری ہے۔ یہ آپ کی رکنیت کو منسوخ یا واپسی نہیں کرتی ہے، تو Google Play میں بھی اسے منسوخ کریں۔ دونوں کے لیے اسی Google اکاؤنٹ کا استعمال کریں۔</string>
+    <string name="upgrade_screen_switch_locked_note">دستیاب ہے جب آپ کی رکنیت اب تجدید کے لیے مقرر نہ ہو۔ منتقل کرنے کے لیے Google Play میں اسے منسوخ کریں — آپ موجودہ مدت کے اختتام تک Pro رکھیں۔</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">حالت غلط لگ رہی ہے؟</string>
+    <string name="upgrade_screen_status_restore_body">اگر آپ کی خریداری یہاں نظر نہیں آ رہی ہے، تو اسے بحال کرنے کی کوشش کریں۔</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">آپ کی خریداری کی تصدیق کی جا رہی ہے</string>
+    <string name="upgrade_screen_grace_body_short">صبر کریں — ہم آپ کی خریداری کو Google Play کے ساتھ دوبارہ جانچ رہے ہیں۔</string>
+    <string name="upgrade_screen_grace_body">ہم ابھی بھی آپ کی خریداری کو Google Play کے ساتھ تصدیق نہیں کر سکتے۔ اسے بحال کرنے کی کوشش کریں، یا یقینی بنائیں کہ آپ صحیح اکاؤنٹ کے ساتھ سائن ان ہیں۔</string>
+    <string name="upgrade_screen_retry_action">دوبارہ کوشش کریں</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">رکنیت ابھی فعال ہے</string>
+    <string name="upgrade_screen_sub_still_renewing_message">آپ کی رکنیت ابھی بھی تجدید کے لیے سیٹ ہے۔ پہلے اسے Google Play میں منسوخ کریں، پھر واپس آئیں اور ایک بار کی خریداری کریں — اس طریقے آپ سے دوہری رقم نہیں لی جائے گی۔</string>
+    <string name="upgrade_screen_sub_check_failed_message">ہم آپ کی رکنیت کی حالت کو چیک نہیں کر سکے۔ براہ کرم اپنا کنکشن چیک کریں اور دوبارہ کوشش کریں۔</string>
+    <string name="upgrades_gplay_already_owned_error_title">پہلے سے خریدا گیا</string>
+    <string name="upgrades_gplay_already_owned_error_description">اپنی خریداری کو بحال کرنے کے لیے \"خریداری بحال کریں\" آپشن استعمال کریں۔ اگر مسئلہ برقرار ہے، تو Google Play کیش صاف کرنے اور اپنے ڈیوائس کو دوبارہ شروع کرنے کی کوشش کریں۔</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play خرابی</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play میں ایک اندرونی خرابی واقع ہوئی ہے۔ براہ کرم درج ذیل کی کوشش کریں:\n\n• اپنے ڈیوائس کو دوبارہ شروع کریں\n• Google Play Store کیش صاف کریں\n• بعد میں دوبارہ کوشش کریں</string>
+    <string name="upgrades_gplay_network_error_title">کنکشن میں خرابی</string>
+    <string name="upgrades_gplay_network_error_description">Google Play سے جڑ نہیں سکے۔ براہ کرم اپنی انٹرنیٹ کنکشن چیک کریں اور دوبارہ کوشش کریں۔</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play دستیاب نہیں ہے</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager گوگل پلے سے منسلک نہیں ہو سکتا۔ کیا گوگل پلے نصب اور تازہ کاری ہے؟ کیا آپ کا گوگل اکاؤنٹ لاگ ان ہے؟ گوگل پلے ایپ کیں صاف کریں اور ڈیوائس ریبوٹ کریں۔</string>
     <string name="upgrades_no_purchases_found_check_account">کوئی خریداری نہیں ملی۔ کیا آپ صحیح اکاؤنٹ استعمال کر رہے ہیں؟</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Obuna yiliga %s turadi.</string>
     <string name="upgrade_screen_iap_action">Bir martalik xarid</string>
     <string name="upgrade_screen_iap_action_hint">Bir martalik xarid %s turadi.</string>
+    <string name="upgrade_screen_offer_divider_or">yoki</string>
+    <string name="upgrade_screen_offer_same_features">Bir xil xususiyatlar, faqat turli xil narx modellari.</string>
     <string name="upgrade_screen_thanks_toast">Siz eng zo\'rsiz! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Xaridni tiklash</string>
+    <string name="upgrade_screen_restore_banner_title">Allaqachon BVM Pro sotib oldingizmi?</string>
+    <string name="upgrade_screen_restore_banner_body">Ko\'rinadi, bu qurilmada oldindan yangilagan edingiz. Xaridingizni tiklang.</string>
     <string name="upgrade_screen_restore_purchase_message">Sizning yanglanishingiz bir xil Google hisobidagi qurilmalarda amal qiladi.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Tan olinmagan yangilanishlar uchun muammolarni hal qilish maslahatlari:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sinxronlashtiruvi vaqt olishi mumkin. Qayta ishga tushirish, Google Play keshini tozalash yoki shunchaki kutishni sinab ko\'ring.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Ko\'p hisoblar Google Play-ni chalkashtirib yuborishi mumkin. Boshqa hisoblardan chiqing yoki Google Play veb-sayti orqali o\'rnating, bu esa ma\'lum bir hisob bilan bog\'lanishni majburiy qiladi.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Pro statusini ko\'ring</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Tabriklaymiz!</string>
+    <string name="upgrade_screen_owned_congrats_body">Siz BVM Pro-ni oldingiz — rivojlanishni qo\'llab-quvvatlashingiz uchun rahmat. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Bir martalik xarid</string>
+    <string name="upgrade_screen_owned_iap_body">Siz BVM Pro-ni abadiy egalaysiz. Qo\'llab-quvvatlashingiz uchun rahmat ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Obuna</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Sizning BVM Pro obunangiz faol va qayta yangilanishga o\'rnatilgan.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Sizning BVM Pro obunangiz faol, lekin qayta yangilanmaydi. U joriy davr oxirigacha amal qiladi.</string>
+    <string name="upgrade_screen_owned_both_warning">Sizda ham obuna va bir martalik xarid mavjud. Google Play\'da obunani bekor qiling, shunda yana hisoblanmaysiz.</string>
+    <string name="upgrade_screen_manage_subscription">Obunani boshqarish</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Bir martalik xaridga o\'ting</string>
+    <string name="upgrade_screen_switch_purchase_note">Bu alohida bir martalik xariddir. U sizning obunangizni bekor qilmaydi yoki pul qaytarmaydi, shuning uchun buni Google Play\'da ham bekor qiling. Ikkalasi uchun ham bir xil Google hisobini ishlating.</string>
+    <string name="upgrade_screen_switch_locked_note">Sizning obunangiz qayta yangilanishga o\'rnatilmagan bo\'lgach mavjud bo\'ladi. O\'tish uchun uni Google Play\'da bekor qiling — siz joriy davr oxirigacha Pro sifatida qolasiz.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Holat noto\'g\'rimi ko\'rinmoqda?</string>
+    <string name="upgrade_screen_status_restore_body">Agar sizning xaridingiz bu yerda ko\'rinmasa, uni tiklashni harakat qiling.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Sizning xaridingiz tasdiqlanmoqda</string>
+    <string name="upgrade_screen_grace_body_short">Sabr qiling — biz sizning Google Play-dagi xaridingizni qayta tekshiryapmiz.</string>
+    <string name="upgrade_screen_grace_body">Biz hali ham sizning Google Play-dagi xaridingizni tasdiqlay olmayapmiz. Uni tiklashga harakat qiling yoki to\'g\'ri hisob bilan kirganingizni tekshiring.</string>
+    <string name="upgrade_screen_retry_action">Qayta harakat qiling</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Obuna hali ham faol</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Sizning obunangiz hali ham yangilashga o\'rnatilib boradi. Avval Google Play-da uni bekor qiling, so\'ng bir marta xaridni sotib olish uchun qaytib keling — shu tarzda sizdan ikki marta to\'lov qilinmaydi.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Biz sizning obunaning holatini tekshire olmadik. Iltimos, ulanishni tekshiring va qayta harakat qiling.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Allaqachon sotib olingan</string>
+    <string name="upgrades_gplay_already_owned_error_description">Xaridingizni tiklash uchun \"Xaridni tiklash\" variantidan foydalaning. Agar muammo davom etsa, Google Play keshini o\'chirib, qurilmangizni qayta ishga tushiring.</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play xatosi</string>
+    <string name="upgrades_gplay_internal_error_description">Google Play-da ichki xato yuz berdi. Iltimos, quyidagi amallarni bajarib ko\'ring:\n\n• Qurilmangizni qayta ishga tushiring\n• Google Play Store keshini o\'chiring\n• Keyinroq qayta harakat qiling</string>
+    <string name="upgrades_gplay_network_error_title">Ulanish xatosi</string>
+    <string name="upgrades_gplay_network_error_description">Google Play bilan bog\'lana olmadi. Iltimos, internet ulanishingizni tekshiring va qayta urinib ko\'ring.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play mavjud emas</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play ga ulana olmadi. Google Play o\'rnatilgan va yangilangan? Google hisobingizda kirgansizmi? Google Play ilovasi keshini tozalab, qurilmangizni qayta yoqishga urinib ko\'ring.</string>
     <string name="upgrades_no_purchases_found_check_account">Hech qanday xarid topilmadi. To\'g\'ri hisobdan foydalanyapsizmi?</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Chi phí đăng ký %s mỗi năm.</string>
     <string name="upgrade_screen_iap_action">Thanh toán một lần</string>
     <string name="upgrade_screen_iap_action_hint">Chi phí mua một lần là %s.</string>
+    <string name="upgrade_screen_offer_divider_or">hoặc</string>
+    <string name="upgrade_screen_offer_same_features">Cùng tính năng, chỉ khác mô hình giá.</string>
     <string name="upgrade_screen_thanks_toast">Bạn là nhất! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Khôi phục thanh toán</string>
+    <string name="upgrade_screen_restore_banner_title">Đã mua BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Có vẻ bạn đã nâng cấp trên thiết bị này trước đó. Khôi phục giao dịch mua để mở khóa lại.</string>
     <string name="upgrade_screen_restore_purchase_message">Bản nâng cấp của bạn hợp lệ trên các thiết bị trên cùng một tài khoản Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Mẹo khắc phục sự cố cho các bản nâng cấp không được nhận dạng:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Đồng bộ hóa Cửa hàng Play có thể mất thời gian. Hãy thử khởi động lại, xóa bộ nhớ đệm của Google Play hoặc chỉ cần đợi.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Nhiều tài khoản có thể gây nhầm lẫn cho Google Play. Đăng xuất khỏi các tài khoản khác hoặc cài đặt thông qua trang web Google Play, trang này buộc liên kết với một tài khoản cụ thể.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Xem trạng thái Pro của bạn</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Chúc mừng!</string>
+    <string name="upgrade_screen_owned_congrats_body">Bạn đã có BVM Pro — cảm ơn bạn đã ủng hộ quá trình phát triển. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Thanh toán một lần</string>
+    <string name="upgrade_screen_owned_iap_body">Bạn sở hữu BVM Pro vĩnh viễn. Cảm ơn sự ủng hộ của bạn ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Gói đăng ký</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Gói đăng ký BVM Pro của bạn đang hoạt động và sẽ tự động gia hạn.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Gói đăng ký BVM Pro của bạn đang hoạt động nhưng sẽ không gia hạn. Gói vẫn có hiệu lực đến hết kỳ hiện tại.</string>
+    <string name="upgrade_screen_owned_both_warning">Bạn có cả gói đăng ký và giao dịch mua một lần. Hãy hủy gói đăng ký trong Google Play để không bị tính phí lần nữa.</string>
+    <string name="upgrade_screen_manage_subscription">Quản lý gói đăng ký</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Chuyển sang mua một lần</string>
+    <string name="upgrade_screen_switch_purchase_note">Đây là một giao dịch mua một lần riêng biệt. Nó không hủy hay hoàn tiền gói đăng ký của bạn, vì vậy hãy hủy gói đó trong Google Play luôn. Sử dụng cùng một tài khoản Google cho cả hai.</string>
+    <string name="upgrade_screen_switch_locked_note">Chỉ khả dụng khi gói đăng ký của bạn không còn được đặt để gia hạn. Hủy gói đó trong Google Play để chuyển đổi — bạn vẫn giữ Pro đến khi kỳ hiện tại kết thúc.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Trạng thái có vẻ không đúng?</string>
+    <string name="upgrade_screen_status_restore_body">Nếu giao dịch mua của bạn không hiển thị ở đây, hãy thử khôi phục lại.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Đang xác nhận giao dịch mua của bạn</string>
+    <string name="upgrade_screen_grace_body_short">Chờ chút — chúng tôi đang kiểm tra lại giao dịch mua của bạn với Google Play.</string>
+    <string name="upgrade_screen_grace_body">Chúng tôi vẫn chưa thể xác nhận giao dịch mua của bạn với Google Play. Hãy thử khôi phục lại, hoặc kiểm tra xem bạn đã đăng nhập đúng tài khoản chưa.</string>
+    <string name="upgrade_screen_retry_action">Thử lại</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">Gói đăng ký vẫn đang hoạt động</string>
+    <string name="upgrade_screen_sub_still_renewing_message">Gói đăng ký của bạn vẫn được đặt để gia hạn. Hãy hủy gói đó trong Google Play trước, sau đó quay lại mua giao dịch một lần — như vậy bạn sẽ không bị tính phí hai lần.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Chúng tôi không thể kiểm tra trạng thái gói đăng ký của bạn. Vui lòng kiểm tra kết nối và thử lại.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Đã mua</string>
+    <string name="upgrades_gplay_already_owned_error_description">Sử dụng tùy chọn \"Khôi phục giao dịch mua\" để khôi phục giao dịch mua của bạn. Nếu vấn đề vẫn tiếp diễn, hãy thử xóa bộ nhớ đệm Google Play và khởi động lại thiết bị của bạn.</string>
+    <string name="upgrades_gplay_internal_error_title">Lỗi Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Đã xảy ra lỗi nội bộ của Google Play. Vui lòng thử những điều sau:\n\n• Khởi động lại thiết bị của bạn\n• Xóa bộ nhớ cache của Google Play Store\n• Thử lại sau</string>
+    <string name="upgrades_gplay_network_error_title">Lỗi kết nối</string>
+    <string name="upgrades_gplay_network_error_description">Không thể kết nối với Google Play. Vui lòng kiểm tra kết nối internet của bạn và thử lại.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play không khả dụng</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager không thể kết nối với Google Play. Google Play đã được cài đặt và cập nhật chưa? Bạn đã đăng nhập tài khoản Google chưa? Hãy thử xóa bộ nhớ cache của ứng dụng Google Play và khởi động lại thiết bị.</string>
     <string name="upgrades_no_purchases_found_check_account">Không tìm thấy giao dịch nào. Bạn có đang sử dụng đúng tài khoản không?</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">每年的订阅费用为 %s。</string>
     <string name="upgrade_screen_iap_action">一次性购买</string>
     <string name="upgrade_screen_iap_action_hint">一次性购买费用为 %s。</string>
+    <string name="upgrade_screen_offer_divider_or">或</string>
+    <string name="upgrade_screen_offer_same_features">功能相同,只是定价模式不同。</string>
     <string name="upgrade_screen_thanks_toast">您最棒了！❤️</string>
     <string name="upgrade_screen_restore_purchase_action">恢复购买</string>
+    <string name="upgrade_screen_restore_banner_title">已经购买过 BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">看起来您之前在此设备上升级过。恢复您的购买以再次解锁。</string>
     <string name="upgrade_screen_restore_purchase_message">购买在同一 Google 账户的所有设备上都有效。</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">无法识别购买的故障排除提示：</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play 商店同步可能需要一些时间。尝试重启设备、清除 Google Play 缓存或稍作等候。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">多个账户可能会导致 Google Play 混乱。注销其他账户或通过 Google Play 网站进行安装，这可强制与特定账户关联。</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">查看您的 Pro 状态</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">恭喜!</string>
+    <string name="upgrade_screen_owned_congrats_body">您已获得 BVM Pro — 感谢您支持开发。❤️</string>
+    <string name="upgrade_screen_owned_iap_title">一次性购买</string>
+    <string name="upgrade_screen_owned_iap_body">您永远拥有 BVM Pro。感谢您的支持 ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">订阅</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">您的 BVM Pro 订阅处于活跃状态,已设置为自动续订。</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">您的 BVM Pro 订阅处于活跃状态,但不会自动续订。它将保持有效期至当前周期结束。</string>
+    <string name="upgrade_screen_owned_both_warning">您同时拥有订阅和一次性购买。请在 Google Play 中取消订阅,以避免重复扣费。</string>
+    <string name="upgrade_screen_manage_subscription">管理订阅</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">切换为一次性购买</string>
+    <string name="upgrade_screen_switch_purchase_note">这是一个独立的一次性购买。它不会取消或退款您的订阅,因此也需在 Google Play 中取消订阅。两者请使用同一个 Google 账户。</string>
+    <string name="upgrade_screen_switch_locked_note">订阅停止自动续订后即可使用。请在 Google Play 中取消订阅以切换 — 您将保有 Pro 权限至当前周期结束。</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">状态显示有误？</string>
+    <string name="upgrade_screen_status_restore_body">如果您的购买未显示在此处,请尝试恢复购买。</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">正在确认您的购买</string>
+    <string name="upgrade_screen_grace_body_short">请稍候 — 我们正在与 Google Play 核实您的购买。</string>
+    <string name="upgrade_screen_grace_body">我们仍然无法与 Google Play 确认您的购买。请尝试恢复购买,或检查您是否使用正确的账户登录。</string>
+    <string name="upgrade_screen_retry_action">重试</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">订阅仍然有效</string>
+    <string name="upgrade_screen_sub_still_renewing_message">您的订阅仍设置为续订。请先在 Google Play 中取消订阅,然后返回购买一次性购买项目 — 这样您就不会被收费两次。</string>
+    <string name="upgrade_screen_sub_check_failed_message">我们无法检查您的订阅状态。请检查您的连接并重试。</string>
+    <string name="upgrades_gplay_already_owned_error_title">已购买</string>
+    <string name="upgrades_gplay_already_owned_error_description">使用“恢复购买”选项来恢复您的购买。如果问题仍然存在,请尝试清除 Google Play 缓存并重启您的设备。</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play 错误</string>
+    <string name="upgrades_gplay_internal_error_description">发生 Google Play 内部错误。请尝试以下操作：\n\n• 重启您的设备\n• 清除 Google Play Store 缓存\n• 稍后再试</string>
+    <string name="upgrades_gplay_network_error_title">连接错误</string>
+    <string name="upgrades_gplay_network_error_description">无法连接到 Google Play。请检查您的互联网连接并重试。</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play 不可用</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager 无法连接到 Google Play。Google Play 是否已安装并更新至最新版本？您的 Google 账户是否已登录？请尝试清除 Google Play 应用的缓存并重启设备。</string>
     <string name="upgrades_no_purchases_found_check_account">未找到任何购买记录。您确定账号正确吗？</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">訂閱費用為 %s 每年。</string>
     <string name="upgrade_screen_iap_action">一次購買</string>
     <string name="upgrade_screen_iap_action_hint">一次購買的費用為 %s。</string>
+    <string name="upgrade_screen_offer_divider_or">或</string>
+    <string name="upgrade_screen_offer_same_features">相同功能，只是定價模式不同。</string>
     <string name="upgrade_screen_thanks_toast">您是最棒的！❤️</string>
     <string name="upgrade_screen_restore_purchase_action">恢復購買</string>
+    <string name="upgrade_screen_restore_banner_title">已購買 BVM Pro？</string>
+    <string name="upgrade_screen_restore_banner_body">看起來您曾在此裝置上升級過。恢復您的購買以重新解鎖。</string>
     <string name="upgrade_screen_restore_purchase_message">您的升級在同一 Google 帳戶的裝置上有效。</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">無法識別升級的故障排除提示：</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store 同步可能需要時間。嘗試重新啟動、清除 Google Play 快取或只是等待。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">多個帳戶可能會混淆 Google Play。從其他帳戶登出或透過 Google Play 網站安裝，這會強制與特定帳戶建立關聯。</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">檢視您的 Pro 狀態</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">恭喜！</string>
+    <string name="upgrade_screen_owned_congrats_body">您已獲得 BVM Pro — 感謝您支持開發。❤️</string>
+    <string name="upgrade_screen_owned_iap_title">一次購買</string>
+    <string name="upgrade_screen_owned_iap_body">您永遠擁有 BVM Pro。感謝您的支持 ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">訂閱</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">你的 BVM Pro 訂閱已啟用並設定為續訂。</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">你的 BVM Pro 訂閱已啟用但不會續訂。訂閱在目前期間結束前將保持有效。</string>
+    <string name="upgrade_screen_owned_both_warning">你同時擁有訂閱和一次性購買。請在 Google Play 中取消訂閱以避免再次被扣費。</string>
+    <string name="upgrade_screen_manage_subscription">管理訂閱</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">改用一次性購買</string>
+    <string name="upgrade_screen_switch_purchase_note">這是一個獨立的一次性購買。它不會取消或退款你的訂閱，因此亦需在 Google Play 中取消訂閱。請為兩者使用相同的 Google 帳戶。</string>
+    <string name="upgrade_screen_switch_locked_note">當訂閱不再設定為自動續訂後即可使用。在 Google Play 中取消訂閱以切換 — 目前期間結束前你將保留 Pro。</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">狀態看起來不對？</string>
+    <string name="upgrade_screen_status_restore_body">如果你的購買未顯示於此，請嘗試還原。</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">確認購買中</string>
+    <string name="upgrade_screen_grace_body_short">稍等 — 我們正在與 Google Play 確認您的購買。</string>
+    <string name="upgrade_screen_grace_body">我們仍無法與 Google Play 確認您的購買。嘗試還原購買，或檢查您是否使用正確的帳戶登入。</string>
+    <string name="upgrade_screen_retry_action">重試</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">訂閱仍然有效</string>
+    <string name="upgrade_screen_sub_still_renewing_message">您的訂閱仍設定為續約。請先在 Google Play 中取消，然後回來購買一次性購買 — 這樣就不會被收費兩次。</string>
+    <string name="upgrade_screen_sub_check_failed_message">我們無法檢查您的訂閱狀態。請檢查您的連線並重試。</string>
+    <string name="upgrades_gplay_already_owned_error_title">已購買</string>
+    <string name="upgrades_gplay_already_owned_error_description">使用「還原購買」選項來還原您的購買。如果問題仍然存在，請嘗試清除 Google Play 快取並重新啟動您的裝置。</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play 錯誤</string>
+    <string name="upgrades_gplay_internal_error_description">發生內部 Google Play 錯誤。請嘗試以下操作：\n\n• 重新啟動您的裝置\n• 清除 Google Play Store 快取\n• 稍後再試</string>
+    <string name="upgrades_gplay_network_error_title">連接錯誤</string>
+    <string name="upgrades_gplay_network_error_description">無法連接 Google Play。請檢查您的網際網路連接並重試。</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play 無法使用</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager 無法連接 Google Play。Google Play 已安裝且是最新版本？你的 Google 帳戶已登入？請嘗試清除 Google Play 應用的快取並重新啟動裝置。</string>
     <string name="upgrades_no_purchases_found_check_account">找不到購買，您正在使用正確的帳戶嗎？</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">訂閱費用為 %s 每年。</string>
     <string name="upgrade_screen_iap_action">一次購買</string>
     <string name="upgrade_screen_iap_action_hint">一次購買的費用為 %s。</string>
+    <string name="upgrade_screen_offer_divider_or">或</string>
+    <string name="upgrade_screen_offer_same_features">功能一樣，只是定價模式不同。</string>
     <string name="upgrade_screen_thanks_toast">您是最棒的！❤️</string>
     <string name="upgrade_screen_restore_purchase_action">還原購買</string>
+    <string name="upgrade_screen_restore_banner_title">已經買過 BVM Pro？</string>
+    <string name="upgrade_screen_restore_banner_body">看起來您之前在此裝置上已升級過。還原您的購買以再次解鎖。</string>
     <string name="upgrade_screen_restore_purchase_message">您的升級在同一 Google 帳戶的所有裝置上都有效。</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">無法辨識升級的疑難排解提示：</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Play 商店同步處理可能需要一些時間。請嘗試重新開機、清除 Google Play 快取或只需等候。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">多重帳戶可能會導致 Google Play 混亂。登出其他帳戶或透過 Google Play 網站安裝，這會強制與特定帳戶關聯。</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">查看您的 Pro 狀態</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">恭喜！</string>
+    <string name="upgrade_screen_owned_congrats_body">您已獲得 BVM Pro——謝謝您支持開發。❤️</string>
+    <string name="upgrade_screen_owned_iap_title">一次購買</string>
+    <string name="upgrade_screen_owned_iap_body">您永遠擁有 BVM Pro。感謝您的支持 ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">訂閱</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">您的 BVM Pro 訂閱處於有效狀態且將續訂。</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">您的 BVM Pro 訂閱處於有效狀態但不會續訂。它在目前期間結束前保持有效。</string>
+    <string name="upgrade_screen_owned_both_warning">您同時擁有訂閱和一次性購買。請在 Google Play 中取消訂閱以避免再次收費。</string>
+    <string name="upgrade_screen_manage_subscription">管理訂閱</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">切換為一次性購買</string>
+    <string name="upgrade_screen_switch_purchase_note">這是獨立的一次性購買。它不會取消或退款您的訂閱，因此請也在 Google Play 中取消該訂閱。兩者請使用同一個 Google 帳戶。</string>
+    <string name="upgrade_screen_switch_locked_note">當您的訂閱不再設定為續訂後即可使用。在 Google Play 中取消訂閱以進行切換 — 您將保持 Pro 狀態直到目前期間結束。</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">狀態看起來有誤？</string>
+    <string name="upgrade_screen_status_restore_body">如果您的購買未顯示在這裡，請嘗試還原它。</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">確認您的購買</string>
+    <string name="upgrade_screen_grace_body_short">稍等一下 — 我們正在透過 Google Play 驗證您的購買。</string>
+    <string name="upgrade_screen_grace_body">我們仍無法透過 Google Play 確認您的購買。請嘗試還原購買，或檢查您是否使用正確帳戶登入。</string>
+    <string name="upgrade_screen_retry_action">重試</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">訂閱仍然有效</string>
+    <string name="upgrade_screen_sub_still_renewing_message">您的訂閱仍設定為自動續約。請先在 Google Play 中取消訂閱，然後回來購買一次性版本 — 這樣您就不會被重複收費。</string>
+    <string name="upgrade_screen_sub_check_failed_message">我們無法檢查您的訂閱狀態。請檢查您的網路連線並再試一次。</string>
+    <string name="upgrades_gplay_already_owned_error_title">已購買</string>
+    <string name="upgrades_gplay_already_owned_error_description">使用「還原購買」選項來還原您的購買。如果問題仍未解決，請嘗試清除 Google Play 商店快取並重新啟動您的裝置。</string>
+    <string name="upgrades_gplay_internal_error_title">Google Play 錯誤</string>
+    <string name="upgrades_gplay_internal_error_description">發生 Google Play 內部錯誤。請嘗試以下操作：\n\n• 重新啟動您的裝置\n• 清除 Google Play 商店快取\n• 稍後再試</string>
+    <string name="upgrades_gplay_network_error_title">連線錯誤</string>
+    <string name="upgrades_gplay_network_error_description">無法連線到 Google Play。請檢查您的網際網路連線並重試。</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play 無法使用</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager 無法連接到 Google Play。Google Play 是否已安裝且為最新版本？您的 Google 帳戶是否已登入？請嘗試清除 Google Play 應用程式的快取並重新啟動您的裝置。</string>
     <string name="upgrades_no_purchases_found_check_account">找不到購買，您正在使用正確的帳戶嗎？</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -15,12 +15,51 @@
     <string name="upgrade_screen_subscription_action_hint">Ukubhalisela kubiza %s ngonyaka.</string>
     <string name="upgrade_screen_iap_action">Ukuthenga kube kanye</string>
     <string name="upgrade_screen_iap_action_hint">Ukuthenga kube kanye kubiza %s.</string>
+    <string name="upgrade_screen_offer_divider_or">noma</string>
+    <string name="upgrade_screen_offer_same_features">Izici ezifanayo, amamodeli emali ahlukile nje.</string>
     <string name="upgrade_screen_thanks_toast">Ungcono kakhulu! ❤️</string>
     <string name="upgrade_screen_restore_purchase_action">Buyisela ukuthenga</string>
+    <string name="upgrade_screen_restore_banner_title">Uvele uthenge i-BVM Pro?</string>
+    <string name="upgrade_screen_restore_banner_body">Kusobala ukuthi waqhubela kudivaysi yalena ngaphambi. Buyisela okuthenga kwakho ukuze ukuvule futhi.</string>
     <string name="upgrade_screen_restore_purchase_message">Ukuthuthukiswa kwakho kusebenza emadivayisini ane-akhawunti efanayo ye-Google.</string>
     <string name="upgrade_screen_restore_troubleshooting_msg">Amathiphu okuxazulula izinkinga zokuthuthukiswa okungamukeleki:</string>
     <string name="upgrade_screen_restore_sync_patience_hint">Ukuvumelanisa kwe-Play Store kungathatha isikhathi. Zama ukuphinde uqalise, ukusula i-cache ye-Google Play noma ulinde nje.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Ama-akhawunti amaningi angadunga i-Google Play. Phuma kwamanye ama-akhawunti noma ufake ngewebhusayithi ye-Google Play, ephoqa ukuhlobanisa ne-akhawunti ethile.</string>
+    <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
+    <string name="settings_upgrade_status_title">BVM Pro</string>
+    <string name="settings_upgrade_status_desc">Buka isimo sakho se-Pro</string>
+    <!-- Pro status view: owned products -->
+    <string name="upgrade_screen_owned_congrats_title">Amahle!</string>
+    <string name="upgrade_screen_owned_congrats_body">Unayo i-BVM Pro — ngiyabonga ngokuxhasa ubuKhonkho. ❤️</string>
+    <string name="upgrade_screen_owned_iap_title">Ukuthenga kube kanye</string>
+    <string name="upgrade_screen_owned_iap_body">Uyinayo i-BVM Pro kunaphakade. Ngiyabonga ngokuxhasa kwakho ❤️</string>
+    <string name="upgrade_screen_owned_sub_title">Isinxephiso</string>
+    <string name="upgrade_screen_owned_sub_renewing_body">Isub-ukhski yakho se-BVM Pro isebenza futhi imiselwe ukulungiswa.</string>
+    <string name="upgrade_screen_owned_sub_not_renewing_body">Isub-ukhski yakho se-BVM Pro isebenza kodwa ngeke ilungiswe. Lihlala ligcine kuze kufike ekupheleni kwesikhathi samanje.</string>
+    <string name="upgrade_screen_owned_both_warning">Unobophelo lwesub-ukhski kanye nokuthenga okusodwa. Khansela isub-ukhski kuGoogle Play ukuze ungachawe futhi.</string>
+    <string name="upgrade_screen_manage_subscription">Phatha isub-ukhski</string>
+    <!-- Pro status view: switch subscription -> one-time purchase -->
+    <string name="upgrade_screen_switch_title">Shintsha ekuthengeni okusodwa</string>
+    <string name="upgrade_screen_switch_purchase_note">Leli isithengelo esisodwa esehlukile. Akuphelisi noma akubuyiseli imali yesub-ukhski yakho, ngakho khansela naleyo kuGoogle Play futhi. Sebenzisa i-akhaunthi eyodwa ye-Google kuzo zombili.</string>
+    <string name="upgrade_screen_switch_locked_note">Ifumanekile uma isub-ukhski yakho ayimiselwe ukulungiswa. Khansela kuGoogle Play ukuze ushintshe — uhlala nePro kuze kufike ekupheleni kwesikhathi samanje.</string>
+    <!-- Pro status view: restore section -->
+    <string name="upgrade_screen_status_restore_title">Isimo sibukeka singalungile?</string>
+    <string name="upgrade_screen_status_restore_body">Uma isithengelo sakho singabonakali lapha, zama ukusibuyisela.</string>
+    <!-- Grace period: confirming a purchase with Google Play -->
+    <string name="upgrade_screen_grace_title">Kuqinisekiswa isithengelo lakho</string>
+    <string name="upgrade_screen_grace_body_short">Nzamela — siphenya kabusha ukuthenga kwakho nge-Google Play.</string>
+    <string name="upgrade_screen_grace_body">Asikwazi ukuthixela ukuthenga kwakho nge-Google Play. Zama ukulungisisa, noma ukhone ukuthi usingene ngale akhawunti efanele.</string>
+    <string name="upgrade_screen_retry_action">Zama futhi</string>
+    <!-- Fail-closed switch gate dialogs -->
+    <string name="upgrade_screen_sub_still_renewing_title">I-subscription isaphila</string>
+    <string name="upgrade_screen_sub_still_renewing_message">I-subscription yakho isashintshile ngokwazisela iyabuya. Isikisele ku-Google Play kuqala, khona-ke buya ukuthenga okuthengwa kanye — ngale ndlela ngeke ubhalwe kabili.</string>
+    <string name="upgrade_screen_sub_check_failed_message">Asikwazi ukukhexuza isimo se-subscription yakho. Sicela ukhone ukuxhumana kwakho zama futhi.</string>
+    <string name="upgrades_gplay_already_owned_error_title">Sekuthengile</string>
+    <string name="upgrades_gplay_already_owned_error_description">Sebenzisa inketho \"Lusulula ukuthenga\" ukubuya kwazisela ukuthenga kwakho. Uma inkinga ihlala ikhona, zama okusula i-cache ye-Google Play nokuwutshela isishintshi sakho.</string>
+    <string name="upgrades_gplay_internal_error_title">Iphutha le-Google Play</string>
+    <string name="upgrades_gplay_internal_error_description">Iphutha langaphakathi le-Google Play lichubane. Sicela uzame lokulandelayo:\n\n• Buyisela isishintshi sakho\n• Sula i-cache ye-Google Play Store\n• Zama ngemuva kwesikhathi</string>
+    <string name="upgrades_gplay_network_error_title">Iphutha lokuxhumana</string>
+    <string name="upgrades_gplay_network_error_description">Ayikwazi ukuxhumana ne-Google Play. Ngiyacela uhlole ikonekshini yakho ye-inthanethi futhi uphinde uzame.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ayitholakali</string>
     <string name="upgrades_gplay_unavailable_error_description">I-Bluetooth Volume Manager ayikwazi ukuxhuma ku-Google Play. Ingabe i-Google Play ifakiwe futhi ibuyekeziwe? Ingabe i-Google Account yakho ingene? Zama ukukhwebula i-cache ye-Google Play uqalise kabusha idivayisi yakho.</string>
     <string name="upgrades_no_purchases_found_check_account">Akukho ukuthenga okutholiwe. Ingabe usebenzisa i-akhawunti efanele?</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -57,6 +57,7 @@
     <string name="devices_device_config_visible_adjustments_label">የምስተካኪያ ለይት</string>
     <string name="devices_device_config_visible_adjustments_desc">ይህ አፕሊኬሰን ለይህ መሣሪያ ምስተካኪያ በሜደረግበት ወቀት የስርዓቱን ድምፅ መስካኪያን ኣይጥ (window) አሳይ።</string>
     <string name="devices_device_config_keep_awake_label">ተገናት ዘዅር</string>
+    <string name="devices_device_config_keep_awake_desc">ተገናኙ ሲሆኑ አተገባበሪያውን በስርዓተ ኃላፍ ንቁ ያርቃል ስለዚህም የድምጽ ቁጥጥር ሥራ ይቀጥላል፣ እና መሳሪያ ሲገናኝ ስክሪኑን ይነቅሳል (ይህ \"መተግበሪያ ላይ ጣቢያ ማሳያ\" ፍቃድ ይሻል)። በአዳዲስ አንድሮይድ ስሪቶች ውስጥ ስክሪኑ በራሱ ሊጠፋ ይችላል።</string>
     <string name="devices_device_config_volume_observe_label">ለውጦች ታይ</string>
     <string name="devices_device_config_volume_observe_desc">ይህ መሣሪያ ሲጸራ ብራልት ቅበር ይህ አፕሊኬሰን ካልመኃ የተደረጉት የድምፅ ለውጦችን አዓርቦም።</string>
     <string name="devices_device_config_volume_save_on_disconnect_label">በደረጩቦት ክምፅ አክብቢ</string>
@@ -396,6 +397,8 @@
     <string name="battery_optimization_hint_title">የደም ያሌዅ አመ፥ት</string>
     <string name="battery_optimization_hint_message">የደም ያሌዅ አመ፥ቶች ተፈንንዎል፥ ጀነታ ስራት እንዲያደርኑ እይዻይ።</string>
     <string name="battery_optimization_fix_action">አመ፥ት አታካል</string>
+    <string name="android10_applaunch_hint_title">መተግበሪያ ላይ ጣቢያ ማሳያ ፍቃድ</string>
+    <string name="android10_applaunch_hint_message">አንድሮይድ 10+ ወይም በላይ መተግበሪያ ለጀመር፣ መነሻ ስክሪን ለማሳየት፣ ወይም ተገናኙ በሚሆንበት ጊዜ ስክሪን ከስርዓተ ኃላፍ ለመነቅስ ልዩ ፍቃድ ይፈልጋል። \"መተግበሪያ ላይ ጣቢያ ማሳያ\" ፍቃድ ይስጡ።</string>
     <string name="notification_permission_hint_title">የክርዘት እዋዀ</string>
     <string name="notification_permission_hint_message">ድምጣዎችን በሚካካልበት ሁኔተት ለማወቀት የክርዘት እዋዀ ክርድ ይስጀዘ።</string>
     <string name="dnd_access_hint_title">አትረብሽ ፍቃድ</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -57,6 +57,7 @@
     <string name="devices_device_config_visible_adjustments_label">မြင်သာသော ချိန်ညှိမှုများ</string>
     <string name="devices_device_config_visible_adjustments_desc">ဤကိရိယာအတွက် ဤအပ် ချိန်ညှိမှုများ ပြုလုပ်နေစဉ် စနစ်၏ အသံ ဝင်းဒိုး ပြသမည်။</string>
     <string name="devices_device_config_keep_awake_label">နိုးနေစေမည်</string>
+    <string name="devices_device_config_keep_awake_desc">ချိတ်ဆက်ထားစဉ်အက်ပ်အားနောက်ခံတွင်နိုးထားစွာထားခြင်းဖြင့်အသံအတိုးအကျယ်ထိန်းချုပ်မှုအလုပ်မြဲမြံစွာဆောင်ရွက်နိုင်ပြီးစက်ပစ္စည်းမှချိတ်ဆက်သည့်အခါမျက်နှာပြင်နိုးထားစေသည် (\"အခြားအက်ပ်များအပေါ်တွင်ပြသခွင့်ပြုချက်လိုအပ်သည်\")။ ပိုမိုအသစ်သော Android ဗားရှင်းများတွင်မျက်နှာပြင်သည်အကဆီကိုယ်တိုင်ပိတ်သွားနိုင်သည်။</string>
     <string name="devices_device_config_volume_observe_label">ပြောင်းလဲမှုများ စောင့်ကြည့်မည်</string>
     <string name="devices_device_config_volume_observe_desc">ဤကိရိယာ ချိတ်ဆက်နေစဉ် အသက်ဝင်နေ၍ ဤအပ် မဖြစ်ပေါ် စေသော အသံ ပြောင်းလဲမှုများ သိမ်းဆည်းမည်။</string>
     <string name="devices_device_config_volume_save_on_disconnect_label">ဖြတ်တောက်သောအခါ အသံ သိမ်းဆည်းမည်</string>
@@ -390,6 +391,8 @@
     <string name="battery_optimization_hint_title">ဘက်ထရီ ပိုမိုကောင်းမွန်အောင် ပြုလုပ်ခြင်း</string>
     <string name="battery_optimization_hint_message">ဘက်ထရီ ပိုမိုကောင်းမွန်အောင် ပြုလုပ်ခြင်း ဖွင့်ထားပြီး မှန်ကန်သော လုပ်ဆောင်မှုကို တားဆီးနိုင်သည်။ ပိတ်ရန် စဉ်းစားပါ။</string>
     <string name="battery_optimization_fix_action">ပိုမိုကောင်းမွန်အောင် ပြုလုပ်ခြင်း ပိတ်မည်</string>
+    <string name="android10_applaunch_hint_title">အခြားအက်ပ်များအပေါ်တွင်ပြသခွင့်ပြုချက်</string>
+    <string name="android10_applaunch_hint_message">Android 10+ တွင်အက်ပ်များစတင်ခြင်း၊ပင်မမျက်နှာပြင်ကိုပြသခြင်းသို့မဟုတ်ချိတ်ဆက်စဉ်နောက်ခံမှမျက်နှာပြင်နိုးထားစေရန်အတွက်အထူးခွင့်ပြုချက်လိုအပ်သည်။ \"အခြားအက်ပ်များအပေါ်တွင်ပြသခွင့်ပြုချက်\" ကိုပေးအပ်ပါ။</string>
     <string name="notification_permission_hint_title">အကြောင်းကြားချက် ခွင့်ပြုချက်</string>
     <string name="notification_permission_hint_message">အသံ ချိန်ညှိမှု ပြုလုပ်စဉ် အခြေအနေ မွမ်းမံချက်များ ကြည့်ရှုရန် အကြောင်းကြားချက် ခွင့်ပြုချက် ပေးပါ။</string>
     <string name="dnd_access_hint_title">မနှောင့်ယှက်ရ ဝင်ရောက်ခွင့်</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -57,6 +57,7 @@
     <string name="devices_device_config_visible_adjustments_label">දෘශ්‍ය සකසීම්</string>
     <string name="devices_device_config_visible_adjustments_desc">උපාංග කාඩ්පතෙහි දැකිය හැකි සකසීම් ටොගල් කරන්න</string>
     <string name="devices_device_config_keep_awake_label">සක්‍රිය තබා ගන්න</string>
+    <string name="devices_device_config_keep_awake_desc">යෙදුම පසුබිම්ගතව ඉතිරි තබා ගනී සංයුක්ත වී ඇති අතරතුර එමඟින් ශබ්දය පාලනය ක්‍රියා කිරීම දිගටම පවතින අතර, ස්ථාපනයක් සංයුක්ත වූ විට තිරය ජාග්‍රත් කරයි (\"අනෙකුත් යෙදුම්ට වඩා ඉහළින් ප්‍රදර්ශනය\" අවසරය අවශ්‍යයි). නවතර Android අනුවාදවල තිරය තවම ස්වයංක්‍රීයව වසා ගතහැකිය.</string>
     <string name="devices_device_config_volume_observe_label">වෙනස්කම් නිරීක්ෂණය කරන්න</string>
     <string name="devices_device_config_volume_observe_desc">මෙම උපාංගය සම්බන්ධ වී ඇති විට සක්‍රිය ව සිටින්න සහ මෙම යෙදුමෙන් නොකළ හඩ වෙනස්කම් සුරකින්න.</string>
     <string name="devices_device_config_volume_save_on_disconnect_label">විසන්ධිය හදී හඩ සුරකින්න</string>
@@ -396,6 +397,7 @@
     <string name="battery_optimization_hint_message">බැටරි ප්‍රශස්තකරණ සබල කර ඇති අතර නිසි ක්‍රියාකාරිත්වය වළක්වා ගත හැකිය. ඒවා අක්‍රිය කිරීම සලකා බලන්න.</string>
     <string name="battery_optimization_fix_action">ප්‍රශස්තකරණ අක්‍රිය කරන්න</string>
     <string name="android10_applaunch_hint_title">යෙදුම් වලට වඩා පෙන්වන්න අවසරය</string>
+    <string name="android10_applaunch_hint_message">Android 10+ ට යෙදුම් ආරම්භ කිරීම, මුල් තිරය පෙන්වීම, හෝ සංයොගයේදී පසුබිම මිට තිරය ජාග්‍රත් කිරීම සඳහා විශේෂ අවසරයක් අවශ්‍ය වේ. \"අනෙකුත් යෙදුම්ට වඩා ඉහළින් ප්‍රදර්ශනය\" අවසරය ලබා දෙන්න.</string>
     <string name="notification_permission_hint_title">දැනුම්දීම් අවසරය</string>
     <string name="notification_permission_hint_message">හඩ සකසීමේදී තත්ව යාවත්කාලීන දැකීමට දැනුම්දීම් අවසරය ලබා දෙන්න.</string>
     <string name="dnd_access_hint_title">බාධා නොකරන්න ප්‍රවේශය</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -214,6 +214,7 @@
     <string name="settings_acknowledgements_description">заслуге, лиценце и посебна захвалност</string>
     <string name="settings_acks_translation_header">Превод</string>
     <string name="settings_acks_translators_title">Преводиоци</string>
+    <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
     <string name="settings_acks_translate_title">Преведи BVM</string>
     <string name="settings_acks_translate_desc">Помози превођење BVM на свој језик</string>
     <string name="settings_acks_thanks_header">Хвала</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -212,6 +212,7 @@
     <string name="settings_acknowledgements_description">Tack, licenser och särskilt tack</string>
     <string name="settings_acks_translation_header">Översättning</string>
     <string name="settings_acks_translators_title">Översättare</string>
+    <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
     <string name="settings_acks_translate_title">Översätt BVM</string>
     <string name="settings_acks_translate_desc">Hjälp till att översätta BVM till ditt språk</string>
     <string name="settings_acks_thanks_header">Tack</string>


### PR DESCRIPTION
Pulls the latest translations from Crowdin. This covers the recently added upgrade-screen and Google Play billing strings — Pro status view, grace period, subscription switch gate, restore banner, and the Google Play error dialogs.

- 159 `strings.xml` files updated across 77 locales (3,629 new lines)
- No fastlane store-listing changes in this pull

## Validation

Every locale was checked for escaping, placeholder integrity, and vandalism. Two classes of problem were found and corrected:

- **Literal line breaks instead of `\n` escapes in `upgrades_gplay_internal_error_description` (29 locales).** The Crowdin export returned real newlines where the base English uses `\n\n` / `\n` for a bulleted troubleshooting list. Android's resource compiler collapses those to a single space, so the list would have rendered as one run-on line. Fixed in place — only the escaping changed, translated text is untouched.
- **`zh-rTW` / `devices_device_config_visible_adjustments_label`** came back with a stray line break the base string doesn't have; reverted to its previous value. That was the file's only change, so `main/values-zh-rTW` drops out of the diff — hence 159 files rather than the 160 downloaded.

No placeholder mismatches, unescaped quotes or ampersands, or vandalism found in any locale.

`./gradlew assembleFossDebug assembleGplayDebug` passes — both flavors were built since the change spans both source sets.

## Known upstream issues, not fixed here

Two pre-existing mixed-script typos sit on lines this pull doesn't touch: `hu` has `naprакész` and `ro` has `avanсați`, both with Cyrillic characters inside Latin words. These need correcting in Crowdin — a local edit would be overwritten by the next pull.
