### PR TITLE
Keep the Pro upgrade screen usable when Google Play or storage fails

### DIFF
--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -16,6 +16,7 @@ import eu.darken.bluemusic.common.flow.setupCommonEventHandlers
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.upgrade.core.billing.BillingData
 import eu.darken.bluemusic.upgrade.core.billing.BillingManager
+import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.bluemusic.upgrade.core.billing.ItemAlreadyOwnedBillingException
 import eu.darken.bluemusic.upgrade.core.billing.PurchasedSku
 import eu.darken.bluemusic.upgrade.core.billing.Sku
@@ -31,6 +32,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
@@ -81,6 +83,10 @@ class UpgradeRepoGplay @Inject constructor(
     // Which purchase launch (if any) is currently in flight, so the UI can present the busy state
     // even for a launch a previous ViewModel instance started.
     val purchaseLaunchSku: StateFlow<Sku?> = launchBusySku
+
+    // Test seam: the launch body runs on AppScope (a real dispatcher), so a virtual-time test
+    // cannot advance the production bound. Same pattern as UpgradeViewModel's `clock`.
+    internal var launchTimeoutMs: Long = LAUNCH_TIMEOUT_MS
 
     // Serializes the pro-state recorders: the fresh-data collector and the failure paths in
     // refresh()/restorePurchaseNow() can run concurrently, and a stale unconfirmed-stamp read must
@@ -194,14 +200,32 @@ class UpgradeRepoGplay @Inject constructor(
 
     // True once we've ever confirmed a (known) Pro purchase on this install; drives the proactive
     // restore banner. Local signal only — a fresh install or switched Google account starts false.
+    //
+    // Fail-soft, and that matters more here than the value itself: this is combined into the whole
+    // upgrade-screen state, whose safeStateIn fallback is TERMINAL (it catches, so the retry button
+    // can't revive the stream). A full-disk DataStore would otherwise take the entire screen down
+    // until it is reopened, over a decoration. Degrade to "not previously pro" instead — entitlement
+    // does not depend on this, upgradeInfo reads the cache on its own retrying path.
     val wasEverPro: Flow<Boolean> = billingCache.lastProStateAt.flow
         .map { it > 0 }
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, WARN) { "wasEverPro read failed: ${e.asLog()}" }
+            emit(false)
+        }
         .distinctUntilChanged()
 
     // Epoch millis of the first fresh reconciliation that couldn't confirm Pro in the current grace
     // episode (0 = none). The upgrade screen delays its grace diagnostics until this has aged, so
     // self-healing Play blips never surface it.
+    //
+    // Same fail-soft reasoning as wasEverPro — 0 reads as "no episode", i.e. the quiet grace stage.
     val proUnconfirmedSince: Flow<Long> = billingCache.proUnconfirmedSince.flow
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, WARN) { "proUnconfirmedSince read failed: ${e.asLog()}" }
+            emit(0L)
+        }
         .distinctUntilChanged()
 
     // Suspends until the Play launch resolved (sheet up, or failed) — callers holding an
