### PR TITLE
Ignore agent worktree directory in .claude

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,1 +1,2 @@
 scheduled_tasks.lock
+worktrees/


### PR DESCRIPTION
Root `.gitignore` line 30 has `.worktrees`, but Claude Code creates agent worktrees at `.claude/worktrees/` — no leading dot, so the pattern never matched.

The result: `.claude/worktrees/` showed as untracked in `git status` whenever any agent had a worktree task running, which is a standing risk of it being swept into a `git add .claude/`.

Verified before and after:

```
$ git check-ignore -v .claude/worktrees/     # before
NOT IGNORED

$ git check-ignore -v .claude/worktrees/     # after
.claude/.gitignore:2:worktrees/	.claude/worktrees/
```

Found while cleaning up after #242.