### PR TITLE
Fix .claude rules path scoping and align guidance with Opus 5

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -32,15 +32,28 @@ Detailed guidance is in `.claude/rules/`:
 - **[architecture.md](rules/architecture.md)** - Package structure, Navigation3, ViewModel pattern, base classes, error handling, permissions
 - **[code-style.md](rules/code-style.md)** - Kotlin conventions, Compose patterns, state management
 - **[testing.md](rules/testing.md)** - JUnit/Mockk/Kotest, screenshot tests; no instrumented androidTest
-- **[localization.md](rules/localization.md)** - String extraction, 77 translated locales, translation workflow
+- **[localization.md](rules/localization.md)** - String extraction, 77 locales, Crowdin flow
 - **[build-commands.md](rules/build-commands.md)** - All gradlew commands
 - **[release.md](rules/release.md)** - Release flow, version bumping, and tag validation
 - **[commit-guidelines.md](rules/commit-guidelines.md)** - Commit message format and conventions
-- **[agent-instructions.md](rules/agent-instructions.md)** - Sub-agent delegation, exploring vs implementing
+- **[agent-instructions.md](rules/agent-instructions.md)** - When to delegate to a sub-agent
+
+`architecture.md`, `code-style.md`, `testing.md`, `localization.md`, and `release.md` are
+path-scoped via `paths:` frontmatter — they load only when you touch matching files. The
+rest load every session.
+
+## Working Style
+
+- Before the first tool call, say in one sentence what you're about to do. While working,
+  give a brief update only when you find something important or change direction. Lead the
+  final message with the outcome.
+- Match written artifacts — PR descriptions, plan docs, reports — to what the task needs.
+  Cover the substance; no filler sections or redundant summaries.
 
 ## Dev Tips
 
-- Run builds and lint checks in sub-agents to keep the main context window clean.
 - The FOSS debug variant (`assembleFossDebug`) builds fastest for iteration.
 - Check `rules/architecture.md` before adding new screens or ViewModels.
-- All user-facing strings must be localized (see `rules/localization.md`).
+- Write user-facing strings in the base `values/strings.xml` only — translations come from
+  Crowdin, never from you.
+- No `androidTest` in this project; Compose UI is covered by the `screenshotTest` source set.

--- a/.claude/rules/agent-instructions.md
+++ b/.claude/rules/agent-instructions.md
@@ -1,24 +1,28 @@
 ---
-description: Guidelines for sub-agent delegation and task execution
+description: Sub-agent delegation limits
 ---
 
 # Agent Instructions
 
 ## Sub-Agent Delegation
 
-- Use sub-agents for independent, parallelizable work (e.g., translations, multi-file searches).
-- Each sub-agent should have a clear, focused task.
-- Prefer one sub-agent per TODO item when working through a list.
+Delegate only for large, genuinely independent tracks of work — a wide multi-file
+investigation across unfamiliar packages, or a sweep that would otherwise mean reading
+dozens of files to answer one question.
 
-## Exploring vs Implementing
+- Do not delegate work you can finish yourself in a handful of tool calls.
+- Do not use a sub-agent to verify or double-check your own work.
+- If one sub-agent can do the job, use one rather than several. Keep spawn counts low.
+- Prefer `jvm-tools:jvm-dev` over a generic agent when the task needs dependency API
+  inspection, and `jvm-tools:jar-explorer` for deep API exploration of a library.
 
-- Use the Explore agent type for codebase research and understanding.
-- Use the Plan agent type for designing implementation strategies.
-- Only write code after understanding the existing patterns.
+## Output Isolation Is Not Delegation
 
-## Critical Thinking
+The cap above is about splitting up *work*. Routing a command through an agent purely to
+keep its output out of the main context is a different thing, and the cap does not apply:
 
-- Read existing code before modifying it.
-- Follow established patterns in the codebase.
-- When unsure about an approach, explore first, then plan, then implement.
-- Run builds/tests in sub-agents to keep context clean.
+- `devtools:build-runner` for every build, test, and lint run (see `rules/build-commands.md`).
+- `jvm-tools:jar-explorer` when inspecting a dependency's API would mean dozens of `javap` calls.
+
+Large tool output is re-sent on every subsequent turn, so isolating it stays worthwhile
+regardless of context window size.

--- a/.claude/rules/architecture.md
+++ b/.claude/rules/architecture.md
@@ -1,7 +1,7 @@
 ---
 description: Architecture patterns, navigation, ViewModels, base classes, error handling, permissions
-globs:
-  - "app/src/main/java/**/*.kt"
+paths:
+  - "app/src/{main,foss,gplay,debug}/java/**/*.kt"
   - "app/src/main/java/**/*.java"
 ---
 

--- a/.claude/rules/build-commands.md
+++ b/.claude/rules/build-commands.md
@@ -1,10 +1,5 @@
 ---
 description: Gradle build, test, and lint commands
-globs:
-  - "build.gradle*"
-  - "app/build.gradle*"
-  - "settings.gradle*"
-  - "gradle/**"
 ---
 
 # Build Commands
@@ -32,5 +27,8 @@ globs:
 
 ## Tips
 
-- Prefer running builds and lint in sub-agents to keep the main context window clean.
+- Run builds, tests, and lint through the `devtools:build-runner` agent. It keeps verbose
+  output out of the main context and returns a pass/fail summary with the exact error lines.
+  Do not tail the log inline instead — on a gradle failure the last N lines are the
+  `BUILD FAILED` banner, not the compile error that caused it.
 - Use `assembleFossDebug` for quick iteration; it's the fastest build variant.

--- a/.claude/rules/code-style.md
+++ b/.claude/rules/code-style.md
@@ -1,7 +1,7 @@
 ---
 description: Kotlin conventions, Compose patterns, state management
