### PR TITLE
Make supporter status, debug logs and flavor labels more dependable

### DIFF
--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
@@ -60,6 +60,8 @@ class UpgradeRepoFoss @Inject constructor(
         }
         .shareIn(scope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
+    // Synchronous so the caller learns whether the page actually opened: the FOSS unlock heuristic
+    // only arms on a successful launch, and a fire-and-forget coroutine can't report that back.
     fun openGithubSponsorsPage(): Boolean {
         log(TAG) { "openGithubSponsorsPage()" }
         return webpageTool.open(upgradeSite)

--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -143,18 +143,21 @@ class UpgradeViewModel @Inject constructor(
 
     fun checkSponsorReturn() = launch {
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
+
+        // Evaluated before the duration: an already upgraded supporter (recurring donation button)
+        // has nothing left to unlock, and persisting again would rewrite their upgradedAt — visibly
+        // resetting the "supporter since" date the status screen shows them.
+        if (upgradeRepo.upgradeInfo.first().isPro) {
+            log(tag) { "checkSponsorReturn(): Already upgraded, staying quiet" }
+            return@launch
+        }
+
         val elapsed = SystemClock.elapsedRealtime() - pressedAt
         log(tag) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
 
         if (elapsed < SPONSOR_DELAY_MS) {
-            // The nudge belongs to the unlock heuristic. An already upgraded user (recurring
-            // donation button) has nothing to unlock — peeking at the page needs no feedback.
-            if (upgradeRepo.upgradeInfo.first().isPro) {
-                log(tag) { "checkSponsorReturn(): Too quick, but already upgraded, staying quiet" }
-            } else {
-                log(tag) { "checkSponsorReturn(): Too quick, showing snackbar" }
-                snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_too_fast)
-            }
+            log(tag) { "checkSponsorReturn(): Too quick, showing snackbar" }
+            snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_too_fast)
         } else {
             log(tag) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
             upgradeRepo.persistUpgrade()

--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Vereis BVM FOSS</string>
     <string name="upgrade_prompt_title">Opgradeer na BVM FOSS</string>
     <string name="upgrade_prompt_body">Ontsluit addisionele funksies en word \'n beskermheer om voortgesette ontwikkeling te ondersteun!</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS ያስፈሉ።</string>
     <string name="upgrade_prompt_title">ወደ BVM FOSS ክበቱ</string>
     <string name="upgrade_prompt_body">ተጨማሪ ባህሪያትን ይክፈቱ እና ቀጣይ ልማትን ለመደገፍ ደጋፊ ይሁኑ!</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">البرمجيات الحرة (FOSS)</string>
-    <string name="upgrade_badge_label">البرمجيات الحرة (FOSS)</string>
     <string name="upgrade_feature_requires_pro">يتطلب BVM FOSS</string>
     <string name="upgrade_prompt_title">الترقية إلى BVM FOSS</string>
     <string name="upgrade_prompt_body">افتح ميزات إضافية وكن راعياً لدعم التطوير المستمر!</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS tələb olunur</string>
     <string name="upgrade_prompt_title">BVM FOSS-a yüksəldin</string>
     <string name="upgrade_prompt_body">Əlavə xüsusiyyətləri açın və davamlı inkişafı dəstəkləmək üçün himayədar olun!</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Патрабуе BVM FOSS</string>
     <string name="upgrade_prompt_title">Перайсці на BVM FOSS</string>
     <string name="upgrade_prompt_body">Адкрыйце дадатковыя функцыі і станьце спонсарам, каб падтрымаць далейшую распрацоўку!</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Изисква BVM FOSS</string>
     <string name="upgrade_prompt_title">Надграждане до BVM FOSS</string>
     <string name="upgrade_prompt_body">Отключете допълнителни функции и станете покровител, за да подкрепите непрекъснатото развитие!</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS প্রয়োজন</string>
     <string name="upgrade_prompt_title">BVM FOSS-এ আপগ্রেড করুন</string>
     <string name="upgrade_prompt_body">অতিরিক্ত ফিচার আনলক করুন এবং ক্রমাগত বিকাশকে সমর্থন করার জন্য একজন পৃষ্ঠপোষক হন!</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Requereix BVM FOSS</string>
     <string name="upgrade_prompt_title">Millora a BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloquegeu funcions addicionals i convertiu-vos en mecenes per donar suport al continuïtat del suport!</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Vyžaduje BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgradovat na BVM FOSS</string>
     <string name="upgrade_prompt_body">Odemkněte další funkce a staňte se patronem, který podpoří další vývoj!</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Kræver BVM FOSS</string>
     <string name="upgrade_prompt_title">Opgrader til BVM FOSS</string>
     <string name="upgrade_prompt_body">Lås op for flere funktioner, og bliv patron for at støtte den fortsatte udvikling!</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Erfordert BVM FOSS</string>
     <string name="upgrade_prompt_title">Auf BVM FOSS upgraden</string>
     <string name="upgrade_prompt_body">Schalte zusätzliche Funktionen frei und werde Patron, um die Weiterentwicklung zu unterstützen!</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Απαιτεί το BVM FOSS</string>
     <string name="upgrade_prompt_title">Αναβαθμίστε στο BVM FOSS</string>
     <string name="upgrade_prompt_body">Ξεκλειδώστε πρόσθετες δυνατότητες και γίνετε patron για να υποστηρίξετε τη συνεχή ανάπτυξη!</string>

--- a/app/src/foss/res/values-eo-rUY/strings.xml
+++ b/app/src/foss/res/values-eo-rUY/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Postulas BVM FOSS</string>
     <string name="upgrade_prompt_title">Plibonigi al BVM FOSS</string>
     <string name="upgrade_prompt_body">Malŝlosi pliajn funkciojn kaj fiĝiĝi patrono por subteni daŭran disvolvadon!</string>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Requiere BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">¡Desbloqueá funciones adicionales y hacete patreon para ayudar a continuar el desarrollo!</string>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Requiere BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">¡Desbloquea funciones adicionales y conviértete en pratrocinador para apoyar el desarrollo continuo!</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Requiere BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">¡Desbloquea las funciones adicionales y conviértete en patrocinador para apoyar el desarrollo continuo!</string>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Vajab BVM FOSS versiooni</string>
     <string name="upgrade_prompt_title">Uuenda BVM FOSS-iks</string>
     <string name="upgrade_prompt_body">Lubage lisavõimalused ja hakake toetajaks, et edendada arendamist.</string>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS beharrezkoa da</string>
     <string name="upgrade_prompt_title">Berritu BVM FOSS-era</string>
     <string name="upgrade_prompt_body">Eginbide gehigarriak desblokeatu eta babesle izan etengabeko garapena laguntzeko!</string>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">منبع‌آزاد</string>
-    <string name="upgrade_badge_label">منبع‌آزاد</string>
     <string name="upgrade_feature_requires_pro">نیاز به BVM FOSS دارد</string>
     <string name="upgrade_prompt_title">ارتقاء به BVM FOSS</string>
     <string name="upgrade_prompt_body">قفل ویژگی های اضافی را باز کنید و برای حمایت از توسعه مداوم، حامی شوید!</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Vaatii BVM FOSS:in</string>
     <string name="upgrade_prompt_title">Päivitä BVM FOSS:iin</string>
     <string name="upgrade_prompt_body">Avaa lisäominaisuuksia ja ryhdy tukijaksi tukeaksesi jatkuvaa kehitystä!</string>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Nangangailangan ng BVM FOSS</string>
     <string name="upgrade_prompt_title">I-upgrade sa BVM FOSS</string>
     <string name="upgrade_prompt_body">I-unlock ang mga karagdagang feature at maging patron para suportahan ang patuloy na development!</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">Logiciel libre</string>
-    <string name="upgrade_badge_label">Logiciel libre</string>
     <string name="upgrade_feature_requires_pro">Nécessite BVM FOSS</string>
     <string name="upgrade_prompt_title">Passer à BVM FOSS</string>
     <string name="upgrade_prompt_body">Débloquez des fonctions supplémentaires et devenez mécène pour soutenir le développement continu.</string>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Require BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloquea características adicionais e convértete en mecenas para apoiar o desenvolvemento continuo!</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS आवश्यक है</string>
     <string name="upgrade_prompt_title">BVM FOSS में अपग्रेड करें</string>
     <string name="upgrade_prompt_body">अतिरिक्त सुविधाओं को अनलॉक करें और निरंतर विकास का समर्थन करने के लिए संरक्षक बनें!</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Zahtijeva BVM FOSS</string>
     <string name="upgrade_prompt_title">Nadogradite na BVM FOSS</string>
     <string name="upgrade_prompt_body">Otključajte dodatne značajke i postanite pokrovitelj kako biste podržali daljnji razvoj!</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS szükséges</string>
     <string name="upgrade_prompt_title">Frissítés BVM FOSS-ra</string>
     <string name="upgrade_prompt_body">Fedezze fel a további funkciókat, és legyen patron támogató, hogy támogassa a folyamatos fejlesztést!</string>

--- a/app/src/foss/res/values-hy-rAM/strings.xml
+++ b/app/src/foss/res/values-hy-rAM/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Պահանջվում է BVM FOSS</string>
     <string name="upgrade_prompt_title">Անցնել BVM FOSS-ին</string>
     <string name="upgrade_prompt_body">Բացեք լրացուցիչ գործառույթներ և դարձեք հովանավոր՝ շարունակական զարգացումը աջակցելու համար:</string>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">Perangkat Lunak Gratis dan Sumber Terbuka</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Membutuhkan BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgrade ke BVM FOSS</string>
     <string name="upgrade_prompt_body">Buka fitur-fitur tambahan dan jadilah penyokong yang mendukung pengembangan yang berkelanjutan!</string>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Krefst BVM FOSS</string>
     <string name="upgrade_prompt_title">Uppfæra í BVM FOSS</string>
     <string name="upgrade_prompt_body">Opnaðu viðbótareiginleika og vertu styrktaraðili til að styðja áframhaldandi þróun!</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Richiede BVM FOSS</string>
     <string name="upgrade_prompt_title">Aggiorna a BVM FOSS</string>
     <string name="upgrade_prompt_body">Sblocca funzioni aggiuntive e diventa un sostenitore per supportare lo sviluppo continuo!</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">דורש BVM FOSS</string>
     <string name="upgrade_prompt_title">שדרג ל-BVM FOSS</string>
     <string name="upgrade_prompt_body">בטל נעילה של תכונות נוספות והפוך לפטרון לתמיכה בהמשך הפיתוח!</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS が必要です</string>
     <string name="upgrade_prompt_title">BVM FOSS にアップグレード</string>
     <string name="upgrade_prompt_body">開発を続けるためパトロンになって追加機能を解除してください</string>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">საჭიროა BVM FOSS</string>
     <string name="upgrade_prompt_title">გადაიდგეს BVM FOSS-ზე</string>
     <string name="upgrade_prompt_body">განბლოკეთ დამატებითი ფუნქციები და გახდით მფარველი მუდმივი განვითარების მხარდასაჭერად!</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">ត្រូវការ BVM FOSS</string>
     <string name="upgrade_prompt_title">ធ្វើឱ្យប្រសើរទៅ BVM FOSS</string>
     <string name="upgrade_prompt_body">ដោះសោមុខងារបន្ថែម និងក្លាយជាអ្នកឧបត្ថម្ភដើម្បីគាំទ្រការអភិវឌ្ឍន៍បន្ត!</string>

--- a/app/src/foss/res/values-kmr-rTR/strings.xml
+++ b/app/src/foss/res/values-kmr-rTR/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS hewce dike</string>
     <string name="upgrade_prompt_title">Biçe BVM FOSS</string>
     <string name="upgrade_prompt_body">Taybetmendîên zêde veke!</string>

--- a/app/src/foss/res/values-kn-rIN/strings.xml
+++ b/app/src/foss/res/values-kn-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS ಅಗತ್ಯ</string>
     <string name="upgrade_prompt_title">BVM FOSS ಗೆ ದರ್ಜೆಯೇರಿ</string>
     <string name="upgrade_prompt_body">ಹೆಚ್ಚಿನ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಅನ್ಲಾಕ್ ಮಾಡಿ ಮತ್ತು ನಿರಂತರ ಅಭಿವರ್ಧನೆಗೆ ಬೆಂಬಲಿಸಲು ಪ್ರಾಯೋಜಕರಾಗಿ!</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS가 필요합니다</string>
     <string name="upgrade_prompt_title">BVM FOSS로 업그레이드</string>
     <string name="upgrade_prompt_body">후원자가 되어 앱 개발을 지원하고 추가 기능을 잠금해제 하세요!</string>

--- a/app/src/foss/res/values-ky-rKG/strings.xml
+++ b/app/src/foss/res/values-ky-rKG/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS талап кылат</string>
     <string name="upgrade_prompt_title">BVM FOSS га өтүү</string>
     <string name="upgrade_prompt_body">Кошумча функцияларды ачыңыз жана үзгөлтүрүлгөн ишкерленишти колдоо үчүн патрон болуңуз!</string>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">ຕ້ອງການ BVM FOSS</string>
     <string name="upgrade_prompt_title">ອັບເກຣດເປັນ BVM FOSS</string>
     <string name="upgrade_prompt_body">ປົດລັອກຄຸນສົມບັດເພີ່ມເຕີມ ແລະ ກາຍເປັນຜູ້ອຸປະຖໍາເພື່ອສະໜັບສະໜູນການພັດທະນາຢ່າງຕໍ່ເນື່ອງ!</string>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Reikia BVM FOSS</string>
     <string name="upgrade_prompt_title">Atnaujinti į BVM FOSS</string>
     <string name="upgrade_prompt_body">Atrakinkite papildomas funkcijas ir tapkite globėju, kad palaikytumėte tolesnį plėtojimą!</string>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BSP FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Nepieciešams BSP FOSS</string>
     <string name="upgrade_prompt_title">Jaunināt uz BSP FOSS</string>
     <string name="upgrade_prompt_body">Atslēdz papildu iespējas un kļūsti par aizbildni, lai atbalstītu izstrādes nepārtrauktību!</string>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Потребен е BVM FOSS</string>
     <string name="upgrade_prompt_title">Надгради на BVM FOSS</string>
     <string name="upgrade_prompt_body">Отклучете дополнителни функции и станете покровител за да го поддржите континуираниот развој!</string>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS ആവശ്യമാണ്</string>
     <string name="upgrade_prompt_title">BVM FOSS യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrade_prompt_body">കൂടുതൽ സവിശേഷതകൾ അൺലോക്കുചെയ്‌ത് തുടർ വികസനത്തെ പിന്തുണയ്ക്കുന്നതിന് ഒരു പാട്രോൺ ആകുക!</string>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS шаардлагана</string>
     <string name="upgrade_prompt_title">BVM FOSS рүү шилжээх</string>
     <string name="upgrade_prompt_body">Нэмэлт боломжуудыг нээж, тасралтгүй хөгжлийг дэмжихийн тулд ивээн тэтгэгч болоорой!</string>

--- a/app/src/foss/res/values-mr-rIN/strings.xml
+++ b/app/src/foss/res/values-mr-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS आवश्यक आहे</string>
     <string name="upgrade_prompt_title">BVM FOSS वर अपग्रेड करा</string>
     <string name="upgrade_prompt_body">अद्यावत वैशिष्ट्ये अनलॉक करा आणि सतत विकासास सहाय्य करण्यासाठी प्रायोजक व्हा!</string>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Memerlukan BVM FOSS</string>
     <string name="upgrade_prompt_title">Naik taraf ke BVM FOSS</string>
     <string name="upgrade_prompt_body">Buka kunci ciri tambahan dan menjadi penaung untuk menyokong pembangunan berterusan!</string>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS လိုအပ်သည်</string>
     <string name="upgrade_prompt_title">BVM FOSS သို့ အဆင့်မြှင့်ပါ</string>
     <string name="upgrade_prompt_body">အပိုဝန်ဆောင်မှုများကို ဖွင့်ပြီး ဆက်လက်ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးရန် ကူညီသူဖြစ်လာပါ!</string>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS आवश्यक छ</string>
     <string name="upgrade_prompt_title">BVM FOSS मा अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_prompt_body">थप सुविधाहरू अनलक गर्नुहोस् र निरन्तर विकासलाई समर्थन गर्न संरक्षक बन्नुहोस्!</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Vereist BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgrade naar BVM FOSS</string>
     <string name="upgrade_prompt_body">Ontgrendel extra functies en word een patroon om verdere ontwikkeling te ondersteunen!</string>

--- a/app/src/foss/res/values-no/strings.xml
+++ b/app/src/foss/res/values-no/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Krever BVM FOSS</string>
     <string name="upgrade_prompt_title">Oppgrader til BVM FOSS</string>
     <string name="upgrade_prompt_body">Lås opp flere funksjoner og bli en patron for å støtte utviklingen videre!</string>

--- a/app/src/foss/res/values-pcm-rNG/strings.xml
+++ b/app/src/foss/res/values-pcm-rNG/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Need BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgrade to BVM FOSS</string>
     <string name="upgrade_prompt_body">Unlock additional features and become patron to support continued development!</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Wymaga BVM FOSS</string>
     <string name="upgrade_prompt_title">Uaktualnij do BVM FOSS</string>
     <string name="upgrade_prompt_body">Odblokuj dodatkowe funkcje i zostań patronem, aby wesprzeć dalszy rozwój!</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Requer BVM FOSS</string>
     <string name="upgrade_prompt_title">Atualizar para BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloqueie recursos adicionais e torne-se um patrão para apoiar o desenvolvimento contínuo!</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Requer BVM FOSS</string>
     <string name="upgrade_prompt_title">Atualizar para BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloqueie funcionalidades extra e torne-se um patrono para apoiar o desenvolvimento contínuo!</string>

--- a/app/src/foss/res/values-rm/strings.xml
+++ b/app/src/foss/res/values-rm/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Basegna BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualisar a BVM FOSS</string>
     <string name="upgrade_prompt_body">Deblocha funcziuns supplementaras e daventescha in patronu per sustegnair il svilup ulterior!</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Necesită BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizează la BVM FOSS</string>
     <string name="upgrade_prompt_body">Deblochează funcții suplimentare și devino un patron pentru a suporta dezvoltarea continuată!</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Требуется BVM FOSS</string>
     <string name="upgrade_prompt_title">Обновить до BVM FOSS</string>
     <string name="upgrade_prompt_body">Разблокируйте дополнительные возможности и станьте спонсором, чтобы поддержать разработку приложения!</string>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Riquerit BVM FOSS</string>
     <string name="upgrade_prompt_title">Addobba a BVM FOSS</string>
     <string name="upgrade_prompt_body">Aberri funtzionalidades addizionales e diventa patronu pro sustènnere su isvilupu continuadu!</string>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS අවශ්‍යයි</string>
     <string name="upgrade_prompt_title">BVM FOSS වෙත උත්‍යෝජනය කරන්න</string>
     <string name="upgrade_prompt_body">අමතර විශේෂාංග අඟුල හරිමින් අඛණ්ඩ සංවර්ධනයට සහාය වීමට අනුග්‍රාහකයෙකු වන්න!</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Vyžaduje BVM FOSS</string>
     <string name="upgrade_prompt_title">Prejsť na BVM FOSS</string>
     <string name="upgrade_prompt_body">Odomknite ďalšie funkcie a staňte sa patrónom na podporu ďalšieho vývoja!</string>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Zahteva BVM FOSS</string>
     <string name="upgrade_prompt_title">Nadgradite na BVM FOSS</string>
     <string name="upgrade_prompt_body">Odklenite dodatne funkcije in postanite pokrovitelj, da podprete nadaljnji razvoj!</string>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Kërkon BVM FOSS</string>
     <string name="upgrade_prompt_title">Përmirëso në BVM FOSS</string>
     <string name="upgrade_prompt_body">Çelni veçori shtesë dhe bëhuni një mbrojtës për të mbështetur zhvillimin e vazhdueshëm!</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Захтева BVM FOSS</string>
     <string name="upgrade_prompt_title">Надогради на BVM FOSS</string>
     <string name="upgrade_prompt_body">Откључај додатне функције и постани покровитељ да подржиш континуирани развој!</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Kräver BVM FOSS</string>
     <string name="upgrade_prompt_title">Uppgradera till BVM FOSS</string>
     <string name="upgrade_prompt_body">Lås upp ytterligare funktioner och bli en beskyddare för att stödja fortsatt utveckling!</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Inahitaji BVM FOSS</string>
     <string name="upgrade_prompt_title">Boresha hadi BVM FOSS</string>
     <string name="upgrade_prompt_body">Fungua vipengele vya ziada na uwe mfumo wa kuunga mkono maendeleo ya kuendelea!</string>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS தேவைப்படுகிறது</string>
     <string name="upgrade_prompt_title">BVM FOSSக்கு மேம்படுத்து</string>
     <string name="upgrade_prompt_body">கூடுதல் அம்சங்களைத் திறக்கவும் மற்றும் தொடர்ச்சியான மேம்பாட்டை ஆதரிக்க புரவலராக மாறவும்!</string>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS అవసరం</string>
     <string name="upgrade_prompt_title">BVM FOSS కి అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_prompt_body">అదనపు ఫీచర్లను అన్‌లాక్ చేసి, నిరంతర అభివృద్ధికి మద్దతు ఇవ్వడానికి పేట్రన్ అవ్వండి!</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">บังคับ</string>
-    <string name="upgrade_badge_label">บังคับ</string>
     <string name="upgrade_feature_requires_pro">ต้องใช้ BVM FOSS</string>
     <string name="upgrade_prompt_title">อัปเกรดเป็น BVM FOSS</string>
     <string name="upgrade_prompt_body">ปลดล็อกฟีเจอร์เพิ่มเติมและเป็นผู้อุปถัมภ์เพื่อสนับสนุนการพัฒนาอย่างต่อเนื่อง!</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS gereklidir</string>
     <string name="upgrade_prompt_title">BVM FOSS\'a Yükselt</string>
     <string name="upgrade_prompt_body">Ek özelliklerin kilidini açın ve sürekli gelişimi desteklemek için bir patron olun!</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Потрібен BVM FOSS</string>
     <string name="upgrade_prompt_title">Оновити до BVM FOSS</string>
     <string name="upgrade_prompt_body">Розблокуйте додаткові функції та станьте спонсором, щоб підтримати подальший розвиток!</string>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS کی ضرورت ہے</string>
     <string name="upgrade_prompt_title">BVM FOSS میں اپ گریڈ کریں</string>
     <string name="upgrade_prompt_body">اضافی خصوصیات کو غیر مقفل کریں اور مسلسل ترقی کی حمایت کے لیے سرپرست بنیں!</string>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS talab qilinadi</string>
     <string name="upgrade_prompt_title">BVM FOSS ga o\'tish</string>
     <string name="upgrade_prompt_body">Qo\'shimcha xususiyatlarni oching va doimiy rivojlanishni qo\'llab-quvvatlash uchun homiy bo\'ling!</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Yêu cầu BVM FOSS</string>
     <string name="upgrade_prompt_title">Nâng cấp lên BVM FOSS</string>
     <string name="upgrade_prompt_body">Mở khóa các tính năng bổ sung và trở thành người bảo trợ để hỗ trợ sự phát triển liên tục!</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">需要 BVM FOSS</string>
     <string name="upgrade_prompt_title">升级至 BVM FOSS</string>
     <string name="upgrade_prompt_body">解锁附加功能，成为支持持续开发的赞助人！</string>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">需要 BVM FOSS</string>
     <string name="upgrade_prompt_title">升級到 BVM FOSS</string>
     <string name="upgrade_prompt_body">解鎖額外功能，並成為贊助者，以支持持續開發！</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">需要 BVM FOSS</string>
     <string name="upgrade_prompt_title">升級至 BVM FOSS</string>
     <string name="upgrade_prompt_body">解鎖額外功能，並成為贊助者，以支持持續開發！</string>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -1,8 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
     <string name="upgrade_feature_requires_pro">Kudingeka i-BVM FOSS</string>
     <string name="upgrade_prompt_title">Buyekeza kuya ku-BVM FOSS</string>
     <string name="upgrade_prompt_body">Vula izici ezengeziwe futhi ube ngumnikazi ukuze usekele ukuthuthukiswa okuqhubekayo!</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="app_name_upgraded">BVM FOSS</string>
-    <string name="app_name_upgrade_postfix">FOSS</string>
-    <string name="upgrade_badge_label">FOSS</string>
+    <string name="app_name_upgrade_postfix" translatable="false">FOSS</string>
+    <string name="upgrade_badge_label" translatable="false">FOSS</string>
 
     <string name="upgrade_feature_requires_pro">Requires BVM FOSS</string>
 

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/BillingCache.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/BillingCache.kt
@@ -12,8 +12,10 @@ import eu.darken.bluemusic.common.datastore.basicReader
 import eu.darken.bluemusic.common.datastore.basicWriter
 import eu.darken.bluemusic.common.datastore.createValue
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
+import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.withTimeoutOrNull
 import java.io.IOException
@@ -93,14 +95,24 @@ class BillingCache internal constructor(
     // not erase.
     suspend fun stampLastProState(skuId: String, at: Long) {
         // Fail-soft: this decorates the entitlement path, it must never be the thing that blocks it.
-        withTimeoutOrNull(cacheTimeoutMs) {
-            dataStore.edit { prefs ->
-                prefs[lastProStateSkuKey] = skuId
-                prefs[lastProStateAtKey] = at
-                val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
-                if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
-            }
-        } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+        // A wedged file lock (timeout) and a broken write (IOException, corrupt file, no disk space)
+        // are the same to the caller — the stamp is lost, the bookkeeping around it carries on.
+        try {
+            withTimeoutOrNull(cacheTimeoutMs) {
+                dataStore.edit { prefs ->
+                    prefs[lastProStateSkuKey] = skuId
+                    prefs[lastProStateAtKey] = at
+                    val episodeStart = prefs[proUnconfirmedSinceKey] ?: 0L
+                    if (episodeStart in 1..at) prefs[proUnconfirmedSinceKey] = 0L
+                }
+            } ?: log(TAG, WARN) { "stampLastProState($skuId, $at) timed out after ${cacheTimeoutMs}ms, write skipped" }
+        } catch (e: CancellationException) {
+            // Caught before the general case on purpose: our caller going away is not a write
+            // failure, and swallowing it would break their structured concurrency.
+            throw e
+        } catch (e: Exception) {
+            log(TAG, WARN) { "stampLastProState($skuId, $at) failed, write skipped: ${e.asLog()}" }
+        }
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeDiagnosticsGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeDiagnosticsGplay.kt
@@ -7,6 +7,7 @@ import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.upgrade.UpgradeDiagnostics
 import eu.darken.bluemusic.main.core.CurriculumVitae
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.withTimeoutOrNull
 import java.time.Instant
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -28,6 +29,10 @@ class UpgradeDiagnosticsGplay @Inject constructor(
     private val curriculumVitae: CurriculumVitae,
 ) : UpgradeDiagnostics {
 
+    // Test seam: the bounded read below runs on real dispatchers, so a virtual-time test cannot
+    // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
+    internal var historyTimeoutMs: Long = HISTORY_TIMEOUT_MS
+
     override suspend fun debugInfo(): String {
         val cache = try {
             val snapshot = billingCache.snapshot()
@@ -47,7 +52,12 @@ class UpgradeDiagnosticsGplay @Inject constructor(
         // and the counters only cover installs new enough to have them. A failure to read one must
         // not suppress the other's independent evidence.
         val history = try {
-            curriculumVitae.proHistory().toString()
+            // Bounded like the cache read above: a wedged DataStore file lock would otherwise hold
+            // the debug-log header - and with it the start of the recording - forever.
+            withTimeoutOrNull(historyTimeoutMs) { curriculumVitae.proHistory().toString() } ?: run {
+                log(TAG, WARN) { "Pro history timed out after ${historyTimeoutMs}ms" }
+                "unavailable"
+            }
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
@@ -58,6 +68,7 @@ class UpgradeDiagnosticsGplay @Inject constructor(
     }
 
     companion object {
+        private const val HISTORY_TIMEOUT_MS = 2_000L
         private val TAG = logTag("Upgrade", "Gplay", "Diagnostics")
     }
 }

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BSP Pro</string>
     <string name="app_name_upgrade_postfix">Pro</string>
     <string name="upgrade_badge_label">PRO</string>
     <string name="upgrade_feature_requires_pro">Nepieciešams BSP Pro</string>

--- a/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModule.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeoutOrNull
 import androidx.annotation.VisibleForTesting
 import java.io.File
 import javax.inject.Inject
@@ -41,6 +42,10 @@ class RecorderModule @Inject constructor(
     private val upgradeDiagnostics: UpgradeDiagnostics,
     private val recorderProvider: Provider<Recorder>,
 ) {
+
+    // Test seam: the header read below is bounded on real dispatchers, so a virtual-time test cannot
+    // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
+    internal var headerReadTimeoutMs: Long = HEADER_READ_TIMEOUT_MS
 
     @Volatile
     internal var currentLogDir: File? = null
@@ -91,8 +96,19 @@ class RecorderModule @Inject constructor(
 
                 try {
                     // Billing complaints usually arrive as debug logs: having the local entitlement
-                    // record in the header saves a support round-trip.
-                    upgradeDiagnostics.debugInfo()?.let { log(TAG, INFO) { "Upgrade diagnostics: $it" } }
+                    // record in the header saves a support round-trip. Bounded on top of that: debug
+                    // recording is what a user reaches for when the app is ALREADY misbehaving, so a
+                    // source that never answers (a stuck DataStore file lock, a billing store that
+                    // doesn't respond) must not hold up the start of the recording either.
+                    val read = withTimeoutOrNull(headerReadTimeoutMs) { HeaderRead(upgradeDiagnostics.debugInfo()) }
+                    when {
+                        read == null -> log(TAG, WARN) {
+                            "Upgrade diagnostics unavailable, read did not finish within ${headerReadTimeoutMs}ms"
+                        }
+                        // Completion is tracked separately from the value: a flavor that legitimately has
+                        // nothing to report (FOSS) returns null and gets no line at all, not an "unavailable".
+                        read.value != null -> log(TAG, INFO) { "Upgrade diagnostics: ${read.value}" }
+                    }
                 } catch (e: CancellationException) {
                     throw e
                 } catch (e: Exception) {
@@ -146,6 +162,12 @@ class RecorderModule @Inject constructor(
             }
         }
     }
+
+    /**
+     * Completion marker for a header read: tells a source that legitimately has nothing to report
+     * (no diagnostics on FOSS) apart from one that never answered within the deadline.
+     */
+    private class HeaderRead<T>(val value: T)
 
     private fun createSessionDir(): File {
         val timestamp = java.time.ZonedDateTime.now(java.time.ZoneOffset.UTC)
@@ -233,6 +255,9 @@ class RecorderModule @Inject constructor(
         internal val TAG = logTag("Debug", "Log", "Recorder", "Module")
         private const val FORCE_FILE = "bluemusic_force_debug_run"
         private const val MIN_RECORDING_MS = 5_000L
+
+        // Budget for the header's diagnostics read.
+        private const val HEADER_READ_TIMEOUT_MS = 5_000L
 
         @VisibleForTesting
         internal fun findExistingSessionDir(logDirectories: List<File>): File? {

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name"></string>
     <string name="app_name_short">BVM</string>
     <!-- General -->
     <string name="general_error_label">錯誤</string>

--- a/app/src/test/java/eu/darken/bluemusic/common/WebpageToolTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/common/WebpageToolTest.kt
@@ -1,0 +1,57 @@
+package eu.darken.bluemusic.common
+
+import android.app.Application
+import android.content.ActivityNotFoundException
+import android.content.ContextWrapper
+import android.content.Intent
+import androidx.core.net.toUri
+import androidx.test.core.app.ApplicationProvider
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The return value is a contract, not a convenience: the FOSS sponsor unlock heuristic only arms
+ * when the page actually opened. Every swallow point has to report the failure back.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class WebpageToolTest : BaseTest() {
+
+    private val application: Application
+        get() = ApplicationProvider.getApplicationContext()
+
+    @Test
+    fun `a launched page reports success`() {
+        WebpageTool(application).open(URL) shouldBe true
+
+        shadowOf(application).nextStartedActivity!!.data shouldBe URL.toUri()
+    }
+
+    @Test
+    fun `a missing browser reports failure`() {
+        val context = object : ContextWrapper(application) {
+            override fun startActivity(intent: Intent) = throw ActivityNotFoundException("No browser")
+        }
+
+        WebpageTool(context).open(URL) shouldBe false
+    }
+
+    @Test
+    fun `a denied launch reports failure`() {
+        val context = object : ContextWrapper(application) {
+            override fun startActivity(intent: Intent) = throw SecurityException("Permission Denial")
+        }
+
+        WebpageTool(context).open(URL) shouldBe false
+    }
+
+    companion object {
+        private const val URL = "https://github.com/sponsors/d4rken"
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModuleTest.kt
@@ -2,7 +2,9 @@ package eu.darken.bluemusic.common.debug.recorder.core
 
 import android.content.Context
 import eu.darken.bluemusic.common.BlueMusicId
+import eu.darken.bluemusic.common.debug.logging.Logging
 import eu.darken.bluemusic.common.upgrade.UpgradeDiagnostics
+import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
@@ -13,15 +15,20 @@ import io.mockk.mockk
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.yield
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -31,7 +38,9 @@ import testhelpers.BaseTest
 import testhelpers.coroutine.TestDispatcherProvider
 import java.io.File
 import java.io.IOException
+import java.util.concurrent.CopyOnWriteArrayList
 import javax.inject.Provider
+import kotlin.system.measureTimeMillis
 
 class RecorderModuleTest : BaseTest() {
 
@@ -199,6 +208,38 @@ class RecorderModuleTest : BaseTest() {
             recorderProvider = recorderProvider,
         )
 
+        private val logLines = CopyOnWriteArrayList<String>()
+        private val logCapture = object : Logging.Logger {
+            override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+                logLines.add(message)
+            }
+        }
+
+        /**
+         * Real dispatchers on purpose: the header's read deadline is wall-clock, so a virtual-time
+         * test would skip past it instead of exercising it — an ignored seam has to fail this, not
+         * pass after the full production budget. The seam is set before [RecorderModule.startRecorder]
+         * so no header read can run against the production bound.
+         *
+         * The block runs inside its own deadline: a missing or mis-wired production bound must fail
+         * this test rather than wedge the gradle worker on a read that never answers.
+         */
+        private fun withRealtimeModule(
+            headerTimeoutMs: Long = 300L,
+            block: suspend (RecorderModule) -> Unit,
+        ) {
+            val moduleScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+            Logging.install(logCapture)
+            try {
+                val module = createModule(moduleScope, Dispatchers.IO)
+                module.headerReadTimeoutMs = headerTimeoutMs
+                runBlocking { withTimeout(TEST_ENVELOPE_MS) { block(module) } }
+            } finally {
+                Logging.remove(logCapture)
+                moduleScope.cancel()
+            }
+        }
+
         /** A recorder started from the debug settings has no trigger file yet — and an unwritable
          * external files dir makes creating it fail right after the recorder went live. */
         private fun blockTriggerFileCreation() {
@@ -217,7 +258,9 @@ class RecorderModuleTest : BaseTest() {
             val dispatcher = UnconfinedTestDispatcher(testScheduler)
             val moduleScope = CoroutineScope(dispatcher + Job())
             val module = createModule(moduleScope, dispatcher)
-            advanceUntilIdle()
+            // runCurrent, not advanceUntilIdle: the header read is bounded, and advancing virtual
+            // time would jump that deadline so the header completes before the cancellation lands.
+            runCurrent()
 
             // Cancelling the module's scope cancels the in-flight header read.
             moduleScope.cancel()
@@ -305,5 +348,41 @@ class RecorderModuleTest : BaseTest() {
             starter.cancel()
             moduleScope.cancel()
         }
+
+        /**
+         * Debug recording is what a user reaches for when the app is ALREADY misbehaving, so a
+         * diagnostics source that never answers must not be the thing that denies them the log.
+         */
+        @Test
+        fun `a wedged upgrade diagnostics read does not hold up the recording`() {
+            coEvery { upgradeDiagnostics.debugInfo() } coAnswers { awaitCancellation() }
+
+            withRealtimeModule(headerTimeoutMs = 300L) { module ->
+                val elapsed = measureTimeMillis { module.startRecorder() }
+
+                module.state.first().isRecording shouldBe true
+                logLines.any { it.startsWith("Upgrade diagnostics unavailable") } shouldBe true
+                // Non-vacuity: without the bound this would sit on the wedged read forever.
+                elapsed shouldBeLessThan 1_500L
+            }
+        }
+
+        @Test
+        fun `a flavor without diagnostics is not reported as unavailable`() {
+            // FOSS has nothing to report and returns null: no diagnostics line at all, and above all
+            // not one claiming the read failed or timed out.
+            coEvery { upgradeDiagnostics.debugInfo() } returns null
+
+            withRealtimeModule { module ->
+                module.startRecorder()
+
+                module.state.first().isRecording shouldBe true
+                logLines.any { it.startsWith("Upgrade diagnostics") } shouldBe false
+            }
+        }
     }
 }
+
+// Independent of the production bound: a missing or mis-wired one has to fail the test, not hang
+// the gradle worker.
+private const val TEST_ENVELOPE_MS = 10_000L

--- a/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -358,4 +358,44 @@ class FossUpgradeViewModelTest : BaseTest() {
         coVerify(exactly = 0) { repo.persistUpgrade() }
         vm.state.value.supporterSince shouldBe Instant.EPOCH
     }
+
+    @Test
+    fun `a long sponsor visit by an already upgraded user does not re-persist the upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The armed path taken by a supporter who tapped the pitch's sponsor button again: persisting
+        // would rewrite upgradedAt and visibly reset the "supporter since" date the status screen
+        // shows, and the thanks toast belongs to an unlock that already happened.
+        val repo = mockRepo(MutableStateFlow(upgradedInfo()))
+        val vm = buildVm(repo = repo)
+
+        val nudges = mutableListOf<Int>()
+        val thanks = mutableListOf<Int>()
+        val snackbarCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.snackbarEvents.collect { nudges.add(it) }
+        }
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        thanks.shouldBeEmpty()
+        nudges.shouldBeEmpty()
+        // The pending launch is consumed even on the quiet path.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // A later resume finds nothing armed and stays a no-op.
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        thanks.shouldBeEmpty()
+        nudges.shouldBeEmpty()
+
+        snackbarCollector.cancel()
+        toastCollector.cancel()
+    }
 }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/BillingCacheTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/BillingCacheTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ApplicationProvider
 import eu.darken.bluemusic.common.datastore.value
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
@@ -94,6 +95,28 @@ class BillingCacheTest : BaseTest() {
         // The write only decorates the entitlement path, it must never block it.
         cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
     }
+
+    @Test
+    fun `a failing datastore write does not abort the entitlement bookkeeping`() = runTest {
+        // A broken write (corrupt file, no disk space) is not the same failure as a wedged lock, and
+        // the timeout alone doesn't cover it -- the exception would propagate straight through the
+        // stamp into the caller that was only decorating its entitlement work.
+        val cache = BillingCache(ThrowingPreferencesDataStore())
+
+        cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L)
+
+        // Reads stay loud: a snapshot that can't be read must not look like "never bought".
+        shouldThrow<IOException> { cache.snapshot() }
+    }
+
+    @Test
+    fun `a cancelled stamp still cancels`() = runTest {
+        // Fail-soft must not extend to cancellation -- swallowing it would break the structured
+        // concurrency of whatever entitlement work is being torn down.
+        val cache = BillingCache(CancellingPreferencesDataStore())
+
+        shouldThrow<CancellationException> { cache.stampLastProState(OurSku.Iap.PRO_UPGRADE.id, 1234L) }
+    }
 }
 
 /** DataStore that never answers -- stands in for a wedged file lock. */
@@ -102,4 +125,20 @@ internal class HangingPreferencesDataStore : DataStore<Preferences> {
 
     override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
         awaitCancellation()
+}
+
+/** DataStore whose I/O fails -- stands in for a corrupt file or a full disk. */
+internal class ThrowingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { throw IOException("Preferences file is broken") }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        throw IOException("Preferences file is broken")
+}
+
+/** DataStore whose write is cancelled from the outside. */
+internal class CancellingPreferencesDataStore : DataStore<Preferences> {
+    override val data: Flow<Preferences> = flow { throw CancellationException("Torn down") }
+
+    override suspend fun updateData(transform: suspend (Preferences) -> Preferences): Preferences =
+        throw CancellationException("Torn down")
 }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeDiagnosticsGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeDiagnosticsGplayTest.kt
@@ -2,15 +2,21 @@ package eu.darken.bluemusic.upgrade.core
 
 import eu.darken.bluemusic.main.core.CurriculumVitae
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
 import io.mockk.coEvery
 import io.mockk.mockk
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import kotlin.system.measureTimeMillis
 
 class UpgradeDiagnosticsGplayTest : BaseTest() {
 
@@ -124,6 +130,36 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
     }
 
     @Test
+    fun `a wedged history is reported as unavailable`() = runTest {
+        // Counterpart to the wedged cache above: a never-answering CurriculumVitae store would hold
+        // the debug-log header -- and with it the start of the recording -- forever.
+        val diagnostics = UpgradeDiagnosticsGplay(
+            billingCache = mockk<BillingCache>().apply {
+                coEvery { snapshot() } returns BillingCache.Snapshot(
+                    lastProStateAt = 0L,
+                    lastProStateSku = "",
+                    proUnconfirmedSince = 0L,
+                )
+            },
+            curriculumVitae = mockk<CurriculumVitae>().apply {
+                coEvery { proHistory() } coAnswers { awaitCancellation() }
+            },
+        ).apply { historyTimeoutMs = 50L }
+
+        lateinit var info: String
+        // Real time on purpose: under virtual time the bound would fire instantly while nothing else
+        // is scheduled, so an ignored seam would still pass. The envelope is independent of the
+        // production bound: a missing or mis-wired one has to fail the test, not hang the worker.
+        val elapsed = withContext(Dispatchers.IO) {
+            withTimeout(TEST_ENVELOPE_MS) { measureTimeMillis { info = diagnostics.debugInfo() } }
+        }
+
+        info shouldContain "BillingCache(lastProStateAt=never"
+        info shouldContain "ProHistory=unavailable"
+        elapsed shouldBeLessThan 1_000L
+    }
+
+    @Test
     fun `a confirmed purchase reports an instant and the sku`() = runTest {
         val info = create(
             {
@@ -155,3 +191,7 @@ class UpgradeDiagnosticsGplayTest : BaseTest() {
         info shouldContain "proUnconfirmedSince=2023-11-14T22:21:40Z"
     }
 }
+
+// Independent of the production bound: a missing or mis-wired one has to fail the test, not hang
+// the gradle worker.
+private const val TEST_ENVELOPE_MS = 10_000L


### PR DESCRIPTION
## What changed

FOSS version: a supporter who opens the GitHub Sponsors page from the main pitch and comes back later can no longer accidentally reset their "supporter since" date — the return check now recognizes an already-upgraded install before doing anything else. And the "FOSS" flavor labels are no longer translatable: several languages had them translated into regular words (the Thai one meant "force", the Indonesian one was a 44-character phrase), which leaked into the screen title, settings row, dashboard card and widget configuration. Two stray translation defects are also fixed: the Traditional Chinese launcher label was empty, and the Latvian upgraded-app titles carried the wrong app's acronym.

For support: debug-log recording now starts even when the billing storage is wedged — the log header's diagnostics read is bounded instead of waiting forever. A failed write to the purchase cache also no longer interrupts the surrounding entitlement bookkeeping.

## Technical Context

- Propagates the latest canonical billing/upgrade batch (follow-up to #247). This app already carried most of the sponsor-flow hardening (it originated the launch-success gate and the unarmed donate path); the remaining piece was hoisting the already-Pro check in `checkSponsorReturn()` above the duration check, so the armed pitch path can no longer re-run `persistUpgrade()` for an existing supporter.
- `stampLastProState()` was fail-soft for timeouts only; thrown write exceptions now degrade to a logged skip (cancellation rethrown, covered by dedicated fakes). Reads stay loud.
- The recorder's single header read is bounded by a 5s seam with a completion marker distinguishing "timed out" from "legitimately nothing to report" (FOSS has no upgrade diagnostics and stays silent). The GPlay diagnostics' pro-history read gets the same 2s bound its billing-cache read already had. The existing cancellation regression test needed one adjustment (`runCurrent()` instead of the first `advanceUntilIdle()`) so virtual time doesn't skip past the new deadline before cancellation — verified load-bearing in both directions.
- Resources: `app_name_upgrade_postfix` and `upgrade_badge_label` (FOSS flavor) are `translatable="false"` with all locale entries removed; completeness was verified by occurrence checks since unused-translation lint isn't fatal here. The GPlay "Pro" postfix/badge translations are intentional and untouched. The Latvian `app_name_upgraded` entries and the empty zh-TW `app_name` were content defects and fall back to the base strings.
- Review guidance: the wedge tests run on real dispatchers with short seams, elapsed ceilings, and independent 10s envelopes (a regressed bound fails the test rather than hanging the worker); the launch-success Boolean's contract now has its first dedicated tests.
