### PR TITLE
Fix app freezes and crashes when the volume monitor starts

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/App.kt
+++ b/app/src/main/java/eu/darken/bluemusic/App.kt
@@ -1,7 +1,6 @@
 package eu.darken.bluemusic
 
 import android.app.Application
-import android.os.Looper
 import dagger.hilt.android.HiltAndroidApp
 import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
 import eu.darken.bluemusic.common.coroutine.AppScope
@@ -10,7 +9,6 @@ import eu.darken.bluemusic.common.debug.DebugSettings
 import eu.darken.bluemusic.common.debug.logging.LogCatLogger
 import eu.darken.bluemusic.common.debug.logging.Logging
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
-import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
 import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
@@ -107,15 +105,8 @@ class App : Application() {
                 .collect { widgetManager.refreshWidgets() }
         }
 
-        var foregroundExceptionHandled = false
         val oldHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler { thread, throwable ->
-            if (throwable.isForegroundServiceTimingException() && !foregroundExceptionHandled) {
-                foregroundExceptionHandled = true
-                log(TAG, WARN) { "Suppressed foreground service timing exception: ${throwable.asLog()}" }
-                Looper.loop()
-                return@setDefaultUncaughtExceptionHandler
-            }
             log(TAG, ERROR) { "UNCAUGHT EXCEPTION: ${throwable.asLog()}" }
             if (oldHandler != null) oldHandler.uncaughtException(thread, throwable) else exitProcess(1)
             Thread.sleep(100)
@@ -126,14 +117,5 @@ class App : Application() {
 
     companion object {
         private val TAG = logTag("App")
-
-        private fun Throwable.isForegroundServiceTimingException(): Boolean {
-            var current: Throwable? = this
-            while (current != null) {
-                if (current.javaClass.simpleName == "ForegroundServiceDidNotStartInTimeException") return true
-                current = current.cause
-            }
-            return false
-        }
     }
 }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorControl.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorControl.kt
@@ -1,13 +1,17 @@
 package eu.darken.bluemusic.monitor.core.service
 
+import android.annotation.SuppressLint
+import android.app.ForegroundServiceStartNotAllowedException
 import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
+import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.flow.setupCommonEventHandlers
+import eu.darken.bluemusic.common.hasApiLevel
 import eu.darken.bluemusic.common.startServiceCompat
 import eu.darken.bluemusic.devices.core.DeviceRepo
 import eu.darken.bluemusic.devices.core.DevicesSettings
@@ -72,6 +76,7 @@ class MonitorControl @Inject constructor(
             .launchIn(appScope)
     }
 
+    @SuppressLint("NewApi")
     suspend fun startMonitor(forceStart: Boolean = false) {
         log(TAG, VERBOSE) { "startMonitor(forceStart=$forceStart)" }
         if (!devicesSettings.currentEnabledState().isEnabled) {
@@ -82,7 +87,11 @@ class MonitorControl @Inject constructor(
             context.startServiceCompat(MonitorService.intent(context, forceStart))
             log(TAG) { "Monitor start request sent." }
         } catch (e: IllegalStateException) {
-            log(TAG, WARN) { "Failed to start monitor service: ${e.message}" }
+            if (hasApiLevel(31) && e is ForegroundServiceStartNotAllowedException) {
+                log(TAG, WARN) { "Start rejected, app is not allowed to start a FGS from the background: ${e.asLog()}" }
+            } else {
+                log(TAG, WARN) { "Failed to start monitor service: ${e.asLog()}" }
+            }
         }
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorService.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorService.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.monitor.core.service
 
 import android.annotation.SuppressLint
+import android.app.Notification
 import android.app.NotificationManager
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -50,27 +51,34 @@ class MonitorService : Service2() {
     private var injectionComplete = false
     private var monitoringJob: Job? = null
     @Volatile private var monitorGeneration = 0
+    @Volatile private var lastNotification: Notification? = null
 
     override fun onBind(intent: Intent?): IBinder? = null
 
     @SuppressLint("InlinedApi")
+    private fun promoteToForeground(notification: Notification): Boolean {
+        try {
+            if (hasApiLevel(29)) {
+                startForeground(
+                    MonitorNotifications.NOTIFICATION_ID,
+                    notification,
+                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
+                )
+            } else {
+                startForeground(MonitorNotifications.NOTIFICATION_ID, notification)
+            }
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Foreground promotion failed: ${e.asLog()}" }
+            return false
+        }
+        return true
+    }
+
     override fun onCreate() {
         log(TAG, VERBOSE) { "onCreate()" }
 
         // Promote to foreground BEFORE Hilt injection (super.onCreate) to avoid 5-second timeout
-        try {
-            val earlyNotification = MonitorNotifications.createEarlyNotification(this)
-            if (hasApiLevel(29)) {
-                startForeground(
-                    MonitorNotifications.NOTIFICATION_ID,
-                    earlyNotification,
-                    ServiceInfo.FOREGROUND_SERVICE_TYPE_CONNECTED_DEVICE
-                )
-            } else {
-                startForeground(MonitorNotifications.NOTIFICATION_ID, earlyNotification)
-            }
-        } catch (e: Exception) {
-            log(TAG, ERROR) { "Early foreground promotion failed: ${e.asLog()}" }
+        if (!promoteToForeground(MonitorNotifications.createEarlyNotification(this))) {
             stopSelf()
             return
         }
@@ -94,6 +102,13 @@ class MonitorService : Service2() {
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         log(TAG, VERBOSE) { "onStartCommand(intent=$intent, flags=$flags, startId=$startId)" }
+
+        // Every startForegroundService() re-arms the startForeground() obligation,
+        // so every onStartCommand has to satisfy it again, no matter how it exits.
+        if (!promoteToForeground(lastNotification ?: MonitorNotifications.createEarlyNotification(this))) {
+            stopSelf()
+            return START_NOT_STICKY
+        }
 
         if (!injectionComplete) {
             log(TAG, WARN) { "onStartCommand: Injection incomplete, stopping service." }
@@ -150,10 +165,9 @@ class MonitorService : Service2() {
     }
 
     private suspend fun updateNotification(activeDevices: List<ManagedDevice>) {
-        notificationManager.notify(
-            MonitorNotifications.NOTIFICATION_ID,
-            notifications.getDevicesNotification(activeDevices),
-        )
+        val notification = notifications.getDevicesNotification(activeDevices)
+        lastNotification = notification
+        notificationManager.notify(MonitorNotifications.NOTIFICATION_ID, notification)
     }
 
     private val stopMonitorReceiver = object : BroadcastReceiver() {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorService.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/MonitorService.kt
@@ -101,14 +101,14 @@ class MonitorService : Service2() {
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
-        log(TAG, VERBOSE) { "onStartCommand(intent=$intent, flags=$flags, startId=$startId)" }
-
         // Every startForegroundService() re-arms the startForeground() obligation,
         // so every onStartCommand has to satisfy it again, no matter how it exits.
         if (!promoteToForeground(lastNotification ?: MonitorNotifications.createEarlyNotification(this))) {
             stopSelf()
             return START_NOT_STICKY
         }
+
+        log(TAG, VERBOSE) { "onStartCommand(intent=$intent, flags=$flags, startId=$startId)" }
 
         if (!injectionComplete) {
             log(TAG, WARN) { "onStartCommand: Injection incomplete, stopping service." }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/ui/MonitorNotifications.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/ui/MonitorNotifications.kt
@@ -132,8 +132,15 @@ class MonitorNotifications @Inject constructor(
 
         fun createEarlyNotification(context: Context): Notification {
             ensureNotificationChannel(context)
+
+            val openIntent = Intent(context, MainActivity::class.java)
+            val openPi = PendingIntent.getActivity(context, 0, openIntent, PendingIntentCompat.FLAG_IMMUTABLE)
+
             return NotificationCompat.Builder(context, NOTIFICATION_CHANNEL_ID)
                 .setSmallIcon(R.drawable.ic_notification_small)
+                .setContentTitle(context.getString(R.string.app_name))
+                .setContentText(context.getString(R.string.monitor_notification_starting))
+                .setContentIntent(openPi)
                 .build()
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -351,6 +351,7 @@
     <string name="label_add_device">Add device</string>
     <string name="label_just_a_moment_please">Just a moment, please.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Starting up…</string>
     <string name="action_set">Set</string>
     <string name="action_cancel">Cancel</string>
     <string name="label_invalid_input">Invalid input</string>

--- a/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManagerAtomicityTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManagerAtomicityTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.main.backup.core
 
+import android.app.Application
 import android.content.Context
 import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider
@@ -29,7 +30,7 @@ import testhelpers.coroutine.TestDispatcherProvider
 import java.io.IOException
 
 @RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE, sdk = [34])
+@Config(manifest = Config.NONE, sdk = [34], application = Application::class)
 class BackupRestoreManagerAtomicityTest {
 
     private lateinit var roomDb: DevicesRoomDb

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorControlTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorControlTest.kt
@@ -154,6 +154,22 @@ class MonitorControlTest : BaseTest() {
     }
 
     @Test
+    fun `startMonitor swallows a rejected service start`() = runTest(UnconfinedTestDispatcher()) {
+        every { context.startServiceCompat(any()) } throws IllegalStateException("Not allowed to start service")
+        val control = MonitorControl(
+            appScope = backgroundScope,
+            context = context,
+            deviceRepo = deviceRepo,
+            devicesSettings = devicesSettings,
+            monitorNotifications = monitorNotifications,
+        )
+
+        control.startMonitor()
+
+        verify(atLeast = 1) { context.startServiceCompat(fakeIntent) }
+    }
+
+    @Test
     fun `startMonitor is a no-op while app is disabled`() = runTest(UnconfinedTestDispatcher()) {
         enabledFlow.value = DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
         val control = MonitorControl(

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorServiceTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorServiceTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.monitor.core.service
 
+import android.app.Application
 import android.app.Notification
 import android.app.NotificationManager
 import android.app.Service
@@ -26,14 +27,16 @@ import kotlin.reflect.full.declaredMemberFunctions
 import kotlin.reflect.jvm.isAccessible
 
 @RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE, sdk = [34])
+@Config(manifest = Config.NONE, sdk = [34], application = Application::class)
 class MonitorServiceTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()
 
     /**
-     * `create()` runs the real Hilt injection and the initial foreground promotion, internal
-     * state that only the running monitor produces is set directly afterwards.
+     * Runs against a plain [Application]: booting the real Hilt app would install its uncaught
+     * exception handler in the test JVM (killing the executor on stray background exceptions)
+     * and spin up flavor-specific singletons. `create()` runs the initial foreground promotion;
+     * Hilt injection fails gracefully and all internal state is set directly via reflection.
      */
     private fun createService(): MonitorService = Robolectric.buildService(MonitorService::class.java)
         .create()

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorServiceTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorServiceTest.kt
@@ -1,0 +1,113 @@
+package eu.darken.bluemusic.monitor.core.service
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Context
+import androidx.core.app.NotificationCompat
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.monitor.ui.MonitorNotifications
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.runBlocking
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import kotlin.reflect.full.callSuspend
+import kotlin.reflect.full.declaredMemberFunctions
+import kotlin.reflect.jvm.isAccessible
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class MonitorServiceTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    /**
+     * `create()` runs the real Hilt injection and the initial foreground promotion, internal
+     * state that only the running monitor produces is set directly afterwards.
+     */
+    private fun createService(): MonitorService = Robolectric.buildService(MonitorService::class.java)
+        .create()
+        .get()
+
+    private fun MonitorService.setField(name: String, value: Any?) {
+        MonitorService::class.java.getDeclaredField(name)
+            .apply { isAccessible = true }
+            .set(this, value)
+    }
+
+    private fun MonitorService.updateNotification(devices: List<ManagedDevice>) = runBlocking {
+        MonitorService::class.declaredMemberFunctions
+            .single { it.name == "updateNotification" }
+            .apply { isAccessible = true }
+            .callSuspend(this@updateNotification, devices)
+    }
+
+    private fun notification(title: String): Notification = NotificationCompat
+        .Builder(context, "notification.channel.core")
+        .setSmallIcon(R.drawable.ic_notification_small)
+        .setContentTitle(title)
+        .build()
+
+    @Test
+    fun `repeated non-force starts promote to foreground every time`() {
+        val service = createService()
+        service.setField("injectionComplete", true)
+        service.setField("monitoringJob", Job())
+
+        val first = notification("first")
+        service.setField("lastNotification", first)
+        service.onStartCommand(MonitorService.intent(context), 0, 1) shouldBe Service.START_STICKY
+        shadowOf(service).lastForegroundNotification shouldBe first
+
+        val second = notification("second")
+        service.setField("lastNotification", second)
+        service.onStartCommand(MonitorService.intent(context), 0, 2) shouldBe Service.START_STICKY
+        shadowOf(service).lastForegroundNotification shouldBe second
+        shadowOf(service).lastForegroundNotificationId shouldBe MonitorNotifications.NOTIFICATION_ID
+    }
+
+    @Test
+    fun `incomplete injection promotes with the early notification before stopping`() {
+        val service = createService()
+        service.setField("injectionComplete", false)
+        service.setField("lastNotification", null)
+        val fromOnCreate = shadowOf(service).lastForegroundNotification.shouldNotBeNull()
+
+        service.onStartCommand(MonitorService.intent(context), 0, 1) shouldBe Service.START_NOT_STICKY
+
+        val promoted = shadowOf(service).lastForegroundNotification.shouldNotBeNull()
+        (promoted === fromOnCreate) shouldBe false
+        promoted.extras.getString(Notification.EXTRA_TEXT) shouldBe
+                context.getString(R.string.monitor_notification_starting)
+        shadowOf(service).lastForegroundNotificationId shouldBe MonitorNotifications.NOTIFICATION_ID
+        shadowOf(service).isStoppedBySelf shouldBe true
+    }
+
+    @Test
+    fun `re-promotion uses the notification cached by the last update`() {
+        val service = createService()
+        service.setField("injectionComplete", true)
+        service.setField("monitoringJob", Job())
+
+        val current = notification("connected devices")
+        service.setField("notifications", mockk<MonitorNotifications> {
+            coEvery { getDevicesNotification(any()) } returns current
+        })
+        service.setField("notificationManager", mockk<NotificationManager>(relaxed = true))
+
+        service.updateNotification(emptyList())
+        service.onStartCommand(MonitorService.intent(context), 0, 1) shouldBe Service.START_STICKY
+
+        shadowOf(service).lastForegroundNotification shouldBe current
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/ui/MonitorNotificationsTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/ui/MonitorNotificationsTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.monitor.ui
 
+import android.app.Application
 import android.app.Notification
 import android.app.NotificationManager
 import android.content.Context
@@ -13,7 +14,7 @@ import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 
 @RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE, sdk = [34])
+@Config(manifest = Config.NONE, sdk = [34], application = Application::class)
 class MonitorNotificationsTest {
 
     private val context: Context = ApplicationProvider.getApplicationContext()

--- a/app/src/test/java/eu/darken/bluemusic/monitor/ui/MonitorNotificationsTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/ui/MonitorNotificationsTest.kt
@@ -1,0 +1,41 @@
+package eu.darken.bluemusic.monitor.ui
+
+import android.app.Notification
+import android.app.NotificationManager
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeEmpty
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+@RunWith(RobolectricTestRunner::class)
+@Config(manifest = Config.NONE, sdk = [34])
+class MonitorNotificationsTest {
+
+    private val context: Context = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `early notification is user presentable`() {
+        val notification = MonitorNotifications.createEarlyNotification(context)
+
+        notification.extras.getString(Notification.EXTRA_TITLE)!!.shouldNotBeEmpty()
+        notification.extras.getString(Notification.EXTRA_TEXT)!!.shouldNotBeEmpty()
+        notification.smallIcon.shouldNotBeNull()
+        notification.contentIntent.shouldNotBeNull()
+    }
+
+    @Test
+    fun `early notification ensures the status channel exists`() {
+        MonitorNotifications.createEarlyNotification(context)
+
+        val nm = context.getSystemService(NotificationManager::class.java)
+        val channel = nm.getNotificationChannel("notification.channel.core")
+
+        channel.shouldNotBeNull()
+        channel.importance shouldBe NotificationManager.IMPORTANCE_MIN
+    }
+}


### PR DESCRIPTION
Play vitals showed ~2,700 ANRs/month tagged "Context.startForegroundService() did not then call Service.startForeground()", plus a wave of `BadForegroundServiceNotificationException` crashes on Android 16 — together ~95% of all vitals reports.

Root causes and fixes:

- Every `startForegroundService()` call re-arms the 10s `startForeground()` obligation, even when the service is already running in the foreground. The monitor only promoted itself in `onCreate()`, so every Bluetooth connect/disconnect re-start left an unsatisfied obligation. `onStartCommand` now re-promotes as its first statement on every call, using the most recently posted notification (or the early one as fallback).
- The early foreground notification was icon-only. Some Android 16 builds reject content-less foreground notifications, which surfaced either as `BadForegroundServiceNotificationException` or as a never-satisfied foreground contract. It now carries a title, text, and a tap intent to open the app.
- The uncaught-exception handler swallowed `ForegroundServiceDidNotStartInTimeException` and parked the main thread in a nested `Looper.loop()`. That converted each crash into a zombie process that racked up repeated, unattributable ANRs (crashes -97%, ANRs 100× since April). The suppression is removed so residual failures surface as real, attributable crashes again.
- `MonitorControl` now logs foreground-service-start rejections (`ForegroundServiceStartNotAllowedException`) distinctly with the full stack instead of a bare message.

Tests: Robolectric coverage for the early notification contents and for foreground promotion on every `onStartCommand` path (repeat starts, incomplete injection, cached notification). Verified on an API 36 emulator: repeated service starts produce zero foreground-service timeout errors, and the notification posts with content and `isForeground=true`.