-globs:
-  - "app/src/main/java/**/*.kt"
+paths:
+  - "app/src/{main,foss,gplay,debug}/java/**/*.kt"
   - "app/src/main/java/**/*.java"
 ---
 
@@ -12,6 +12,7 @@ globs:
 - Follow existing patterns in the codebase
 - Prefer immutable data classes for state
 - When writing user facing texts, prefer informal and casual language.
+- Never hardcode a user-facing string; extract it to `values/strings.xml` (see `rules/localization.md`).
 - Use Hilt for dependency injection in new code
 - Do NOT add comments on obvious code
 - Prefer exposing fewer fields and functions and enabling specific functionality via extension functions

--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -1,14 +1,13 @@
 ---
-description: String resource extraction, locales, and translation workflow
-globs:
-  - "app/src/main/res/values*/strings.xml"
-  - "app/src/foss/res/values*/strings.xml"
-  - "app/src/gplay/res/values*/strings.xml"
+description: String resource layout and the Crowdin translation flow
+paths:
+  - "app/src/{main,foss,gplay}/res/values*/strings.xml"
+  - "fastlane/metadata/android/**"
 ---
 
 # Localization
 
-- All user facing strings should be extracted to `values/strings.xml` and translated for all other languages too.
+- All user facing strings should be extracted to `values/strings.xml`.
 - String resources are spread across:
   - Common: `app/src/main/res/values*/strings.xml` (77 translated locales + base `values/`)
   - FOSS flavor: `app/src/foss/res/values*/strings.xml`
@@ -16,5 +15,9 @@ globs:
 
 ## Translation Workflow
 
-- When localizing texts, create a TODO for each locale you need to provide translations for.
-- Use sub-agents, one agent per TODO (if possible).
+Translations come from Crowdin (project `879504`, see `crowdin.yaml` / `crowdin.sh`), not
+from you. Write the English string in the base `values/strings.xml` and stop there.
+
+- Do not hand-write or fan out sub-agents to produce per-locale translations.
+- To pull and validate incoming translations, use the `android-translation:crowdin-pull`
+  skill; to fill gaps on Crowdin itself, use `android-translation:crowdin-translate`.

--- a/.claude/rules/release.md
+++ b/.claude/rules/release.md
@@ -1,3 +1,13 @@
+---
+description: Release flow, version bumping, and tag validation
+paths:
+  - "version.properties"
+  - "VERSION"
+  - "tools/release/**"
+  - ".github/workflows/release-*.yml"
+  - "buildSrc/src/main/java/ProjectConfigPlugin.kt"
+---
+
 # Release
 
 Operator-facing release docs: see `.github/RELEASING.md`.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,10 +1,7 @@
 ---
 description: Testing approach, frameworks, and guidelines
-globs:
-  - "app/src/test/**/*.kt"
-  - "app/src/testFossDebug/**/*.kt"
-  - "app/src/testGplayDebug/**/*.kt"
-  - "app/src/screenshotTest/**/*.kt"
+paths:
+  - "app/src/{test,testGplay,screenshotTest,screenshotTestGplayDebug}/**/*.{kt,java}"
 ---
 
 # Testing


### PR DESCRIPTION
Audit of `.claude/` against the [Opus 5 prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-opus-5).

## The frontmatter was inert

Six rules files carried `globs:` frontmatter — that is Cursor's field name. Claude Code reads `paths:`, so the key was ignored and **every rule loaded unconditionally**, which is the opposite of what the frontmatter looked like it was doing.

Renaming it surfaced patterns that matched nothing:

| Rule | Problem |
|---|---|
| `testing.md` | Pointed at `testFossDebug/` and `testGplayDebug/` — neither exists. Real dirs are `test/`, `testGplay/`, `screenshotTest/`, `screenshotTestGplayDebug/`. |
| `architecture.md`, `code-style.md` | `app/src/main/java/**` excluded all 32 Kotlin files under `foss/`, `gplay/`, `debug/` — including the gplay billing code. |
| `build-commands.md` | Scoped to `build.gradle*`, which is backwards: build commands are needed when *running* builds, not editing gradle files. Now unconditional. |
| `release.md` | No frontmatter at all, despite being the best scope candidate in the set. |

All patterns verified against the working tree: `architecture`/`code-style` 318 files, `localization` 1153, `testing` 66, `release` 8.

## Guidance retuned for Opus 5

- **`agent-instructions.md`** is now a delegation *cap*. It previously said "prefer one sub-agent per TODO item", which turns any list into a fan-out — the guide calls this out specifically. Dropped the Explore/Plan agent pushes and the generic "read code first / follow patterns" advice the model does natively.
- **Output isolation is called out as exempt** from that cap. `devtools:build-runner` and `jvm-tools:jar-explorer` are about keeping large tool output out of context, not about splitting up work, and large output is re-sent every turn regardless of window size.
- **`localization.md`** described creating a TODO per locale and spawning an agent each — a 77-agent fan-out. Translations actually come from Crowdin (`crowdin.yaml`, project `879504`).
- **`CLAUDE.md`** gains narration cadence and written-artifact length calibration, both of which the guide flags as needing explicit instruction on Opus 5. The androidTest and Crowdin prohibitions moved here so they stay unconditional now that their rules are path-scoped.

## Not changed

`commit-guidelines.md` was already correct. The Codex review rules are untouched — the guide's over-verification warning targets *self*-verification, and Codex is a different model.

Requires Claude Code >= 2.1.217 for the brace-expansion behavior; this repo is on 2.1.220.

Path scoping takes effect on new sessions — verify with `/context` that `architecture.md` is absent from Memory files until a `.kt` is read.