### PR TITLE
Protect the supporter date and improve the debug log warning

### DIFF
--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/core/FossCache.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/core/FossCache.kt
@@ -11,16 +11,20 @@ import kotlinx.serialization.json.Json
 import javax.inject.Inject
 import javax.inject.Singleton
 
+private val Context.fossCacheDataStore by preferencesDataStore(name = "settings_foss")
+
 @Singleton
-class FossCache @Inject constructor(
-    @param:ApplicationContext private val context: Context,
-    json: Json
+class FossCache internal constructor(
+    // Test seam: the store is handed in so a test can supply its own DataStore instead of the
+    // Context-bound production delegate.
+    private val dataStore: DataStore<Preferences>,
+    json: Json,
 ) {
 
-    private val Context.dataStore by preferencesDataStore(name = "settings_foss")
-
-    private val dataStore: DataStore<Preferences>
-        get() = context.dataStore
+    @Inject constructor(
+        @ApplicationContext context: Context,
+        json: Json,
+    ) : this(context.fossCacheDataStore, json)
 
     val upgrade = dataStore.createValue<FossUpgrade?>(
         key = "foss.upgrade",

--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
@@ -2,7 +2,7 @@ package eu.darken.bluemusic.upgrade.core
 
 import eu.darken.bluemusic.common.WebpageTool
 import eu.darken.bluemusic.common.coroutine.AppScope
-import eu.darken.bluemusic.common.datastore.valueBlocking
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.flow.setupCommonEventHandlers
@@ -67,12 +67,36 @@ class UpgradeRepoFoss @Inject constructor(
         return webpageTool.open(upgradeSite)
     }
 
-    suspend fun persistUpgrade() {
+    /**
+     * Create-only-if-absent inside the store transaction: an existing record (and its upgradedAt —
+     * the user-visible "supporter since" date) is never replaced. The VM-level isPro guard alone is
+     * not race-free: it reads a shareIn replay that can be stale. Note the kept record is still
+     * re-encoded through the current schema — decoded fields are preserved exactly.
+     *
+     * Caveat, and it is build-type conditional here: [FossCache] enables `onErrorFallbackToDefault`
+     * only on RELEASE builds. On release, a stored record that fails to decode reads as null and
+     * therefore counts as ABSENT to this transaction, i.e. it gets replaced. That matches the
+     * pre-existing read behaviour — such a record already presents the user as free — and
+     * re-creating it on the next successful sponsor visit is the recovery path. On debug/beta the
+     * decode THROWS instead, so this persist fails outright and the caller restores its
+     * pending-return marker for a later retry.
+     *
+     * @return true if a new record was created, false if an existing record was kept.
+     */
+    suspend fun persistUpgrade(): Boolean {
         log(TAG) { "persistUpgrade()" }
-        fossCache.upgrade.valueBlocking = FossUpgrade(
-            upgradedAt = Instant.now(),
-            upgradeType = FossUpgrade.Type.GITHUB_SPONSORS
-        )
+        val updated = fossCache.upgrade.update { existing ->
+            existing ?: FossUpgrade(
+                upgradedAt = Instant.now(),
+                upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+            )
+        }
+        return if (updated.old == null) {
+            true
+        } else {
+            log(TAG, WARN) { "persistUpgrade(): Record already exists (upgradedAt=${updated.old.upgradedAt}), keeping it" }
+            false
+        }
     }
 
     override suspend fun refresh() {

--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -144,24 +144,45 @@ class UpgradeViewModel @Inject constructor(
     fun checkSponsorReturn() = launch {
         val pressedAt = handle.remove<Long>(KEY_SPONSOR_PRESSED_AT) ?: return@launch
 
-        // Evaluated before the duration: an already upgraded supporter (recurring donation button)
-        // has nothing left to unlock, and persisting again would rewrite their upgradedAt — visibly
-        // resetting the "supporter since" date the status screen shows them.
-        if (upgradeRepo.upgradeInfo.first().isPro) {
-            log(tag) { "checkSponsorReturn(): Already upgraded, staying quiet" }
-            return@launch
-        }
+        try {
+            // Evaluated before the duration: an already upgraded supporter (recurring donation
+            // button) has nothing left to unlock, so this fast path exists for the UX — return
+            // quietly, no redundant write attempt and no thanks toast for an unlock that already
+            // happened. Data integrity is not this guard's job: the repo's create-only transaction
+            // owns that.
+            if (upgradeRepo.upgradeInfo.first().isPro) {
+                log(tag) { "checkSponsorReturn(): Already upgraded, staying quiet" }
+                return@launch
+            }
 
-        val elapsed = SystemClock.elapsedRealtime() - pressedAt
-        log(tag) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
+            val elapsed = SystemClock.elapsedRealtime() - pressedAt
+            log(tag) { "checkSponsorReturn(): elapsed=${elapsed}ms" }
 
-        if (elapsed < SPONSOR_DELAY_MS) {
-            log(tag) { "checkSponsorReturn(): Too quick, showing snackbar" }
-            snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_too_fast)
-        } else {
-            log(tag) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
-            upgradeRepo.persistUpgrade()
-            toastEvents.tryEmit(R.string.upgrade_screen_thanks_toast)
+            if (elapsed < SPONSOR_DELAY_MS) {
+                log(tag) { "checkSponsorReturn(): Too quick, showing snackbar" }
+                snackbarEvents.tryEmit(R.string.upgrade_screen_sponsor_too_fast)
+            } else {
+                log(tag) { "checkSponsorReturn(): Delay passed, persisting upgrade" }
+                val created = upgradeRepo.persistUpgrade()
+                if (created) {
+                    toastEvents.tryEmit(R.string.upgrade_screen_thanks_toast)
+                } else {
+                    // The isPro fast-path read a stale emission; the transaction kept the existing record.
+                    log(tag) { "checkSponsorReturn(): Record already existed, staying quiet" }
+                }
+            }
+        } catch (e: Exception) {
+            // The marker was consumed above; neither a failed entitlement read nor a failed write may
+            // eat the user's valid sponsor visit — restore it so the next return/resume can retry the
+            // unlock. Conditional: the user may have armed a NEWER launch while this attempt was
+            // suspended, and that one must survive. The contains-check has a small check-then-act
+            // window against a concurrent new arm; accepted — the create-only transaction owns data
+            // integrity, a wrong winner only changes which REAL visit's timestamp gates the unlock.
+            // Rethrow unconditionally: cancellation is not swallowed.
+            if (!handle.contains(KEY_SPONSOR_PRESSED_AT)) {
+                handle[KEY_SPONSOR_PRESSED_AT] = pressedAt
+            }
+            throw e
         }
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModule.kt
@@ -47,6 +47,11 @@ class RecorderModule @Inject constructor(
     // advance the production bound. Same pattern as BillingCache.cacheTimeoutMs.
     internal var headerReadTimeoutMs: Long = HEADER_READ_TIMEOUT_MS
 
+    // Test seams for the two clocks the recording heuristics use. Same pattern as the header bound:
+    // the durations are wall-clock/monotonic, so virtual time cannot drive them.
+    internal var wallClock: () -> Long = System::currentTimeMillis
+    internal var monotonicClock: () -> Long = android.os.SystemClock::elapsedRealtime
+
     @Volatile
     internal var currentLogDir: File? = null
         private set
@@ -79,6 +84,12 @@ class RecorderModule @Inject constructor(
 
     private suspend fun reconcileState(state: State) {
         if (!state.isRecording && state.shouldRecord) {
+            // Keyed on the trigger file, NOT on directory reuse: a completed session dir survives
+            // stopping, so findExistingSessionDir() also matches an ordinary repeat recording. Only
+            // a trigger that already existed before this start sequence means the process died
+            // mid-recording and we are resuming it — the one case with no usable monotonic base.
+            val isProcessResume = triggerFile.exists()
+
             val existingDir = findExistingSessionDir()
             val sessionDir = existingDir ?: createSessionDir()
             val logFile = File(sessionDir, "core.log")
@@ -119,7 +130,7 @@ class RecorderModule @Inject constructor(
                 val recordingStartedAt = if (existingDir != null) {
                     existingDir.lastModified()
                 } else {
-                    System.currentTimeMillis()
+                    wallClock()
                 }
 
                 this@RecorderModule.currentLogDir = sessionDir
@@ -129,6 +140,10 @@ class RecorderModule @Inject constructor(
                         recorder = newRecorder,
                         currentLogDir = sessionDir,
                         recordingStartedAt = recordingStartedAt,
+                        // A fresh start that reuses an old session dir gets BOTH bases: the mtime
+                        // wall stamp above and this monotonic one. The heuristic prefers the
+                        // monotonic base, so the stale mtime never decides a live recording.
+                        recordingStartedAtMonotonic = if (isProcessResume) null else monotonicClock(),
                     )
                 }
             } catch (e: Exception) {
@@ -158,6 +173,7 @@ class RecorderModule @Inject constructor(
                     recorder = null,
                     currentLogDir = null,
                     recordingStartedAt = 0L,
+                    recordingStartedAtMonotonic = null,
                 )
             }
         }
@@ -224,8 +240,12 @@ class RecorderModule @Inject constructor(
         if (!currentState.isRecording) return StopResult.NotRecording
 
         val logDir = currentState.currentLogDir ?: return StopResult.NotRecording
-        val elapsed = System.currentTimeMillis() - currentState.recordingStartedAt
-        if (elapsed < MIN_RECORDING_MS) return StopResult.TooShort
+        val elapsed = currentState.recordingStartedAtMonotonic
+            ?.let { monotonicClock() - it }             // live session: immune to wall-clock adjustments
+            ?: (wallClock() - currentState.recordingStartedAt)  // resumed: only the mtime-derived wall start exists
+        // Negative = wall clock moved backward across a resume; fail open (no warning) rather than
+        // trap the user in TooShort.
+        if (elapsed in 0 until MIN_RECORDING_MS) return StopResult.TooShort
 
         stopRecorder()
         val sessionId = DebugSessionManager.deriveSessionId(logDir)
@@ -243,6 +263,11 @@ class RecorderModule @Inject constructor(
         internal val recorder: Recorder? = null,
         val currentLogDir: File? = null,
         val recordingStartedAt: Long = 0L,
+        // Monotonic base for the duration heuristic, null when there is none: a session resumed
+        // after process death has only the persisted wall-clock start, and a monotonic value from a
+        // previous process or boot is meaningless. Nullable rather than 0L — 0 is a legal
+        // elapsedRealtime near boot.
+        val recordingStartedAtMonotonic: Long? = null,
     ) {
         val isRecording: Boolean
             get() = recorder != null
@@ -254,7 +279,18 @@ class RecorderModule @Inject constructor(
     companion object {
         internal val TAG = logTag("Debug", "Log", "Recorder", "Module")
         private const val FORCE_FILE = "bluemusic_force_debug_run"
-        private const val MIN_RECORDING_MS = 5_000L
+        /**
+         * Duration heuristic for "did you forget to reproduce the issue?". A recording stopped
+         * this quickly usually contains nothing but the recorder starting and stopping, which
+         * costs a support round-trip to re-request.
+         *
+         * It stays a prompt because short recordings can be perfectly valid: a crash is logged
+         * and flushed immediately, so the reproduction is already on disk. The
+         * [StopResult.TooShort] consumers (the Support and ContactSupport screens) turn it into
+         * a ShowShortRecordingWarning event, and their "stop anyway" answer goes through the
+         * direct force-stop path, which has no duration check.
+         */
+        private const val MIN_RECORDING_MS = 10_000L
 
         // Budget for the header's diagnostics read.
         private const val HEADER_READ_TIMEOUT_MS = 5_000L

--- a/app/src/main/java/eu/darken/bluemusic/common/flow/DynamicStateFlow.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/flow/DynamicStateFlow.kt
@@ -5,7 +5,10 @@ import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -140,17 +143,27 @@ class DynamicStateFlow<T>(
      *
      * Any errors that occurred during [action] will be rethrown by this method.
      */
-    suspend fun updateBlocking(action: suspend T.() -> T): T {
+    suspend fun updateBlocking(action: suspend T.() -> T): T = coroutineScope {
         val update: Update<T> = Update(onModify = action)
+
+        // Subscribe BEFORE emitting: UNDISPATCHED runs the awaiter synchronously up to its first
+        // suspension inside first's collect, so the collector is registered on the shared flow
+        // before the update can be processed. Emitting first is a lost wakeup: a fast producer
+        // plus a reactive collector (RecorderModule reacts to every state with its own update)
+        // can process our update AND a successor before we subscribe, displacing our State from
+        // the replay-1 cache — the await then never completes.
+        val awaiter = async(start = CoroutineStart.UNDISPATCHED) {
+            internalFlow.first { it.updatedBy == update }
+        }
         updateActions.emit(update)
 
         lTag?.let { log(it, VERBOSE) { "Waiting for update." } }
-        val ourUpdate = internalFlow.first { it.updatedBy == update }
+        val ourUpdate = awaiter.await()
         lTag?.let { log(it, VERBOSE) { "Finished waiting, got $ourUpdate" } }
 
         ourUpdate.error?.let { throw it }
 
-        return ourUpdate.value
+        ourUpdate.value
     }
 
     private data class Update<T>(

--- a/app/src/test/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModuleDurationTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModuleDurationTest.kt
@@ -1,0 +1,293 @@
+package eu.darken.bluemusic.common.debug.recorder.core
+
+import android.content.Context
+import eu.darken.bluemusic.common.BlueMusicId
+import eu.darken.bluemusic.common.debug.logging.FileLogger
+import eu.darken.bluemusic.common.debug.logging.Logging
+import eu.darken.bluemusic.common.upgrade.UpgradeDiagnostics
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.File
+import javax.inject.Provider
+
+/**
+ * The "that recording looks too short" prompt is a duration heuristic, and duration was measured
+ * against the wall clock. A clock adjustment mid-recording (NTP sync, the user changing the time)
+ * therefore either invented a long recording out of a short one or trapped a long recording in the
+ * warning. A live session now measures monotonically; only a session resumed after process death
+ * has to fall back to the session directory's wall-clock age, because monotonic time does not
+ * survive a reboot.
+ */
+class RecorderModuleDurationTest : BaseTest() {
+
+    @TempDir
+    lateinit var externalDir: File
+
+    @TempDir
+    lateinit var cacheDir: File
+
+    private val context: Context = mockk(relaxed = true)
+    private val blueMusicId: BlueMusicId = mockk()
+    private val upgradeDiagnostics: UpgradeDiagnostics = mockk()
+    private val recorderProvider: Provider<Recorder> = mockk()
+    private val mockRecorder: Recorder = mockk()
+
+    private lateinit var appScope: CoroutineScope
+
+    // Set by [withModule] when a resumable session was seeded: the tests read the mtime BACK from
+    // it, because the filesystem is free to store something other than what setLastModified asked
+    // for and the module measures against what is actually on disk.
+    private var resumeSessionDir: File? = null
+
+    @BeforeEach
+    fun setup() {
+        File(externalDir, "debug/logs").mkdirs()
+        File(cacheDir, "debug/logs").mkdirs()
+
+        every { context.getExternalFilesDir(null) } returns externalDir
+        every { context.cacheDir } returns cacheDir
+
+        every { blueMusicId.id } returns "abcdefgh12345678"
+        // Inert diagnostics: the header reads are covered by RecorderModuleTest, these fixtures only
+        // need them to not touch storage.
+        coEvery { upgradeDiagnostics.debugInfo() } returns null
+
+        every { recorderProvider.get() } returns mockRecorder
+        coEvery { mockRecorder.start(any()) } returns Unit
+        coEvery { mockRecorder.stop() } returns Unit
+
+        appScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    }
+
+    @AfterEach
+    fun teardown() {
+        appScope.cancel()
+    }
+
+    // Test-controlled clocks, handed to the module's two seams. The durations under test are
+    // wall-clock/monotonic, so virtual time cannot drive them.
+    private class TestClocks(var wall: Long, var monotonic: Long)
+
+    /**
+     * The recorder is stopped in a nested finally, before the scope goes: cancelling the scope alone
+     * does NOT uninstall a running recorder's globally installed [FileLogger], and the forward-jump
+     * case deliberately ends still recording. This harness injects a mocked [Recorder], so nothing
+     * should install one at all — the accounting is what catches a change that starts doing so.
+     *
+     * [resumeDirModifiedAt] seeds a resumable session: a `bluemusic_`-prefixed directory with a
+     * `core.log` in it and a controlled mtime, plus the (empty) trigger file that marks a recording
+     * as interrupted by process death. Both are written BEFORE the module is constructed — seeding
+     * afterwards races the init collector, which resumes the session during construction. The
+     * resume path reads neither clock seam, so setting the seams right after construction is safe.
+     */
+    private fun withModule(
+        clocks: TestClocks,
+        resumeDirModifiedAt: Long? = null,
+        block: suspend (RecorderModule) -> Unit,
+    ) {
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        val triggerFile = File(externalDir, TRIGGER_FILE)
+        if (resumeDirModifiedAt != null) {
+            val sessionDir = File(externalDir, "debug/logs/bluemusic_test_resume").also { it.mkdirs() }
+            // findExistingSessionDir() only accepts a session dir that has a core.log.
+            check(File(sessionDir, "core.log").createNewFile()) { "Failed to seed core.log" }
+            // Last: creating the file inside the directory bumps the directory's own mtime.
+            check(sessionDir.setLastModified(resumeDirModifiedAt)) { "Failed to set the session dir mtime" }
+            resumeSessionDir = sessionDir
+            check(triggerFile.createNewFile()) { "Failed to seed the trigger file" }
+        } else if (triggerFile.exists()) {
+            triggerFile.delete()
+        }
+
+        var module: RecorderModule? = null
+        try {
+            try {
+                val created = RecorderModule(
+                    context = context,
+                    appScope = appScope,
+                    dispatcherProvider = TestDispatcherProvider(Dispatchers.IO),
+                    blueMusicId = blueMusicId,
+                    upgradeDiagnostics = upgradeDiagnostics,
+                    recorderProvider = recorderProvider,
+                ).apply {
+                    wallClock = { clocks.wall }
+                    monotonicClock = { clocks.monotonic }
+                }
+                module = created
+                // Envelope: a wedged start or stop must fail in seconds, not hold the gradle worker.
+                runBlocking {
+                    withTimeout(TEST_ENVELOPE_MS) {
+                        if (resumeDirModifiedAt != null) created.state.first { it.isRecording }
+                        block(created)
+                    }
+                }
+            } finally {
+                module?.let { runBlocking { withTimeoutOrNull(TEST_ENVELOPE_MS) { it.stopRecorder() } } }
+            }
+        } finally {
+            appScope.cancel()
+            if (triggerFile.exists()) triggerFile.delete()
+            // Remove stragglers after asserting so one failure can't cascade into later tests.
+            val leaked = Logging.loggers.filterIsInstance<FileLogger>() - fileLoggersBefore.toSet()
+            leaked.forEach { Logging.remove(it) }
+            leaked shouldBe emptyList<FileLogger>()
+        }
+    }
+
+    @Test
+    fun `an eight second recording warns`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            clocks.monotonic += 8_000L
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+            module.state.first().isRecording shouldBe true
+
+            // "Stop anyway" is the user's own next step, and past the threshold it stops cleanly.
+            clocks.monotonic += 3_000L
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
+    @Test
+    fun `a ten second recording stops`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            clocks.monotonic += 10_000L
+
+            val result = module.requestStopRecorder()
+            result.shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+            result.logDir.exists() shouldBe true
+            result.sessionId.isNotEmpty() shouldBe true
+            module.state.first().isRecording shouldBe false
+        }
+    }
+
+    @Test
+    fun `a backward wall-clock jump does not warn on a long recording`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            // Twelve real seconds of recording, and an NTP sync that moves the wall clock an hour
+            // back. Wall-clock measurement would report a negative duration here.
+            clocks.monotonic += 12_000L
+            clocks.wall -= 3_600_000L
+
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+
+    @Test
+    fun `a forward wall-clock jump does not skip the warning`() {
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            module.startRecorder()
+
+            // Three real seconds of recording, and a clock correction an hour forward. Wall-clock
+            // measurement would call this a one-hour recording and skip the prompt.
+            clocks.monotonic += 3_000L
+            clocks.wall += 3_600_000L
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+            module.state.first().isRecording shouldBe true
+        }
+    }
+
+    @Test
+    fun `a resumed session measures from the session directory age`() {
+        // Resumed after a process death: there is no monotonic base to measure against, so the
+        // session directory's age is all the module has. Anchored near real time so the seeded
+        // mtime stays a plausible file timestamp.
+        val base = System.currentTimeMillis()
+        val clocks = TestClocks(wall = base, monotonic = 100_000L)
+
+        withModule(clocks, resumeDirModifiedAt = base) { module ->
+            val startedAt = resumeSessionDir!!.lastModified()
+
+            clocks.wall = startedAt + 8_000L
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+
+            clocks.wall = startedAt + 10_000L
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+
+    @Test
+    fun `a resumed session with a future directory age fails open`() {
+        // The session directory's age lies in the future (the wall clock moved backward across the
+        // resume). A negative duration must not trap the user in the warning. The wall clock is
+        // anchored below whatever the filesystem actually stored, so the delta is negative even if
+        // the future mtime was not honoured.
+        val base = System.currentTimeMillis()
+        val clocks = TestClocks(wall = base, monotonic = 100_000L)
+
+        withModule(clocks, resumeDirModifiedAt = base + 60_000L) { module ->
+            clocks.wall = resumeSessionDir!!.lastModified() - 60_000L
+
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+        }
+    }
+
+    @Test
+    fun `a repeat recording with a stale old session measures monotonically`() {
+        // A completed session directory stays on disk, so findExistingSessionDir() matches it again
+        // on the NEXT ordinary recording. Keying the "no monotonic base" case on directory reuse
+        // instead of on the trigger file would route that repeat recording to the stale directory's
+        // mtime — a wall-clock measurement, and the wrong one at that.
+        val clocks = TestClocks(wall = WALL_BASE, monotonic = 100_000L)
+        withModule(clocks) { module ->
+            val firstDir = module.startRecorder()
+
+            clocks.monotonic += 11_000L
+            module.requestStopRecorder().shouldBeInstanceOf<RecorderModule.StopResult.Stopped>()
+            module.state.first().isRecording shouldBe false
+
+            // Production leaves the finished directory in place for the zipper, with the core.log
+            // the recorder wrote. The mocked recorder writes nothing, so stand it in by hand.
+            check(File(firstDir, "core.log").createNewFile()) { "Failed to seed the stale core.log" }
+            // Stopping deleted the trigger file, and a fresh recording must not look like a resume.
+            File(externalDir, TRIGGER_FILE).exists() shouldBe false
+
+            module.startRecorder()
+            // Non-vacuity: the stale directory really is the one being recorded into again, so the
+            // assertion below is about which start time wins, not about a fresh directory.
+            module.state.first().currentLogDir shouldBe firstDir
+
+            clocks.monotonic += 3_000L
+            clocks.wall += 3_600_000L
+
+            module.requestStopRecorder() shouldBe RecorderModule.StopResult.TooShort
+            module.state.first().isRecording shouldBe true
+        }
+    }
+
+    companion object {
+        // Independent of any production bound: a wedged wait has to fail the test, not hang the
+        // gradle worker.
+        private const val TEST_ENVELOPE_MS = 10_000L
+        private const val WALL_BASE = 1_800_000_000_000L
+        private const val TRIGGER_FILE = "bluemusic_force_debug_run"
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModuleTest.kt
@@ -206,7 +206,12 @@ class RecorderModuleTest : BaseTest() {
             blueMusicId = blueMusicId,
             upgradeDiagnostics = upgradeDiagnostics,
             recorderProvider = recorderProvider,
-        )
+        ).apply {
+            // The monotonic seam defaults to SystemClock.elapsedRealtime, an Android framework stub
+            // that throws in plain JVM tests. Nothing here measures durations — RecorderModuleDurationTest
+            // does — these starts just must not trip over the default.
+            monotonicClock = { 0L }
+        }
 
         private val logLines = CopyOnWriteArrayList<String>()
         private val logCapture = object : Logging.Logger {

--- a/app/src/test/java/eu/darken/bluemusic/common/flow/DynamicStateFlowTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/common/flow/DynamicStateFlowTest.kt
@@ -1,0 +1,76 @@
+package eu.darken.bluemusic.common.flow
+
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import java.util.concurrent.atomic.AtomicInteger
+
+class DynamicStateFlowTest : BaseTest() {
+
+    /**
+     * Pre-fix, [DynamicStateFlow.updateBlocking] emitted its update BEFORE subscribing to the
+     * shared flow. Under contention its awaited State could be displaced from the replay-1 cache
+     * by a successor update before the subscription existed, and the await then never completed
+     * (jstack-verified: the pre-fix suite wedged a CI runner until the 6h job timeout). This pins
+     * the subscribe-before-emit contract, and the timeout envelope turns any regression into a
+     * fast failure instead of another wedged runner.
+     */
+    @Test
+    fun `concurrent blocking updates survive a reactive collector`() {
+        val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        try {
+            val hotData = DynamicStateFlow(
+                loggingTag = "tag",
+                parentScope = scope,
+                startValueProvider = { 0 },
+            )
+
+            // Mirrors RecorderModule: a collector that reacts to every state with an update of its
+            // own, keeping the producer busy between the other callers' updates. The echo updates
+            // are value-neutral so the final count stays exact, and capped so the echo terminates.
+            val echoes = AtomicInteger(0)
+            val subscribed = CompletableDeferred<Unit>()
+            scope.launch {
+                hotData.flow.collect { value ->
+                    subscribed.complete(Unit)
+                    if (value % 2 == 1 && echoes.getAndIncrement() < 100) {
+                        hotData.updateAsync { this + 0 }
+                    }
+                }
+            }
+
+            runBlocking {
+                withTimeout(20_000) {
+                    // The contention only means anything with the reactive collector actually
+                    // attached: its first received value proves the subscription exists.
+                    subscribed.await()
+
+                    val workers = (1..2).map {
+                        launch(Dispatchers.IO) {
+                            repeat(100) { hotData.updateBlocking { this + 1 } }
+                        }
+                    }
+                    workers.forEach { it.join() }
+                    workers.all { it.isCompleted } shouldBe true
+
+                    hotData.flow.first() shouldBe 200
+                    // Non-vacuity: without a single echo there was no successor update to displace
+                    // an awaited State, and the test would pass for the wrong reason.
+                    echoes.get() shouldBeGreaterThan 0
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+}

--- a/app/src/testFoss/java/eu/darken/bluemusic/upgrade/core/FossCacheWiringTest.kt
+++ b/app/src/testFoss/java/eu/darken/bluemusic/upgrade/core/FossCacheWiringTest.kt
@@ -1,0 +1,46 @@
+package eu.darken.bluemusic.upgrade.core
+
+import android.app.Application
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.common.datastore.value
+import eu.darken.bluemusic.common.serialization.SerializationModule
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import java.time.Instant
+
+/**
+ * The persist tests drive [FossCache]'s constructor seam against temp files, so this is the one
+ * test that exercises the file-level `settings_foss` delegate the @Inject constructor actually
+ * wires up — a delegate that got moved out of the class body to make that seam possible.
+ *
+ * One test method on purpose: DataStore forbids two active instances on the same file, and
+ * FossCache is a @Singleton in production.
+ */
+// A plain Application on purpose: the manifest's App is @HiltAndroidApp and would build its own
+// singletons on onCreate().
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [34], application = Application::class)
+class FossCacheWiringTest {
+
+    @Test
+    fun `the injected constructor reads and writes the settings_foss store`() = runTest {
+        // The real DI Json config: FossUpgrade's upgradedAt needs the contextual Instant serializer.
+        val cache = FossCache(
+            context = ApplicationProvider.getApplicationContext(),
+            json = SerializationModule().json(),
+        )
+
+        cache.upgrade.value() shouldBe null
+
+        val record = FossUpgrade(
+            upgradedAt = Instant.EPOCH,
+            upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+        )
+        cache.upgrade.value(record)
+        cache.upgrade.value() shouldBe record
+    }
+}

--- a/app/src/testFoss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFossPersistTest.kt
+++ b/app/src/testFoss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFossPersistTest.kt
@@ -1,0 +1,184 @@
+package eu.darken.bluemusic.upgrade.core
+
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import eu.darken.bluemusic.common.WebpageTool
+import eu.darken.bluemusic.common.datastore.createValue
+import eu.darken.bluemusic.common.datastore.value
+import eu.darken.bluemusic.common.serialization.SerializationModule
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.mockk
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import testhelpers.BaseTest
+import java.io.File
+import java.time.Instant
+
+/**
+ * The FOSS supporter record is create-only-if-absent: the sponsor-return heuristic can fire again
+ * for someone who is already a supporter (the recurring-donation button, or a stale entitlement
+ * replay), and a rewrite would move their "supporter since" date — the one the status screen shows.
+ *
+ * Driven through a real DataStore on a temp file via [FossCache]'s test seam, because the guarantee
+ * is the store transaction's, not the caller's.
+ */
+class UpgradeRepoFossPersistTest : BaseTest() {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    // One store scope per test: the DataStore keeps its own actor alive on it.
+    private var storeScope: CoroutineScope? = null
+
+    @AfterEach
+    fun teardown() {
+        storeScope?.cancel()
+        storeScope = null
+    }
+
+    private class Harness(val cache: FossCache, val repo: UpgradeRepoFoss)
+
+    // Unique file name per test method: DataStore forbids two active instances on the same file.
+    private fun newStoreScope(): CoroutineScope =
+        CoroutineScope(Dispatchers.IO + SupervisorJob()).also { storeScope = it }
+
+    private fun TestScope.buildHarness(storeName: String): Harness {
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = newStoreScope(),
+            produceFile = { File(tempDir, "$storeName.preferences_pb") },
+        )
+        val cache = FossCache(dataStore, SerializationModule().json())
+        val repo = UpgradeRepoFoss(
+            // backgroundScope: the repo's shareIn keeps a collector alive for the scope's lifetime.
+            scope = backgroundScope,
+            fossCache = cache,
+            webpageTool = mockk<WebpageTool>(relaxed = true),
+        )
+        return Harness(cache, repo)
+    }
+
+    @Test
+    fun `persistUpgrade keeps an existing record`() = runTest {
+        val harness = buildHarness("existing_record")
+        // The EPOCH date is the regression payload: a rewrite would move the "supporter since" date
+        // an existing supporter is being shown.
+        harness.cache.upgrade.value(
+            FossUpgrade(
+                upgradedAt = Instant.EPOCH,
+                upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+            )
+        )
+
+        harness.repo.persistUpgrade() shouldBe false
+
+        harness.cache.upgrade.value() shouldBe FossUpgrade(
+            upgradedAt = Instant.EPOCH,
+            upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+        )
+        harness.repo.upgradeInfo.first().apply {
+            isPro shouldBe true
+            upgradedAt shouldBe Instant.EPOCH
+        }
+    }
+
+    @Test
+    fun `persistUpgrade creates on an empty store`() = runTest {
+        val harness = buildHarness("empty_store")
+        harness.cache.upgrade.value() shouldBe null
+
+        // Plain, untruncated: the InstantSerializer is ISO-8601 and preserves nanoseconds, so the
+        // stored value can be compared against a nanosecond-precision bracket.
+        val before = Instant.now()
+        harness.repo.persistUpgrade() shouldBe true
+        val after = Instant.now()
+
+        val created = harness.cache.upgrade.value()
+        created shouldNotBe null
+        created!!.upgradeType shouldBe FossUpgrade.Type.GITHUB_SPONSORS
+        (created.upgradedAt >= before) shouldBe true
+        (created.upgradedAt <= after) shouldBe true
+
+        // Boolean-proven keep: immune to a timestamp collision between the two writes.
+        harness.repo.persistUpgrade() shouldBe false
+        harness.cache.upgrade.value() shouldBe created
+    }
+
+    @Test
+    fun `concurrent persists elect exactly one creator`() = runTest {
+        val harness = buildHarness("concurrent")
+        harness.cache.upgrade.value() shouldBe null
+
+        val before = Instant.now()
+        val gate = CompletableDeferred<Unit>()
+        val racers = List(2) {
+            async(Dispatchers.IO) {
+                gate.await()
+                harness.repo.persistUpgrade()
+            }
+        }
+        gate.complete(Unit)
+        val results = racers.awaitAll()
+        val after = Instant.now()
+
+        // Exactly one creator: the loser must report the record it found, not a second creation.
+        results.sorted() shouldBe listOf(false, true)
+
+        val record = harness.cache.upgrade.value()
+        record shouldNotBe null
+        record!!.upgradeType shouldBe FossUpgrade.Type.GITHUB_SPONSORS
+        (record.upgradedAt >= before) shouldBe true
+        (record.upgradedAt <= after) shouldBe true
+    }
+
+    @Test
+    fun `an undecodable record counts as absent when fallback is enabled`() = runTest {
+        // FossCache enables onErrorFallbackToDefault only on RELEASE builds, so persistUpgrade's
+        // "an undecodable record counts as absent" caveat is release-only. This validates the
+        // library behaviour that caveat depends on, without touching the build-type-conditional
+        // production config.
+        val dataStore = PreferenceDataStoreFactory.create(
+            scope = newStoreScope(),
+            produceFile = { File(tempDir, "undecodable.preferences_pb") },
+        )
+        val keyName = "foss.upgrade"
+        dataStore.edit { prefs -> prefs[stringPreferencesKey(keyName)] = "{ not valid json }" }
+
+        val stored = dataStore.createValue<FossUpgrade?>(
+            key = keyName,
+            defaultValue = null,
+            json = SerializationModule().json(),
+            onErrorFallbackToDefault = true,
+        )
+        stored.value() shouldBe null
+
+        val before = Instant.now()
+        val updated = stored.update { existing ->
+            existing ?: FossUpgrade(
+                upgradedAt = Instant.now(),
+                upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+            )
+        }
+        val after = Instant.now()
+
+        updated.old shouldBe null
+
+        val record = stored.value()
+        record shouldNotBe null
+        record!!.upgradeType shouldBe FossUpgrade.Type.GITHUB_SPONSORS
+        (record.upgradedAt >= before) shouldBe true
+        (record.upgradedAt <= after) shouldBe true
+    }
+}

--- a/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeScreenHostTest.kt
+++ b/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeScreenHostTest.kt
@@ -43,7 +43,7 @@ class FossUpgradeScreenHostTest : BaseTest() {
     private fun mockRepo(): UpgradeRepoFoss = mockk<UpgradeRepoFoss>(relaxed = true).apply {
         every { upgradeInfo } returns MutableStateFlow(UpgradeRepoFoss.Info())
         every { openGithubSponsorsPage() } returns true
-        coEvery { persistUpgrade() } answers { persisted++ }
+        coEvery { persistUpgrade() } answers { persisted++; true }
     }
 
     private fun buildVm(

--- a/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.upgrade.ui
 
+import android.os.SystemClock
 import androidx.lifecycle.SavedStateHandle
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.navigation.Nav
@@ -8,15 +9,21 @@ import eu.darken.bluemusic.upgrade.core.FossUpgrade
 import eu.darken.bluemusic.upgrade.core.UpgradeRepoFoss
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -33,6 +40,7 @@ import testhelpers.BaseTest
 import testhelpers.TestApplication
 import testhelpers.coroutine.TestDispatcherProvider
 import testhelpers.coroutine.runTest2
+import java.io.IOException
 import java.time.Duration
 import java.time.Instant
 
@@ -65,6 +73,9 @@ class FossUpgradeViewModelTest : BaseTest() {
         every { upgradeInfo } returns info
         // The launch gate is what arms the unlock heuristic — a relaxed mock would report failure.
         every { openGithubSponsorsPage() } returns true
+        // Explicit: a relaxed mock would answer the Boolean with false, i.e. "record already
+        // existed", silently turning every thanks-toast assertion below into a no-op.
+        coEvery { persistUpgrade() } returns true
     }
 
     private fun buildVm(
@@ -299,6 +310,163 @@ class FossUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `a sponsor return whose record already existed stays quiet`() = runTest2(context = testDispatcher) {
+        // The isPro fast path reads a shareIn replay that can be stale, so a supporter's return can
+        // get past it. Only the store transaction knows the record is already there — it keeps it
+        // and reports "not created", and there is no unlock to thank anyone for.
+        val repo = mockRepo()
+        coEvery { repo.persistUpgrade() } returns false
+        val vm = buildVm(repo = repo)
+
+        val nudges = mutableListOf<Int>()
+        val thanks = mutableListOf<Int>()
+        val snackbarCollector = launch(start = CoroutineStart.UNDISPATCHED) {
+            vm.snackbarEvents.collect { nudges.add(it) }
+        }
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { repo.persistUpgrade() }
+        thanks.shouldBeEmpty()
+        nudges.shouldBeEmpty()
+        // Consumed: the visit was evaluated, there is nothing left to retry.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        snackbarCollector.cancel()
+        toastCollector.cancel()
+    }
+
+    @Test
+    fun `a failed persist restores the pending sponsor launch`() = runTest2(context = testDispatcher) {
+        // The marker is consumed before the write. If the write then fails, dropping it would eat a
+        // valid sponsor visit for good — the next return/resume has to be able to retry the unlock.
+        val repo = mockRepo()
+        coEvery { repo.persistUpgrade() } throws IOException("write failed")
+        val vm = buildVm(repo = repo)
+
+        val thanks = mutableListOf<Int>()
+        val errors = mutableListOf<Throwable>()
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        thanks.shouldBeEmpty()
+        // Rethrown, not swallowed: the failure still travels the normal error path.
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        toastCollector.cancel()
+        errorCollector.cancel()
+    }
+
+    @Test
+    fun `a thrown entitlement read restores the pending sponsor launch`() = runTest2(context = testDispatcher) {
+        // The guard's entitlement read happens after the marker was consumed, so it can eat the
+        // sponsor visit just as a failed write can. Installed after arming: the ViewModel's own init
+        // collectors already hold the working flow, so the only failing read is the guard's.
+        // Scope: this covers the THROWN-read path. A production read that HANGS instead of throwing
+        // is a separate, separately filed canonical item.
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        val thanks = mutableListOf<Int>()
+        val errors = mutableListOf<Throwable>()
+        val toastCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.toastEvents.collect { thanks.add(it) } }
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+        every { repo.upgradeInfo } returns flow { throw IOException("read failed") }
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        thanks.shouldBeEmpty()
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        toastCollector.cancel()
+        errorCollector.cancel()
+    }
+
+    @Test
+    fun `a hung entitlement read releases the visit when the screen dies`() = runTest2(context = testDispatcher) {
+        // A read that never answers holds the check open with the marker already consumed. When the
+        // screen goes away the coroutine is cancelled — the catch's cancellation path has to hand
+        // the sponsor visit back, otherwise it is lost with nothing to retry from.
+        val repo = mockRepo()
+        val vm = buildVm(repo = repo)
+
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+        every { repo.upgradeInfo } returns flow { awaitCancellation() }
+
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+        // Suspended inside the guard's read, marker already consumed.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // The ViewModel going away: vmScope shares viewModelScope's job, so this is the cleared VM.
+        vm.vmScope.cancel()
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        coVerify(exactly = 0) { repo.persistUpgrade() }
+    }
+
+    @Test
+    fun `a newer sponsor launch survives a failed older attempt`() = runTest2(context = testDispatcher) {
+        // The restore must not clobber a launch armed while the old attempt was still suspended:
+        // the newer visit is the one the user is actually waiting on.
+        val repo = mockRepo()
+        val gate = CompletableDeferred<Unit>()
+        coEvery { repo.persistUpgrade() } coAnswers {
+            gate.await()
+            throw IOException("write failed")
+        }
+        val handle = SavedStateHandle()
+        val vm = buildVm(repo = repo, handle = handle)
+
+        val errors = mutableListOf<Throwable>()
+        val errorCollector = launch(start = CoroutineStart.UNDISPATCHED) { vm.errorEvents.collect { errors.add(it) } }
+
+        vm.goGithubSponsors()
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(6))
+        vm.checkSponsorReturn()
+        advanceUntilIdle()
+        // Consumed and parked in the write.
+        vm.hasPendingSponsorLaunch() shouldBe false
+
+        // A second sponsor visit while the first attempt is still hanging.
+        ShadowSystemClock.advanceBy(Duration.ofSeconds(30))
+        val newerPressedAt = SystemClock.elapsedRealtime()
+        vm.goGithubSponsors()
+        advanceUntilIdle()
+
+        gate.complete(Unit)
+        advanceUntilIdle()
+
+        vm.hasPendingSponsorLaunch() shouldBe true
+        // Mirrors the ViewModel's private KEY_SPONSOR_PRESSED_AT: the newer timestamp must still be
+        // the one stored, the failed older attempt must not have written its own back over it.
+        handle.get<Long>("sponsor_pressed_at") shouldBe newerPressedAt
+        errors.single().shouldBeInstanceOf<IOException>()
+
+        errorCollector.cancel()
+    }
+
+    @Test
     fun `a sponsor page that never opened arms nothing and a later retry still works`() = runTest2(
         context = testDispatcher,
     ) {
@@ -340,7 +508,7 @@ class FossUpgradeViewModelTest : BaseTest() {
         context = testDispatcher,
     ) {
         // The status view's donate button is unarmed on purpose: a supporter browsing the sponsors
-        // page for a while must not run the unlock heuristic again and rewrite their upgrade date.
+        // page for a while must not run the unlock heuristic again — no write attempt, no toast.
         val repo = mockRepo(MutableStateFlow(upgradedInfo()))
         val vm = buildVm(repo = repo)
 
@@ -363,9 +531,9 @@ class FossUpgradeViewModelTest : BaseTest() {
     fun `a long sponsor visit by an already upgraded user does not re-persist the upgrade`() = runTest2(
         context = testDispatcher,
     ) {
-        // The armed path taken by a supporter who tapped the pitch's sponsor button again: persisting
-        // would rewrite upgradedAt and visibly reset the "supporter since" date the status screen
-        // shows, and the thanks toast belongs to an unlock that already happened.
+        // The armed path taken by a supporter who tapped the pitch's sponsor button again. The store
+        // transaction keeps the existing record either way, so this is about the feedback: no
+        // redundant write attempt, and no thanks toast for an unlock that already happened.
         val repo = mockRepo(MutableStateFlow(upgradedInfo()))
         val vm = buildVm(repo = repo)
 


### PR DESCRIPTION
## What changed

FOSS version: an existing supporter's "supporter since" date is now protected by the storage layer itself and can no longer be reset by re-visiting the sponsors page. The "thanks for supporting" toast only appears when supporter status was actually newly granted, and if checking or saving the status fails, the pending unlock is retried on the next return instead of being lost (without clobbering a newer visit started in the meantime).

Both versions: the "that debug log looks too short" warning now catches recordings up to 10 seconds (previously 5) and no longer misjudges the length when the device clock changes mid-recording — or when a new recording reuses the folder of an older completed one. Also fixed: a rare internal race that could hang state updates (it wedged a CI runner for 6 hours in a sibling project before being caught).

## Technical Context

- The race fix lands first: `DynamicStateFlow.updateBlocking` emitted its update before subscribing to the replay-1 shared flow; a fast producer plus a reactive collector (RecorderModule's react-to-every-state pattern) could displace the awaited emission before the subscription existed, suspending the caller forever. Fixed with a `CoroutineStart.UNDISPATCHED` awaiter registered before the emit; the regression test uses a subscription barrier so the reactive-successor contention is guaranteed, not probabilistic.
- Root cause (supporter date): `persistUpgrade()` unconditionally overwrote the record while the VM's already-Pro guard reads a `shareIn(replay = 1)` flow whose stale replay can report not-Pro. The persist is now a create-only-if-absent transaction returning whether a record was created; the marker restore wraps everything after the marker consume and is conditional so a newer launch survives. A small check-then-act window in that conditional is documented as accepted — the transaction owns data integrity, so a wrong winner only changes which real visit's timestamp gates the unlock.
- KDoc documents the flavor-config nuance: `onErrorFallbackToDefault` is enabled only on release builds, so there an undecodable stored record counts as absent (replaced — matching pre-existing read behavior), while debug/beta builds throw and restore the marker instead. A test seeds malformed raw JSON through a fallback-enabled value to pin the behavior the caveat depends on.
- Recording duration: live sessions now measure via `elapsedRealtime()`; the monotonic base is keyed on process resume (trigger-file pre-existence), NOT on session-directory reuse — completed directories survive stopping, so a repeat recording would otherwise be measured from a stale directory timestamp. Resumed-after-process-death sessions keep the directory-age wall fallback and fail open on negative deltas. `recordingStartedAt` stays wall-clock for its consumers (support screen, session metadata).
- Review guidance: the persist tests run on `FossCache`'s new constructor seam against per-test temp stores (including a two-coroutine race electing exactly one creator); a one-method Robolectric test covers the moved real-file delegate. The duration-test harness mocks `Recorder` (the real `FileLogger` needs Android APIs) and stops recorders in nested finally with `FileLogger` accounting kept as a guard. The existing `RecorderModuleTest` gained a two-line fake monotonic clock — the seam's `SystemClock` default throws on plain JVM.
