### PR TITLE
Fix back buttons not working on the device configuration screen

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,21 +1,6 @@
 {
   "permissions": {
-    "allow": [
-      "mcp__ide__getDiagnostics",
-      "Bash(./gradlew:*)",
-      "Bash(git add:*)",
-      "Bash(git log:*)",
-      "Bash(git commit:*)",
-      "Bash(git show:*)",
-      "Bash(git checkout:*)",
-      "Bash(git branch:*)",
-      "Bash(git stash:*)",
-      "Bash(gh issue list:*)",
-      "Bash(gh pr list:*)",
-      "Bash(gh label list:*)",
-      "WebSearch",
-      "WebFetch(domain:developer.android.com)"
-    ],
+    "allow": [],
     "deny": []
   },
   "enabledPlugins": {
@@ -24,6 +9,8 @@
     "jvm-tools@claude-code-cafe": true,
     "frontend-design@claude-plugins-official": true,
     "kotlin-lsp@claude-plugins-official": true,
-    "support-investigator@claude-code-cafe": true
+    "support-investigator@claude-code-cafe": true,
+    "google-play@claude-code-cafe": true,
+    "devtools@claude-code-cafe": true
   }
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -31,9 +31,15 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
         tools:ignore="AllowBackup,GoogleAppIndexingWarning">
+        <!-- singleTask: single-activity app, there must never be two MainActivity instances in one
+             task. The monitor notification's open-app intent is a bare component intent, which
+             defeats root-intent task matching — with launchMode=standard a launcher-icon tap onto a
+             notification-rooted task stacked a duplicate instance, wedging the singleton
+             NavigationController (dead back navigation, emulator-confirmed). -->
         <activity
             android:name="eu.darken.bluemusic.main.ui.MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/eu/darken/bluemusic/common/navigation/Nav.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/navigation/Nav.kt
@@ -6,34 +6,22 @@ import kotlinx.serialization.Serializable
 sealed interface Nav : NavigationDestination {
     sealed interface Main : Nav {
         @Serializable
-        data object Onboarding : Main {
-            private fun readResolve(): Any = Onboarding
-        }
+        data object Onboarding : Main
 
         @Serializable
-        data object ManageDevices : Main {
-            private fun readResolve(): Any = ManageDevices
-        }
+        data object ManageDevices : Main
 
         @Serializable
-        data object DiscoverDevices : Main {
-            private fun readResolve(): Any = ManageDevices
-        }
+        data object DiscoverDevices : Main
 
         @Serializable
-        data class DeviceConfig(val addr: DeviceAddr) : Main {
-            private fun readResolve(): Any = ManageDevices
-        }
+        data class DeviceConfig(val addr: DeviceAddr) : Main
 
         @Serializable
-        data class AppSelection(val addr: DeviceAddr) : Main {
-            private fun readResolve(): Any = ManageDevices
-        }
+        data class AppSelection(val addr: DeviceAddr) : Main
 
         @Serializable
-        data object SettingsIndex : Main {
-            private fun readResolve(): Any = SettingsIndex
-        }
+        data object SettingsIndex : Main
 
         @Serializable
         data class Upgrade(val manage: Boolean = false) : Main
@@ -42,33 +30,21 @@ sealed interface Nav : NavigationDestination {
 
     sealed interface Settings : Nav {
         @Serializable
-        data object General : Settings {
-            private fun readResolve(): Any = General
-        }
+        data object General : Settings
 
         @Serializable
-        data object Devices : Settings {
-            private fun readResolve(): Any = Devices
-        }
+        data object Devices : Settings
 
         @Serializable
-        data object Support : Settings {
-            private fun readResolve(): Any = General
-        }
+        data object Support : Settings
 
         @Serializable
-        data object Acks : Settings {
-            private fun readResolve(): Any = General
-        }
+        data object Acks : Settings
 
         @Serializable
-        data object BackupRestore : Settings {
-            private fun readResolve(): Any = BackupRestore
-        }
+        data object BackupRestore : Settings
 
         @Serializable
-        data object ContactSupport : Settings {
-            private fun readResolve(): Any = ContactSupport
-        }
+        data object ContactSupport : Settings
     }
 }

--- a/app/src/main/java/eu/darken/bluemusic/common/navigation/NavigationDestination.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/navigation/NavigationDestination.kt
@@ -1,6 +1,5 @@
 package eu.darken.bluemusic.common.navigation
 
 import androidx.navigation3.runtime.NavKey
-import java.io.Serializable
 
-interface NavigationDestination : NavKey, Serializable
+interface NavigationDestination : NavKey

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/MainActivity.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/MainActivity.kt
@@ -11,6 +11,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleEventEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
@@ -75,7 +77,14 @@ class MainActivity : Activity2() {
 
         val backStack = rememberNavBackStack(start)
 
-        LaunchedEffect(Unit) { navCtrl.setup(backStack) }
+        LaunchedEffect(backStack) { navCtrl.setup(backStack) }
+
+        // Re-bind on every resume: if another MainActivity instance ever grabbed the singleton
+        // controller, the foregrounded composition takes ownership back (see issue with dead
+        // back navigation after a second activity instance).
+        LifecycleEventEffect(Lifecycle.Event.ON_RESUME) {
+            navCtrl.setup(backStack)
+        }
 
         NavDisplay(
             backStack = backStack,


### PR DESCRIPTION
Fixes a user-reported bug where the device configuration screen could not be left anymore: the system back gesture made the screen close and instantly reopen, and the toolbar back arrow did nothing.

## Cause

When the app's task was originally opened via the monitor notification and later reopened from the launcher, Android stacked a second `MainActivity` instance in the same task. Both instances bound the app-wide `NavigationController`, so the surviving instance ended up popping the finished instance's back stack — reproduced on an emulator, with logs confirming `up() prevented removing the last element in backstack` while the visible screen had two entries.

## Changes

- `MainActivity` now uses `launchMode="singleTask"` so a second instance can never stack in the same task (same approach and reasoning as SD Maid SE, which hit the identical bug).
- The `NavigationController` binding moved from a one-shot `LaunchedEffect` to an eager bind plus a re-bind on every `ON_RESUME`, so the foreground UI always owns the controller even if multiple instances ever coexist again.
- Removed the copy-paste-broken `readResolve()` overrides from the navigation keys (`DeviceConfig`, `DiscoverDevices`, and `AppSelection` resolved to `ManageDevices`; `Support` and `Acks` to `General`) and dropped the unused `java.io.Serializable` from `NavigationDestination`. Navigation3 persists the back stack via kotlinx serialization; process-death restore verified before and after.

Also folds in a `.claude/settings.json` update (plugin list and permissions cleanup).

## Verification

- Reproduced the broken state on an emulator pre-fix; post-fix the same sequence keeps a single activity instance and back navigation works.
- Process-death restore onto the device configuration screen still restores the full back stack.
- `assembleFossDebug` and all 721 unit tests pass.