@@ -233,7 +257,19 @@ class UpgradeRepoGplay @Inject constructor(
             return
         }
         try {
-            billingManager.startIapFlow(activity, sku, offer)
+            // Bounded, like every other Play path (refresh, restore, SKU query, ack). useConnection
+            // waits for a healthy connection indefinitely, so a Play outage between rendering the
+            // offers and this tap would park the launch forever — with launchBusySku still held,
+            // which leaves every purchase button busy and never surfaces an error. Generous on
+            // purpose: a cold Play can take >8s just for the SKU query this launch does first.
+            // Residual: a timeout landing in the millisecond window between launchBillingFlow's
+            // binder call and its result shows an error while the sheet opens. The purchase itself
+            // is unaffected — it arrives via onPurchasesUpdated, independent of this coroutine.
+            withTimeoutOrNull(launchTimeoutMs) {
+                billingManager.startIapFlow(activity, sku, offer)
+            } ?: throw GplayServiceUnavailableException(
+                RuntimeException("Billing flow launch timed out for ${sku.id}")
+            )
         } catch (e: CancellationException) {
             // Not an error: must not reach onError (spurious dialog) — rethrow for structured
             // cancellation.
@@ -544,6 +580,10 @@ class UpgradeRepoGplay @Inject constructor(
         val GRACE_PERIOD_IAP_MS = Duration.ofDays(30).toMillis()
         private const val RESTORE_ON_OWNED_TIMEOUT_MS = 15_000L
         private const val REFRESH_TIMEOUT_MS = 30_000L
+
+        // Covers connecting, the SKU query the launch does first, and the sheet launch itself.
+        // Matches REFRESH_TIMEOUT_MS: both bound "connection wait + Play round-trip".
+        internal const val LAUNCH_TIMEOUT_MS = 30_000L
         val TAG: String = logTag("Upgrade", "Gplay", "Repo")
 
         // The SKU whose grace window applies when several are owned: the permanent one-time purchase

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
@@ -8,6 +8,7 @@ import eu.darken.bluemusic.common.datastore.DataStoreValue
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.upgrade.core.billing.BillingData
 import eu.darken.bluemusic.upgrade.core.billing.BillingManager
+import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.bluemusic.upgrade.core.billing.ItemAlreadyOwnedBillingException
 import eu.darken.bluemusic.upgrade.core.billing.PurchasedSku
 import eu.darken.bluemusic.upgrade.core.billing.UserCanceledBillingException
@@ -25,6 +26,7 @@ import io.mockk.slot
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -69,6 +71,10 @@ class UpgradeRepoGplayTest : BaseTest() {
         proUnconfirmedSince: Long = 0L,
         connectionFailures: Flow<Long> = emptyFlow(),
         failureSettled: Flow<Boolean> = flowOf(false),
+        // The cache-backed flows are dereferenced during construction, so a test that needs a
+        // FAILING one has to install it here — overriding the mock afterwards is too late.
+        lastProAtFlow: Flow<Long>? = null,
+        proUnconfirmedFlow: Flow<Long>? = null,
     ): UpgradeRepoGplay {
         every { billingManager.billingData } returns (billingDataFlow ?: flowOf(billingData))
         every { billingManager.freshBillingData } returns
@@ -83,7 +89,7 @@ class UpgradeRepoGplayTest : BaseTest() {
             else -> flowOf(*purchaseFailures.toTypedArray())
         }
         lastProAtMock = mockk<DataStoreValue<Long>>(relaxed = true).apply {
-            every { flow } returns flowOf(lastProAt)
+            every { flow } returns (lastProAtFlow ?: flowOf(lastProAt))
         }
         every { billingCache.lastProStateAt } returns lastProAtMock
         lastProSkuMock = mockk<DataStoreValue<String>>(relaxed = true).apply {
@@ -91,7 +97,7 @@ class UpgradeRepoGplayTest : BaseTest() {
         }
         every { billingCache.lastProStateSku } returns lastProSkuMock
         proUnconfirmedMock = mockk<DataStoreValue<Long>>(relaxed = true).apply {
-            every { flow } returns flowOf(proUnconfirmedSince)
+            every { flow } returns (proUnconfirmedFlow ?: flowOf(proUnconfirmedSince))
         }
         every { billingCache.proUnconfirmedSince } returns proUnconfirmedMock
         coJustRun { billingCache.stampLastProState(any(), any()) }
@@ -403,6 +409,22 @@ class UpgradeRepoGplayTest : BaseTest() {
         errors.single() shouldBe failure
     }
 
+    @Test fun `a launch that never resolves times out instead of parking the busy guard`() = runTest2 {
+        // useConnection waits for a healthy connection indefinitely. Unbounded, a Play outage
+        // between rendering the offers and this tap parks the launch forever with launchBusySku
+        // still held — every purchase button stays busy and no error ever reaches the user.
+        coEvery { billingManager.startIapFlow(any(), any(), null) } coAnswers { awaitCancellation() }
+
+        val errors = mutableListOf<Throwable>()
+        val repo = repo(lastProAt = 0L).apply { launchTimeoutMs = 50L }
+        repo.launchBillingFlowNow(mockk<Activity>(), OurSku.Iap.PRO_UPGRADE, null) { errors.add(it) }
+
+        // Play unavailable, not a generic failure: the user gets the dialog with the Play fix action.
+        errors.single().shouldBeInstanceOf<GplayServiceUnavailableException>()
+        // Released, so the next deliberate tap works.
+        repo.purchaseLaunchSku.value shouldBe null
+    }
+
     @Test fun `fresh empty full snapshot during grace starts the unconfirmed episode clock`() = runTest2 {
         repo(
             lastProAt = System.currentTimeMillis() - 1_000,
@@ -708,6 +730,22 @@ class UpgradeRepoGplayTest : BaseTest() {
         // Monotonic across the retry resubscribe: the re-emitted null seed must not regress an
         // already-settled stream back to unsettled (the runningReduce latch).
         infos[1].isSettled shouldBe true
+    }
+
+    @Test fun `wasEverPro degrades to false when the cache is unreadable`() = runTest2 {
+        // Fail-soft on purpose: this feeds the upgrade screen's combine, whose safeStateIn fallback
+        // is terminal (it catches, so the retry button can't revive it). Erroring here would take
+        // the whole screen down until it is reopened, over a restore banner.
+        val repo = repo(lastProAt = 0L, lastProAtFlow = flow { throw IOException("disk full") })
+
+        repo.wasEverPro.first() shouldBe false
+    }
+
+    @Test fun `proUnconfirmedSince degrades to zero when the cache is unreadable`() = runTest2 {
+        // 0 reads as "no unconfirmed episode", i.e. the quiet grace stage without diagnostics.
+        val repo = repo(lastProAt = 0L, proUnconfirmedFlow = flow { throw IOException("disk full") })
+
+        repo.proUnconfirmedSince.first() shouldBe 0L
     }
 
     @Test fun `a persistently failing grace cache does not kill upgradeInfo`() = runTest2 {


### PR DESCRIPTION
Two fixes in the gplay billing layer, both found while auditing the upgrade flow after the billing stack replacement.

### The upgrade screen died when the billing cache couldn't be read

`wasEverPro` and `proUnconfirmedSince` propagated a DataStore read failure (full disk, corrupt prefs) straight into the upgrade screen's state combine. That combine's `safeStateIn` fallback is terminal — it catches and completes the stream — so the retry button couldn't revive it and the screen stayed unavailable until it was reopened. Both flows now degrade to `false` / `0` instead, which costs the restore banner and the grace diagnostics stage but keeps the screen alive. Entitlement is unaffected either way: `upgradeInfo` reads the cache on its own retrying path.

### Purchase buttons could stay busy forever

`launchBillingFlowInternal` had no timeout, and `useConnection` waits for a healthy billing connection indefinitely. If Play became unreachable between the offers rendering and the buy tap, the launch parked forever with `launchBusySku` still held — every purchase button stayed busy and no error ever reached the user. The launch is now bounded at 30s, matching the existing refresh and ack timeouts, and surfaces the usual "Play unavailable" dialog on expiry.

30s is deliberately generous because the launch does a SKU query first and a cold Play can take over 8s for that alone. One residual: a timeout landing in the millisecond window between `launchBillingFlow`'s binder call and its result would show an error while the sheet opens. The purchase itself is unaffected — it arrives via `onPurchasesUpdated`, independent of that coroutine.

### Testing

- All 928 gplay unit tests pass, including 3 new ones in `UpgradeRepoGplayTest` covering both fixes.
- Negative control: with the production change reverted, all 3 new tests fail and the other 64 in the class still pass, so they genuinely gate the fixes.
- `lintVitalGplayRelease` passes.
