### PR TITLE
Explain how to restore volumes after Bluetooth disconnects

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverItem.kt
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverItem.kt
@@ -6,9 +6,12 @@ import androidx.compose.material3.ListItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
+import eu.darken.bluemusic.R
 import eu.darken.bluemusic.bluetooth.core.MockDevice
 import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import eu.darken.bluemusic.bluetooth.core.speaker.FakeSpeakerDevice
 import eu.darken.bluemusic.bluetooth.core.toIcon
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
@@ -28,9 +31,10 @@ fun DeviceItem(
             )
         },
         supportingContent = {
+            val isSpeaker = device.deviceType == SourceDevice.Type.PHONE_SPEAKER
             Text(
-                text = device.address,
-                maxLines = 1,
+                text = if (isSpeaker) stringResource(R.string.discover_device_speaker_desc) else device.address,
+                maxLines = if (isSpeaker) 3 else 1,
                 overflow = TextOverflow.Companion.Ellipsis
             )
         },
@@ -50,6 +54,17 @@ private fun DeviceItemPreview() {
     PreviewWrapper {
         DeviceItem(
             device = MockDevice(),
+            onClick = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun DeviceItemSpeakerPreview() {
+    PreviewWrapper {
+        DeviceItem(
+            device = FakeSpeakerDevice(label = "Device speaker (Pixel 7)", isConnected = false),
             onClick = {},
         )
     }

--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverItem.kt
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverItem.kt
@@ -34,7 +34,7 @@ fun DeviceItem(
             val isSpeaker = device.deviceType == SourceDevice.Type.PHONE_SPEAKER
             Text(
                 text = if (isSpeaker) stringResource(R.string.discover_device_speaker_desc) else device.address,
-                maxLines = if (isSpeaker) 3 else 1,
+                maxLines = if (isSpeaker) Int.MAX_VALUE else 1,
                 overflow = TextOverflow.Companion.Ellipsis
             )
         },

--- a/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/bluetooth/ui/discover/DiscoverViewModel.kt
@@ -11,6 +11,7 @@ import eu.darken.bluemusic.common.navigation.NavigationController
 import eu.darken.bluemusic.common.ui.ViewModel4
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.common.upgrade.isProForUi
+import eu.darken.bluemusic.devices.core.DeviceLimits
 import eu.darken.bluemusic.devices.core.DeviceRepo
 import eu.darken.bluemusic.devices.core.NewDeviceCreator
 import kotlinx.coroutines.flow.combine
@@ -54,7 +55,7 @@ class DiscoverViewModel @Inject constructor(
                 ),
             managedDeviceCount = managed.size,
             isProVersion = upgradeInfo.isPro,
-            freeDeviceLimit = FREE_DEVICE_LIMIT,
+            freeDeviceLimit = DeviceLimits.FREE_DEVICE_LIMIT,
         )
     }.asStateFlow()
 
@@ -63,7 +64,7 @@ class DiscoverViewModel @Inject constructor(
         val isLoading: Boolean = false,
         val isProVersion: Boolean = false,
         val managedDeviceCount: Int = 0,
-        val freeDeviceLimit: Int = FREE_DEVICE_LIMIT,
+        val freeDeviceLimit: Int = DeviceLimits.FREE_DEVICE_LIMIT,
         val error: String? = null,
         val showUpgradeDialog: Boolean = false,
         val shouldClose: Boolean = false
@@ -76,17 +77,13 @@ class DiscoverViewModel @Inject constructor(
 
             // Limit first so free users under the limit never pay the gate's wait; the gate itself
             // reads through isProForUi so a Pro user isn't blocked while billing is still settling.
-            if (currentState.managedDeviceCount >= FREE_DEVICE_LIMIT && !upgradeRepo.isProForUi()) {
+            if (currentState.managedDeviceCount >= DeviceLimits.FREE_DEVICE_LIMIT && !upgradeRepo.isProForUi()) {
                 events.emit(DiscoverEvent.RequiresUpgrade)
             } else {
                 deviceCreator.createNewdevice(device.address)
                 navCtrl.up()
             }
         }
-    }
-
-    companion object {
-        private const val FREE_DEVICE_LIMIT = 2
     }
 
 }

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/DeviceLimits.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/DeviceLimits.kt
@@ -1,0 +1,5 @@
+package eu.darken.bluemusic.devices.core
+
+object DeviceLimits {
+    const val FREE_DEVICE_LIMIT = 2
+}

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/DeviceRepo.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/DeviceRepo.kt
@@ -103,6 +103,22 @@ class DeviceRepo @Inject constructor(
         }
     }
 
+    suspend fun createDeviceIfAbsent(address: DeviceAddr, create: () -> DeviceConfigEntity): Boolean =
+        mutexFor(address).withLock {
+            withContext(dispatcherProvider.IO) {
+                val existing = deviceDatabase.devices.getDevice(address)
+                if (existing != null) {
+                    log(TAG) { "createDeviceIfAbsent: config already exists for $address, keeping it" }
+                    return@withContext false
+                }
+
+                val config = create()
+                deviceDatabase.devices.updateDevice(config)
+                log(TAG, INFO) { "New device config: $config" }
+                true
+            }
+        }
+
     suspend fun isManaged(address: DeviceAddr): Boolean =
         deviceDatabase.devices.getDevice(address) != null
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/NewDeviceCreator.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/NewDeviceCreator.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.devices.core
 
 import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
+import eu.darken.bluemusic.bluetooth.core.speaker.SpeakerDeviceProvider
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
@@ -17,16 +18,19 @@ class NewDeviceCreator @Inject constructor(
     private val deviceRepo: DeviceRepo,
     private val volumeTool: VolumeTool,
     private val bluetoothRepo: BluetoothRepo,
+    private val speakerDeviceProvider: SpeakerDeviceProvider,
 ) {
 
     suspend fun createNewdevice(address: DeviceAddr) {
         log(TAG, INFO) { "createNewdevice: $address" }
 
-        bluetoothRepo.state
-            .filter { it.isReady }
-            .first()
-            .devices
-            .find { it.address == address } ?: throw IllegalStateException("Device not found: $address")
+        if (address != speakerDeviceProvider.address) {
+            bluetoothRepo.state
+                .filter { it.isReady }
+                .first()
+                .devices
+                .find { it.address == address } ?: throw IllegalStateException("Device not found: $address")
+        }
 
         val config = DeviceConfigEntity(
             address = address,

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/NewDeviceCreator.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/NewDeviceCreator.kt
@@ -38,10 +38,8 @@ class NewDeviceCreator @Inject constructor(
             musicVolume = volumeTool.getVolumePercentage(AudioStream.Id.STREAM_MUSIC),
         )
 
-        deviceRepo.updateDevice(address) {
-            config
-        }
-        log(TAG) { "Created new device config: $address" }
+        val created = deviceRepo.createDeviceIfAbsent(address) { config }
+        log(TAG) { "createNewdevice: $address created=$created" }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardAction.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardAction.kt
@@ -24,5 +24,9 @@ sealed interface DashboardAction {
 
     data object DismissDndAccessHint : DashboardAction
 
+    data object DismissSpeakerHint : DashboardAction
+
+    data object AddSpeakerDevice : DashboardAction
+
     data class ToggleAdjustmentLock(val addr: DeviceAddr) : DashboardAction
 }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
@@ -71,6 +71,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.bluemusic.devices.core.DeviceAddr
 import eu.darken.bluemusic.devices.ui.dashboard.rows.Android10AppLaunchHintCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.BatteryOptimizationHintCard
+import eu.darken.bluemusic.devices.ui.dashboard.rows.DeviceSpeakerHintCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.DndAccessHintCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.EmptyDevicesCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.NotificationPermissionHintCard
@@ -221,6 +222,15 @@ fun DevicesScreen(
                     NotificationPermissionHintCard(
                         onRequestPermission = { onDeviceAction(DashboardAction.RequestNotificationPermission) },
                         onDismiss = { onDeviceAction(DashboardAction.DismissNotificationPermissionHint) }
+                    )
+                }
+            }
+
+            if (state.showSpeakerHint) {
+                item {
+                    DeviceSpeakerHintCard(
+                        onDismiss = { onDeviceAction(DashboardAction.DismissSpeakerHint) },
+                        onAdd = { onDeviceAction(DashboardAction.AddSpeakerDevice) }
                     )
                 }
             }
@@ -460,6 +470,29 @@ private fun DevicesScreenPreview() {
                 devicesWithApps = devices.map { DashboardViewModel.DeviceWithApps(it, emptyList()) },
                 isBluetoothEnabled = true,
                 isProVersion = false,
+            ),
+            onAddDevice = {},
+            onDeviceConfig = {},
+            onDeviceAction = {},
+            onNavigateToSettings = {},
+            onNavigateToUpgrade = {},
+            onRequestBluetoothPermission = {},
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun DevicesScreenSpeakerHintPreview() {
+    val devices = listOf(MockDevice().toManagedDevice(isConnected = true))
+
+    PreviewWrapper {
+        DevicesScreen(
+            state = DashboardViewModel.State(
+                devicesWithApps = devices.map { DashboardViewModel.DeviceWithApps(it, emptyList()) },
+                isBluetoothEnabled = true,
+                isProVersion = false,
+                showSpeakerHint = true,
             ),
             onAddDevice = {},
             onDeviceConfig = {},

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
@@ -3,6 +3,8 @@ package eu.darken.bluemusic.devices.ui.dashboard
 import android.content.Intent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
+import eu.darken.bluemusic.bluetooth.core.speaker.SpeakerDeviceProvider
 import eu.darken.bluemusic.common.apps.AppInfo
 import eu.darken.bluemusic.common.apps.AppRepo
 import eu.darken.bluemusic.common.coroutine.DispatcherProvider
@@ -15,9 +17,11 @@ import eu.darken.bluemusic.common.ui.ViewModel4
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.common.upgrade.isProForUi
 import eu.darken.bluemusic.devices.core.DeviceAddr
+import eu.darken.bluemusic.devices.core.DeviceLimits
 import eu.darken.bluemusic.devices.core.DeviceRepo
 import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.core.NewDeviceCreator
 import eu.darken.bluemusic.devices.core.getDevice
 import eu.darken.bluemusic.devices.core.updateVolume
 import eu.darken.bluemusic.main.core.GeneralSettings
@@ -41,6 +45,8 @@ class DashboardViewModel @Inject constructor(
     bluetoothSource: BluetoothRepo,
     private val generalSettings: GeneralSettings,
     private val devicesSettings: DevicesSettings,
+    private val deviceCreator: NewDeviceCreator,
+    private val speakerProvider: SpeakerDeviceProvider,
     dispatcherProvider: DispatcherProvider,
     navCtrl: NavigationController,
     appRepo: AppRepo,
@@ -132,7 +138,8 @@ class DashboardViewModel @Inject constructor(
         notificationPermissionHintFlow,
         dndAccessHintFlow,
         devicesSettings.lockedDevices.flow,
-    ) { upgradeInfo, bluetoothState, devicesWithApps, batteryHint, overlayHint, notificationHint, dndHint, lockedDevices ->
+        generalSettings.isSpeakerHintDismissed.flow,
+    ) { upgradeInfo, bluetoothState, devicesWithApps, batteryHint, overlayHint, notificationHint, dndHint, lockedDevices, speakerHintDismissed ->
         State(
             isProVersion = upgradeInfo.isPro,
             isBluetoothEnabled = bluetoothState.isEnabled,
@@ -146,6 +153,9 @@ class DashboardViewModel @Inject constructor(
             showNotificationPermissionHint = notificationHint.shouldShow,
             showDndAccessHint = dndHint.shouldShow,
             dndAccessIntent = dndHint.intent,
+            showSpeakerHint = !speakerHintDismissed &&
+                devicesWithApps.any { it.device.type != SourceDevice.Type.PHONE_SPEAKER } &&
+                devicesWithApps.none { it.device.type == SourceDevice.Type.PHONE_SPEAKER },
         )
     }.asStateFlow()
 
@@ -168,6 +178,7 @@ class DashboardViewModel @Inject constructor(
         val showNotificationPermissionHint: Boolean = false,
         val showDndAccessHint: Boolean = false,
         val dndAccessIntent: Intent? = null,
+        val showSpeakerHint: Boolean = false,
     ) {
         // Convenience property for backwards compatibility
         val devices: List<ManagedDevice> get() = devicesWithApps.map { it.device }
@@ -222,6 +233,30 @@ class DashboardViewModel @Inject constructor(
                 launch {
                     generalSettings.isDndAccessHintDismissed.update { true }
                 }
+            }
+
+            is DashboardAction.DismissSpeakerHint -> {
+                launch {
+                    generalSettings.isSpeakerHintDismissed.update { true }
+                }
+            }
+
+            is DashboardAction.AddSpeakerDevice -> {
+                val devices = deviceRepo.devices.first()
+                val speakerAddr = speakerProvider.address
+
+                if (devices.any { it.type == SourceDevice.Type.PHONE_SPEAKER }) {
+                    navTo(Nav.Main.DeviceConfig(speakerAddr))
+                    return@launch
+                }
+
+                if (devices.size >= DeviceLimits.FREE_DEVICE_LIMIT && !upgradeRepo.isProForUi()) {
+                    navTo(Nav.Main.Upgrade())
+                    return@launch
+                }
+
+                deviceCreator.createNewdevice(speakerAddr)
+                navTo(Nav.Main.DeviceConfig(speakerAddr))
             }
 
             is DashboardAction.ToggleAdjustmentLock -> {

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/DeviceSpeakerHintCard.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/DeviceSpeakerHintCard.kt
@@ -1,0 +1,103 @@
+package eu.darken.bluemusic.devices.ui.dashboard.rows
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.twotone.SpeakerPhone
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.compose.Preview2
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+
+@Composable
+fun DeviceSpeakerHintCard(
+    onDismiss: () -> Unit,
+    onAdd: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .animateContentSize(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Icon(
+                    imageVector = Icons.TwoTone.SpeakerPhone,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = stringResource(R.string.device_speaker_hint_title),
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.device_speaker_hint_message),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSecondaryContainer
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.action_dismiss))
+                }
+                Button(
+                    onClick = onAdd,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Text(stringResource(R.string.device_speaker_hint_action))
+                }
+            }
+        }
+    }
+}
+
+@Preview2
+@Composable
+fun DeviceSpeakerHintCardPreview() {
+    PreviewWrapper {
+        DeviceSpeakerHintCard(
+            onDismiss = {},
+            onAdd = {}
+        )
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupData.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupData.kt
@@ -62,4 +62,5 @@ data class GeneralSettingsBackup(
     val isAndroid10AppLaunchHintDismissed: Boolean = false,
     val isNotificationPermissionHintDismissed: Boolean = false,
     val isDndAccessHintDismissed: Boolean = false,
+    val isSpeakerHintDismissed: Boolean = false,
 )

--- a/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManager.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManager.kt
@@ -144,7 +144,7 @@ class BackupRestoreManager @Inject constructor(
             DEBUG
         ) { "Parsed: ${backup.deviceConfigs.size} devices, devicesSettings=${backup.devicesSettings}, generalSettings=${backup.generalSettings}" }
 
-        if (backup.formatVersion != CURRENT_FORMAT_VERSION) {
+        if (backup.formatVersion !in SUPPORTED_FORMAT_VERSIONS) {
             log(TAG, WARN) { "Unsupported format version: ${backup.formatVersion} (expected $CURRENT_FORMAT_VERSION)" }
             throw BackupError.UnsupportedFormatVersion(backup.formatVersion)
         }
@@ -262,7 +262,8 @@ class BackupRestoreManager @Inject constructor(
 
     companion object {
         private val TAG = logTag("Backup", "Restore", "Manager")
-        const val CURRENT_FORMAT_VERSION = 1
+        const val CURRENT_FORMAT_VERSION = 2
+        val SUPPORTED_FORMAT_VERSIONS = setOf(1, 2)
         const val BACKUP_JSON_ENTRY = "backup.json"
     }
 }

--- a/app/src/main/java/eu/darken/bluemusic/main/core/GeneralSettings.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/core/GeneralSettings.kt
@@ -48,6 +48,7 @@ class GeneralSettings @Inject constructor(
     val isAndroid10AppLaunchHintDismissed = dataStore.createValue("hints.android10.applaunch.dismissed", false)
     val isNotificationPermissionHintDismissed = dataStore.createValue("hints.notification.permission.dismissed", false)
     val isDndAccessHintDismissed = dataStore.createValue("hints.dnd.access.dismissed", false)
+    val isSpeakerHintDismissed = dataStore.createValue("hints.speaker.device.dismissed", false)
 
 
     suspend fun toBackup(): GeneralSettingsBackup = GeneralSettingsBackup(
@@ -59,6 +60,7 @@ class GeneralSettings @Inject constructor(
         isAndroid10AppLaunchHintDismissed = isAndroid10AppLaunchHintDismissed.value(),
         isNotificationPermissionHintDismissed = isNotificationPermissionHintDismissed.value(),
         isDndAccessHintDismissed = isDndAccessHintDismissed.value(),
+        isSpeakerHintDismissed = isSpeakerHintDismissed.value(),
     )
 
     suspend fun applyBackup(backup: GeneralSettingsBackup) {
@@ -73,6 +75,7 @@ class GeneralSettings @Inject constructor(
                 if (backup.isAndroid10AppLaunchHintDismissed) isAndroid10AppLaunchHintDismissed.setIn(this, true)
                 if (backup.isNotificationPermissionHintDismissed) isNotificationPermissionHintDismissed.setIn(this, true)
                 if (backup.isDndAccessHintDismissed) isDndAccessHintDismissed.setIn(this, true)
+                if (backup.isSpeakerHintDismissed) isSpeakerHintDismissed.setIn(this, true)
             }.toPreferences()
         }
     }

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Luitoon</string>
     <string name="devices_audio_stream_notification_label">Kennisgewing</string>
     <string name="devices_audio_stream_alarm_label">Wekker</string>
-    <string name="label_speaker_autosave">Outosave-volume</string>
-    <string name="description_speaker_autosave">Die \"Toestel-luidspreker\"-inskrywing, wat verantwoordelik is vir standaard volumes, dateer homself op wanneer \'n Bluetooth-toestel koppel. Let wel: Dit werk nie op alle toestelle nie.</string>
     <string name="devices_neverseen_label">Nog nie gesien nie</string>
     <string name="devices_state_connected_label">Gekoppel</string>
     <string name="devices_last_connected_label">Laas gekoppel: %s</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">ዚማት</string>
     <string name="devices_audio_stream_notification_label">ክርዘት</string>
     <string name="devices_audio_stream_alarm_label">ቃሌሚ</string>
-    <string name="label_speaker_autosave">የድምፅ አውቲማቲክ አክብቢ</string>
-    <string name="description_speaker_autosave">ለደርግ ድምጣዎች የሚወድ የመሣሪያ የገዛ ስፒከር ብቱን Bluetooth መሣሪያ ሲጸራ እናቱን ያዘምናል። ስጀራዊ። ይህ በሁሉም መሣሪያ ላይ አይቀዳደም።</string>
     <string name="devices_neverseen_label">አልተካከለም</string>
     <string name="devices_state_connected_label">ተጸርቦል።</string>
     <string name="devices_last_connected_label">መጨረሻይም ሰዓት %s</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -142,8 +142,6 @@
     <string name="devices_audio_stream_ring_label">رنين</string>
     <string name="devices_audio_stream_notification_label">تنبيه</string>
     <string name="devices_audio_stream_alarm_label">منبّه</string>
-    <string name="label_speaker_autosave">حفظ تلقائي للصوت</string>
-    <string name="description_speaker_autosave">مدخل \"مكبر صوت الجهاز\"، المسؤول عن مستويات الصوت الافتراضية، يحديث نفسه عند اتصال جهاز بلوتوث. ملاحظة: هـذا لا يعمل على جميع الأجهزة.</string>
     <string name="devices_neverseen_label">لم يسبق رؤيته</string>
     <string name="devices_state_connected_label">متصل</string>
     <string name="devices_last_connected_label">آخر اتصال: %s</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Zəng səsi</string>
     <string name="devices_audio_stream_notification_label">Bildiriş</string>
     <string name="devices_audio_stream_alarm_label">Zəngli saat</string>
-    <string name="label_speaker_autosave">Səsi avtomatik saxla</string>
-    <string name="description_speaker_autosave">Standart səs səviyyələrindən məsul olan \"Cihaz dinamiki\" girişi, Bluetooth cihazı bağlantı qurduqda özünü yeniləyir. Qeyd: Bu, bütün cihazlarda işləmir.</string>
     <string name="devices_neverseen_label">Heç vaxt görünmədi</string>
     <string name="devices_state_connected_label">Bağlantı quruldu</string>
     <string name="devices_last_connected_label">Son qoşulma: %s</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -140,8 +140,6 @@
     <string name="devices_audio_stream_ring_label">Званок</string>
     <string name="devices_audio_stream_notification_label">Апавяшчэнне</string>
     <string name="devices_audio_stream_alarm_label">Будзільнік</string>
-    <string name="label_speaker_autosave">Аўтазахаванне гучнасці</string>
-    <string name="description_speaker_autosave">Запіс \"Дынамік прылады\", які адказвае за гучнасць па змаўчанні, абнаўляецца пры падключэнні прылады Bluetooth. Заўвага: гэта не працуе на ўсіх прыладах.</string>
     <string name="devices_neverseen_label">Ніколі не бачылася</string>
     <string name="devices_state_connected_label">Падключана</string>
     <string name="devices_last_connected_label">Апошняе падключэнне: %s</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Звънене</string>
     <string name="devices_audio_stream_notification_label">Известие</string>
     <string name="devices_audio_stream_alarm_label">Аларма</string>
-    <string name="label_speaker_autosave">Автоматично запазване на звука</string>
-    <string name="description_speaker_autosave">Записът „Високоговорител на устройство\", отговорен за стандартните нива на звука, се актуализира автоматично при свързване на Bluetooth устройство. Забележка: Не работи на всички устройства.</string>
     <string name="devices_neverseen_label">Несвързван</string>
     <string name="devices_state_connected_label">Свързано</string>
     <string name="devices_last_connected_label">Последно свързване: %s</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">রিং</string>
     <string name="devices_audio_stream_notification_label">নোটিফিকেশন</string>
     <string name="devices_audio_stream_alarm_label">অ্যালার্ম</string>
-    <string name="label_speaker_autosave">অটোসেভ ভলিউম</string>
-    <string name="description_speaker_autosave">\"ডিভাইস স্পিকার\" প্রবিষ্টি, যা ডিফল্ট ভলিউমের জন্য দায়ী, ব্লুটুথ ডিভাইস সংযুক্ত হলে নিজেই আপডেট হয়। নোট: এটি সব ডিভাইসে কাজ করে না।</string>
     <string name="devices_neverseen_label">কখনো দেখা যায়নি</string>
     <string name="devices_state_connected_label">সংযুক্ত</string>
     <string name="devices_last_connected_label">শেষ সংযোগ: %s</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">To</string>
     <string name="devices_audio_stream_notification_label">Notificació</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="label_speaker_autosave">Desa automàticament el volum</string>
-    <string name="description_speaker_autosave">L\'entrada «altaveu del dispositiu», que és responsable dels volums per defecte, s\'actualitza quan es connecta un dispositiu Bluetooth. Nota: això no funciona en tots els dispositius.</string>
     <string name="devices_neverseen_label">Mai vist</string>
     <string name="devices_state_connected_label">Connectat</string>
     <string name="devices_last_connected_label">Última connexió: %s</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -140,8 +140,6 @@
     <string name="devices_audio_stream_ring_label">Vyzvánění</string>
     <string name="devices_audio_stream_notification_label">Oznámení</string>
     <string name="devices_audio_stream_alarm_label">Budík</string>
-    <string name="label_speaker_autosave">Automaticky uložit hlasitost</string>
-    <string name="description_speaker_autosave">Vstup \"reproduktor zařízení\", který je zodpovědný za výchozí hlasitosti se sám aktualizuje po připojení zařízení Bluetooth. Poznámka: Toto nefunguje na všech zařízeních.</string>
     <string name="devices_neverseen_label">Nikdy neviděno</string>
     <string name="devices_state_connected_label">Připojeno</string>
     <string name="devices_last_connected_label">Naposledy připojeno: %s</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Ringetone</string>
     <string name="devices_audio_stream_notification_label">Notifikation</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Autogemme volumen</string>
-    <string name="description_speaker_autosave">\"Enhedshøjttaler\"-posten, som er ansvarlig for standardlydstyrker, opdaterer sig selv, når en Bluetooth-enhed opretter forbindelse. Bemærk: Dette virker ikke på alle enheder.</string>
     <string name="devices_neverseen_label">Aldrig set</string>
     <string name="devices_state_connected_label">Forbundet</string>
     <string name="devices_last_connected_label">Sidst tilsluttet: %s</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Klingeln</string>
     <string name="devices_audio_stream_notification_label">Benachrichtigung</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Lautstärke automatisch speichern</string>
-    <string name="description_speaker_autosave">Der \"Geräte-Lautsprecher\"-Eintrag, der zuständig für die Standardeinstellung der Lautstärke ist, aktualisiert sich selbst, sobald sich ein Bluetooth-Gerät verbindet. Anmerkung: Dies funktioniert nicht bei allen Geräten.</string>
     <string name="devices_neverseen_label">Nie gesehen</string>
     <string name="devices_state_connected_label">Verbunden</string>
     <string name="devices_last_connected_label">Zuletzt verbunden: %s</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Κλήση</string>
     <string name="devices_audio_stream_notification_label">Ειδοποίηση</string>
     <string name="devices_audio_stream_alarm_label">Ξυπνητήρι</string>
-    <string name="label_speaker_autosave">Αυτόματη αποθήκευση έντασης</string>
-    <string name="description_speaker_autosave">Η καταχώρηση \"Ακουστικό Συσκευής\", η οποία είναι υπεύθυνη για προεπιλεγμένες εντάσεις, ενημερώνεται αυτόματα όταν συνδέεται μια συσκευή Bluetooth. Σημείωση: Αυτό δεν λειτουργεί σε όλες τις συσκευές.</string>
     <string name="devices_neverseen_label">Ποτέ δεν συνδέθηκε</string>
     <string name="devices_state_connected_label">Συνδέθηκε</string>
     <string name="devices_last_connected_label">Τελευταία σύνδεση: %s</string>

--- a/app/src/main/res/values-eo-rUY/strings.xml
+++ b/app/src/main/res/values-eo-rUY/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Sonorilo</string>
     <string name="devices_audio_stream_notification_label">Sciiĝo</string>
     <string name="devices_audio_stream_alarm_label">Alarmo</string>
-    <string name="label_speaker_autosave">Aŭtomata konservado de volumeno</string>
-    <string name="description_speaker_autosave">La eniro \"Aparata Laŭtparolilo\", kiu respondecas pri implicaj volumenoj, ĝisdatigas sin kiam Bluetooth-aparato konektas. Noto: Ĉi tio ne funkcias sur ĉiuj aparatoj.</string>
     <string name="devices_neverseen_label">Neniam vidita</string>
     <string name="devices_state_connected_label">Konektita</string>
     <string name="devices_last_connected_label">Laste konektita: %s</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Tono</string>
     <string name="devices_audio_stream_notification_label">Notificación</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="label_speaker_autosave">Guardado automático de volumen</string>
-    <string name="description_speaker_autosave">La entrada \"Altavoz del dispositivo\", responsable de los volúmenes predeterminados, se actualiza cuando se conecta un dispositivo Bluetooth. Nota: Esto no funciona en todos los dispositivos.</string>
     <string name="devices_neverseen_label">Nunca visto</string>
     <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Última conexión: %s</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Tono</string>
     <string name="devices_audio_stream_notification_label">Notificación</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="label_speaker_autosave">Autoguardar volumen</string>
-    <string name="description_speaker_autosave">La entrada \"Altavoz del dispositivo\", que es responsable de los volúmenes predeterminados, se actualiza cuando se conecta un dispositivo Bluetooth. Nota: Esto no funciona en todos los dispositivos.</string>
     <string name="devices_neverseen_label">Nunca visto</string>
     <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Última conexión: %s</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Timbre</string>
     <string name="devices_audio_stream_notification_label">Notificación</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="label_speaker_autosave">Guardar el volumen automáticamente</string>
-    <string name="description_speaker_autosave">La entrada \"altavoz del dispositivo\", que es responsable de los volúmenes predeterminados, se actualiza cuando se conecta un dispositivo Bluetooth. Nota: Esto no funciona en todos los dispositivos.</string>
     <string name="devices_neverseen_label">Nunca se ha visto</string>
     <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Última conexión: %s</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Helin</string>
     <string name="devices_audio_stream_notification_label">Teavitus</string>
     <string name="devices_audio_stream_alarm_label">Häire</string>
-    <string name="label_speaker_autosave">Salvesta heli automaatselt</string>
-    <string name="description_speaker_autosave">Kanne „Seadme kõlar\", mis on seotud tavahelidega, uuendab end sinihammast toetava seadme ühendumisel ise. Märkus: see ei toimi kõigis seadmetes.</string>
     <string name="devices_neverseen_label">Esmakordne</string>
     <string name="devices_state_connected_label">Ühendatud</string>
     <string name="devices_last_connected_label">Viimati ühendatud: %s</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Tonua</string>
     <string name="devices_audio_stream_notification_label">Jakinarazpena</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="label_speaker_autosave">Bolumen gorde automatikoa</string>
-    <string name="description_speaker_autosave">\"Gailuaren bozgorailua\" sarrerak, lehenetsitako bolumenen ardura duena, bere burua eguneratzen du Bluetooth gailu bat konektatzen denean. Oharra: Honek ez du gailu guztietan funtzionatzen.</string>
     <string name="devices_neverseen_label">Inoiz ikusi ez</string>
     <string name="devices_state_connected_label">Konektatuta</string>
     <string name="devices_last_connected_label">Azken konexioa: %s</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">زنگ</string>
     <string name="devices_audio_stream_notification_label">اعلان</string>
     <string name="devices_audio_stream_alarm_label">هشدار</string>
-    <string name="label_speaker_autosave">ذخیره خودکار صدا</string>
-    <string name="description_speaker_autosave">ورودی «بلندگوی دستگاه» که مسئول صداهای پیش‌فرض است، هنگام اتصال دستگاه بلوتوث خود را به‌روز می‌کند. توجه: روی همه دستگاه‌ها کار نمی‌کند.</string>
     <string name="devices_neverseen_label">هرگز دیده نشده</string>
     <string name="devices_state_connected_label">متصل</string>
     <string name="devices_last_connected_label">آخرین اتصال: %s</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Soitto</string>
     <string name="devices_audio_stream_notification_label">Ilmoitus</string>
     <string name="devices_audio_stream_alarm_label">Hälytys</string>
-    <string name="label_speaker_autosave">Tallenna äänenvoimakkuus automaattisesti</string>
-    <string name="description_speaker_autosave">\"Laitteen kaiutin\" merkintä, mikä on vastuussa oletus äänenvoimakkuuksista, päivittää itsensä, kun Bluetooth laite yhdistää. Huomio: tämä ei toimi kaikilla laitteilla.</string>
     <string name="devices_neverseen_label">Ei nähty</string>
     <string name="devices_state_connected_label">Yhdistetty</string>
     <string name="devices_last_connected_label">Viimeksi yhdistetty: %s</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Ring</string>
     <string name="devices_audio_stream_notification_label">Notification</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Awtomatikong pag-save ng volume</string>
-    <string name="description_speaker_autosave">Ang entry na \"Device Speaker\", na responsable sa mga default na volume, ay ina-update ang sarili kapag kumonekta ang isang Bluetooth device. Tandaan: Hindi ito gumagana sa lahat ng device.</string>
     <string name="devices_neverseen_label">Hindi nakikita</string>
     <string name="devices_state_connected_label">Nakakonekta</string>
     <string name="devices_last_connected_label">Huling nakakonekta: %s</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Sonnerie</string>
     <string name="devices_audio_stream_notification_label">Notification</string>
     <string name="devices_audio_stream_alarm_label">Alarme</string>
-    <string name="label_speaker_autosave">Enregistrement automatique du volume</string>
-    <string name="description_speaker_autosave">L\'entrée « Haut-parleur de l\'appareil », qui gère les volumes par défaut, se met à jour quand un périphérique Bluetooth se connecte. Note : Cette option ne fonctionne pas sur tous les appareils.</string>
     <string name="devices_neverseen_label">Jamais rencontré</string>
     <string name="devices_state_connected_label">Connecté</string>
     <string name="devices_last_connected_label">Dernière connexion : %s</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Ton</string>
     <string name="devices_audio_stream_notification_label">Notificación</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="label_speaker_autosave">Gardar volume automaticamente</string>
-    <string name="description_speaker_autosave">A entrada \&quot;Altofalante do dispositivo\&quot;, responsable dos volumes predeterminados, actualízase automaticamente cando se conecta un dispositivo Bluetooth. Nota: Isto non funciona en todos os dispositivos.</string>
     <string name="devices_neverseen_label">Nunca visto</string>
     <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Último acceso: %s</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">रिंग</string>
     <string name="devices_audio_stream_notification_label">अधिसूचना</string>
     <string name="devices_audio_stream_alarm_label">अलार्म</string>
-    <string name="label_speaker_autosave">स्वचलित ध्वनि सहेजन</string>
-    <string name="description_speaker_autosave">\&quot;डिवाइस स्पीकर\&quot; प्रविष्टि, जो डिफ़ॉल्ट वॉल्यूम के लिए ज़िंमेदार है, किसी ब्लूटूथ डिवाइस के कनेक्ट होने पर स्वयं अद्यतन करता है । नोट: यह सभी डिवाइस पर काम नहीं करता है ।</string>
     <string name="devices_neverseen_label">कभी नहीं देखा</string>
     <string name="devices_state_connected_label">जुड गया</string>
     <string name="devices_last_connected_label">आखिरी बार जुड़ा: %s</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -139,8 +139,6 @@
     <string name="devices_audio_stream_ring_label">Zvono</string>
     <string name="devices_audio_stream_notification_label">Obavijest</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Automatsko spremanje glasnoće zvuka</string>
-    <string name="description_speaker_autosave">Unos \&quot;Zvučnik uređaja\&quot;, koji je zadužen za zadane glasnoće zvuka, samostalno se ažurira tijekom spajanja Bluetooth uređaja. Napomena: ovo ne radi na svim uređajima.</string>
     <string name="devices_neverseen_label">Nikad viđen</string>
     <string name="devices_state_connected_label">Povezano</string>
     <string name="devices_last_connected_label">Posljednji put povezan: %s</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Csengő</string>
     <string name="devices_audio_stream_notification_label">Értesítés</string>
     <string name="devices_audio_stream_alarm_label">Ébresztő</string>
-    <string name="label_speaker_autosave">Hangerő automatikus mentése</string>
-    <string name="description_speaker_autosave">Az \&quot;Eszköz hangszóró\&quot; bejegyzés, amely az alapértelmezett hangerőért felelős, frissíti magát, amikor egy Bluetooth eszköz csatlakozik. Megjegyzés: Ez nem minden eszközön működik.</string>
     <string name="devices_neverseen_label">Soha nem látott</string>
     <string name="devices_state_connected_label">Csatlakozva</string>
     <string name="devices_last_connected_label">Utoljára csatlakozva: %s</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">զանգակոց</string>
     <string name="devices_audio_stream_notification_label">Ծակուցություն</string>
     <string name="devices_audio_stream_alarm_label">Ռլարմ</string>
-    <string name="label_speaker_autosave">Ծավալի ավտոպահպանում</string>
-    <string name="description_speaker_autosave">\"Device Speaker\" կետքը, որն լռկլի ծավալների համար և, ինքնաթարկվում և երբ Bluetooth սարք կապակցվում և:</string>
     <string name="devices_neverseen_label">Արտասակ չի կապված</string>
     <string name="devices_state_connected_label">Կապակցված</string>
     <string name="devices_last_connected_label">վերջին կապակցությունը: %s</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -137,8 +137,6 @@
     <string name="devices_audio_stream_ring_label">Dering</string>
     <string name="devices_audio_stream_notification_label">Pemberitahuan</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Otosimpan volume</string>
-    <string name="description_speaker_autosave">Masukan \&quot;Pelantang Perangkat\&quot;, yang bertanggung jawab terhadap volume asali, memperbarui sendiri ketika perangkat Bluetooth terhubung. Catatan: Tindakan ini tidak bekerja untuk semua perangkat.</string>
     <string name="devices_neverseen_label">Tak pernah terlihat</string>
     <string name="devices_state_connected_label">Terhubung</string>
     <string name="devices_last_connected_label">Terakhir terhubung: %s</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Hringja</string>
     <string name="devices_audio_stream_notification_label">Tilkynning</string>
     <string name="devices_audio_stream_alarm_label">Viðvörun</string>
-    <string name="label_speaker_autosave">Sjálfvirk hljóðstyrksupp-skráning</string>
-    <string name="description_speaker_autosave">Færslan \"Hátalari tækis\", sem ber ábyrgð á sjálfgefnum hljóðstyrkum, uppfærir sig þgar Bluetooth tæki tengist. Athugið: Þetta virkar ekki á öllum tækjum.</string>
     <string name="devices_neverseen_label">Aldrei séð</string>
     <string name="devices_state_connected_label">Tengt</string>
     <string name="devices_last_connected_label">Síðast tengt: %s</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Suoneria</string>
     <string name="devices_audio_stream_notification_label">Notifica</string>
     <string name="devices_audio_stream_alarm_label">Sveglia</string>
-    <string name="label_speaker_autosave">Salva automaticamente il volume</string>
-    <string name="description_speaker_autosave">La voce \&quot;Speaker del dispositivo\&quot;, responsabile dei volumi di default, si aggiorna in modo automatico alla connessione di una periferica Bluetooth. Nota: questa funzione non è disponibile per tutti i dispositivi.</string>
     <string name="devices_neverseen_label">Mai visto</string>
     <string name="devices_state_connected_label">Connesso</string>
     <string name="devices_last_connected_label">Ultima connessione: %s</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -140,8 +140,6 @@
     <string name="devices_audio_stream_ring_label">צלצול</string>
     <string name="devices_audio_stream_notification_label">התראה</string>
     <string name="devices_audio_stream_alarm_label">התראה</string>
-    <string name="label_speaker_autosave">שמירה אוטומטית של עוצמה</string>
-    <string name="description_speaker_autosave">הרשומה של \&quot;רמקול מכשיר\&quot;, האחראית לעוצמות ברירת מחדל, מעדכנת את עצמה כאשר מתחבר מכשיר בלוטוס. הערה: זה לא עובד בכל המכשירים.</string>
     <string name="devices_neverseen_label">לא נראה מעולם</string>
     <string name="devices_state_connected_label">מחובר</string>
     <string name="devices_last_connected_label">חיבור אחרון: %s</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -137,8 +137,6 @@
     <string name="devices_audio_stream_ring_label">着信</string>
     <string name="devices_audio_stream_notification_label">通知</string>
     <string name="devices_audio_stream_alarm_label">アラーム</string>
-    <string name="label_speaker_autosave">音量を自動保存</string>
-    <string name="description_speaker_autosave">\&quot;端末スピーカー\&quot;はデフォルト音量を担当しており、Bluetoothデバイスが接続されたときに自分自身を更新します。注: すべての端末で動作するわけではありません。</string>
     <string name="devices_neverseen_label">接続履歴なし</string>
     <string name="devices_state_connected_label">接続済み</string>
     <string name="devices_last_connected_label">最後の接続: %s</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">ზარის მელოდია</string>
     <string name="devices_audio_stream_notification_label">შეტყობინება</string>
     <string name="devices_audio_stream_alarm_label">მაღვიძარა</string>
-    <string name="label_speaker_autosave">ხმის ავტომატური შენახვა</string>
-    <string name="description_speaker_autosave">\"მოწყობილობის დინამიკი\" ჩანაწერი, რომელიც პასუხისმგებელია ნაგულისხმევ ხმებზე, ახლდება Bluetooth მოწყობილობის დაკავშირებისას. შენიშვნა: ეს ყველა მოწყობილობაზე არ მუშაობს.</string>
     <string name="devices_neverseen_label">არასდროს დანახული</string>
     <string name="devices_state_connected_label">დაკავშირებული</string>
     <string name="devices_last_connected_label">ბოლოს დაკავშირება: %s</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -137,8 +137,6 @@
     <string name="devices_audio_stream_ring_label">រោត៍</string>
     <string name="devices_audio_stream_notification_label">ការជូនដំណឹង</string>
     <string name="devices_audio_stream_alarm_label">រោត៍ភ្ញាក</string>
-    <string name="label_speaker_autosave">រក្សាតុកកម្រិតសំឡេងស័យប្រវត្តិ</string>
-    <string name="description_speaker_autosave">ធាតុ \"ស្ពីករឧបករណ៍\" ដែលត្រស្រួមខុសត្រូវចំពោះកម្រិតសំឡេងលំនាំដើម ធ្វើបច្ចុប្បន្នភាពខ្លួនវាពេលឧបករណ៍ Bluetooth ភ្ជាប់។ ចំណាំ: វាមិនដំណើរការលើឧបករណ៍តាំងអស់ទេ។</string>
     <string name="devices_neverseen_label">មិនធ្លាបឃើញ</string>
     <string name="devices_state_connected_label">បានភ្ជាប់</string>
     <string name="devices_last_connected_label">ភ្ជាប់ចុងក្រោយ: %s</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Zengil</string>
     <string name="devices_audio_stream_notification_label">Agahdarî</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Dengê bixweber tomar bike</string>
-    <string name="description_speaker_autosave">Tomara Bilendkera Cîhazê, ku berpirsiyara dengên pêwîst e, xwe nûve dike dema cîhazek Bluetooth bi hestek dibe. Not: Ev li ser hemû cîhazan naxebite.</string>
     <string name="devices_neverseen_label">Hên nehatî dîtin</string>
     <string name="devices_state_connected_label">Bi hestek</string>
     <string name="devices_last_connected_label">Dawiya hevbestê: %s</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">ರಿಂಗ್</string>
     <string name="devices_audio_stream_notification_label">ಅಧಿಸೂಚನೆ</string>
     <string name="devices_audio_stream_alarm_label">ಅಲಾರ್ಮ್</string>
-    <string name="label_speaker_autosave">ಸ್ವಯಂಚಾಲಿತ ವಾಲ್ಯೂಮ್ ಉಳಿಸಿ</string>
-    <string name="description_speaker_autosave">ಇಂಗ್ಲಿಷ್‌ನಲ್ಲಿ \"Device Speaker\" ನಮೋದು, ಅಂದರೆ ಡಿಫಾಲ್ಟ್ ವಾಲ್ಯೂಮ್ಗಳ್ಗೆ ಜವಾಬ್ದಾರಿಯಾದದು, Bluetooth ಸಾಧನ ಜೋಡಿಗೊಂಡಾಗ ತನ್ನನ್ನು ತಾನೇ ನವೀಕರಿಸಿಕೊಳ್ಳುತ್ತದೆ. ಟಿಪ್ಪಣಿ: ಇದು ಎಲ್ಲಾ ಸಾಧನಗಳಲ್ಲಿ ಕಾರ್ಯನಿರ್ವಹಿಸುವುದಿಲ್ಲ.</string>
     <string name="devices_neverseen_label">ಎಂದೂ ಕಂಡಿಲ್ಲ</string>
     <string name="devices_state_connected_label">ಜೋಡಿಗೊಂಡಿದೆ</string>
     <string name="devices_last_connected_label">ಕೊನೆಯಾಗಿ ಜೋಡಿಗೊಂಡದ್ದು: %s</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -137,8 +137,6 @@
     <string name="devices_audio_stream_ring_label">벨소리</string>
     <string name="devices_audio_stream_notification_label">알림</string>
     <string name="devices_audio_stream_alarm_label">알람</string>
-    <string name="label_speaker_autosave">음량 자동 저장</string>
-    <string name="description_speaker_autosave">기본 음량을 담당하는 \&quot;디바이스 스피커\&quot; 항목을 블루투스 장치가 연결될 때 자동으로 업데이트합니다. 이 설정은 모든 기기에서 동작하지는 않습니다.</string>
     <string name="devices_neverseen_label">마지막 연결 없음</string>
     <string name="devices_state_connected_label">연결됨</string>
     <string name="devices_last_connected_label">마지막 연결: %s</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Коңгуроо</string>
     <string name="devices_audio_stream_notification_label">Билдирме</string>
     <string name="devices_audio_stream_alarm_label">Ойготкуч</string>
-    <string name="label_speaker_autosave">Үндү автосактоо</string>
-    <string name="description_speaker_autosave">Демейки үндөр үчүн жооп берген \"Түзмөктүн динамиги\" жазуусу Bluetooth түзмөк туташканда өзүн жаңыртат. Ескертүү: Бул бардык түзмөктөрдө иштебейт.</string>
     <string name="devices_neverseen_label">Эч качан көрүлгөн жок</string>
     <string name="devices_state_connected_label">Туташкан</string>
     <string name="devices_last_connected_label">Акыркы туташуу: %s</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -137,8 +137,6 @@
     <string name="devices_audio_stream_ring_label">ເວົ້າ</string>
     <string name="devices_audio_stream_notification_label">ການແຈ້ງ</string>
     <string name="devices_audio_stream_alarm_label">ເຕືອນ</string>
-    <string name="label_speaker_autosave">ບັນທຶກລະດັບສຽງອັດຕາ</string>
-    <string name="description_speaker_autosave">ລາຍການ \"Device Speaker\" ຋ຶ່ງສ້າງໃຫ້ລະດັບສຽງເຣິ່ມຕ້ນ ຈະອັບເດດຕັວເອງເມື່ອອຸປະກອນ Bluetooth ຕ່ອ. ຫມາຍເຫດຸ: ອັນນີ້ບໍ່ໃຊ້ໄດ້ກັບທຸກອຸປະກອນ.</string>
     <string name="devices_neverseen_label">ບໍ່ເຄີຍພົບເຫັນ</string>
     <string name="devices_state_connected_label">ຕ່ອອຍູ່</string>
     <string name="devices_last_connected_label">ຕ່ອລ່າສຸດ: %s</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -140,8 +140,6 @@
     <string name="devices_audio_stream_ring_label">Skambėjimas</string>
     <string name="devices_audio_stream_notification_label">Pranešimas</string>
     <string name="devices_audio_stream_alarm_label">Signalas</string>
-    <string name="label_speaker_autosave">Automatiškai išsaugoti garsumą</string>
-    <string name="description_speaker_autosave">\&quot;Įrenginio garsiakalbis\&quot; punktas, atsakingas už numatytą garsumą, automatiškai atsinaujina kai prijungiamas Bluetooth įrenginys. Pastaba: Tai veikia ne visuose įrenginiuose.</string>
     <string name="devices_neverseen_label">Nematytas</string>
     <string name="devices_state_connected_label">Prisijungta</string>
     <string name="devices_last_connected_label">Paskutinį kartą prisijungta: %s</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -139,8 +139,6 @@
     <string name="devices_audio_stream_ring_label">Zvanīšana</string>
     <string name="devices_audio_stream_notification_label">Paziņojums</string>
     <string name="devices_audio_stream_alarm_label">Trauksme</string>
-    <string name="label_speaker_autosave">Automātiskā skaļuma saglabāšana</string>
-    <string name="description_speaker_autosave">Ieraksts \"Ierīces skalruņis\", kas ir atbildīgs par noklusejuma skaļumiem, atjauninās sevi, kad pievienojas Bluetooth ierīce. Piezmīšme: Tas nedarbojas visās ierīcēs.</string>
     <string name="devices_neverseen_label">Nekad nav redzets</string>
     <string name="devices_state_connected_label">Pievienots</string>
     <string name="devices_last_connected_label">Pēdējā reize pievienots: %s</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Ѕвонење</string>
     <string name="devices_audio_stream_notification_label">Известување</string>
     <string name="devices_audio_stream_alarm_label">Аларм</string>
-    <string name="label_speaker_autosave">Автозачувај глас</string>
-    <string name="description_speaker_autosave">\&quot;Звучник на уредот\&quot;, кој е одговорен за стандардниот глас, се ажурира кога Блутут уред ќе се поврзе. Забелешка: Ова не работи на сите уреди.</string>
     <string name="devices_neverseen_label">Никогаш не виден</string>
     <string name="devices_state_connected_label">Конектирано</string>
     <string name="devices_last_connected_label">Последно поврзано: %s</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">റിംഗ്</string>
     <string name="devices_audio_stream_notification_label">നോട്ടിഫിക്കേഷൻ</string>
     <string name="devices_audio_stream_alarm_label">അലാം</string>
-    <string name="label_speaker_autosave">ഓട്ടോ സേവ് വോള്യം</string>
-    <string name="description_speaker_autosave">ഡിഫോൾട് വോള്യങ്ങൾക്ക് ഉത്തരവാദിത്വമുള്ള \"ഡിവൈസ് സ്പീക്കർ\" എൻട്രി, ഒരു Bluetooth ഉപകരണം കണക്‌റ് ചെയ്യുമ്പോൾ സ്വയം അപ്ഡേറ്റ് ചെയ്യുന്നു. ശ്രദ്ധ: ഇത് എല്ലാ ഉപകരണങ്ങളിലും പ്രവർത്തിക്കുന്നില്ല.</string>
     <string name="devices_neverseen_label">ഒരിക്കലും കണ്ടിട്ടില്ല</string>
     <string name="devices_state_connected_label">കണക്‌റ് ആണ്</string>
     <string name="devices_last_connected_label">അവസാനം കണക്‌റ് ആയത്: %s</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Дүүгэх</string>
     <string name="devices_audio_stream_notification_label">Мэдэгдэлгэ</string>
     <string name="devices_audio_stream_alarm_label">Дохио</string>
-    <string name="label_speaker_autosave">Дууг автоматаар хадгалах</string>
-    <string name="description_speaker_autosave">Өөрчлөлтийн дараахи төхөөрөмжийн дууг хариуладаг \"Төхөөрөмжийн чайгъ\" оролго Bluetooth төхөөрөмжий холбогдоход өөрөө өөрчлөгдөнө. Тайлбар: энэ бүх төхөөрөмжийд ажиллахгүй.</string>
     <string name="devices_neverseen_label">Хэзээгүй байсан</string>
     <string name="devices_state_connected_label">Холбогдсон</string>
     <string name="devices_last_connected_label">Сүүлийн холбогдолт: %s</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">रिंग</string>
     <string name="devices_audio_stream_notification_label">सूचना</string>
     <string name="devices_audio_stream_alarm_label">अलार्म</string>
-    <string name="label_speaker_autosave">व्हॉल्युम स्वयं-जतन</string>
-    <string name="description_speaker_autosave">\"डिव्हाइस स्पीकर\" नोंद, जी डीफॉल्ट व्हॉल्युमसाठी जबाबदार आहे, Bluetooth डिव्हाइस कनेक्ट झाल्यावर स्वतःला अद्यतनित करते. टीप: हे सर्व डिव्हाइसवर कार्य करत नाही.</string>
     <string name="devices_neverseen_label">कधीही दिसले नाही</string>
     <string name="devices_state_connected_label">कनेक्ट केलेले</string>
     <string name="devices_last_connected_label">शेवटचे कनेक्ट: %s</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -137,8 +137,6 @@
     <string name="devices_audio_stream_ring_label">Deringan</string>
     <string name="devices_audio_stream_notification_label">Pemberitahuan</string>
     <string name="devices_audio_stream_alarm_label">Penggera</string>
-    <string name="label_speaker_autosave">Volum autosimpan</string>
-    <string name="description_speaker_autosave">Kemasukan \&quot;Pembesar Suara Peranti\&quot;, yang mana bertanggungjawab pada volum lalai, mengemas kini dengan sendirinya bila peranti Bluetooth bersambung. Nota: Ini tidak berlaku pada semua peranti.</string>
     <string name="devices_neverseen_label">Tiada terlihat</string>
     <string name="devices_state_connected_label">Dihubungkan</string>
     <string name="devices_last_connected_label">Terakhir disambung: %s</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -137,8 +137,6 @@
     <string name="devices_audio_stream_ring_label">မြည်သံ</string>
     <string name="devices_audio_stream_notification_label">အကြောင်းကြားချက်</string>
     <string name="devices_audio_stream_alarm_label">နှိုးစက်</string>
-    <string name="label_speaker_autosave">အသံ အလိုအလျောက် သိမ်းဆည်း</string>
-    <string name="description_speaker_autosave">မူရင်း အသံများ တာဝန်ရှိသော &quot;Device Speaker&quot; ဝင်ခွင့်သည် Bluetooth ကိရိယာ ချိတ်ဆက်သောအခါ မိမိ အပ်ဒိတ်လုပ်သည်။ မှတ်ချက်: ကိရိယာ အားလုံးတွင် အလုပ်မဖြစ်နိုင်ပါ။</string>
     <string name="devices_neverseen_label">မတွေ့ဖူးသေး</string>
     <string name="devices_state_connected_label">ချိတ်ဆက်ထားသည်</string>
     <string name="devices_last_connected_label">နောက်ဆုံး ချိတ်ဆက်: %s</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">रिङ</string>
     <string name="devices_audio_stream_notification_label">सूचना</string>
     <string name="devices_audio_stream_alarm_label">अलार्म</string>
-    <string name="label_speaker_autosave">स्वतः भोल्युम सुरक्षित</string>
-    <string name="description_speaker_autosave">\"Device Speaker\" प्रविष्टि, जो पूर्वनिर्धारित भोल्युमहरूको लागि जिम्मेवार छ, Bluetooth उपकरण जडान हुँदा आफैं अद्यावधिक हुन्छ। नोट: यो सबै उपकरणहरूमा काम गर्दैन।</string>
     <string name="devices_neverseen_label">कहिल्यै देखिएन</string>
     <string name="devices_state_connected_label">जडान भयो</string>
     <string name="devices_last_connected_label">अन्तिम जडान: %s</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Beltoon</string>
     <string name="devices_audio_stream_notification_label">Melding</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Volume automatisch opslaan</string>
-    <string name="description_speaker_autosave">De \&quot;Apparaat luidspreker\&quot; entry, die verantwoordelijk is voor standaard volumes, updates zichzelf wanneer een Bluetooth-apparaat verbinding maakt. Opmerking: dit werkt niet op alle apparaten.</string>
     <string name="devices_neverseen_label">Nooit gezien</string>
     <string name="devices_state_connected_label">Verbonden</string>
     <string name="devices_last_connected_label">Laatst verbonden: %s</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Ringing</string>
     <string name="devices_audio_stream_notification_label">Varsling</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Autolagringsvolum</string>
-    <string name="description_speaker_autosave">\&quot;Enhetshøyttaler\&quot;, som er ansvarlig for standardvolumene, oppdaterer seg selv når en Bluetooth-enhet kobles til. Merk: Dette virker ikke på alle enheter.</string>
     <string name="devices_neverseen_label">Aldri sett</string>
     <string name="devices_state_connected_label">Tilkoblet</string>
     <string name="devices_last_connected_label">Sist tilkoblet: %s</string>

--- a/app/src/main/res/values-pcm-rNG/strings.xml
+++ b/app/src/main/res/values-pcm-rNG/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Ring</string>
     <string name="devices_audio_stream_notification_label">Notification</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Autosave volume</string>
-    <string name="description_speaker_autosave">Di \"Device Speaker\" entry, wey dey responsible for default volumes, dey update imself when Bluetooth device connect. Note: Dis no dey work on all devices.</string>
     <string name="devices_neverseen_label">Never seen</string>
     <string name="devices_state_connected_label">Connected</string>
     <string name="devices_last_connected_label">Last connected: %s</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -140,8 +140,6 @@
     <string name="devices_audio_stream_ring_label">Dzwonek</string>
     <string name="devices_audio_stream_notification_label">Powiadomienie</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Automatyczny zapis głośności</string>
-    <string name="description_speaker_autosave">Wpis \&quot;Głośnik urządzenia\&quot;, który jest odpowiedzialny za domyślne głośności, aktualizuje się samodzielnie, gdy urządzenie Bluetooth podłącza się. Informacja: Nie działa ze wszystkimi urządzeniami.</string>
     <string name="devices_neverseen_label">Nigdy nie podłączone</string>
     <string name="devices_state_connected_label">Połączony</string>
     <string name="devices_last_connected_label">Ostatnio połączony: %s</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Toque</string>
     <string name="devices_audio_stream_notification_label">Notificação</string>
     <string name="devices_audio_stream_alarm_label">Alarme</string>
-    <string name="label_speaker_autosave">Salvar volume automaticamente</string>
-    <string name="description_speaker_autosave">O registro de \&quot;Alto-falante do dispositivo\&quot;, que é responsável pelos volumes padrão, é atualizado quando um dispositivo Bluetooth é conectado. Nota: Isto não funciona em todos os dispositivos.</string>
     <string name="devices_neverseen_label">Nunca visto</string>
     <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Última conexão: %s</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Toque</string>
     <string name="devices_audio_stream_notification_label">Notificação</string>
     <string name="devices_audio_stream_alarm_label">Alarme</string>
-    <string name="label_speaker_autosave">Guardar volume automaticamente</string>
-    <string name="description_speaker_autosave">A entrada \&quot;Altifalante do Dispositivo\&quot;, que é responsável pelos volumes predefinidos, atualiza-se quando um dispositivo Bluetooth se conecta. Nota: Isto não funciona em todos os dispositivos.</string>
     <string name="devices_neverseen_label">Nunca</string>
     <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Última conexão: %s</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Siglun</string>
     <string name="devices_audio_stream_notification_label">Notificaziún</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Salvar automaticamain il volum</string>
-    <string name="description_speaker_autosave">L\'entrada «Locutur da l\'apparat», che è responsabla per ils volumes standard, s\'actualisescha cura ch\'in apparat Bluetooth sa connecta. Remarca: Quai na funcziunescha betg sin tuts apparats.</string>
     <string name="devices_neverseen_label">Mai vist</string>
     <string name="devices_state_connected_label">Connectà</string>
     <string name="devices_last_connected_label">Ultima connexiun: %s</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -139,8 +139,6 @@
     <string name="devices_audio_stream_ring_label">Sonerie</string>
     <string name="devices_audio_stream_notification_label">Notificare</string>
     <string name="devices_audio_stream_alarm_label">Alarmă</string>
-    <string name="label_speaker_autosave">Salvare automată volum</string>
-    <string name="description_speaker_autosave">Intrarea \&quot;Difuzorul Dispozitivului\&quot;, care este responsabilă pentru volumele implicite, se actualizează singură când se conectează un dispozitiv Bluetooth. Notă: Aceasta nu funcționează pe toate dispozitivele.</string>
     <string name="devices_neverseen_label">Niciodată văzut</string>
     <string name="devices_state_connected_label">Conectat</string>
     <string name="devices_last_connected_label">Ultima conectare: %s</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -140,8 +140,6 @@
     <string name="devices_audio_stream_ring_label">Звонок</string>
     <string name="devices_audio_stream_notification_label">Уведомления</string>
     <string name="devices_audio_stream_alarm_label">Будильник</string>
-    <string name="label_speaker_autosave">Автосохранение громкости</string>
-    <string name="description_speaker_autosave">Пункт \&quot;Динамик устройства\&quot;, отвечающий за уровни громкости по умолчанию, обновляется при подключении устройства Bluetooth. Примечание: это работает не на всех устройствах.</string>
     <string name="devices_neverseen_label">Не обнаруживалось</string>
     <string name="devices_state_connected_label">Подключено</string>
     <string name="devices_last_connected_label">Последнее подключение: %s</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Suoneria</string>
     <string name="devices_audio_stream_notification_label">Notìfica</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="label_speaker_autosave">Autosàlvataggiu de volume</string>
-    <string name="description_speaker_autosave">S\'entràda \&quot;Altoparlante de su dispositivu\&quot;, chi est responsàbbile de sos volumes predefinìdos, s\'aggiornant a se stèssu cando unu dispositivu Bluetooth si connèttet. Nota: Custu non funtzionat in tùdos sos dispositivos.</string>
     <string name="devices_neverseen_label">Mai vìstu</string>
     <string name="devices_state_connected_label">Connètidu</string>
     <string name="devices_last_connected_label">Ùltimu connètidu: %s</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">රිංඟ</string>
     <string name="devices_audio_stream_notification_label">දැනුම්දීම</string>
     <string name="devices_audio_stream_alarm_label">සීනුව</string>
-    <string name="label_speaker_autosave">හඩ ස්වයං-සුරකින්න</string>
-    <string name="description_speaker_autosave">පෙරනිමි හඩ සඳහා වගකිව යුතු \&quot;උපාංග ශ්‍රවණය\&quot; ඇතුළත් කිරීම, බ්ලූටූත් උපාංගයක් සම්බන්ධ වූ විට ස්වයංව යාවත්කාලීන කරයි. සටහන: මෙය සියලු උපාංගයන් හි ක්‍රියා නොකරයි.</string>
     <string name="devices_neverseen_label">කිසිදා දක්නා නොලැබිණ</string>
     <string name="devices_state_connected_label">සම්බන්ධිතයි</string>
     <string name="devices_last_connected_label">අවසාන සම්බන්ධය: %s</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -140,8 +140,6 @@
     <string name="devices_audio_stream_ring_label">Zvonenie</string>
     <string name="devices_audio_stream_notification_label">Upozornenie</string>
     <string name="devices_audio_stream_alarm_label">Budík</string>
-    <string name="label_speaker_autosave">Automaticky uložiť hlasitosť</string>
-    <string name="description_speaker_autosave">Vstup reproduktoru zariadenia, ktorý je zodpovedný za predvolené hlasitosti sa sám aktualizuje po pripojení Bluetooth zariadenia. Poznámka: Toto nefunguje na všetkých zariadeniach.</string>
     <string name="devices_neverseen_label">Nikdy nevidené</string>
     <string name="devices_state_connected_label">Pripojené</string>
     <string name="devices_last_connected_label">Naposledy pripojené: %s</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -140,8 +140,6 @@
     <string name="devices_audio_stream_ring_label">Zvonjenje</string>
     <string name="devices_audio_stream_notification_label">Obvestilo</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Samodejno shrani glasnost</string>
-    <string name="description_speaker_autosave">Vnos „Sistemski zvoknik“, ki je odgovoren za privzete glasnosti, se posodobi ob priklopu naprave Bluetooth. Opomba: To ne deluje na vseh napravah.</string>
     <string name="devices_neverseen_label">Nikoli videno</string>
     <string name="devices_state_connected_label">Povezano</string>
     <string name="devices_last_connected_label">Nazadnje povezano: %s</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Zile</string>
     <string name="devices_audio_stream_notification_label">Njoftim</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="label_speaker_autosave">Ruajtje automatike e volumit</string>
-    <string name="description_speaker_autosave">Hyrja \"Altoparlanti i pajisjes\", e cila është përgjegjëse për volumet e paracaktuara, përditësohet vetvetiu kur lidhet një pajisje Bluetooth. Shënim: Kjo nuk funksionon në të gjitha pajisjet.</string>
     <string name="devices_neverseen_label">Kurrë i parë</string>
     <string name="devices_state_connected_label">I lidhur</string>
     <string name="devices_last_connected_label">I lidhur për herë të fundit: %s</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -139,8 +139,6 @@
     <string name="devices_audio_stream_ring_label">Звон</string>
     <string name="devices_audio_stream_notification_label">Обавештење</string>
     <string name="devices_audio_stream_alarm_label">Аларм</string>
-    <string name="label_speaker_autosave">Аутоматско чување јачине</string>
-    <string name="description_speaker_autosave">Унос „Звучник уређаја“, који је одговоран за подразумеване јачине, ажурира се сам кад се Bluetooth уређај повеже. Напомена: Ово не ради на свим уређајима.</string>
     <string name="devices_neverseen_label">Никад није виђен</string>
     <string name="devices_state_connected_label">Повезан</string>
     <string name="devices_last_connected_label">Последња веза: %s</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Ringsignal</string>
     <string name="devices_audio_stream_notification_label">Avisering</string>
     <string name="devices_audio_stream_alarm_label">Larm</string>
-    <string name="label_speaker_autosave">Autospara volym</string>
-    <string name="description_speaker_autosave">Posten \&quot;Enhetshögtalare\&quot;, som ansvarar för standardvolymerna, uppdaterar sig själv när en Bluetooth-enhet ansluts. Obs: Detta fungerar inte på alla enheter.</string>
     <string name="devices_neverseen_label">Aldrig sedd</string>
     <string name="devices_state_connected_label">Ansluten</string>
     <string name="devices_last_connected_label">Senast ansluten: %s</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Mlio</string>
     <string name="devices_audio_stream_notification_label">Arifa</string>
     <string name="devices_audio_stream_alarm_label">Kengele</string>
-    <string name="label_speaker_autosave">Hifadhi sauti kiotomatiki</string>
-    <string name="description_speaker_autosave">Ingizo la \"Spika ya Kifaa\", ambalo linawajibika kwa sauti chaguo-msingi, hujisasisha yenyewe wakati kifaa cha Bluetooth kinaunganishwa. Kumbuka: Hii haifanyi kazi katika vifaa vyote.</string>
     <string name="devices_neverseen_label">Haijawahi kuonekana</string>
     <string name="devices_state_connected_label">Imeunganishwa</string>
     <string name="devices_last_connected_label">Iliunganishwa mara ya mwisho: %s</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">ரிங்</string>
     <string name="devices_audio_stream_notification_label">அறிவிப்பு</string>
     <string name="devices_audio_stream_alarm_label">அலாரம்</string>
-    <string name="label_speaker_autosave">ஒலி அளவு தானாக சேமி</string>
-    <string name="description_speaker_autosave">இயற்படியான ஒலி அளவுகளுக்கு பொறுப்பான \"சாதன ஸ்பீக்கர்\" பதிவு Bluetooth சாதனம் இணைக்கப்படும்போது தானாக புதுப்பிக்கப்படும். குறிப்பு: இது அனைத்து சாதனங்களிலும் இயங்காது.</string>
     <string name="devices_neverseen_label">ஒருமுறையும் காணப்படவில்லை</string>
     <string name="devices_state_connected_label">இணைக்கப்பட்டது</string>
     <string name="devices_last_connected_label">கடைசியாக இணைக்கப்பட்டது: %s</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">రింగ్</string>
     <string name="devices_audio_stream_notification_label">నోటిఫికేషన్</string>
     <string name="devices_audio_stream_alarm_label">అలారం</string>
-    <string name="label_speaker_autosave">వాల్యూమ్ స్వయంచాలకంగా సేవ్ చేయి</string>
-    <string name="description_speaker_autosave">\"Device Speaker\" ఎంట్రీ, ఇది డిఫాల్ట్ వాల్యూమ్‌లకు బాధ్యత వహిస్తుంది, Bluetooth పరికరం కనెక్ట్ అయినప్పుడు తనంతట తానే అప్‌డేట్ అవుతుంది. గమనిక: ఇది అన్ని పరికరాలలో పని చేయదు.</string>
     <string name="devices_neverseen_label">ఎప్పుడూ కనుగొనబడలేదు</string>
     <string name="devices_state_connected_label">కనెక్ట్ అయింది</string>
     <string name="devices_last_connected_label">చివరిగా కనెక్ట్ అయింది: %s</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -137,8 +137,6 @@
     <string name="devices_audio_stream_ring_label">เสียงเรียกเข้า</string>
     <string name="devices_audio_stream_notification_label">การแจ้งเตือน</string>
     <string name="devices_audio_stream_alarm_label">การแจ้งเตือน</string>
-    <string name="label_speaker_autosave">บันทึกระดับเสียงอัตโนมัติ</string>
-    <string name="description_speaker_autosave">รายการอุปกรณ์ \&quot;Device Speaker\&quot; ซึ่งมีหน้าที่รับผิดชอบเกี่ยวกับระดับเสียงเริ่มต้นจะอัปเดตเองเมื่ออุปกรณ์เชื่อมต่อกับบลูทูธ หมายเหตุ: ไม่สามารถใช้ได้กับทุกอุปกรณ์</string>
     <string name="devices_neverseen_label">ไม่เคยเห็น</string>
     <string name="devices_state_connected_label">เชื่อมต่อแล้ว</string>
     <string name="devices_last_connected_label">เชื่อมต่อครั้งล่าสุด: %s</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Zil</string>
     <string name="devices_audio_stream_notification_label">Bildirim</string>
     <string name="devices_audio_stream_alarm_label">Alarm Sesi</string>
-    <string name="label_speaker_autosave">Sesi otomatik kaydetme</string>
-    <string name="description_speaker_autosave">Varsayılan seslerden sorumlu olan \&quot;Aygıt Hoparlörü\&quot; girişi, bir Bluetooth aygıtı bağlandığında kendini günceller. Not: Bu, tüm cihazlarda çalışmaz.</string>
     <string name="devices_neverseen_label">Hiç görülmedi</string>
     <string name="devices_state_connected_label">Bağlandı</string>
     <string name="devices_last_connected_label">Son bağlantı: %s</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -140,8 +140,6 @@
     <string name="devices_audio_stream_ring_label">Дзвінок</string>
     <string name="devices_audio_stream_notification_label">Сповіщення</string>
     <string name="devices_audio_stream_alarm_label">Будильник</string>
-    <string name="label_speaker_autosave">Автозбереження гучності</string>
-    <string name="description_speaker_autosave">Запис \&quot;Динамік пристрою\&quot;, який відповідає за стандартні гучності, оновлюється при підключенні Bluetooth-пристрою. Примітка: Працює не на всіх пристроях.</string>
     <string name="devices_neverseen_label">Незнайомий пристрій</string>
     <string name="devices_state_connected_label">Під\'єднано</string>
     <string name="devices_last_connected_label">Останнє під\'єднання: %s</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">رنگٹون</string>
     <string name="devices_audio_stream_notification_label">نوٹیفیکیشن</string>
     <string name="devices_audio_stream_alarm_label">الارم</string>
-    <string name="label_speaker_autosave">والیوم خودکار محفوظ</string>
-    <string name="description_speaker_autosave">\"ڈیوائس اسپیکر\" کی اینٹری، جو ڈیفالٹ والیومز کی ذمہ دار ہے، ایچ جب بلوٹوتھ ڈیوائس منسلک ہوتی ہے تو خود بخود اپڈیٹ ہو جاتی ہے۔ نوٹ: یہ تمام ڈیوائسز پر کام نہیں کرتا۔</string>
     <string name="devices_neverseen_label">کبھی نہیں دیکھی</string>
     <string name="devices_state_connected_label">منسلک</string>
     <string name="devices_last_connected_label">آخری کنیکشن: %s</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Jiringlash</string>
     <string name="devices_audio_stream_notification_label">Bildirishnoma</string>
     <string name="devices_audio_stream_alarm_label">Signal</string>
-    <string name="label_speaker_autosave">Ovozni avtomatik saqlash</string>
-    <string name="description_speaker_autosave">Bluetooth qurilma ulanganda standart ovozlarni boshqaradigan \"Qurilma dinamigi\" yozuvi o\'zini yangilaydi. Eslatma: Bu barcha qurilmalarda ishlamaydi.</string>
     <string name="devices_neverseen_label">Hech qachon ko\'rilmagan</string>
     <string name="devices_state_connected_label">Ulangan</string>
     <string name="devices_last_connected_label">Oxirgi ulanish: %s</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -137,8 +137,6 @@
     <string name="devices_audio_stream_ring_label">Chuông</string>
     <string name="devices_audio_stream_notification_label">Thông báo</string>
     <string name="devices_audio_stream_alarm_label">Báo thức</string>
-    <string name="label_speaker_autosave">Lưu mức âm lượng tự động</string>
-    <string name="description_speaker_autosave">Mục \&quot;Loa thiết bị\&quot;, chịu trách nhiệm về âm lượng mặc định, sẽ tự cập nhật khi thiết bị Bluetooth kết nối. Lưu ý: Điều này không hoạt động trên tất cả các thiết bị.</string>
     <string name="devices_neverseen_label">Không nhìn thấy</string>
     <string name="devices_state_connected_label">Đã kết nối</string>
     <string name="devices_last_connected_label">Lần kết nối cuối: %s</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -137,8 +137,6 @@
     <string name="devices_audio_stream_ring_label">铃声</string>
     <string name="devices_audio_stream_notification_label">通知</string>
     <string name="devices_audio_stream_alarm_label">闹钟</string>
-    <string name="label_speaker_autosave">自动保存音量</string>
-    <string name="description_speaker_autosave">负责默认音量的\"设备扬声器\"条目在蓝牙设备连接时会自动更新。注意：这不适用于所有设备。</string>
     <string name="devices_neverseen_label">设备未曾连接</string>
     <string name="devices_state_connected_label">设备已连接</string>
     <string name="devices_last_connected_label">最后连接：%s</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -137,8 +137,6 @@
     <string name="devices_audio_stream_ring_label">鈴聲</string>
     <string name="devices_audio_stream_notification_label">通知</string>
     <string name="devices_audio_stream_alarm_label">鬧鐘</string>
-    <string name="label_speaker_autosave">自動儲存音量</string>
-    <string name="description_speaker_autosave">「裝置揚聲器」條目負責預設音量，會在藍牙裝置連接時自動更新。注意：這并非在所有裝置上都有效。</string>
     <string name="devices_neverseen_label">從未見過</string>
     <string name="devices_state_connected_label">已連接</string>
     <string name="devices_last_connected_label">上次連接：%s</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -136,8 +136,6 @@
     <string name="devices_audio_stream_ring_label">鈴聲</string>
     <string name="devices_audio_stream_notification_label">通知</string>
     <string name="devices_audio_stream_alarm_label">鬧鐘</string>
-    <string name="label_speaker_autosave">自動儲存音量</string>
-    <string name="description_speaker_autosave">負責預設音量的「裝置揚聲器」條目在有藍牙裝置連線時會自動更新。注意：這並非在所有裝置上都有效。</string>
     <string name="devices_neverseen_label">從未見過</string>
     <string name="devices_state_connected_label">已連線</string>
     <string name="devices_last_connected_label">最後連接時間：%s</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -138,8 +138,6 @@
     <string name="devices_audio_stream_ring_label">Ukhalo</string>
     <string name="devices_audio_stream_notification_label">Isaziso</string>
     <string name="devices_audio_stream_alarm_label">I-alamu</string>
-    <string name="label_speaker_autosave">Londoloza ivolumu ngokuzenzakalelayo</string>
-    <string name="description_speaker_autosave">Isidindo \"Isipika Sedivayisi\", esibhekele amavolumu omqoka, zibuyekeza yona ngokwayo uma idivayisi ye-Bluetooth ixhuma. Qaphela: Lokhu akusebenzi kuzo zonke izidivayisi.</string>
     <string name="devices_neverseen_label">Akuzange ibonakale</string>
     <string name="devices_state_connected_label">Ixhunyiwe</string>
     <string name="devices_last_connected_label">Ixhunyiwe okwedlule: %s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="discover_no_unmnaged_devices_msg">No unmanaged devices found</string>
     <string name="discover_all_devices_managed_msg">All your paired devices are managed! Need a new one?</string>
     <string name="discover_pair_new_device_action">Pair new device</string>
+    <string name="discover_device_speaker_desc">This phone\'s own speaker. Its volumes are applied when audio switches back to the phone, e.g. after your Bluetooth device disconnects.</string>
 
     <!-- Devices -->
     <string name="devices_device_config_label">Device configuration</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -444,6 +444,9 @@
     <string name="dnd_access_hint_title">Do Not Disturb access</string>
     <string name="dnd_access_hint_message">Without Do Not Disturb access, ringtone, notification, and DND mode settings can\'t be applied when your devices connect.</string>
     <string name="dnd_access_fix_action">Grant access</string>
+    <string name="device_speaker_hint_title">Volumes after disconnect</string>
+    <string name="device_speaker_hint_message">Want your volumes restored when a Bluetooth device disconnects? Add \"Device speaker\" as a managed device — its volumes are applied when audio switches back to your phone.</string>
+    <string name="device_speaker_hint_action">Add</string>
 
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Purchase cancelled</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,9 +148,6 @@
     <string name="devices_audio_stream_notification_label">Notification</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
 
-    <string name="label_speaker_autosave">Autosave volume</string>
-    <string name="description_speaker_autosave">The \"Device Speaker\" entry, which is responsible for default volumes, updates itself when a Bluetooth device connects. Note: This does not work on all devices.</string>
-
     <string name="devices_neverseen_label">Never seen</string>
     <string name="devices_state_connected_label">Connected</string>
     <string name="devices_last_connected_label">Last connected: %s</string>

--- a/app/src/test/java/eu/darken/bluemusic/devices/core/NewDeviceCreatorTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/core/NewDeviceCreatorTest.kt
@@ -1,0 +1,56 @@
+package eu.darken.bluemusic.devices.core
+
+import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
+import eu.darken.bluemusic.bluetooth.core.speaker.SpeakerDeviceProvider
+import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class NewDeviceCreatorTest : BaseTest() {
+
+    private lateinit var deviceRepo: DeviceRepo
+    private lateinit var volumeTool: VolumeTool
+    private lateinit var bluetoothRepo: BluetoothRepo
+    private lateinit var speakerProvider: SpeakerDeviceProvider
+
+    @BeforeEach
+    fun setup() {
+        deviceRepo = mockk(relaxed = true)
+        volumeTool = mockk(relaxed = true)
+        bluetoothRepo = mockk(relaxed = true)
+        speakerProvider = mockk(relaxed = true)
+
+        every { speakerProvider.address } returns SPEAKER_ADDR
+        every { bluetoothRepo.state } returns MutableStateFlow(
+            BluetoothRepo.State(isEnabled = false, hasPermission = false, devices = emptySet())
+        )
+    }
+
+    private fun creator() = NewDeviceCreator(
+        deviceRepo = deviceRepo,
+        volumeTool = volumeTool,
+        bluetoothRepo = bluetoothRepo,
+        speakerDeviceProvider = speakerProvider,
+    )
+
+    @Test
+    fun `speaker device is created without waiting for a ready bluetooth state`() =
+        runTest(UnconfinedTestDispatcher()) {
+            creator().createNewdevice(SPEAKER_ADDR)
+
+            coVerify { deviceRepo.updateDevice(eq(SPEAKER_ADDR), any()) }
+        }
+
+    companion object {
+        private const val SPEAKER_ADDR = "self:speaker:main"
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/devices/core/NewDeviceCreatorTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/core/NewDeviceCreatorTest.kt
@@ -2,10 +2,13 @@ package eu.darken.bluemusic.devices.core
 
 import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
 import eu.darken.bluemusic.bluetooth.core.speaker.SpeakerDeviceProvider
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
+import io.kotest.matchers.shouldBe
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -47,8 +50,19 @@ class NewDeviceCreatorTest : BaseTest() {
         runTest(UnconfinedTestDispatcher()) {
             creator().createNewdevice(SPEAKER_ADDR)
 
-            coVerify { deviceRepo.updateDevice(eq(SPEAKER_ADDR), any()) }
+            coVerify { deviceRepo.createDeviceIfAbsent(eq(SPEAKER_ADDR), any()) }
         }
+
+    @Test
+    fun `creating a device inserts if absent instead of overwriting`() = runTest(UnconfinedTestDispatcher()) {
+        val configSlot = slot<() -> DeviceConfigEntity>()
+
+        creator().createNewdevice(SPEAKER_ADDR)
+
+        coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+        coVerify { deviceRepo.createDeviceIfAbsent(eq(SPEAKER_ADDR), capture(configSlot)) }
+        configSlot.captured().address shouldBe SPEAKER_ADDR
+    }
 
     companion object {
         private const val SPEAKER_ADDR = "self:speaker:main"

--- a/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModelTest.kt
@@ -3,6 +3,7 @@ package eu.darken.bluemusic.devices.ui.dashboard
 import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
 import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.bluetooth.core.SourceDeviceWrapper
+import eu.darken.bluemusic.bluetooth.core.speaker.SpeakerDeviceProvider
 import eu.darken.bluemusic.common.apps.AppRepo
 import eu.darken.bluemusic.common.datastore.DataStoreValue
 import eu.darken.bluemusic.common.navigation.Nav
@@ -13,9 +14,11 @@ import eu.darken.bluemusic.devices.core.DeviceAddr
 import eu.darken.bluemusic.devices.core.DeviceRepo
 import eu.darken.bluemusic.devices.core.DevicesSettings
 import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.core.NewDeviceCreator
 import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
 import eu.darken.bluemusic.main.core.GeneralSettings
 import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -49,10 +52,14 @@ class DashboardViewModelTest : BaseTest() {
     private lateinit var appRepo: AppRepo
     private lateinit var navCtrl: NavigationController
 
+    private lateinit var deviceCreator: NewDeviceCreator
+    private lateinit var speakerProvider: SpeakerDeviceProvider
+
     private lateinit var batteryHintDismissed: DataStoreValue<Boolean>
     private lateinit var android10HintDismissed: DataStoreValue<Boolean>
     private lateinit var notificationHintDismissed: DataStoreValue<Boolean>
     private lateinit var dndHintDismissed: DataStoreValue<Boolean>
+    private lateinit var speakerHintDismissed: DataStoreValue<Boolean>
     private lateinit var lockedDevices: DataStoreValue<Set<DeviceAddr>>
 
     @BeforeEach
@@ -65,6 +72,9 @@ class DashboardViewModelTest : BaseTest() {
         devicesSettings = mockk(relaxed = true)
         appRepo = mockk(relaxed = true)
         navCtrl = mockk(relaxed = true)
+        deviceCreator = mockk(relaxed = true)
+        speakerProvider = mockk(relaxed = true)
+        every { speakerProvider.address } returns SPEAKER_ADDR
 
         devicesFlow = MutableStateFlow(emptyList())
         every { deviceRepo.devices } returns devicesFlow
@@ -80,12 +90,14 @@ class DashboardViewModelTest : BaseTest() {
         android10HintDismissed = stubBoolValue(false)
         notificationHintDismissed = stubBoolValue(true)
         dndHintDismissed = stubBoolValue(true)
+        speakerHintDismissed = stubBoolValue(false)
         lockedDevices = stubSetValue(emptySet())
 
         every { generalSettings.isBatteryOptimizationHintDismissed } returns batteryHintDismissed
         every { generalSettings.isAndroid10AppLaunchHintDismissed } returns android10HintDismissed
         every { generalSettings.isNotificationPermissionHintDismissed } returns notificationHintDismissed
         every { generalSettings.isDndAccessHintDismissed } returns dndHintDismissed
+        every { generalSettings.isSpeakerHintDismissed } returns speakerHintDismissed
         every { devicesSettings.lockedDevices } returns lockedDevices
 
         // Default: hint helpers report shouldShow=false unless test sets up otherwise.
@@ -119,6 +131,8 @@ class DashboardViewModelTest : BaseTest() {
         bluetoothSource = bluetoothRepo,
         generalSettings = generalSettings,
         devicesSettings = devicesSettings,
+        deviceCreator = deviceCreator,
+        speakerProvider = speakerProvider,
         dispatcherProvider = TestDispatcherProvider(UnconfinedTestDispatcher(testScheduler)),
         navCtrl = navCtrl,
         appRepo = appRepo,
@@ -144,6 +158,21 @@ class DashboardViewModelTest : BaseTest() {
             keepAwake = keepAwake,
             showHomeScreen = showHomeScreen,
             launchPkgs = launchPkgs,
+        ),
+    )
+
+    private fun speakerDevice(): ManagedDevice = ManagedDevice(
+        isConnected = false,
+        device = SourceDeviceWrapper(
+            address = SPEAKER_ADDR,
+            alias = "Device speaker",
+            name = "Device speaker",
+            deviceType = SourceDevice.Type.PHONE_SPEAKER,
+            isConnected = false,
+        ),
+        config = DeviceConfigEntity(
+            address = SPEAKER_ADDR,
+            isEnabled = true,
         ),
     )
 
@@ -225,5 +254,94 @@ class DashboardViewModelTest : BaseTest() {
 
         viewModel().state.filterNotNull().first()
         needsOverlaySlot.captured shouldBe true
+    }
+
+    @Test
+    fun `speaker hint shows while the speaker is unmanaged`() = runTest(UnconfinedTestDispatcher()) {
+        devicesFlow.value = listOf(device())
+
+        viewModel().state.filterNotNull().first().showSpeakerHint shouldBe true
+    }
+
+    @Test
+    fun `speaker hint stays hidden once dismissed`() = runTest(UnconfinedTestDispatcher()) {
+        every { speakerHintDismissed.flow } returns MutableStateFlow(true)
+        devicesFlow.value = listOf(device())
+
+        viewModel().state.filterNotNull().first().showSpeakerHint shouldBe false
+    }
+
+    @Test
+    fun `speaker hint stays hidden without any managed device`() = runTest(UnconfinedTestDispatcher()) {
+        devicesFlow.value = emptyList()
+
+        viewModel().state.filterNotNull().first().showSpeakerHint shouldBe false
+    }
+
+    @Test
+    fun `speaker hint stays hidden when the speaker is already managed`() = runTest(UnconfinedTestDispatcher()) {
+        devicesFlow.value = listOf(device(), speakerDevice())
+
+        viewModel().state.filterNotNull().first().showSpeakerHint shouldBe false
+    }
+
+    @Test
+    fun `speaker hint shows for a free user at the device limit`() = runTest(UnconfinedTestDispatcher()) {
+        upgradeInfos.value = FakeUpgradeInfo(isPro = false, isSettled = true)
+        devicesFlow.value = listOf(device(address = "AA:AA:AA:AA:AA:AA"), device(address = "BB:BB:BB:BB:BB:BB"))
+
+        viewModel().state.filterNotNull().first().showSpeakerHint shouldBe true
+    }
+
+    @Test
+    fun `adding the speaker creates it and opens its config`() = runTest(UnconfinedTestDispatcher()) {
+        devicesFlow.value = listOf(device())
+
+        viewModel().action(DashboardAction.AddSpeakerDevice)
+        advanceUntilIdle()
+
+        coVerify { deviceCreator.createNewdevice(SPEAKER_ADDR) }
+        verify { navCtrl.goTo(Nav.Main.DeviceConfig(SPEAKER_ADDR), any(), any()) }
+    }
+
+    @Test
+    fun `adding the speaker at the free limit routes to upgrade`() = runTest(UnconfinedTestDispatcher()) {
+        upgradeInfos.value = FakeUpgradeInfo(isPro = false, isSettled = true)
+        devicesFlow.value = listOf(device(address = "AA:AA:AA:AA:AA:AA"), device(address = "BB:BB:BB:BB:BB:BB"))
+
+        viewModel().action(DashboardAction.AddSpeakerDevice)
+        advanceUntilIdle()
+
+        coVerify(exactly = 0) { deviceCreator.createNewdevice(any()) }
+        verify { navCtrl.goTo(Nav.Main.Upgrade(), any(), any()) }
+    }
+
+    @Test
+    fun `adding an already managed speaker opens its config even at the free limit`() =
+        runTest(UnconfinedTestDispatcher()) {
+            upgradeInfos.value = FakeUpgradeInfo(isPro = false, isSettled = true)
+            devicesFlow.value = listOf(device(address = "AA:AA:AA:AA:AA:AA"), speakerDevice())
+
+            viewModel().action(DashboardAction.AddSpeakerDevice)
+            advanceUntilIdle()
+
+            coVerify(exactly = 0) { deviceCreator.createNewdevice(any()) }
+            verify(exactly = 0) { navCtrl.goTo(Nav.Main.Upgrade(), any(), any()) }
+            verify { navCtrl.goTo(Nav.Main.DeviceConfig(SPEAKER_ADDR), any(), any()) }
+        }
+
+    @Test
+    fun `dismissing the speaker hint persists the flag`() = runTest(UnconfinedTestDispatcher()) {
+        val updateSlot = slot<(Boolean) -> Boolean?>()
+
+        viewModel().action(DashboardAction.DismissSpeakerHint)
+        advanceUntilIdle()
+
+        coVerify { speakerHintDismissed.update(capture(updateSlot)) }
+        updateSlot.captured(false) shouldBe true
+    }
+
+    companion object {
+        private const val SPEAKER_ADDR = "self:speaker:main"
     }
 }

--- a/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupDataTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupDataTest.kt
@@ -23,7 +23,7 @@ class BackupDataTest : BaseTest() {
     }
 
     private fun createMaximalFixture() = AppBackup(
-        formatVersion = 1,
+        formatVersion = 2,
         appVersion = "3.3.1",
         appVersionCode = 33100L,
         createdAt = "2026-04-16T14:30:00Z",
@@ -76,6 +76,7 @@ class BackupDataTest : BaseTest() {
             isAndroid10AppLaunchHintDismissed = true,
             isNotificationPermissionHintDismissed = true,
             isDndAccessHintDismissed = true,
+            isSpeakerHintDismissed = true,
         ),
     )
 
@@ -93,7 +94,7 @@ class BackupDataTest : BaseTest() {
 
         actualJson.toComparableJson() shouldBe """
             {
-                "formatVersion": 1,
+                "formatVersion": 2,
                 "appVersion": "3.3.1",
                 "appVersionCode": 33100,
                 "createdAt": "2026-04-16T14:30:00Z",
@@ -167,7 +168,8 @@ class BackupDataTest : BaseTest() {
                     "isBatteryOptimizationHintDismissed": true,
                     "isAndroid10AppLaunchHintDismissed": true,
                     "isNotificationPermissionHintDismissed": true,
-                    "isDndAccessHintDismissed": true
+                    "isDndAccessHintDismissed": true,
+                    "isSpeakerHintDismissed": true
                 }
             }
         """.trimIndent()
@@ -244,6 +246,32 @@ class BackupDataTest : BaseTest() {
         defaults.autoplayKeycodes shouldBe emptyList()
         defaults.showHomeScreen shouldBe false
         defaults.visibleAdjustments shouldBe true
+    }
+
+    @Test
+    fun `v1 payload without the speaker hint flag decodes with it disabled`() {
+        val jsonString = """
+        {
+            "formatVersion": 1,
+            "appVersion": "3.3.1",
+            "createdAt": "2026-04-16T14:30:00Z",
+            "generalSettings": {
+                "themeMode": "DARK",
+                "themeStyle": "MATERIAL_YOU",
+                "themeColor": "SUNSET",
+                "isOnboardingCompleted": true,
+                "isBatteryOptimizationHintDismissed": true,
+                "isAndroid10AppLaunchHintDismissed": true,
+                "isNotificationPermissionHintDismissed": true,
+                "isDndAccessHintDismissed": true
+            }
+        }
+        """.trimIndent()
+
+        val backup = json.decodeFromString(AppBackup.serializer(), jsonString)
+        backup.formatVersion shouldBe 1
+        backup.generalSettings.isDndAccessHintDismissed shouldBe true
+        backup.generalSettings.isSpeakerHintDismissed shouldBe false
     }
 
     @Test

--- a/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManagerTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupRestoreManagerTest.kt
@@ -227,6 +227,35 @@ class BackupRestoreManagerTest : BaseTest() {
     }
 
     @Test
+    fun `parseBackup accepts a v1 backup without the speaker hint flag`() = runTest {
+        val file = File(tempDir, "v1.zip")
+        val backupJson = """
+            {
+                "formatVersion": 1,
+                "appVersion": "3.3.1",
+                "createdAt": "2026-01-01T00:00:00Z",
+                "deviceConfigs": [{"address": "AA:BB:CC:DD:EE:FF"}],
+                "generalSettings": {"isDndAccessHintDismissed": true}
+            }
+        """.trimIndent()
+        ZipOutputStream(FileOutputStream(file)).use { zip ->
+            zip.putNextEntry(ZipEntry("backup.json"))
+            zip.write(backupJson.toByteArray())
+            zip.closeEntry()
+        }
+        val uri = mockk<Uri>(relaxed = true)
+        every { contentResolver.openInputStream(uri) } answers { FileInputStream(file) }
+
+        val parsed = manager.parseBackup(uri)
+
+        parsed.backup.formatVersion shouldBe 1
+        parsed.backup.generalSettings.isSpeakerHintDismissed shouldBe false
+
+        manager.applyRestore(parsed.backup, skipExisting = false).deviceCount shouldBe 1
+        coVerify { generalSettings.applyBackup(parsed.backup.generalSettings) }
+    }
+
+    @Test
     fun `parseBackup flags duplicate addresses in warnings`() = runTest {
         val (uri, file) = tempUri("dup.zip")
         val backup = AppBackup(


### PR DESCRIPTION
## Summary

Users were repeatedly confused about how to set up volume restoration for when their Bluetooth device disconnects — the key concept (add the "Device speaker" entry itself as a managed device) was never explained anywhere in the app.

- The "Device speaker" entry in the add-device list now explains its purpose ("This phone's own speaker. Its volumes are applied when audio switches back to the phone, e.g. after your Bluetooth device disconnects.") instead of showing an internal address.
- New dismissible dashboard hint card ("Volumes after disconnect"), shown when Bluetooth devices are managed but the device speaker isn't. One tap adds the speaker and opens its volume configuration; free users at the device limit are routed to the upgrade screen.
- Adding a device is now insert-if-absent: re-adding can no longer overwrite an existing configuration, and creating the virtual speaker no longer waits on Bluetooth readiness (previously it could hang with Bluetooth off).
- The hint's dismissed state is included in backups: backup format version bumped to 2, version-1 backups still restore cleanly.
- Removed two unused leftover strings from the old app version across all locales.

## Testing

- New unit tests: dashboard hint visibility and add-action behavior (9 cases), device creation insert-if-absent + speaker path, backup format v2 golden fixture + v1 compatibility.
- `assembleFossDebug` and `testFossDebugUnitTest` (734 tests) pass.
- Smoke-tested on an emulator: fresh-install onboarding, add-device subtitle, and the speaker add flow.
