### PR TITLE
Refresh the upgrade screens and keep the supporter status stable

### DIFF
--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
@@ -3,17 +3,21 @@ package eu.darken.bluemusic.upgrade.core
 import eu.darken.bluemusic.common.WebpageTool
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
+import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.flow.setupCommonEventHandlers
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.retryWhen
 import kotlinx.coroutines.flow.shareIn
 
@@ -35,29 +39,52 @@ class UpgradeRepoFoss @Inject constructor(
 
     private val refreshTrigger = MutableStateFlow(UUID.randomUUID())
 
-    override val upgradeInfo: Flow<UpgradeRepo.Info> = combine(
-        fossCache.upgrade.flow,
-        refreshTrigger
-    ) { data, _ ->
-        if (data == null) {
-            Info()
-        } else {
-            Info(
-                isPro = true,
-                upgradedAt = data.upgradedAt,
-                fossUpgradeType = data.upgradeType,
-            )
+    // Written only from the sharing coroutine (single collector) — no synchronization needed.
+    // Recorded INSIDE the flatMapLatest block, upstream of its channel buffer: a downstream onEach
+    // can still be waiting on a buffered emission when the inner flow throws, and the retry below
+    // would then read a stale (null) value and revoke an entitlement we already saw.
+    private var lastKnownInfo: Info? = null
+
+    // Integer, capped backoff: the old 2.0.pow(attempt) formula slept for hours and could overflow
+    // Long into a delay(negative) hot loop. Overridable so tests can drive the retry loop without
+    // sleeping through the real schedule.
+    internal var retryDelayMs: (attempt: Long) -> Long = { (30_000L * (it + 1)).coerceAtMost(300_000L) }
+
+    // Synthesis of the two shapes: the automatic retry loop stays (nothing calls refresh() while an
+    // error screen is open, so dropping it would strip the only recovery an idle user gets), but it
+    // moves INSIDE the flatMapLatest and gains last-known preservation. Consequences: a late read
+    // failure rides on the previously seen Info instead of revoking a supporter's entitlement, and
+    // refresh() now CANCELS an in-flight backoff delay and resubscribes immediately — where before
+    // a successful persist could take up to five minutes to reach collectors.
+    override val upgradeInfo: Flow<UpgradeRepo.Info> = refreshTrigger
+        .flatMapLatest {
+            fossCache.upgrade.flow
+                .map { data ->
+                    if (data == null) {
+                        Info()
+                    } else {
+                        Info(
+                            isPro = true,
+                            upgradedAt = data.upgradedAt,
+                            fossUpgradeType = data.upgradeType,
+                        )
+                    }
+                }
+                // Same coroutine as the throw below, so the ordering is guaranteed. Only
+                // successfully mapped elements pass here — retry emissions go straight downstream
+                // and never record themselves as a last known state.
+                .onEach { lastKnownInfo = it }
+                .retryWhen { error, attempt ->
+                    if (error is CancellationException) return@retryWhen false
+                    log(TAG, WARN) { "upgradeInfo read failed (attempt=$attempt): ${error.asLog()}" }
+                    emit((lastKnownInfo ?: Info()).copy(error = error))
+                    delay(retryDelayMs(attempt))
+                    true
+                }
         }
-    }
-        .setupCommonEventHandlers(TAG) { "upgradeInfo" }
+        // MainActivity refreshes on every resume: dedupe the identical re-emissions that produces.
         .distinctUntilChanged()
-        .retryWhen { error, attempt ->
-            emit(Info(error = error))
-            // Integer, capped backoff: the old 2.0.pow(attempt) formula slept for hours and could
-            // overflow Long into a delay(negative) hot loop.
-            delay((30_000L * (attempt + 1)).coerceAtMost(300_000L))
-            true
-        }
+        .setupCommonEventHandlers(TAG) { "upgradeInfo" }
         .shareIn(scope, SharingStarted.WhileSubscribed(3000L, 0L), replay = 1)
 
     // Synchronous so the caller learns whether the page actually opened: the FOSS unlock heuristic
@@ -91,6 +118,9 @@ class UpgradeRepoFoss @Inject constructor(
                 upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
             )
         }
+        // A returned transaction proves the store is readable again: revive a possibly error-stuck
+        // inner flow so the record propagates to collectors still holding the error replay.
+        refresh()
         return if (updated.old == null) {
             true
         } else {

--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -148,9 +148,7 @@ private fun UpgradePitchContent(
     UpgradeScreenContent(
         paddingValues = paddingValues,
     ) {
-        UpgradeHeader()
-
-        UpgradePreambleCard(
+        UpgradeHeroCard(
             text = stringResource(R.string.upgrade_screen_preamble),
             colors = CardDefaults.elevatedCardColors(
                 containerColor = MaterialTheme.colorScheme.primaryContainer,

--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager het geen advertensies nie en verkoop nie gebruikersdata nie. Voortgesette ontwikkeling word slegs deur jou moontlik gemaak.</string>
     <string name="upgrade_screen_how_title">Hoe om te help</string>
     <string name="upgrade_screen_how_body">Word \'n beskermheer en borg ontwikkeling! Tik die knoppie hieronder om alle ekstra funksies te aktiveer en my GitHub Sponsors profiel oop te maak.</string>
-    <string name="upgrade_screen_why_title">In die mengsel</string>
-    <string name="upgrade_screen_why_body">• \'n Gemotiveerde ontwikkelaar 🧙
-• Onbeperkte toestelle ➡️➡️
-• Ekstra aksies ⚙️
-en meer…</string>
     <string name="upgrade_screen_sponsor_action">Borg ontwikkeling</string>
     <string name="upgrade_screen_sponsor_action_hint">Die alternatief is advertensies, analitiek en Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Dankie dat jy oopbron ontwikkeling ondersteun ❤️</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ምንም እዋዀት ይረጋል፣ የተገባይ ውሂብንነም አይሸጥም። የተቆተቀወ ቅብት በእርስዎን ብቼድ ይተቀጥላል።</string>
     <string name="upgrade_screen_how_title">እንዴት መርዳት እንደሚችሉ</string>
     <string name="upgrade_screen_how_body">ደጋፊ ይሁኑ እና ልማትን ይደግፉ! ሁሉንም ተጨማሪ ባህሪያት ለማንቃት እና የእኔን GitHub Sponsors መገለጫ ለመክፈት ከታች ያለውን ቁልፍ ይንኩ።</string>
-    <string name="upgrade_screen_why_title">በባልት መካከል</string>
-    <string name="upgrade_screen_why_body">• የተጠቀየ ማድርግዬ 🧙
-• ምንም አይኖን መሣሪያዎች ➡️➡️
-• ✏✏✏✏ ✏✏✏ ⚙️
-እና ይጀምሮ...</string>
     <string name="upgrade_screen_sponsor_action">ልማትን ይደግፉ</string>
     <string name="upgrade_screen_sponsor_action_hint">አማራጩ ማስታወቂያዎች፣ ትንታኔዎች እና Google Play ናቸው 🙁</string>
     <string name="upgrade_screen_thanks_toast">ክፍት ምንጭ ልማትን ስለደገፉ እናመሰግናለን ❤️</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">لا يعرض Bluetooth Volume Manager أية إعلانات ولا يبيع بيانات المستخدم. التطوير المستمر ممكن فقط بدعمكم.</string>
     <string name="upgrade_screen_how_title">كيف أساعدك</string>
     <string name="upgrade_screen_how_body">كن داعما وراعيا للتطوير! انقر على الزر أدناه لتفعيل جميع الميزات الإضافية وفتح ملفي الخاص برعاة GitHub.</string>
-    <string name="upgrade_screen_why_title">في المزيج</string>
-    <string name="upgrade_screen_why_body">• مطوّر متحمس 🧙
-• أجهزة غير محدودة ➡️➡️
-• إجراءات إضافية ⚙️
-والمزيد…</string>
     <string name="upgrade_screen_sponsor_action">ادعم التطوير</string>
     <string name="upgrade_screen_sponsor_action_hint">البديل هو الإعلانات والتحليلات و Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">شكراً على دعمك لتطوير المصادر المفتوحة ❤️</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-də reklam yoxdur və istifadəçi məlumatlarını satmır. Davamlı inkışaf yalnız sizin sayənizdə mümkündür.</string>
     <string name="upgrade_screen_how_title">Necə kömək etmək</string>
     <string name="upgrade_screen_how_body">Himayədar olun və inkişafı sponsor edin! Bütün əlavə xüsusiyyətləri aktivləşdirmək və mənim GitHub Sponsors profilimi açmaq üçün aşağıdakı düyməni toxunun.</string>
-    <string name="upgrade_screen_why_title">Qarışıqda</string>
-    <string name="upgrade_screen_why_body">• Həvəsli bir tərtibatçı 🧙
-• Limitsiz cihazlar ➡️➡️
-• Əlave əməliyyatlar ⚙️
-və daha çox…</string>
     <string name="upgrade_screen_sponsor_action">İnkişafı sponsor edin</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativ reklamlar, analitika və Google Play-dir 🙁</string>
     <string name="upgrade_screen_thanks_toast">Açıq mənbə inkişafını dəstəklədiyiniz üçün təşəkkür edirik ❤️</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не мае рэкламы і не прадае дадзеныя карыстальнікаў. Працягнення разработкі магчыма толькі дзякуючы вам.</string>
     <string name="upgrade_screen_how_title">Як дапамагчы</string>
     <string name="upgrade_screen_how_body">Станьце спонсарам распрацоўкі! Націсніце кнопку ніжэй, каб актывіраваць усе дадатковыя функцыі і адкрыць мой профіль на GitHub Sponsors.</string>
-    <string name="upgrade_screen_why_title">У міксе</string>
-    <string name="upgrade_screen_why_body">• Матываваны разработнік 🧙
-• Неабмежаваная колькасць прылад ➡️➡️
-• Дадатковыя дзеянні ⚙️
-і ншш…</string>
     <string name="upgrade_screen_sponsor_action">Падтрымаць распрацоўку</string>
     <string name="upgrade_screen_sponsor_action_hint">Альтэрнатыва - рэклама, аналітыка і Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Дзякуй за падтрымку распрацоўкі з адкрытым зыходным кодам ❤️</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager няма реклами и не продава потребителски данни. Непрекъснатото развитие е възможно само благодарение на вас.</string>
     <string name="upgrade_screen_how_title">Как да помогнете</string>
     <string name="upgrade_screen_how_body">Станете покровител и спонсорирайте разработката! Докоснете бутона по-долу, за да активирате всички допълнителни функции и да отворите моя GitHub Sponsors профил.</string>
-    <string name="upgrade_screen_why_title">В микса</string>
-    <string name="upgrade_screen_why_body">• Мотивиран разработчик 🧙
-• Неограничени устройства ➡️➡️
-• Допълнителни действия ⚙️
-и още…</string>
     <string name="upgrade_screen_sponsor_action">Спонсорирайте разработката</string>
     <string name="upgrade_screen_sponsor_action_hint">Алтернативата са реклами, анализи и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Благодаря ви, че подкрепяте разработката с отворен код ❤️</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-এ কোনো বিজ্ঞাপন নেই এবং ব্যবহারকারীর তথ্য বিক্রি করে না। চলমান উন্নয়ন শুধুমাত্র আপনার দ্বারা সম্ভব।</string>
     <string name="upgrade_screen_how_title">কিভাবে সাহায্য করতে পারি</string>
     <string name="upgrade_screen_how_body">একটি পৃষ্ঠপোষক এবং স্পনসর উন্নয়ন হয়ে! সমস্ত অতিরিক্ত বৈশিষ্ট্য সক্রিয় করতে নীচের বোতামটি আলতো চাপুন এবং আমার GitHub স্পনসর প্রোফাইল খুলুন।</string>
-    <string name="upgrade_screen_why_title">মিশ্রণে</string>
-    <string name="upgrade_screen_why_body">• একজন উৎসাহী ডেভেলপার 🧙\n• অসীমিত ডিভাইস ➡️➡️\n• অতিরিক্ত অ্যাকশন ⚙️\nআরও অনেক কিছু…</string>
     <string name="upgrade_screen_sponsor_action">স্পনসর ডেভলপমেন্ট</string>
     <string name="upgrade_screen_sponsor_action_hint">বিকল্প হল বিজ্ঞাপন, বিশ্লেষণ এবং Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ওপেন সোর্স ডেভেলপমেন্ট সমর্থন করার জন্য আপনাকে ধন্যবাদ ❤️</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no té anuncis i no ven dades d’usuari. El desenvolupament continuat només és possible gràcies a vosaltres.</string>
     <string name="upgrade_screen_how_title">Com ajudar</string>
     <string name="upgrade_screen_how_body">Convertiu-vos en mecenes i patrocinadors del desenvolupament! Toqueu el botó següent per activar totes les funcions addicionals i obrir el meu perfil de patrocinadors del GitHub.</string>
-    <string name="upgrade_screen_why_title">En la mescla</string>
-    <string name="upgrade_screen_why_body">• Un desenvolupador motivat 🧙\n• Dispositius il·limitats ➡️➡️\n• Accions addicionals ⚙️\ni més…</string>
     <string name="upgrade_screen_sponsor_action">Desenvolupament del patrocinador</string>
     <string name="upgrade_screen_sponsor_action_hint">L\'alternativa són els anuncis, les analítiques i Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gràcies per donar suport al desenvolupament de codi obert ❤️</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neobsahuje žádné reklamy a neprodává data uživatelů. Další vývoj je možný pouze díky vám.</string>
     <string name="upgrade_screen_how_title">Jak pomoci</string>
     <string name="upgrade_screen_how_body">Staňte se patronem a sponzorem vývoje! Klepnutím na tlačítko níže aktivujete všechny další funkce a otevřete můj profil sponzora na GitHubu.</string>
-    <string name="upgrade_screen_why_title">V mixu</string>
-    <string name="upgrade_screen_why_body">• Motivovaný vývojář 🧙\n• Neomezený počet zařízení ➡️➡️\n• Další akce ⚙️\na více…</string>
     <string name="upgrade_screen_sponsor_action">Sponzorovat vývoj</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativou jsou reklamy, analytika a Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Děkujeme vám za podporu vývoje open-source ❤️</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen reklamer og sælger ikke brugerdata. Fortsat udvikling er kun muliggjort af dig.</string>
     <string name="upgrade_screen_how_title">Sådan hjælper du</string>
     <string name="upgrade_screen_how_body">Bliv patron og sponsorér udvikling! Tryk på knappen nedenfor for at aktivere alle ekstra funktioner og åbne min GitHub-sponsorprofil.</string>
-    <string name="upgrade_screen_why_title">I blandingen</string>
-    <string name="upgrade_screen_why_body">• En motiveret udvikler 🧙
-• Ubegrænset antal enheder ➡️➡️
-• Ekstra handlinger ⚙️
-og mere…</string>
     <string name="upgrade_screen_sponsor_action">Sponsorudvikling</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativet er annoncer, analyser og Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Tak, fordi du støtter open source-udvikling ❤️</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager enthält keine Werbung und verkauft keine Nutzerdaten. Die Weiterentwicklung wird nur durch dich ermöglicht.</string>
     <string name="upgrade_screen_how_title">Wie kann ich helfen?</string>
     <string name="upgrade_screen_how_body">Werde Förderer und unterstütze Entwicklung! Klicke auf die Schaltfläche unten, um alle zusätzlichen Funktionen zu aktivieren und mein GitHub-Sponsorenprofil zu öffnen.</string>
-    <string name="upgrade_screen_why_title">Im Mix</string>
-    <string name="upgrade_screen_why_body">• Einen motivierten Entwickler 🧙
-• Unbegrenzte Geräte ➡️➡️
-• Extra-Aktionen ⚙️
-und mehr…</string>
     <string name="upgrade_screen_sponsor_action">Weiterentwicklung unterstützen</string>
     <string name="upgrade_screen_sponsor_action_hint">Die Alternative sind Anzeigen, Analysen und Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Vielen Dank für Deine Unterstützung der Open-Source-Entwicklung ❤️</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Το Bluetooth Volume Manager δεν έχει διαφημίσεις και δεν πωλεί δεδομένα χρηστών. Η συνεχής ανάπτυξη είναι δυνατή μόνο χάρη σε εσάς.</string>
     <string name="upgrade_screen_how_title">Πώς να βοηθήσετε</string>
     <string name="upgrade_screen_how_body">Γίνετε patron και χορηγήστε την ανάπτυξη! Πατήστε το κουμπί παρακάτω για να ενεργοποιήσετε όλα τα επιπλέον χαρακτηριστικά και ανοίξτε το προφίλ μου GitHub Sponsors.</string>
-    <string name="upgrade_screen_why_title">Στο μείγμα</string>
-    <string name="upgrade_screen_why_body">• Ένας παρακινημένος προγραμματιστής 🧙
-• Απεριόριστες συσκευές ➡️➡️
-• Επιπλέον ενέργειες ⚙️
-και άλλα…</string>
     <string name="upgrade_screen_sponsor_action">Χορηγήστε την ανάπτυξη</string>
     <string name="upgrade_screen_sponsor_action_hint">Η εναλλακτική λύση είναι οι διαφημίσεις, τα αναλυτικά και το Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Σας ευχαριστούμε που υποστηρίζετε την ανάπτυξη ανοιχτού κώδικα ❤️</string>

--- a/app/src/foss/res/values-eo-rUY/strings.xml
+++ b/app/src/foss/res/values-eo-rUY/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ne havas reklamojn kaj ne vendas uzantoajn datumojn. Daŭra disvolvado estas ebligita nur de vi.</string>
     <string name="upgrade_screen_how_title">Kiel helpi</string>
     <string name="upgrade_screen_how_body">Fiĝiĝu patrono kaj sponsoru disvolvadon! Frapi la butonon malsupre por aktivigi ĉiujn ekstra funkciojn kaj malfermi mian GitHub Sponsors-profilon.</string>
-    <string name="upgrade_screen_why_title">En la miksajxo</string>
-    <string name="upgrade_screen_why_body">• Motivita programisto 🧙\n• Senlimaj aparatoj ➡️➡️\n• Ekstra agoj ⚙️\nkas pli…</string>
     <string name="upgrade_screen_sponsor_action">Sponsori disvolvadon</string>
     <string name="upgrade_screen_sponsor_action_hint">La alternativo estas reklamoj, analizoj kaj Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Dankon pro subteno de malfermita kodo ❤️</string>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende datos de usuario. El desarrollo continuo solo es posible gracias a vos.</string>
     <string name="upgrade_screen_how_title">Como ayudar</string>
     <string name="upgrade_screen_how_body">¡Conviértete en patrocinador y patrocina el desarrollo! Toque el botón de abajo para activar todas las funciones adicionales y abrir mi perfil de Patrocinadores de GitHub.</string>
-    <string name="upgrade_screen_why_title">En la mezcla</string>
-    <string name="upgrade_screen_why_body">• Un desarrollador motivado 🧙\n• Dispositivos ilimitados ➡️➡️\n• Acciones extra ⚙️\ny más…</string>
     <string name="upgrade_screen_sponsor_action">Sponsorear el desarrollo</string>
     <string name="upgrade_screen_sponsor_action_hint">Las alternativas son anuncios, analíticas y Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo de código abierto ❤️</string>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene publicidad y no vende datos de usuarios. El desarrollo continuo solo es posible gracias a ti.</string>
     <string name="upgrade_screen_how_title">Cómo ayudar</string>
     <string name="upgrade_screen_how_body">¡Conviértete en un patrocinador y apoya el desarrollo constante de la aplicación! Presiona el botón a continuación para activar todas las funciones adicionales además de abrir mi perfil de Patrocinadores en GitHub.</string>
-    <string name="upgrade_screen_why_title">En la mezcla</string>
-    <string name="upgrade_screen_why_body">• Un desarrollador motivado 🧙\n• Dispositivos ilimitados ➡️➡️\n• Acciones extra ⚙️\ny más…</string>
     <string name="upgrade_screen_sponsor_action">Patrocinador el proyecto</string>
     <string name="upgrade_screen_sponsor_action_hint">La alternativa son los anuncios, las analíticas y Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo libre ❤️</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende los datos de los usuarios. El desarrollo continuo solo es posible gracias a ti.</string>
     <string name="upgrade_screen_how_title">Como ayudar</string>
     <string name="upgrade_screen_how_body">¡Conviértete en patrocinador y patrocina el desarrollo! Toque el botón de abajo para activar todas las funciones adicionales y abrir mi perfil de Patrocinadores de GitHub.</string>
-    <string name="upgrade_screen_why_title">En la mezcla</string>
-    <string name="upgrade_screen_why_body">• Un desarrollador motivado 🧙\n• Dispositivos ilimitados ➡️➡️\n• Acciones adicionales ⚙️\ny más…</string>
     <string name="upgrade_screen_sponsor_action">Patrocinadores</string>
     <string name="upgrade_screen_sponsor_action_hint">La alternativa son los anuncios, las analíticas y Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo del código abierto ❤️</string>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manageris pole reklaame ja see ei müü kasutajaandmeid. Jätkuv arendamine on võimalik vaid teie abil.</string>
     <string name="upgrade_screen_how_title">Kuidas aidata?</string>
     <string name="upgrade_screen_how_body">Hakake toetajaks ja rahastage arendamist. Kõikide lisavõimaluste kasutamiseks ja minu GitHub Sponsors profiili avamiseks puudutage alumist nuppu.</string>
-    <string name="upgrade_screen_why_title">Segus</string>
-    <string name="upgrade_screen_why_body">• Motiveeritud arendaja 🧙
-• Piiramatu arv seadmeid ➡️➡️
-• Lisategevused ⚙️
-ja veel…</string>
     <string name="upgrade_screen_sponsor_action">Rahastage arendamist</string>
     <string name="upgrade_screen_sponsor_action_hint">Teiseks võimaluseks on reklaamid, analüüs ja Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Aitäh, et toetate avatud lähtekoodiga arendamist ❤️</string>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ek ez du iragarkirik eta ez du erabiltzailearen daturik saltzen. Garapenarekin jarraitzea zuk soilik egiten da posible.</string>
     <string name="upgrade_screen_how_title">Nola lagundu</string>
     <string name="upgrade_screen_how_body">Izan babesle eta garapen babeslari! Egin klik beheko botoian eginbide gehigarri guztiak aktibatzeko eta nire GitHub Sponsors profila irekitzeko.</string>
-    <string name="upgrade_screen_why_title">Nahasketaren erdian</string>
-    <string name="upgrade_screen_why_body">• Garatzaile motibatu bat 🧙\n• Mugagabeko gailuak ➡️➡️\n• Ekintza gehigarriak ⚙️\neta gehiago…</string>
     <string name="upgrade_screen_sponsor_action">Garapena babestu</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatiboa iragarkinak, analisiak eta Google Play dira 🙁</string>
     <string name="upgrade_screen_thanks_toast">Eskerrik asko iturburu irekiko garapena babesten duzulako ❤️</string>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">مدیر صدای بلوتوث تبلیغات ندارد و داده‌های کاربر را نمی‌فروشد. توسعه مداوم تنها با کمک شما ممکن می‌شود.</string>
     <string name="upgrade_screen_how_title">چگونه کمک کنیم</string>
     <string name="upgrade_screen_how_body">به حامی تبدیل شوید و توسعه را حمایت کنید! برای فعال کردن همه ویژگی‌های اضافی و باز کردن نمایه GitHub Sponsors من، روی دکمه زیر ضربه بزنید.</string>
-    <string name="upgrade_screen_why_title">در جریان</string>
-    <string name="upgrade_screen_why_body">• یک دولوپر انگیزه‌مند 🧙\n• دستگاه‌های نامحدود ➡️➡️\n• اقدامات اضافی ⚙️\nو بیشتر…</string>
     <string name="upgrade_screen_sponsor_action">حامی توسعه دهنده</string>
     <string name="upgrade_screen_sponsor_action_hint">جایگزین تبلیغات، تجزیه و تحلیل و Google Play 🙁 هستند</string>
     <string name="upgrade_screen_thanks_toast">از شما برای حمایت از توسعه منبع باز سپاسگزاریم ❤️</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerissa ei ole mainoksia eikä se myy käyttäjätietoja. Jatkuva kehitys on mahdollista vain sinun avullasi.</string>
     <string name="upgrade_screen_how_title">Kuinka auttaa</string>
     <string name="upgrade_screen_how_body">Ryhdy tukijaksi ja sponsoroi kehitystä! Napauta alla olevaa painiketta aktivoidaksesi kaikki lisäominaisuudet ja avataksesi GitHub Sponsors -profiilini.</string>
-    <string name="upgrade_screen_why_title">Mukana menossa</string>
-    <string name="upgrade_screen_why_body">• Motivoitunut kehittäjä 🧙
-• Rajattomat laitteet ➡️➡️
-• Lisätoimintoja ⚙️
-ja paljon muuta…</string>
     <string name="upgrade_screen_sponsor_action">Sponsoroi kehitystä</string>
     <string name="upgrade_screen_sponsor_action_hint">Vaihtoehto on mainokset, analytiikka ja Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Kiitos avoimen lähdekoodin kehityksen tukemisesta ❤️</string>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Walang mga ads ang Bluetooth Volume Manager at hindi nagbebenta ng data ng user. Ang patuloy na development ay posible lamang dahil sa inyo.</string>
     <string name="upgrade_screen_how_title">Paano tumulong</string>
     <string name="upgrade_screen_how_body">Maging patron at mag-sponsor ng development! I-tap ang button sa ibaba para ma-activate ang lahat ng extra features at buksan ang aking GitHub Sponsors profile.</string>
-    <string name="upgrade_screen_why_title">Sa halo</string>
-    <string name="upgrade_screen_why_body">• Isang motivated na developer 🧙
-• Walang limitasyong mga device ➡️➡️
-• Mga karagdagang aksyon ⚙️
-at marami pa…</string>
     <string name="upgrade_screen_sponsor_action">Mag-sponsor ng development</string>
     <string name="upgrade_screen_sponsor_action_hint">Ang alternative ay ads, analytics at Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Salamat sa pagsuporta sa open-source development ❤️</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n’affiche pas de publicités et ne vend pas les données des utilisateurs. La poursuite du développement n’est possible que grâce à vous.</string>
     <string name="upgrade_screen_how_title">Comment aider</string>
     <string name="upgrade_screen_how_body">Devenez mécène et commanditez le développement d’Octi. Touchez le bouton ci-dessous pour activer les fonctions supplémentaires et ouvrir mon profil « GitHub Sponsors ».</string>
-    <string name="upgrade_screen_why_title">Dans le mix</string>
-    <string name="upgrade_screen_why_body">• Un développeur motivé 🧙
-• Appareils illimités ➡️➡️
-• Actions supplémentaires ⚙️
-et plus…</string>
     <string name="upgrade_screen_sponsor_action">Commanditer le développement</string>
     <string name="upgrade_screen_sponsor_action_hint">L’alternative est des publicités, des analyses et Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Merci de soutenir le développement libre ❤️</string>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non ten anuncios e non vende datos de usuario. O desenvolvemento continuo só é posible grazas a ti.</string>
     <string name="upgrade_screen_how_title">Como axudar</string>
     <string name="upgrade_screen_how_body">Convértete en mecenas e patrocina o desenvolvemento! Toca o botón de abaixo para activar todas as características extra e abrir o meu perfil de GitHub Sponsors.</string>
-    <string name="upgrade_screen_why_title">Na mestura</string>
-    <string name="upgrade_screen_why_body">• Un desenvolvedor motivado 🧙
-• Dispositivos ilimitados ➡️➡️
-• Accións extras ⚙️
-e moito máis…</string>
     <string name="upgrade_screen_sponsor_action">Patrocinar desenvolvemento</string>
     <string name="upgrade_screen_sponsor_action_hint">A alternativa son anuncios, análises e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Grazas por apoiar o desenvolvemento de código aberto ❤️</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager में कोई विज्ञापन नहीं है और वह उपयोगकर्ता डेटा नहीं बेचता। निरंतर विकास केवल आपकी वजह से संभव है।</string>
     <string name="upgrade_screen_how_title">कैसे सहायता करें</string>
     <string name="upgrade_screen_how_body">संरक्षक बनें और विकास को प्रायोजित करें! सभी अतिरिक्त सुविधाओं को सक्रिय करने और मेरी GitHub Sponsors प्रोफ़ाइल खोलने के लिए नीचे दिए गए बटन को टैप करें।</string>
-    <string name="upgrade_screen_why_title">मिश्रण में</string>
-    <string name="upgrade_screen_why_body">• एक प्रेरित डेवलपर 🧙
-• असीमित डिवाइस ➡️➡️
-• अतिरिक्त क्रियाएं ⚙️
-और भी बहुत कुछ…</string>
     <string name="upgrade_screen_sponsor_action">विकास को प्रायोजक करें</string>
     <string name="upgrade_screen_sponsor_action_hint">विज्ञापन, एनालिटिक्स और गूगल प्ले ये सभी वैकल्पिक है🙁</string>
     <string name="upgrade_screen_thanks_toast">ओपन-सोर्स विकास ❤️ का समर्थन करने के लिए धन्यवाद</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nema oglasa i ne prodaje korisničke podatke. Kontinuirani razvoj omogućen je samo zbog vas.</string>
     <string name="upgrade_screen_how_title">Kako pomoći</string>
     <string name="upgrade_screen_how_body">Postanite pokrovitelj i sponzorirajte razvoj! Dodirnite gumb ispod da biste aktivirali sve dodatne značajke i otvorili moj GitHub sponzorski profil.</string>
-    <string name="upgrade_screen_why_title">U miješanju</string>
-    <string name="upgrade_screen_why_body">• Motivirani developer 🧙
-• Neograničeni uređaji ➡️➡️
-• Dodatne radnje ⚙️
-i još mnogo toga…</string>
     <string name="upgrade_screen_sponsor_action">Podržite razvoj</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativa su oglasi, analitika i Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Hvala vam što podržavate razvoj otvorenog koda ❤️</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">A Bluetooth Volume Manager nem tartalmaz hirdetéseket, és nem értékesít felhasználói adatokat. A folyamatos fejlesztést csak te teszed lehetővé.</string>
     <string name="upgrade_screen_how_title">Hogyan lehet segíteni</string>
     <string name="upgrade_screen_how_body">Legyen patron támogató és szponzorálja a fejlesztést! Kattintson az alábbi gombra az összes extra funkció aktiválásához és a GitHub Sponsors profilom megnyitásához.</string>
-    <string name="upgrade_screen_why_title">A keverékben</string>
-    <string name="upgrade_screen_why_body">• Egy motivált fejlesztő 🧙
-• Korlátlan eszközök ➡️➡️
-• Extra műveletek ⚙️
-és még sok más…</string>
     <string name="upgrade_screen_sponsor_action">Szponzori fejlesztés</string>
     <string name="upgrade_screen_sponsor_action_hint">Az alternatívák a hirdetések, az elemzések és a Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Köszönjük, hogy támogatod a nyílt forráskódú fejlesztést ❤️</string>

--- a/app/src/foss/res/values-hy-rAM/strings.xml
+++ b/app/src/foss/res/values-hy-rAM/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ում գովազդներ չկան և ուժղատության տվյալներ չի վարարկում։ Միայն դզեր կողմից ե հնարավոր շարունակ զարգացումն։</string>
     <string name="upgrade_screen_how_title">Ինչպես օգնել</string>
     <string name="upgrade_screen_how_body">Դարձեք հովանավոր և հովանավորեք զարգացումը: Սեղմեք ստորև գտնվող կոճակը՝ բոլոր լրացուցիչ գործառույթները ակտիվացնելու և իմ GitHub Sponsors պրոֆիլը բացելու համար:</string>
-    <string name="upgrade_screen_why_title">Ին կազմին</string>
-    <string name="upgrade_screen_why_body">• Մոտիվացված մշակուշ 🧙
-• Անսահման սարքեր ➡️➡️
-• Դոդական գործություններ ⚙️
-և այլն ավելին։։։</string>
     <string name="upgrade_screen_sponsor_action">Հովանավորել զարգացումը</string>
     <string name="upgrade_screen_sponsor_action_hint">Այլընտրանքը գովազդներն են, վերլուծությունը և Google Play-ը 🙁</string>
     <string name="upgrade_screen_thanks_toast">Շնորհակալություն բաց կոդով զարգացումը աջակցելու համար ❤️</string>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tidak menampilkan iklan dan tidak menjual data pengguna. Pengembangan yang berkelanjutan hanya bisa dilakukan berkat Anda.</string>
     <string name="upgrade_screen_how_title">Cara membantu</string>
     <string name="upgrade_screen_how_body">Jadilah pelindung dan sponsor pengembangan! Ketuk tombol di bawah untuk mengaktifkan semua fitur tambahan dan membuka profil GitHub Sponsors saya.</string>
-    <string name="upgrade_screen_why_title">Dalam perpaduan</string>
-    <string name="upgrade_screen_why_body">• Developer yang bersemangat 🧙\n• Perangkat tak terbatas ➡️➡️\n• Aksi tambahan ⚙️\ndan lainnya…</string>
     <string name="upgrade_screen_sponsor_action">Pengembangan sponsor</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatifnya adalah iklan, analitik, dan Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Terima kasih karena telah mendukung pengembangan sumber terbuka ❤️</string>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager birtir engar auglýsingar og selur ekki notendagögn. Áframhaldandi þróun er eingungu möguleg þökk sé þér.</string>
     <string name="upgrade_screen_how_title">Hvernig á að hjálpa</string>
     <string name="upgrade_screen_how_body">Vertu styrktaraðili og styrktu þróun! Ýttu á hnappinn hér að neðan til að virkja alla viðbótareiginleika og opna GitHub Sponsors prófílinn minn.</string>
-    <string name="upgrade_screen_why_title">Í blöndunni</string>
-    <string name="upgrade_screen_why_body">• Áhugasamur forritari 🧙\n• Ótakmörkuð tæki ➡️➡️\n• Auka aðgerðir ⚙️\nog fleira…</string>
     <string name="upgrade_screen_sponsor_action">Styrkja þróun</string>
     <string name="upgrade_screen_sponsor_action_hint">Valkosturinn eru auglýsingar, greiningar og Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Takk fyrir að styðja opna hugbúnaðarþróun ❤️</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non contiene pubblicità e non vende i dati degli utenti. Lo sviluppo continuo è possibile solo grazie a te.</string>
     <string name="upgrade_screen_how_title">Come aiutare</string>
     <string name="upgrade_screen_how_body">Diventa un sostenitore e sponsorizza lo sviluppo! Clicca il pulsante qui sotto per attivare tutte le funzioni extra e apri il mio profilo Sponsor Github.</string>
-    <string name="upgrade_screen_why_title">Nel mix</string>
-    <string name="upgrade_screen_why_body">• Uno sviluppatore motivato 🧙
-• Dispositivi illimitati ➡️➡️
-• Azioni extra ⚙️
-e altro ancora…</string>
     <string name="upgrade_screen_sponsor_action">Finanzia lo sviluppo</string>
     <string name="upgrade_screen_sponsor_action_hint">L\'alternativa sono annunci, analytics e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Grazie per aver supportato lo sviluppo open-source ❤️</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ללא מודעות ואינה מוכרת נתוני משתמשים. המשך הפיתוח מתאפשר רק על ידך.</string>
     <string name="upgrade_screen_how_title">איך לעזור</string>
     <string name="upgrade_screen_how_body">הפוך לפטרון ונותן חסות לפיתוח! הקש על הכפתור למטה כדי להפעיל את כל התכונות הנוספות ולפתוח את פרופיל הספונסרים בגיטהאב שלי.</string>
-    <string name="upgrade_screen_why_title">בתמהיל</string>
-    <string name="upgrade_screen_why_body">• מפתח מוטיבציה גבוהה 🧙
-• מכשירים ללא הגבלה ➡️➡️
-• פעולות נוספות ⚙️
-ועוד…</string>
     <string name="upgrade_screen_sponsor_action">תמוך בפיתוח</string>
     <string name="upgrade_screen_sponsor_action_hint">האלטרנטיבה הן מודעות, אנליטיקס ו-Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">תודה שתמכת בפיתוח קוד פתוח ❤️</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerは広告がなく、ユーザーデータを販売しません。継続的な開発は、あなたのおかげで成り立っています。</string>
     <string name="upgrade_screen_how_title">協力するには</string>
     <string name="upgrade_screen_how_body">パトロンとスポンサーの開発になりましょう！下のボタンをタップすると、すべての追加機能が有効になり、GitHub Sponsors プロファイルを開きます。</string>
-    <string name="upgrade_screen_why_title">ミックスの中で</string>
-    <string name="upgrade_screen_why_body">• やる気のある開発者 🧙
-• 無制限のデバイス ➡️➡️
-• 追加アクション ⚙️
-その他…</string>
     <string name="upgrade_screen_sponsor_action">開発支援者</string>
     <string name="upgrade_screen_sponsor_action_hint">代替は広告や分析そしてGoogle Playになります</string>
     <string name="upgrade_screen_thanks_toast">オープンソースでの開発に協力してくれてありがとうございます ❤️</string>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager რეკლამაგარეშია და მომხმარეთა მონაცემებს არ ყიდის. განვითარებად განვითარება მხოლოდ მხოლოდ შესაძლებელია ერთიადად თქვენით.</string>
     <string name="upgrade_screen_how_title">როგორ დაგეხმაროთ</string>
     <string name="upgrade_screen_how_body">გახდით მფარველი და სპონსორობა გაუწიეთ განვითარებას! შეეხეთ ქვემოთ მოცემულ ღილაკს, რათა ააქტიუროთ ყველა დამატებითი ფუნქცია და გახსნათ ჩემი GitHub Sponsors პროფილი.</string>
-    <string name="upgrade_screen_why_title">მიქსში</string>
-    <string name="upgrade_screen_why_body">• მოტივირებული დამპროგრამებელი 🧙\n• ულიმიტო მოწყობილობები ➡️➡️\n• დამატებითი მოქმედები ⚙️\nდა მეტი მრავალი…</string>
     <string name="upgrade_screen_sponsor_action">სპონსორის განვითარება</string>
     <string name="upgrade_screen_sponsor_action_hint">ალტერნატივა არის რეკლამა, ანალიტიკა და Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">გმადლობთ ღია კოდის განვითარების მხარდაჭერისთვის ❤️</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager មិនមានការផ្សាយពាណិជ្ជកម្ម ហើយមិនលក់ទិន្នន័យអ្នកប្រើប្រាស់ទេ។ ការអភិវឌ្ឍន៍ជាបន្ត​បន្ទាប់ត្រូវបានធ្វើឱ្យអាចធ្វើទៅបានតែដោយអ្នកប្រើ។</string>
     <string name="upgrade_screen_how_title">របៀបជួយ</string>
     <string name="upgrade_screen_how_body">ក្លាយជាអ្នកឧបត្ថម្ភ និងឧបត្ថម្ភការអភិវឌ្ឍន៍! ចុចប៊ូតុងខាងក្រោមដើម្បីធ្វើឱ្យមុខងារបន្ថែមទាំងអស់សកម្ម និងបើកប្រវត្តិរូប GitHub Sponsors របស់ខ្ញុំ។</string>
-    <string name="upgrade_screen_why_title">នៅក្នុងការបន្សំ</string>
-    <string name="upgrade_screen_why_body">• អ្នកអភិវឌ្ឍន៍ដែលមានការលើកទឹកចិត្ត 🧙
-• ឧបករណ៍គ្មានដែន ➡️➡️
-• សកម្មភាពបន្ថែម ⚙️
-និងច្រើនទៀត…</string>
     <string name="upgrade_screen_sponsor_action">ឧបត្ថម្ភការអភិវឌ្ឍន៍</string>
     <string name="upgrade_screen_sponsor_action_hint">ជម្រើសផ្សេងគឺការផ្សាយពាណិជ្ជកម្ម ការវិភាគ និង Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">សូមអរគុណសម្រាប់ការគាំទ្រការអភិវឌ្ឍន៍ប្រភពបើកចំហ ❤️</string>

--- a/app/src/foss/res/values-kmr-rTR/strings.xml
+++ b/app/src/foss/res/values-kmr-rTR/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">BVM reklamê nake. Geşedana berdewam tenê bi we gengaz e.</string>
     <string name="upgrade_screen_how_title">Çawa bipşixe</string>
     <string name="upgrade_screen_how_body">Bibin patronek û geşedanê sponsor bikin!</string>
-    <string name="upgrade_screen_why_title">Di tevliheviyê de</string>
-    <string name="upgrade_screen_why_body">• Gelek û zêdetir…</string>
     <string name="upgrade_screen_sponsor_action">Geşedanê sponsor bike</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatif reklam, analitik û Google Play ye</string>
     <string name="upgrade_screen_thanks_toast">Spas ji bo pishtgiriya çavkaniya vekirî</string>

--- a/app/src/foss/res/values-kn-rIN/strings.xml
+++ b/app/src/foss/res/values-kn-rIN/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ಜಾಹೀರಾತುಗಳಿಲ್ಲ ಮತ್ತು ಬಳಕೆದಾರರ ಡೇಟಾ ಮಾರಾಟುವುದಿಲ್ಲ. ನಿಮ್ಮಿಂದ ಮಾತ್ರ ನಿರಂತರ ಅಭಿವರ್ಧನೆ ಸಾಧ್ಯ.</string>
     <string name="upgrade_screen_how_title">ಸಹಾಯ ಮಾಡುವ ವಿಧಾನ</string>
     <string name="upgrade_screen_how_body">ಪ್ರಾಯೋಜಕರಾಗಿ ಅಭಿವರ್ಧನೆಯನ್ನು ಬೆಂಬಲಿಸಿ! ಎಲ್ಲಾ ಹೆಚ್ಚಿನ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ಮತ್ತು ನನ್ನ GitHub Sponsors ಪ್ರೋಫೈಲ್ ತೆರೆಯಲು ಕೆಳಗಿನ ಬಟನ ಟ್ಯಾಪ್ ಮಾಡಿ.</string>
-    <string name="upgrade_screen_why_title">ಮಿಶ್ರಣದಲ್ಲಿ</string>
-    <string name="upgrade_screen_why_body">• ಪ್ರೇರಿತ ಅಭಿವರ್ಧಕ 🧙
-• ಸಿಮಿತವಿಲ್ಲದ ಸಾಧನಗಳು ➡️➡️
-• ಹೆಚ್ಚಿನ ಕಾರ್ಯಗಳು ⚙️
-ಮತ್ತು ಇನ್ನಂತಃ…</string>
     <string name="upgrade_screen_sponsor_action">ಅಭಿವರ್ಧನೆಗೆ ಪ್ರಾಯೋಜಕತವನ್ನು ನೀಡಿ</string>
     <string name="upgrade_screen_sponsor_action_hint">ಪರ್ಯಾಯ ಜಾಹೀರಾತುಗಳು, ವಿಶ್ಲೇಷಣೆ ಮತ್ತು Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ಓಪನ್-ಸೋರ್ಸ್ ಅಭಿವರ್ಧನೆಗೆ ಬೆಂಬಲಿಸಿದ್ದಕ್ಕೆ ಧನ್ಯವಾದಗಳು ❤️</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager는 광고가 없고 유저 데이터를 팔지 않습니다. 지속적인 개발은 여러분이 있기에 가능합니다.</string>
     <string name="upgrade_screen_how_title">도움 주기</string>
     <string name="upgrade_screen_how_body">후원자가 되어 개발을 지원하세요! 아래 버튼을 눌러 Github Sponsors 프로필을 열고 추가 기능을 잠금해제하세요.</string>
-    <string name="upgrade_screen_why_title">미스에서</string>
-    <string name="upgrade_screen_why_body">• 열정적인 개발자 🧙
-• 무제한 기기 ➡️➡️
-• 추가 액션 ⚙️
-그리고 더...</string>
     <string name="upgrade_screen_sponsor_action">개발 후원하기</string>
     <string name="upgrade_screen_sponsor_action_hint">다른 방식은 광고, 데이터 수집, 그리고 플레이 스토어입니다 🙁</string>
     <string name="upgrade_screen_thanks_toast">오픈소스 개발을 지원해주셔서 감사합니다 ❤️</string>

--- a/app/src/foss/res/values-ky-rKG/strings.xml
+++ b/app/src/foss/res/values-ky-rKG/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager жарнамаларсыз жана пайдалануучулардын мәлиматын сатпайт. Үзгөлтүрүлгөн ишкерлениш тек сиздин аркасында мүмкүн.</string>
     <string name="upgrade_screen_how_title">Калай жардам берүүгө</string>
     <string name="upgrade_screen_how_body">Патрон болуңуз жана ишкерленишти колдоо! Бардык кошумча функцияларды активдөө жана жеке астындагы GitHub Sponsors профилимди ачуу үчүн төмөндөгү баскычты таптаңыз.</string>
-    <string name="upgrade_screen_why_title">Аралашта</string>
-    <string name="upgrade_screen_why_body">• Мотивацияланган ишкери девелопчу 🧙\n• Чексиз түзмөктөр ➡️➡️\n• Кошумча акциялар ⚙️\nжана көбүрөк…</string>
     <string name="upgrade_screen_sponsor_action">Ишкерленишти спонсорлоо</string>
     <string name="upgrade_screen_sponsor_action_hint">Альтернатив жарнамалар, аналитика жана Google Play болот 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ачык код ишкерленишти колдоодогунуңуз үчүн рахмат ❤️</string>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ບ່ມີໂຆສນາແລະບ່ຂາຍຂ້ອມູນຜູ້ໃຊ້. ການພັດທນາຕ່ອເນື່ອງເປັນໄປໄດ້ໂດຍມີທ່ານເທ່ານັ້ນ.</string>
     <string name="upgrade_screen_how_title">ວິທີການຊ່ວຍເຫຼືອ</string>
     <string name="upgrade_screen_how_body">ກາຍເປັນຜູ້ອຸປະຖໍາ ແລະ ໃຫ້ການສະໜັບສະໜູນການພັດທະນາ! ກົດປຸ່ມຂ້າງລຸ່ມເພື່ອເປີດໃຊ້ງານຄຸນສົມບັດເພີ່ມເຕີມທັງໝົດ ແລະ ເປີດໂປຣໄຟລ໌ GitHub Sponsors ຂອງຂ້ອຍ.</string>
-    <string name="upgrade_screen_why_title">ໃນວົງຈອນ</string>
-    <string name="upgrade_screen_why_body">• ນ଱ກພັດທນາທີ່ມີແຣງຈູງໃຈ ༉
-• ອຸປກອນໄດ້ໄມ່ຈຳກັດ ➡️➡️
-• ການກຳໄວ້ເພິ່ມເຕີມ ⚙️
-ແລະອື່ນຢົ່ວ…</string>
     <string name="upgrade_screen_sponsor_action">ສະໜັບສະໜູນການພັດທະນາ</string>
     <string name="upgrade_screen_sponsor_action_hint">ທາງເລືອກແມ່ນໂຄສະນາ, ການວິເຄາະ ແລະ Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ຂອບໃຈສໍາລັບການສະໜັບສະໜູນການພັດທະນາແຫຼ່ງເປີດ ❤️</string>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neturi reklamų ir neparduoda naudotojų duomenų. Tolesnė plėtra įmanoma tik dėka jūsų.</string>
     <string name="upgrade_screen_how_title">Kaip padėti</string>
     <string name="upgrade_screen_how_body">Tapkite globėju ir rėmėju plėtros! Palieskite žemiau esantį mygtuką, kad suaktyvintumėte visas papildomas funkcijas ir atidarytumėte mano GitHub Sponsors profilį.</string>
-    <string name="upgrade_screen_why_title">Muzikos sraute</string>
-    <string name="upgrade_screen_why_body">• Motyvuotas kūrėjas 🧙
-• Neriboti įrenginiai ➡️➡️
-• Papildomi veiksmai ⚙️
-ir daugiau…</string>
     <string name="upgrade_screen_sponsor_action">Remti plėtrą</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatyva yra reklamos, analitika ir Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ačiū, kad remiате atvirojo kodo plėtrą ❤️</string>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -8,8 +8,6 @@
     <string name="upgrade_screen_preamble">Bluetooth skaļuma pārvaldniekā nav reklāmu, un tas nepārdod lietotāju datus. Izstrādes nepārtrauktība ir iespējama tikai pateicoties jums.</string>
     <string name="upgrade_screen_how_title">Kā palīdzēt</string>
     <string name="upgrade_screen_how_body">Kļūstiet par aizbildni un sponsorējiet attīstību! Pieskarieties pogas zemāk, lai aktivizētu visas papildu funkcijas un atvērtu manu GitHub Sponsors profilu.</string>
-    <string name="upgrade_screen_why_title">Maisījumā</string>
-    <string name="upgrade_screen_why_body">* Motivēts izstrādātājs\n* Neierobežotas ierīces\n* Papildu darbības\nun vairāk...</string>
     <string name="upgrade_screen_sponsor_action">Sponsorēt attīstību</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatīva ir reklāmas, analītika un Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Paldies par atklātā koda attīstības atbalstīšanu ❤️</string>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклами и не продава кориснички податоци. Континуираниот развој е можен само благодарение на вас.</string>
     <string name="upgrade_screen_how_title">Како да помогнете</string>
     <string name="upgrade_screen_how_body">Станете покровител и спонзорирајте го развојот! Допрете го копчето подолу за да ги активирате сите дополнителни функции и да го отворите мојот GitHub Sponsors профил.</string>
-    <string name="upgrade_screen_why_title">Во мешавината</string>
-    <string name="upgrade_screen_why_body">• Мотивиран програмер 🧙
-• Неограничен број уреди ➡️➡️
-• Дополнителни акции ⚙️
-и уште многу…</string>
     <string name="upgrade_screen_sponsor_action">Спонзорирај развој</string>
     <string name="upgrade_screen_sponsor_action_hint">Алтернативата се реклами, аналитика и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ви благодариме што го поддржувате развојот на отворен код ❤️</string>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager പ്രജ്ഞാപനങ്ങൾ ഇല്ല, ഉപയോക്തൃ ഡേറ്റ വിൽക്കുന്നില്ല. ഐക്കമാന വികസനം നിങ്ങൾ വഴി മാത്രം സാധ്യമാകുന്നു.</string>
     <string name="upgrade_screen_how_title">എങ്ങനെ സഹായിക്കാം</string>
     <string name="upgrade_screen_how_body">പാട്രോൺ ആകുകയും വികസനം സ്പോൺസർ ചെയ്യുകയും ചെയ്യുക! എല്ലാ അധിക സവിശേഷതകളും സജീവമാക്കാനും എന്റെ GitHub Sponsors പ്രൊഫൈൽ തുറക്കാനും താഴെയുള്ള ബട്ടൺ ടാപ്പ് ചെയ്യുക.</string>
-    <string name="upgrade_screen_why_title">മിക്സിൽ</string>
-    <string name="upgrade_screen_why_body">• ഒരു പ്രേരണപ്പെട്ട ഡെവലപ്പർ 🧙\n• അപരിമിത ഉപകരണങ്ങൾ ➡️➡️\n• അധിക ആക്ഷനുകൾ ⚙️\nകൂടുതൽ...</string>
     <string name="upgrade_screen_sponsor_action">വികസനം സ്പോൺസർ ചെയ്യുക</string>
     <string name="upgrade_screen_sponsor_action_hint">പരസ്യങ്ങൾ, അനലിറ്റിക്‌സ്, ഗൂഗിൾ പ്ലേ എന്നിവയാണ് ബദൽ🙁</string>
     <string name="upgrade_screen_thanks_toast">ഓപ്പൺ സോഴ്‌സ് വികസനത്തെ പിന്തുണച്ചതിന് നന്ദി ❤️</string>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager сурталчилгаагүй бөгөөд хэрэглэгчийн өгөгдлийг зардаггүй. Цаашид хөгжлөлт зөвхөн тань боломжтой болгог.</string>
     <string name="upgrade_screen_how_title">Хэрхэн тусламж үзүүлэх</string>
     <string name="upgrade_screen_how_body">Ивээн тэтгэгч болж хөгжлийг дэмжээрэй! Бүх нэмэлт боломжуудыг идэвхжүүлж, миний GitHub Sponsors профайлыг нээхийн тулд доорх товчийг дарна уу.</string>
-    <string name="upgrade_screen_why_title">Холилцоонд</string>
-    <string name="upgrade_screen_why_body">• Урамшуулсан хөгжлөлөөр 🧙\n• Хязгаагүй төхөөрөмжүүд ➡️➡️\n• Нэмэлт үйлдлүүд ⚙️\nба дараа…</string>
     <string name="upgrade_screen_sponsor_action">Хөгжлийг дэмжих</string>
     <string name="upgrade_screen_sponsor_action_hint">Өөр сонголт бол зар сурталчилгаа, шинжилгээ, Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Нээлттэй эхийн хөгжлийг дэмжсэнд баярлалаа ❤️</string>

--- a/app/src/foss/res/values-mr-rIN/strings.xml
+++ b/app/src/foss/res/values-mr-rIN/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ला कोणतीही अॅड नाही आणि वापरकर्त्यांचा डेटा विकत नाही. सतत विकास केवळ तुमच्यामुळेही शक्य आहे.</string>
     <string name="upgrade_screen_how_title">कसे मदत करावी</string>
     <string name="upgrade_screen_how_body">प्रायोजक व्हा आणि विकासाला पाठिंबा द्या! सर्व अतिरिक्त वैशिष्ट्ये सक्रिय करण्यासाठी खालील बटण टॅप करा आणि माझे GitHub Sponsors प्रोफाइल उघडा.</string>
-    <string name="upgrade_screen_why_title">मिश्रणात</string>
-    <string name="upgrade_screen_why_body">• एक प्रेरित विकसक 🧙
-• अमर्यादित डिव्हाइसेस ➡️➡️
-• अतिरिक्त क्रिया ⚙️
-आणि बरेच काही…</string>
     <string name="upgrade_screen_sponsor_action">विकासाला पाठिंबा द्या</string>
     <string name="upgrade_screen_sponsor_action_hint">पर्याय म्हणजे अॅड, अॅनालिटिक्स आणि Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ओपन-सोर्स विकासाला पाठिंबा दिल्याबद्दल धन्यवाद ❤️</string>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tiada iklan dan tidak menjual data pengguna. Pembangunan berterusan hanya boleh dilakukan dengan sokongan anda.</string>
     <string name="upgrade_screen_how_title">Bagaimana untuk membantu</string>
     <string name="upgrade_screen_how_body">Menjadi penaung dan penaja pembangunan! Ketik butang di bawah untuk mengaktifkan semua ciri tambahan dan buka profil Penaja GitHub saya.</string>
-    <string name="upgrade_screen_why_title">Dalam campuran</string>
-    <string name="upgrade_screen_why_body">• Pembangun yang bermotivasi 🧙
-• Peranti tanpa had ➡️➡️
-• Tindakan tambahan ⚙️
-dan banyak lagi…</string>
     <string name="upgrade_screen_sponsor_action">Pembangunan penaja</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatifnya ialah iklan, analitik dan Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Terima kasih kerana menyokong pembangunan sumber terbuka ❤️</string>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager တွင် ကြော်ငြာများမရှိပြီး အသုံးပြုသူဒေတာများကိုလည်း မရောင်းချပါ။ ဆက်လက်ဖွံ့ဖြိုးတိုးတက်မှုသည် သင့ေကြောင့်သာသာ ဖြစ်နိုင်သည်။</string>
     <string name="upgrade_screen_how_title">ကူညီနည်းလမ်း</string>
     <string name="upgrade_screen_how_body">ကူညီသူဖြစ်ပြီး ဖွံ့ဖြိုးတိုးတက်မှုကို ကမကထပံ့ပိုးပါ! အပိုဝန်ဆောင်မှုများအားလုံးကို ဖွင့်ပြီး ကျွန်ုပ်၏ GitHub Sponsors ပရိုဖိုင်းကို ဖွင့်ရန် အောက်ပါခလုတ်ကို နှိပ်ပါ။</string>
-    <string name="upgrade_screen_why_title">ရောစပ်မှုတွင့်</string>
-    <string name="upgrade_screen_why_body">• လှုံ့ဆော်မှုရှိသော developer တစ်ဦး 🧙
-• ကန့်သတ်မှုမရှိသော ကိရိယာများ ➡️➡️
-• အပိုလုပ်ဆောင်ချက်များ ⚙️
-နှင့် အခြားများ…</string>
     <string name="upgrade_screen_sponsor_action">ဖွံ့ဖြိုးတိုးတက်မှုကို ကမကထပံ့ပိုးရန်</string>
     <string name="upgrade_screen_sponsor_action_hint">အခြားရွေးချယ်စရာမှာ ကြော်ငြာများ၊ ခွဲခြမ်းစိတ်ဖြာခြင်းနှင့် Google Play တို့ဖြစ်သည် 🙁</string>
     <string name="upgrade_screen_thanks_toast">ပွင့်လင်းရင်းမြစ် ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးပေးသည့်အတွက် ကျေးဇူးတင်ပါသည် ❤️</string>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager मा कुनै विज्ञापन छैन र यसले प्रयोगकर्ताको डेटा बাंड्दैन। निरन्तर विकास केवल तपाईंले गर्नुभएको सहयोगबाट मात्र संभव भएको छ।</string>
     <string name="upgrade_screen_how_title">कसरी मद्दत गर्ने</string>
     <string name="upgrade_screen_how_body">संरक्षक बन्नुहोस् र विकासलाई प्रायोजन गर्नुहोस्! सबै अतिरिक्त सुविधाहरू सक्रिय पार्न र मेरो GitHub Sponsors प्रोफाइल खोल्न तलको बटन ट्याप गर्नुहोस्।</string>
-    <string name="upgrade_screen_why_title">मिश्रणमा</string>
-    <string name="upgrade_screen_why_body">• एक प्रेरित डेभलपर 🧙\n• असीमित यन्त्रहरू ➡️➡️\n• थप क्रियाहरू ⚙️\nर थप…</string>
     <string name="upgrade_screen_sponsor_action">विकासलाई प्रायोजन गर्नुहोस्</string>
     <string name="upgrade_screen_sponsor_action_hint">विकल्प विज्ञापन, विश्लेषण र Google Play हुन् 🙁</string>
     <string name="upgrade_screen_thanks_toast">खुला स्रोत विकासलाई समर्थन गरेकोमा धन्यवाद ❤️</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager bevat geen advertenties en verkoopt geen gebruikersgegevens. Verdere ontwikkeling wordt alleen door jou mogelijk gemaakt.</string>
     <string name="upgrade_screen_how_title">Hoe kun je helpen</string>
     <string name="upgrade_screen_how_body">Word mecenas en sponsor ontwikkelaar! Tik op de onderstaande knop om alle extra functies te activeren en mijn GitHub Sponsors-profiel te openen.</string>
-    <string name="upgrade_screen_why_title">In de mix</string>
-    <string name="upgrade_screen_why_body">• Een gemotiveerde ontwikkelaar 🧙
-• Onbeperkte apparaten ➡️➡️
-• Extra acties ⚙️
-en meer…</string>
     <string name="upgrade_screen_sponsor_action">Sponsor ontwikkeling</string>
     <string name="upgrade_screen_sponsor_action_hint">Het alternatief zijn advertenties, analyses en Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Bedankt voor het ondersteunen van open-sourceontwikkeling ❤️</string>

--- a/app/src/foss/res/values-no/strings.xml
+++ b/app/src/foss/res/values-no/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen annonser og selger ikke brukerdata. Fortsatt utvikling er bare mulig ved hjelp av deg.</string>
     <string name="upgrade_screen_how_title">Hvordan hjelpe</string>
     <string name="upgrade_screen_how_body">Bli en patron og støtt utviklingen! Trykk på knappen under for å aktivere alle ekstra funksjoner og åpne sponsorprofilen min på GitHub.</string>
-    <string name="upgrade_screen_why_title">I miksen</string>
-    <string name="upgrade_screen_why_body">• En motivert utvikler 🧞
-• Ubegrenset antall enheter ➡️➡️
-• Ekstra handlinger ⚙️
-og mer…</string>
     <string name="upgrade_screen_sponsor_action">Støtt utviklingen</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativet er annonser, analyser og Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Takk for at du støtter utviklingen som har åpen kildekode ❤️</string>

--- a/app/src/foss/res/values-pcm-rNG/strings.xml
+++ b/app/src/foss/res/values-pcm-rNG/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no get ads and no dey sell user data. Continued development na only possible because of you.</string>
     <string name="upgrade_screen_how_title">How to help</string>
     <string name="upgrade_screen_how_body">Become patron and sponsor development! Tap di button below to activate all extra features and open my GitHub Sponsors profile.</string>
-    <string name="upgrade_screen_why_title">Inside di mix</string>
-    <string name="upgrade_screen_why_body">- Motivated developer\n- Unlimited devices\n- Extra actions\nand more...</string>
     <string name="upgrade_screen_sponsor_action">Sponsor development</string>
     <string name="upgrade_screen_sponsor_action_hint">Di alternative na ads, analytics and Google Play</string>
     <string name="upgrade_screen_thanks_toast">Thank you for supporting open-source development</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nie ma reklam i nie sprzedaje danych użytkowników. Dalszy rozwój jest możliwy tylko dzięki tobie.</string>
     <string name="upgrade_screen_how_title">Jak pomóc</string>
     <string name="upgrade_screen_how_body">Zostań patronem i wspieraj rozwój! Dotknij przycisku poniżej, aby aktywować wszystkie dodatkowe funkcje i otworzyć mój profil GitHub Sponsors.</string>
-    <string name="upgrade_screen_why_title">W centrum uwagi</string>
-    <string name="upgrade_screen_why_body">• Zmotywowany deweloper 🧙
-• Nieograniczona liczba urządzeń ➡️➡️
-• Dodatkowe akcje ⚙️
-i więcej…</string>
     <string name="upgrade_screen_sponsor_action">Sponsoruj rozwój</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatywą są reklamy, analityka i Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Dziękuję za wsparcie rozwoju oprogramowania otwarto źródłowego❤️</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados do usuário. O desenvolvimento contínuo só é possível graças a você.</string>
     <string name="upgrade_screen_how_title">Como ajudar</string>
     <string name="upgrade_screen_how_body">Torne-se um patrocinador e financie o desenvolvimento! Clique no botão abaixo para ativar todos os recursos extras e abrir meu perfil Github Sponsors.</string>
-    <string name="upgrade_screen_why_title">Na mistura</string>
-    <string name="upgrade_screen_why_body">• Um desenvolvedor motivado 🧙
-• Dispositivos ilimitados ➡️➡️
-• Ações extras ⚙️
-e muito mais…</string>
     <string name="upgrade_screen_sponsor_action">Desenvolvimento do patrocinador</string>
     <string name="upgrade_screen_sponsor_action_hint">A alternativa são anúncios, análises e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Obrigado por apoiar o desenvolvimento de código aberto ❤️</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados dos utilizadores. O desenvolvimento contínuo só é possível graças a si.</string>
     <string name="upgrade_screen_how_title">Como ajudar</string>
     <string name="upgrade_screen_how_body">Torne-se um patrono e patrocine o desenvolvimento! Clique no botão abaixo para ativar todas as funcionalidades extra e abrir o meu perfil nos Patrocinadores GitHub.</string>
-    <string name="upgrade_screen_why_title">Na mistura</string>
-    <string name="upgrade_screen_why_body">• Um programador motivado 🧙
-• Dispositivos ilimitados ➡️➡️
-• Ações extra ⚙️
-e mais…</string>
     <string name="upgrade_screen_sponsor_action">Patrocine o desenvolvimento</string>
     <string name="upgrade_screen_sponsor_action_hint">A alternativa são anúncios, análises e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Obrigado por apoiar o desenvolvimento de código aberto ❤️</string>

--- a/app/src/foss/res/values-rm/strings.xml
+++ b/app/src/foss/res/values-rm/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n\'ha naginas reclamas e na vend betg datas d\'utilisaders. Il svilup ulterior è mo pussaivel grazia a tai.</string>
     <string name="upgrade_screen_how_title">Tge che ti pos far</string>
     <string name="upgrade_screen_how_body">Daventescha in patronu e sustegna il svilup! Tocca il buttun sut per activar tut las funcziuns extras e vrar mai il profil GitHub Sponsors.</string>
-    <string name="upgrade_screen_why_title">En il mix</string>
-    <string name="upgrade_screen_why_body">• In sviluppader motivat 🧙
-• Apparats senza limita ➡️➡️
-• Acziuns extras ⚙️
-e dapli…</string>
     <string name="upgrade_screen_sponsor_action">Sustegnair il svilup</string>
     <string name="upgrade_screen_sponsor_action_hint">L\'alternativa è reclamas, analytics e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Grazia per sustegnair il svilup open-source ❤️</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nu are reclame şi nu vinde datele utilizatorilor. Continuarea dezvoltării este posibilă numai datorită ție.</string>
     <string name="upgrade_screen_how_title">Cum să ajuți</string>
     <string name="upgrade_screen_how_body">Deveniți un patron și o dezvoltare a sponsorului! Apăsați butonul de mai jos pentru a activa toate caracteristicile suplimentare și deschideți profilul meu GitHub Sponsors.</string>
-    <string name="upgrade_screen_why_title">În mix</string>
-    <string name="upgrade_screen_why_body">• Un developer motivat 🧙
-• Dispozitive nelimitate ➡️➡️
-• Acțiuni extra ⚙️
-şi mai mult…</string>
     <string name="upgrade_screen_sponsor_action">Sponsorizează dezvoltarea</string>
     <string name="upgrade_screen_sponsor_action_hint">O alternativă sunt reclamele, analizele și Google Play🙁</string>
     <string name="upgrade_screen_thanks_toast">Mulțumesc că îmi suporți această dezvoltare open-source❤️</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не содержит рекламы и не продаёт данные пользователей. Дальнейшее развитие возможно только благодаря вам.</string>
     <string name="upgrade_screen_how_title">Как помочь</string>
     <string name="upgrade_screen_how_body">Станьте спонсором и поддержите разработку! Нажмите кнопку ниже, чтобы активировать все дополнительные функции и открыть мой профиль GitHub Sponsors.</string>
-    <string name="upgrade_screen_why_title">В деле</string>
-    <string name="upgrade_screen_why_body">• Мотивированный разработчик 🧙
-• Неограниченное количество устройств ➡️➡️
-• Дополнительные действия ⚙️
-и многое другое…</string>
     <string name="upgrade_screen_sponsor_action">Спонсировать разработку</string>
     <string name="upgrade_screen_sponsor_action_hint">Альтернатива — реклама, аналитика и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Спасибо за поддержку разработки с открытым исходным кодом ❤️</string>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tenet pubblicidade e no vendet datos de s\'usuàriu. S\'isvilupu continuadu est possìbile solamente gràtzias a tene.</string>
     <string name="upgrade_screen_how_title">Comente agiudare</string>
     <string name="upgrade_screen_how_body">Diventa patronu e sponsoriza s\'isvilupu! Tocca su butone in bassu pro ativare totu sas funtzionalidades addizionales e abèrrere su profilu meu de GitHub Sponsors.</string>
-    <string name="upgrade_screen_why_title">In su misturadore</string>
-    <string name="upgrade_screen_why_body">• Unu programadore motivadu 🧙
-• Dispositivus illimitados ➡️➡️
-• Atziones extras ⚙️
-e àteru…</string>
     <string name="upgrade_screen_sponsor_action">Sponsoriza s\'isvilupu</string>
     <string name="upgrade_screen_sponsor_action_hint">S\'alternativa sunt sa pubblicidade, s\'anàlisi e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gràtzias pro sustènnere s\'isvilupu de còdighe abertu ❤️</string>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager හි දැන්වීම් නොමැති අතර පරිශීලක දත්ත අලේවි නොකරයි. අකට් සඹ්වර්ධනය ඔබ නිසා පමණක් හෙකියාවක්.</string>
     <string name="upgrade_screen_how_title">උදව් කරන්නේ කෙසේද</string>
     <string name="upgrade_screen_how_body">අනුග්‍රාහකයෙකු වී සංවර්ධනයට අනුග්‍රහ කරන්න! සියලු අමතර විශේෂාංග සක්‍රිය කර මගේ GitHub Sponsors පැතිකඩ විවෘත කිරීමට පහත බොත්තම ස්පර්ශ කරන්න.</string>
-    <string name="upgrade_screen_why_title">මිශ්‍රණයේ</string>
-    <string name="upgrade_screen_why_body">• උනන්දු සංවර්ධකයෙකු 🧙
-• අසීමිත උපකරණ ➡️➡️
-• අමතර ක්‍රියා ⚙️
-සහ තවත්…</string>
     <string name="upgrade_screen_sponsor_action">සංවර්ධනයට අනුග්‍රහය දෙන්න</string>
     <string name="upgrade_screen_sponsor_action_hint">විකල්පය දැන්වීම්, විශ්ලේෂණ සහ Google Play වේ 🙁</string>
     <string name="upgrade_screen_thanks_toast">විවෘත මූලාශ්‍ර සංවර්ධනයට සහාය දීම ගැන ස්තූතියි ❤️</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nemá žiadne reklamy a nepredáva údaje používateľov. Neustály vývoj umožňujete len vy.</string>
     <string name="upgrade_screen_how_title">Ako pomôcť</string>
     <string name="upgrade_screen_how_body">Staňte sa patrónom a sponzorujte rozvoj! Klepnutím na tlačidlo nižšie aktivujete všetky ďalšie funkcie a otvoríte môj profil sponzorov GitHub.</string>
-    <string name="upgrade_screen_why_title">V mixe</string>
-    <string name="upgrade_screen_why_body">• Motivovaný vývojár 🧙
-• Neobmedzené zariadenia ➡️➡️
-• Extra akcie ⚙️
-a viac…</string>
     <string name="upgrade_screen_sponsor_action">Sponzorovaný vývoj</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatívou sú reklamy, analytika a Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ďakujem za podporu vývoja open-source ❤️</string>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nima oglasov in ne prodaja uporabniških podatkov. Nadaljnji razvoj je omogočen samo z vašo podporo.</string>
     <string name="upgrade_screen_how_title">Kako pomagati.</string>
     <string name="upgrade_screen_how_body">Postanite pokrovitelj in prispevajte k razvoju!  Dotaknite se spodnjega gumba, da omogočite dodatne funkcije in odprete moj pokroviteljski profil na GitHubu.</string>
-    <string name="upgrade_screen_why_title">V mešanici</string>
-    <string name="upgrade_screen_why_body">• Motiviran razvijalec 🧙\n• Neomejene naprave ➡️➡️\n• Dodatna dejanja ⚙️\nin več…</string>
     <string name="upgrade_screen_sponsor_action">Podpri razvoj</string>
     <string name="upgrade_screen_sponsor_action_hint">Druga možnost so oglasi, analitika in Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Hvala za podporo odprtokodnemu razvoju ❤️</string>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nuk ka reklama dhe nuk shet të dhënat e përdoruesit. Zhvillimi i vazhdueshëm bëhet i mundur vetëm nga ju.</string>
     <string name="upgrade_screen_how_title">Si të ndihmoj</string>
     <string name="upgrade_screen_how_body">Bëhuni një mbrojtës dhe sponsor i zhvillimit! Prekni butonin më poshtë për të aktivizuar të gjitha veçoritë shtesë dhe për të hapur profilin tim të sponsorëve të GitHub.</string>
-    <string name="upgrade_screen_why_title">Në kombinim</string>
-    <string name="upgrade_screen_why_body">• Një zhvillues i motivuar 🧙
-• Pajisje të pakufizuara ➡️➡️
-• Veprime shtesë ⚙️
-dhe më shumë…</string>
     <string name="upgrade_screen_sponsor_action">Zhvillimi i sponsorëve</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativa janë reklamat, analitika dhe Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Faleminderit për mbështetjen e zhvillimit me burim të hapur ❤️</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклама и не продаје корисничке податке. Наставак развоја могућ је само захваљујући теби.</string>
     <string name="upgrade_screen_how_title">Како помоћи</string>
     <string name="upgrade_screen_how_body">Постаните покровитељ и спонзоришите развој! Додирните дугме испод да активирате све додатне функције и отворите мој GitHub Sponsors профил.</string>
-    <string name="upgrade_screen_why_title">У миксу</string>
-    <string name="upgrade_screen_why_body">• Мотивисан програмер 🧙\n• Неограничен број уређаја ➡️➡️\n• Додатне акције ⚙️\nи још много…</string>
     <string name="upgrade_screen_sponsor_action">Спонзориши развој</string>
     <string name="upgrade_screen_sponsor_action_hint">Алтернатива су рекламе, аналитика и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Хвала вам што подржавате развој отвореног кода ❤️</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har inga annonser och säljer inte användardata. Fortsätt utveckling är endast möjlig tack vare dig.</string>
     <string name="upgrade_screen_how_title">Hur du kan hjälpa</string>
     <string name="upgrade_screen_how_body">Bli en beskyddare och sponsra utvecklingen! Tryck på knappen nedan för att aktivera alla extra funktioner och öppna min GitHub Sponsors-profil.</string>
-    <string name="upgrade_screen_why_title">I mixen</string>
-    <string name="upgrade_screen_why_body">• En motiverad utvecklare 🧙
-• Obegränsade enheter ➡️➡️
-• Extra åtgärder ⚙️
-och mer…</string>
     <string name="upgrade_screen_sponsor_action">Sponsra utvecklingen</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativet är annonser, analys och Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Tack för att du stöder utveckling med öppen källkod ❤️</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager haina matangazo na haiuzi data ya mtumiaji. Maendeleo yanayoendelea yanawezeshwa tu na wewe.</string>
     <string name="upgrade_screen_how_title">Jinsi ya kusaidia</string>
     <string name="upgrade_screen_how_body">Kuwa mfumo na mfadhili wa maendeleo! Gusa kitufe kilicho hapa chini ili kuwezesha vipengele vyote vya ziada na kufungua wasifu wangu wa GitHub Sponsors.</string>
-    <string name="upgrade_screen_why_title">Katika mchanganyiko</string>
-    <string name="upgrade_screen_why_body">• Msanidi aliyehamasika 🧙\n• Vifaa visivyo na kikomo ➡️➡️\n• Vitendo vya ziada ⚙️\nna zaidi…</string>
     <string name="upgrade_screen_sponsor_action">Faidhi maendeleo</string>
     <string name="upgrade_screen_sponsor_action_hint">Mbadala ni matangazo, uchambuzi na Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Asante kwa kuunga mkono maendeleo ya chanzo wazi ❤️</string>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager விளம்பரங்கள் இல்லாதது மற்றும் பயனர் தரவுகளை விற்கவிற்கை இல்லை. தொடர்ந்த மேம்பாடு உங்களால் மட்டுமே சாத்தியமாகிறது.</string>
     <string name="upgrade_screen_how_title">எப்படி உதவுவது</string>
     <string name="upgrade_screen_how_body">புரவலராக மாறி மேம்பாட்டை ஸ்பான்சர் செய்யுங்கள்! அனைத்து கூடுதல் அம்சங்களையும் செயல்படுத்த மற்றும் எனது GitHub Sponsors சுயவிவரத்தைத் திறக்க கீழே உள்ள பொத்தானைத் தட்டவும்.</string>
-    <string name="upgrade_screen_why_title">கலவையில்</string>
-    <string name="upgrade_screen_why_body">• ஒரு உறுதியான உருவாக்கி
-• இம்மியான சாதனங்கள்
-• கூடுதல் செயல்கள்
-மற்றும் பலவற்றுடன்...</string>
     <string name="upgrade_screen_sponsor_action">மேம்பாட்டை ஸ்பான்சர் செய்யுங்கள்</string>
     <string name="upgrade_screen_sponsor_action_hint">மாற்று விளம்பரங்கள், பகுப்பாய்வுகள் மற்றும் Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">திறந்த மூல மேம்பாட்டை ஆதரித்ததற்கு நன்றி ❤️</string>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager కి ప్రకటనలు లేవు మరియు వినియోగదారు డేటాను అమ్మదు. నిరంతర అభివృద్ధి మీ వల్లనే సాధ్యం.</string>
     <string name="upgrade_screen_how_title">ఎలా సహాయం చేయాలి</string>
     <string name="upgrade_screen_how_body">పేట్రన్ అవ్వండి మరియు అభివృద్ధిని స్పాన్సర్ చేయండి! అన్ని అదనపు ఫీచర్లను యాక్టివేట్ చేయడానికి మరియు నా GitHub Sponsors ప్రొఫైల్‌ను తెరవడానికి దిగువ బటన్‌ను నొక్కండి.</string>
-    <string name="upgrade_screen_why_title">మిక్స్‌లో</string>
-    <string name="upgrade_screen_why_body">• ఒక ప్రేరణ పొందిన డెవలపర్ 🧙\n• అపరిమిత పరికరాలు ➡️➡️\n• అదనపు చర్యలు ⚙️\nమరియు మరిన్ని…</string>
     <string name="upgrade_screen_sponsor_action">అభివృద్ధిని స్పాన్సర్ చేయండి</string>
     <string name="upgrade_screen_sponsor_action_hint">ప్రత్యామనాయం ప్రకటనలు, అనలిటిక్స్ మరియు Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ఓపెన్ సోర్స్ అభివృద్ధికి మద్దతు ఇచ్చినందుకు ధన్యవాదాలు ❤️</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ไม่มีโฆษณาและไม่ขายข้อมูลผู้ใช้ การพัฒนาอย่างต่อเนื่องเป็นไปได้เพียงเพราะคุณเท่านั้น</string>
     <string name="upgrade_screen_how_title">วิธีการช่วยเหลือ</string>
     <string name="upgrade_screen_how_body">เป็นผู้อุปถัมภ์และสปอนเซอร์การพัฒนา! แตะปุ่มด้านล่างเพื่อเปิดใช้ฟีเจอร์เพิ่มเติมทั้งหมดและเปิดโปรไฟล์ GitHub Sponsors ของฉัน</string>
-    <string name="upgrade_screen_why_title">อยู่ในวง</string>
-    <string name="upgrade_screen_why_body">• นักพัฒนาที่มีแรงจูงใจ 🧙\n• อุปกรณ์ไม่จำกัด ➡️➡️\n• อาการเพิ่มเติม ⚙️\nและอีกมากมา…</string>
     <string name="upgrade_screen_sponsor_action">สปอนเซอร์การพัฒนา</string>
     <string name="upgrade_screen_sponsor_action_hint">ทางเลือกคือโฆษณา การวิเคราะห์ และ Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ขอบคุณสำหรับการสนับสนุนการพัฒนาโอเพ่นซอร์ส ❤️</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklam içermez ve kullanıcı verilerini satmaz. Sürekli gelişim yalnızca sizin sayenizde mümkündür.</string>
     <string name="upgrade_screen_how_title">Nasıl yardım edilir</string>
     <string name="upgrade_screen_how_body">Haminiz olun ve gelişime sponsor olun! Tüm ekstra özellikleri etkinleştirmek ve GitHub Sponsorları profilimi açmak için aşağıdaki düğmeye dokunun.</string>
-    <string name="upgrade_screen_why_title">Karışımda</string>
-    <string name="upgrade_screen_why_body">• Motive bir geliştirici 🧙
-• Sınırsız cihaz ➡️➡️
-• Ekstra eylemler ⚙️
-ve daha fazlası…</string>
     <string name="upgrade_screen_sponsor_action">Gelişime sponsor ol</string>
     <string name="upgrade_screen_sponsor_action_hint">Bunun alternatifi reklamlar, analizler ve Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Açık kaynak gelişimini desteklediğiniz için teşekkür ederiz ❤️</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не має реклами й не продає дані користувачів. Подальший розвиток можливий лише завдяки вам.</string>
     <string name="upgrade_screen_how_title">Як допомогти</string>
     <string name="upgrade_screen_how_body">Стань меценатом і спонсором розробки! Торкніться кнопки нижче, щоб активувати всі додаткові функції та відкрити мій профіль спонсорів GitHub.</string>
-    <string name="upgrade_screen_why_title">У міксі</string>
-    <string name="upgrade_screen_why_body">• Мотивований розробник 🧙
-• Необмежена кількість пристроїв ➡️➡️
-• Додаткові дії ⚙️
-та більше…</string>
     <string name="upgrade_screen_sponsor_action">Розвиток спонсорів</string>
     <string name="upgrade_screen_sponsor_action_hint">Альтернативою є реклама, аналітика та Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Дякуємо за підтримку розробки з відкритим кодом ❤️</string>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager میں کوئی اشتہار نہیں ہے اور یہ صارف کا ڈیٹا فروخت نہیں کرتا۔ جاری ترقی صرف آپ کی وجہ سے ممکن ہے۔</string>
     <string name="upgrade_screen_how_title">کیسے مدد کریں</string>
     <string name="upgrade_screen_how_body">سرپرست بنیں اور ترقی کو اسپانسر کریں! تمام اضافی خصوصیات کو فعال کرنے اور میری GitHub Sponsors پروفائل کھولنے کے لیے نیچے دیا گیا بٹن دبائیں۔</string>
-    <string name="upgrade_screen_why_title">مکس میں</string>
-    <string name="upgrade_screen_why_body">• ایک حوصلہ مند ڈیولپر 🧙\n• لامحدود ڈیوائسیز ➡️➡️\n• اضافی ایکشنز ⚙️\nاور بھی بہت کچھ…</string>
     <string name="upgrade_screen_sponsor_action">ترقی کو اسپانسر کریں</string>
     <string name="upgrade_screen_sponsor_action_hint">متبادل اشتہارات، تجزیات اور Google Play ہیں 🙁</string>
     <string name="upgrade_screen_thanks_toast">اوپن سورس ڈیولپمنٹ کی حمایت کرنے کا شکریہ ❤️</string>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklamasiz va foydalanuvchi ma\'lumotlarini sotmaydi. Rivojlanishning davom etishi faqat siz tufayli mumkin.</string>
     <string name="upgrade_screen_how_title">Qanday yordam berish</string>
     <string name="upgrade_screen_how_body">Homiy bo\'ling va rivojlanishni sponsorlik qiling! Barcha qo\'shimcha xususiyatlarni faollashtirish va GitHub Sponsors profilimni ochish uchun quyidagi tugmani bosing.</string>
-    <string name="upgrade_screen_why_title">Aralashmada</string>
-    <string name="upgrade_screen_why_body">• Motivatsiyali dasturchi 🧙
-• Cheksiz qurilmalar ➡️➡️
-• Qo\'shimcha amallar ⚙️
-va boshqalar…</string>
     <string name="upgrade_screen_sponsor_action">Rivojlanishni sponsorlik qilish</string>
     <string name="upgrade_screen_sponsor_action_hint">Muqobil reklama, tahlil va Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ochiq manba rivojlanishini qo\'llab-quvvatlaganingiz uchun rahmat ❤️</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager không có quảng cáo và không bán dữ liệu người dùng. Việc tiếp tục phát triển chỉ có thể thực hiện được nhờ bạn.</string>
     <string name="upgrade_screen_how_title">Làm thế nào để giúp đỡ</string>
     <string name="upgrade_screen_how_body">Trở thành người bảo trợ và tài trợ phát triển! Nhấp vào nút bên dưới để kích hoạt tất cả các tính năng bổ sung và mở hồ sơ Nhà tài trợ GitHub của tôi.</string>
-    <string name="upgrade_screen_why_title">Trong vòng xáy</string>
-    <string name="upgrade_screen_why_body">• Nhà phát triển tâm huyết 🧙
-• Thiết bị không giới hạn ➡️➡️
-• Hành động bổ sung ⚙️
-và nhiều hơn nữa…</string>
     <string name="upgrade_screen_sponsor_action">Tài trợ nhà phát triển</string>
     <string name="upgrade_screen_sponsor_action_hint">Giải pháp thay thế là quảng cáo, phân tích và Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Cảm ơn bạn đã hỗ trợ phát triển mã nguồn mở ❤️</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 没有广告，也不出售用户数据。持续开发只因有您的支持。</string>
     <string name="upgrade_screen_how_title">如何帮助我们</string>
     <string name="upgrade_screen_how_body">成为赞助者并支持我们的开发！点击下面的按钮激活所有额外功能并打开我的 GitHub 赞助者资料。</string>
-    <string name="upgrade_screen_why_title">加入混音</string>
-    <string name="upgrade_screen_why_body">• 一位充满动力的开发者 🧙
-• 无限设备 ➡️➡️
-• 额外操作 ⚙️
-以及更多…</string>
     <string name="upgrade_screen_sponsor_action">赞助开发</string>
     <string name="upgrade_screen_sponsor_action_hint">取而代之的是广告、分析和 Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">感谢您支持开源开发 ❤️</string>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不出售用戶數據。持續開發只有靠你的支持才成為可能。</string>
     <string name="upgrade_screen_how_title">如何協助</string>
     <string name="upgrade_screen_how_body">成為贊助者並贊助開發！輕觸下面的按鈕，啟用所有額外功能，並開啟我的 Github 贊助者設定檔。</string>
-    <string name="upgrade_screen_why_title">混音中</string>
-    <string name="upgrade_screen_why_body">• 有動力的開發者 🧙\n• 無限裝置 ➡️➡️\n• 額外動作 ⚙️\n更多…</string>
     <string name="upgrade_screen_sponsor_action">贊助開發</string>
     <string name="upgrade_screen_sponsor_action_hint">替代品為廣告、分析和 Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">感謝您對開放原始碼開發的支持 ❤️</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -9,11 +9,6 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不會出售使用者資料。持續的開發由你們所支援。</string>
     <string name="upgrade_screen_how_title">如何協助</string>
     <string name="upgrade_screen_how_body">成為贊助者並贊助開發！輕觸下面的按鈕，啟用所有額外功能，並開啟我的 Github 贊助者設定檔。</string>
-    <string name="upgrade_screen_why_title">进入混音</string>
-    <string name="upgrade_screen_why_body">• 充滿動力的開發者 🧙
-• 無限裝置 ➡️➡️
-• 額外動作 ⚙️
-以及更多…</string>
     <string name="upgrade_screen_sponsor_action">贊助開發</string>
     <string name="upgrade_screen_sponsor_action_hint">替代品為廣告、分析和 Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">感謝您對開放原始碼開發的支持 ❤️</string>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -9,8 +9,6 @@
     <string name="upgrade_screen_preamble">I-Bluetooth Volume Manager ayinazo izikhangiso futhi ayithengisi idatha yabasebenzisi. Ukuthuthukiswa okuqhubekayo kwenziwa kuphela nguwe.</string>
     <string name="upgrade_screen_how_title">Indlela yokusiza</string>
     <string name="upgrade_screen_how_body">Yiba ngumnikazi futhi uxhase ukuthuthukiswa! Thepha inkinobho engezansi ukuze unike amandla zonke izici ezengeziwe futhi uvule iphrofayili yami ye-GitHub Sponsors.</string>
-    <string name="upgrade_screen_why_title">Kulo mxube</string>
-    <string name="upgrade_screen_why_body">• Umthuthuki okhuthazekile 🧟\n• Amadivayisi angenamkhawulo ➡️➡️\n• Izenzo ezengeziwe ⚙️\nnakunye...</string>
     <string name="upgrade_screen_sponsor_action">Xhasa ukuthuthukiswa</string>
     <string name="upgrade_screen_sponsor_action_hint">Enye indlela izikhangiso, ukuhlaziya ne-Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ngiyabonga ngokusekela ukuthuthukiswa komthombo ovulekile ❤️</string>

--- a/app/src/foss/res/values/colors.xml
+++ b/app/src/foss/res/values/colors.xml
@@ -1,3 +1,0 @@
-<resources>
-    <color name="colorUpgraded">#ffd600</color>
-</resources>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -14,8 +14,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager has no ads and doesn\'t sell user data. Continued development is only made possible by you.</string>
     <string name="upgrade_screen_how_title">How to help</string>
     <string name="upgrade_screen_how_body">Become a patron and sponsor development! Tap the button below to activate all extra features and open my GitHub Sponsors profile.</string>
-    <string name="upgrade_screen_why_title">In the mix</string>
-    <string name="upgrade_screen_why_body">• A motivated developer 🧙\n• Unlimited devices ➡️➡️\n• Extra actions ⚙️\nand more…</string>
+    <string name="upgrade_screen_why_title">Advantages</string>
+    <string name="upgrade_screen_why_body">• Unlimited devices\n• Custom connection actions\n• Theme customization\n• Advanced volume controls\n• Support open-source development 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsor development</string>
     <string name="upgrade_screen_sponsor_action_hint">The alternative are ads, analytics and Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Thank you for supporting open-source development ❤️</string>

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeOwnership.kt
@@ -173,7 +173,8 @@ private fun UpgradeOwnedHero(
                     text = stringResource(
                         if (ownership.hasIap) R.string.upgrade_screen_owned_hero_iap_body
                         else R.string.upgrade_screen_owned_hero_sub_body,
-                        "${stringResource(R.string.app_name)} ${stringResource(R.string.app_name_upgrade_postfix)}",
+                        // Same brand the titles compose: the short name plus the flavor postfix.
+                        "${stringResource(R.string.app_name_short)} ${stringResource(R.string.app_name_upgrade_postfix)}",
                     ),
                     style = MaterialTheme.typography.bodyMedium,
                 )

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -247,11 +247,23 @@ internal fun UpgradeScreen(
             contentPadding = PaddingValues(start = 24.dp, top = 16.dp, end = 24.dp, bottom = 32.dp),
         ) {
             if (ownedState == null) {
-                // Owners get the badge inside the congrats hero card instead. Once a grace episode
-                // ages into the diagnostics stage, the header switches to the attention mood,
-                // matching the "needs your attention" state. A young episode keeps the calm badge:
-                // its message is that nothing is wrong.
-                UpgradeHeader(happy = loaded?.grace?.showDiagnostics != true)
+                if (loaded?.grace != null) {
+                    // Grace users never see the preamble (sales copy contradicts "still active"),
+                    // so there is nothing to pair the icon with — it stays a standalone header
+                    // above the grace card. Once the episode ages into the diagnostics stage the
+                    // header switches to the attention mood, matching the "needs your attention"
+                    // state; a young episode keeps the calm app icon, its message being that
+                    // nothing is wrong.
+                    UpgradeHeader(happy = loaded.grace.showDiagnostics != true)
+                } else {
+                    UpgradeHeroCard(
+                        text = stringResource(R.string.upgrade_screen_preamble),
+                        colors = CardDefaults.elevatedCardColors(
+                            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                        ),
+                    )
+                }
             }
 
             if (ownedState != null) {
@@ -300,14 +312,8 @@ private fun UpgradeAcquisitionContent(
     // blip) shows calm status only, an aged one (likely really gone) adds restore AND the offers,
     // so an expired subscriber can switch without waiting out the full grace window.
     if (!inGrace) {
-        UpgradePreambleCard(
-            text = stringResource(R.string.upgrade_screen_preamble),
-            colors = CardDefaults.elevatedCardColors(
-                containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
-            ),
-        )
-
+        // The preamble itself now lives in the hero card at the top of the screen, next to the
+        // app icon.
         if (uiState is GplayUpgradeUiState.Loaded && uiState.wasPreviouslyPro) {
             // The targeted returning-buyer nudge: prominent placement and emphasis, and the ONLY
             // restore affordance on the screen — a second one below would make the screen feel

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -5,12 +5,14 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.AutoAwesome
 import androidx.compose.material.icons.twotone.WarningAmber
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
@@ -390,6 +392,7 @@ private fun UpgradeOffersBox(
                 // the user re-run the offer queries instead of leaving a dead screen.
                 // No reset needed: this composable unmounts the moment the state leaves Unavailable.
                 var retryTapped by remember { mutableStateOf(false) }
+                val retryEnabled = !retryTapped
                 OutlinedButton(
                     // Guard inside the callback, not just via `enabled`: `enabled` only takes effect
                     // after recomposition, so two taps in the same frame would both fire.
@@ -399,10 +402,20 @@ private fun UpgradeOffersBox(
                             onRetry()
                         }
                     },
-                    enabled = !retryTapped,
+                    enabled = retryEnabled,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(UpgradeScreenTags.GPLAY_RETRY),
+                    // The button sits on the errorContainer card, so the default primary-on-surface
+                    // outlined colors read as a foreign element with poor contrast.
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        disabledContentColor = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.38f),
+                    ),
+                    border = BorderStroke(
+                        1.dp,
+                        MaterialTheme.colorScheme.onErrorContainer.copy(alpha = if (retryEnabled) 1f else 0.1f),
+                    ),
                 ) {
                     Text(stringResource(R.string.upgrade_screen_retry_action))
                 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -204,6 +204,15 @@ internal fun RestoreInconclusiveDialog(
     )
 }
 
+// The acquisition pitch inserts the SAME composed brand the status title uses, postfix colored —
+// one brand rendering for both. Word-order-proof: the brand is spliced into the TRANSLATED pattern,
+// so Android's formatter owns placeholder semantics (numbering, reordering, escaping).
+@Composable
+private fun upgradeAcquisitionTitle(): AnnotatedString = spliceBrandTitle(
+    formatted = stringResource(R.string.upgrade_screen_title_template, BRAND_TITLE_MARKER),
+    brand = upgradeScreenTitle(upgraded = true),
+)
+
 @Composable
 internal fun UpgradeScreen(
     uiState: GplayUpgradeUiState = GplayUpgradeUiState.Loading,
@@ -222,13 +231,14 @@ internal fun UpgradeScreen(
     val ownedState = loaded?.takeIf { it.ownership.ownsAnything }
 
     UpgradeScreenScaffold(
-        // Grace users are still Pro: they get the status title too — a "Get Pro" title on the
-        // status screen would contradict the rest of the app, which behaves upgraded. The postfix
-        // is highlighted like the dashboard title does it.
+        // Grace users are still Pro: they get the bare status title too — a "Upgrade to Pro" title
+        // on the status screen would contradict the rest of the app, which behaves upgraded.
+        // Acquisition wraps that same brand in the pitch sentence. Either way the postfix is
+        // highlighted like the dashboard title does it.
         title = if (ownedState != null || loaded?.grace != null) {
             upgradeScreenTitle(upgraded = true)
         } else {
-            AnnotatedString(stringResource(R.string.upgrade_screen_title))
+            upgradeAcquisitionTitle()
         },
         onNavigateUp = onNavigateUp,
     ) { paddingValues ->

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Opgradeer na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro bied beter resultate, meer funksies en opsies vir kraggebruikers.</string>
     <string name="upgrade_prompt_upgrade_action">Gradeer Op</string>
-    <string name="upgrade_screen_title">Opgradeer na BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager het geen advertensies nie en verkoop nie gebruikersdata nie. My werk word deur jou gefinansier ❤️.</string>
     <string name="upgrade_screen_why_title">Voordele</string>
     <string name="upgrade_screen_subscription_trial_action">Begin gratis 14-dag proef</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">ወደ BVM Pro ክበቱ</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ለተጨማሪ ተመርጸውዎች፣ ተጨማሪ ብካዾች፥ እና የፐወር ተጠቃሚዎችን ይደግጋል።</string>
     <string name="upgrade_prompt_upgrade_action">አሻሽል</string>
-    <string name="upgrade_screen_title">ወደ BVM Pro ክበቱ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ምንም እዋዀት ይረጋል፣ የተገባይ ውሂብንነም አይሸጥም። የ።ቡቡ፡ በ።ቡቡ፠ ዘርድ የካዘለኂው ❤️።</string>
     <string name="upgrade_screen_why_title">ጥቅሞች</string>
     <string name="upgrade_screen_subscription_trial_action">ነፃ የ14 ቀን ሙከራ ይጀምሩ</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">الترقية إلى BVM Pro</string>
     <string name="upgrade_prompt_body">BVM Pro يمنحك نتائج أفضل، ومزيداً من المميزات والخيارات للمستخدمين المحترفين.</string>
     <string name="upgrade_prompt_upgrade_action">تحديث</string>
-    <string name="upgrade_screen_title">الترقية إلى BVM Pro</string>
     <string name="upgrade_screen_preamble">لا يعرض Bluetooth Volume Manager أية إعلانات ولا يبيع بيانات المستخدم. يتم تمويل عملي من قِبَلكم ❤️.</string>
     <string name="upgrade_screen_why_title">المميزات</string>
     <string name="upgrade_screen_subscription_trial_action">بدء التجربة المجانية لمدة 14 يوماً</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro-ya yüksəldin</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro daha yaxşı nəticələr, daha çox xüsusiyyətlər və güc istifadəçiləri üçün seçimlər təklif edir.</string>
     <string name="upgrade_prompt_upgrade_action">Yüksəlt</string>
-    <string name="upgrade_screen_title">BVM Pro-ya yüksəldin</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-də reklam yoxdur və istifadəçi məlumatlarını satmır. Mənim işim sizin tərəfindən maliyyələşdirilir ❤️.</string>
     <string name="upgrade_screen_why_title">Üstünlüklər</string>
     <string name="upgrade_screen_subscription_trial_action">Pulsuz 14 günlük sınağa başlayın</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Перайсці на BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro прапануе лепшыя вынікі, больш функцый і настроек для прасунутых карыстальнікаў.</string>
     <string name="upgrade_prompt_upgrade_action">Абнавіць</string>
-    <string name="upgrade_screen_title">Перайсці на BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не мае рэкламы і не прадае дадзеныя карыстальнікаў. Мая праца фінансуецца вамі ❤️.</string>
     <string name="upgrade_screen_why_title">Перавагі</string>
     <string name="upgrade_screen_subscription_trial_action">Пачаць бясплатны пробны 14-дзённы перыяд</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Надграждане до BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro предлага по-добри резултати, повече функции и опции за напреднали потребители.</string>
     <string name="upgrade_prompt_upgrade_action">Ъпгрейд</string>
-    <string name="upgrade_screen_title">Надграждане до BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager няма реклами и не продава потребителски данни. Работата ми се финансира от вас ❤️.</string>
     <string name="upgrade_screen_why_title">Предимства</string>
     <string name="upgrade_screen_subscription_trial_action">Започнете безплатен 14-дневен пробен период</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro-তে আপগ্রেড করুন</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro পারভার ব্যবহারকারীদের জন্য ভালো ফলাফল, আরও ফিচার এবং বিকল্প দেয়।</string>
     <string name="upgrade_prompt_upgrade_action">আপগ্রেড করুন</string>
-    <string name="upgrade_screen_title">BVM Pro-তে আপগ্রেড করুন</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-এ কোনো বিজ্ঞাপন নেই এবং ব্যবহারকারীর তথ্য বিক্রি করে না। আমার কাজ আপনার দ্বারা পরিচালিত ❤️।</string>
     <string name="upgrade_screen_why_title">সুবিধাসমূহ</string>
     <string name="upgrade_screen_subscription_trial_action">বিনামূল্যে ১৪-দিনের ট্রায়াল শুরু করুন</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Millora a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofereix millors resultats, més funcions i opcions per a usuaris avançats.</string>
     <string name="upgrade_prompt_upgrade_action">Actualitza</string>
-    <string name="upgrade_screen_title">Millora a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no té anuncis i no ven les dades d’usuari. El meu treball està finiançat per vosaltres ❤️.</string>
     <string name="upgrade_screen_why_title">Avantatges</string>
     <string name="upgrade_screen_subscription_trial_action">Comença la prova gratuïta de 14 dies</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Upgradovat na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro nabízí lepší výsledky, více funkcí a možností pro zkušené uživatele.</string>
     <string name="upgrade_prompt_upgrade_action">Upgradovat</string>
-    <string name="upgrade_screen_title">Upgradovat na BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neobsahuje žádné reklamy a neprodává data uživatelů. Moje práce je financována vámi ❤️.</string>
     <string name="upgrade_screen_why_title">Výhody</string>
     <string name="upgrade_screen_subscription_trial_action">Zahájit bezplatnou 14denní zkušební dobu</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Opgrader til BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro giver bedre resultater, flere funktioner og muligheder for superbrugere.</string>
     <string name="upgrade_prompt_upgrade_action">Opgrader</string>
-    <string name="upgrade_screen_title">Opgrader til BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen reklamer og sælger ikke brugerdata. Mit arbejde er finansieret af dig ❤️.</string>
     <string name="upgrade_screen_why_title">Fordele</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis 14-dages prøveperiode</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Auf BVM Pro upgraden</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro bietet bessere Ergebnisse, mehr Funktionen und Optionen für Power-User.</string>
     <string name="upgrade_prompt_upgrade_action">Upgrade</string>
-    <string name="upgrade_screen_title">Auf BVM Pro upgraden</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager enthält keine Werbung und verkauft keine Nutzerdaten. Meine Arbeit wird von dir finanziert ❤️.</string>
     <string name="upgrade_screen_why_title">Vorteile</string>
     <string name="upgrade_screen_subscription_trial_action">Kostenlose 14-tägige Testversion starten</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Αναβαθμίστε στο BVM Pro</string>
     <string name="upgrade_prompt_body">Το Bluetooth Volume Manager Pro προσφέρει καλύτερα αποτελέσματα, περισσότερες δυνατότητες και επιλογές για προχωρημένους χρήστες.</string>
     <string name="upgrade_prompt_upgrade_action">Αναβάθμιση</string>
-    <string name="upgrade_screen_title">Αναβαθμίστε στο BVM Pro</string>
     <string name="upgrade_screen_preamble">Το Bluetooth Volume Manager δεν έχει διαφημίσεις και δεν πωλεί δεδομένα χρηστών. Η δουλειά μου χρηματοδοτείται από εσάς ❤️.</string>
     <string name="upgrade_screen_why_title">Πλεονεκτήματα</string>
     <string name="upgrade_screen_subscription_trial_action">Έναρξη δωρεάν δοκιμής 14 ημερών</string>

--- a/app/src/gplay/res/values-eo-rUY/strings.xml
+++ b/app/src/gplay/res/values-eo-rUY/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Plibonigi al BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofertas pli bonajn rezultojn, pli da funkcioj kaj opcioj por potencaj uzantoj.</string>
     <string name="upgrade_prompt_upgrade_action">Plibonigi</string>
-    <string name="upgrade_screen_title">Plibonigi al BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ne havas reklamojn kaj ne vendas uzantoajn datumojn. Mia laboro estas financata de vi ❤️.</string>
     <string name="upgrade_screen_why_title">Avantaĝoj</string>
     <string name="upgrade_screen_subscription_trial_action">Komenci senpagan 14-tagan provon</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
     <string name="upgrade_prompt_upgrade_action">Mejorar</string>
-    <string name="upgrade_screen_title">Actualizar a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende datos de usuario. Mi trabajo es financiado por vos ❤️.</string>
     <string name="upgrade_screen_why_title">Ventajas</string>
     <string name="upgrade_screen_subscription_trial_action">Empezá la prueba gratuita de 14 días</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
     <string name="upgrade_prompt_upgrade_action">Actualizar</string>
-    <string name="upgrade_screen_title">Actualizar a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene publicidad y no vende datos de usuarios. Mi trabajo es financiado por ti ❤️.</string>
     <string name="upgrade_screen_why_title">Ventajas</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar prueba gratuita de 14 días</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mejores resultados, más características y opciones para los usuarios avanzados.</string>
     <string name="upgrade_prompt_upgrade_action">Actualizar</string>
-    <string name="upgrade_screen_title">Actualizar a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende los datos de los usuarios. Mi trabajo está financiado por ti ❤️.</string>
     <string name="upgrade_screen_why_title">Ventajas</string>
     <string name="upgrade_screen_subscription_trial_action">Empieza la prueba gratuita de 14 días</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Uuenda BVM Pro-ks</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro pakub paremaid tulemusi, rohkem funktsioone ja valikuid edasijõudnutele.</string>
     <string name="upgrade_prompt_upgrade_action">Täienda</string>
-    <string name="upgrade_screen_title">Uuenda BVM Pro-ks</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manageris pole reklaame ja see ei müü kasutajaandmeid. Minu tööd toetate teie ❤️.</string>
     <string name="upgrade_screen_why_title">Eelised</string>
     <string name="upgrade_screen_subscription_trial_action">Alustage tasuta 14 päevast prooviperioodi</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Berritu BVM Pro-ra</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro-k emaitza hobeak, ezaugarri gehiago eta aukera gehiago eskaintzen ditu erabiltzaile aurreratuei.</string>
     <string name="upgrade_prompt_upgrade_action">Eguneratu</string>
-    <string name="upgrade_screen_title">Berritu BVM Pro-ra</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ek ez du iragarkirik eta ez du erabiltzailearen daturik saltzen. Nire lana zuk finantzatzen duzu ❤️.</string>
     <string name="upgrade_screen_why_title">Abantailak</string>
     <string name="upgrade_screen_subscription_trial_action">14 eguneko proba doan hasi</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">ارتقاء به BVM Pro</string>
     <string name="upgrade_prompt_body">مدیر صدای بلوتوث Pro نتایج بهتر، ویژگی‌ها و گزینه‌های بیشتری برای کاربران حرفه‌ای ارائه می‌دهد.</string>
     <string name="upgrade_prompt_upgrade_action">ارتقاء</string>
-    <string name="upgrade_screen_title">ارتقاء به BVM Pro</string>
     <string name="upgrade_screen_preamble">مدیر صدای بلوتوث تبلیغات ندارد و داده‌های کاربر را نمی‌فروشد. کار من توسط شما تأمین می‌شود ❤️.</string>
     <string name="upgrade_screen_why_title">مزایا</string>
     <string name="upgrade_screen_subscription_trial_action">شروع دوره آزمایشی ۱۴ روزه رایگان</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Päivitä BVM Pro:hon</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro tarjoaa parempia tuloksia, enemmän ominaisuuksia ja vaihtoehtoja tehokäyttäjille.</string>
     <string name="upgrade_prompt_upgrade_action">Päivitä</string>
-    <string name="upgrade_screen_title">Päivitä BVM Pro:hon</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerissa ei ole mainoksia eikä se myy käyttäjätietoja. Työni rahoitetaan sinun toimestasi ❤️.</string>
     <string name="upgrade_screen_why_title">Edut</string>
     <string name="upgrade_screen_subscription_trial_action">Aloita ilmainen 14 päivän kokeilu</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">I-upgrade sa BVM Pro</string>
     <string name="upgrade_prompt_body">Ang Bluetooth Volume Manager Pro ay nag-aalok ng mas mahusay na mga resulta, mas maraming mga feature at mga opsyon para sa mga power user.</string>
     <string name="upgrade_prompt_upgrade_action">I-upgrade</string>
-    <string name="upgrade_screen_title">I-upgrade sa BVM Pro</string>
     <string name="upgrade_screen_preamble">Ang Bluetooth Volume Manager ay walang mga ad at hindi nagbebenta ng data ng user. Ang aking trabaho ay pinopondohan mo ❤️.</string>
     <string name="upgrade_screen_why_title">Mga Benepisyo</string>
     <string name="upgrade_screen_subscription_trial_action">Simulan ang libreng 14-day trial</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Passer à BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro offre de meilleurs résultats, plus de fonctions et d’options pour les utilisateurs expérimentés.</string>
     <string name="upgrade_prompt_upgrade_action">Surclasser</string>
-    <string name="upgrade_screen_title">Passer à BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n’affiche pas de publicités et ne vend pas les données des utilisateurs. Mon travail est financé par vous ❤️.</string>
     <string name="upgrade_screen_why_title">Avantages</string>
     <string name="upgrade_screen_subscription_trial_action">Commencer l’essai gratuit de 14 jours</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mellores resultados, máis funcionalidades e opcións para usuarios avanzados.</string>
     <string name="upgrade_prompt_upgrade_action">Actualizar</string>
-    <string name="upgrade_screen_title">Actualizar a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non ten anuncios e non vende datos de usuario. O meu traballo está financiado por ti ❤️.</string>
     <string name="upgrade_screen_why_title">Vantaxes</string>
     <string name="upgrade_screen_subscription_trial_action">Comezar proba gratuíta de 14 días</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro में अपग्रेड करें</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro पावर उपयोगकर्ताओं के लिए बेहतर परिणाम, अधिक सुविधाएं और विकल्प प्रदान करता है।</string>
     <string name="upgrade_prompt_upgrade_action">अपग्रेड</string>
-    <string name="upgrade_screen_title">BVM Pro में अपग्रेड करें</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager में कोई विज्ञापन नहीं है और वह उपयोगकर्ता डेटा नहीं बेचता। मेरा काम आपके द्वारा वित्तपोषित है ❤️।</string>
     <string name="upgrade_screen_why_title">लाभ</string>
     <string name="upgrade_screen_subscription_trial_action">14 दिन का निःशुल्क परीक्षण प्रारंभ करें</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Nadogradite na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro nudi bolje rezultate, više značajki i opcije za napredne korisnike.</string>
     <string name="upgrade_prompt_upgrade_action">Nadogradi</string>
-    <string name="upgrade_screen_title">Nadogradite na BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nema oglasa i ne prodaje korisničke podatke. Moj rad financirate vi ❤️.</string>
     <string name="upgrade_screen_why_title">Prednosti</string>
     <string name="upgrade_screen_subscription_trial_action">Započnite besplatno probno razdoblje od 14 dana</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Frissítés BVM Pro-ra</string>
     <string name="upgrade_prompt_body">A Bluetooth Volume Manager Pro jobb eredményeket, több funkciót és lehetőséget kínál a haladó felhasználóknak.</string>
     <string name="upgrade_prompt_upgrade_action">Frissítés</string>
-    <string name="upgrade_screen_title">Frissítés BVM Pro-ra</string>
     <string name="upgrade_screen_preamble">A Bluetooth Volume Manager nem tartalmaz hirdetéseket, és nem értékesít felhasználói adatokat. A munkámat te finanszírozód ❤️.</string>
     <string name="upgrade_screen_why_title">Előnyök</string>
     <string name="upgrade_screen_subscription_trial_action">Ingyenes 14 napos próbaidőszak indítása</string>

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Անցնել BVM Pro-ին</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ավելի լավ արդյունքներ՝ գորունակություններ և հնարավորություններ հզոր ուժղատություն ունեցողների համար։</string>
     <string name="upgrade_prompt_upgrade_action">Թարմացնել</string>
-    <string name="upgrade_screen_title">Անցնել BVM Pro-ին</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ում գովազդներ չկան և ուժղատության տվյալներ չի վարարկում։ Մեր աշխատանքե ժղարգարվում ե դզեր կողմից։</string>
     <string name="upgrade_screen_why_title">Առավելություններ</string>
     <string name="upgrade_screen_subscription_trial_action">Սկսել անվճար 14 օրվա փորձարկումը</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Upgrade ke BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro menawarkan hasil lebih baik, lebih banyak fitur dan opsi untuk pengguna mahir.</string>
     <string name="upgrade_prompt_upgrade_action">Tingkatkan</string>
-    <string name="upgrade_screen_title">Upgrade ke BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tidak menampilkan iklan dan tidak menjual data pengguna. Pekerjaan saya dibiayai oleh Anda ❤️.</string>
     <string name="upgrade_screen_why_title">Kelebihan</string>
     <string name="upgrade_screen_subscription_trial_action">Mulai coba gratis 14 hari</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Uppfæra í BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro býður upp á betri niðurstöður, fleiri eiginleika og valkosti fyrir öfluga notendur.</string>
     <string name="upgrade_prompt_upgrade_action">Uppfæra</string>
-    <string name="upgrade_screen_title">Uppfæra í BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager birtir engar auglýsingar og selur ekki notendagögn. Verk mitt er fjármagnaö af þér ❤️.</string>
     <string name="upgrade_screen_why_title">Kostir</string>
     <string name="upgrade_screen_subscription_trial_action">Byrja ókeypis 14 daga prufu</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Aggiorna a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro offre risultati migliori, più funzioni e opzioni per gli utenti avanzati.</string>
     <string name="upgrade_prompt_upgrade_action">Acquista</string>
-    <string name="upgrade_screen_title">Aggiorna a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non contiene pubblicità e non vende i dati degli utenti. Il mio lavoro è finanziato da te ❤️.</string>
     <string name="upgrade_screen_why_title">Vantaggi</string>
     <string name="upgrade_screen_subscription_trial_action">Inizia la prova gratuita di 14 giorni</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">שדרג ל-BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro מציע תוצאות טובות יותר, יותר תכונות ואפשרויות למשתמשים מתקדמים.</string>
     <string name="upgrade_prompt_upgrade_action">שדרוג</string>
-    <string name="upgrade_screen_title">שדרג ל-BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ללא מודעות ואינה מוכרת נתוני משתמשים. העבודה שלי ממומנת על ידך ❤️.</string>
     <string name="upgrade_screen_why_title">יתרונות</string>
     <string name="upgrade_screen_subscription_trial_action">התחילו 14 ימי ניסיון</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro にアップグレード</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Proは、パワーユーザーにより良い結果、より多くの機能とオプションを提供します。</string>
     <string name="upgrade_prompt_upgrade_action">アップグレード</string>
-    <string name="upgrade_screen_title">BVM Pro にアップグレード</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerは広告がなく、ユーザーデータを販売しません。私の作業はあなたによって支えられています ❤️。</string>
     <string name="upgrade_screen_why_title">メリット</string>
     <string name="upgrade_screen_subscription_trial_action">14日間の無料トライアルを開始</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">გადაიდგეს BVM Pro-ზე</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro გთავაზობს უკეთეს შედეგადებს, მეტ თვისებასა და პარამეტრებს გამოცდილი მომხმარებისთვის.</string>
     <string name="upgrade_prompt_upgrade_action">გარემონტება</string>
-    <string name="upgrade_screen_title">გადაიდგეს BVM Pro-ზე</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager რეკლამაგარეშია და მომხმარეთა მონაცემებს არ ყიდის. ჩემს სამუშაოს დაფინანსება თქვენია გვიერ გენიათ ❤️.</string>
     <string name="upgrade_screen_why_title">უპირატესობები</string>
     <string name="upgrade_screen_subscription_trial_action">დაიწყეთ უფასო 14-დღიანი საცდელი</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">អ័ពគថ83 ត្រឹមត្រូវ BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ផ្តល់នួវផលលើសជាង្រើសមុខងារនិងជម្រើសប័កព្រមសម្រាប់សម្រាប់សធ្វី។</string>
     <string name="upgrade_prompt_upgrade_action">វិសិដ្ឋកម្ម</string>
-    <string name="upgrade_screen_title">អ័ពគថ83 ត្រឹមត្រូវ BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager មិនមានព្សនា ។។។ ហើយមិនលក់លាយត្រម្វន្តិយរបស់ប្រើបស័រី។ ការការរបស់សម្រាប់របស់ត្រងប្រើទីអ្នក ❤️។</string>
     <string name="upgrade_screen_why_title">អត្ថប្រយោជន៍</string>
     <string name="upgrade_screen_subscription_trial_action">ចាប់ផ្តើមការសាកល្បង 14 ថ្ងៃដោយឥតគិតថ្លៃ</string>

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Biçe BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ji bo bikarhênerên pêşkeftî encamên baştir, taybetmendî û vebijarkên zêdetir pêşkêş dike.</string>
     <string name="upgrade_prompt_upgrade_action">Nûjen bike</string>
-    <string name="upgrade_screen_title">Biçe BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklamê nake û daneya bikarhêner nafroşe. Xebata min ji aliyê we ve tê fînanskirinê ❤️.</string>
     <string name="upgrade_screen_why_title">Avantaj</string>
     <string name="upgrade_screen_subscription_trial_action">Ceribandîna 14-rojî ya belaş dest pê bike</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro ಗೆ ದರ್ಜೆಯೇರಿ</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ಉತ್ತಮ ಫಲಿತಾಂಶಗಳನ್ನು, ಹೆಚ್ಚಿನ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಮತ್ತು ಪವರ್ ಬಳಕೆದಾರರಿಗೆ ಆಯ್ಕೆಗಳನ್ನು ನೀಡುತ್ತದೆ.</string>
     <string name="upgrade_prompt_upgrade_action">ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ</string>
-    <string name="upgrade_screen_title">BVM Pro ಗೆ ದರ್ಜೆಯೇರಿ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ಜಾಹೀರಾತುಗಳಿಲ್ಲ ಮತ್ತು ಬಳಕೆದಾರರ ಡೇಟಾ ಮಾರಾಟುವುದಿಲ್ಲ. ನನ್ನ ಕೆಲಸ ನಿಮ್ಮಿಂದ ಹಗಲಾಗುತ್ತದೆ ❤️.</string>
     <string name="upgrade_screen_why_title">ಪ್ರಯೋಜನಗಳು</string>
     <string name="upgrade_screen_subscription_trial_action">ಉಚಿತ 14-ದಿನಗಳ ಪರೀಕ್ಷೆ ಪ್ರಾರಂಭಿಸಿ</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro로 업그레이드</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro는 파워유저들을 위해 더 나은 결과와 더 많은 기능 및 옵션을 제공합니다.</string>
     <string name="upgrade_prompt_upgrade_action">업그레이드</string>
-    <string name="upgrade_screen_title">BVM Pro로 업그레이드</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager는 광고가 없고 유저 데이터를 팔지 않습니다. 제 작업은 여러분의 지원으로 이루어집니다 ❤️.</string>
     <string name="upgrade_screen_why_title">장점</string>
     <string name="upgrade_screen_subscription_trial_action">14일 무료 평가판 시작</string>

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro га өтүү</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro күчтүү пайдалануучулар үчүн жакшыраак натыйжаларды, көбүрөк функцияларды жана мүмкүнчүлүктөрдү сунат.</string>
     <string name="upgrade_prompt_upgrade_action">Жаңыртуу</string>
-    <string name="upgrade_screen_title">BVM Pro га өтүү</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager жарнамаларсыз жана пайдалануучулардын мәлиматын сатпайт. Менин жумушум сиздин қаржыланат ❤️.</string>
     <string name="upgrade_screen_why_title">Артыкчылыктары</string>
     <string name="upgrade_screen_subscription_trial_action">14 күндүк бепло сынаманы баштоо</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">ອັບເກຣດເປັນ BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ໃຫ້ຜ໏ລໍບທີ່ດີກວ່າ, ມີຄຸນສົມແລະຕັວເລືອກເພິ່ມເຕີມສຳຫຣັບຜູ້ໃຊ້ທີ່ເພີບ.</string>
     <string name="upgrade_prompt_upgrade_action">ອັບເກຣດ</string>
-    <string name="upgrade_screen_title">ອັບເກຣດເປັນ BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ບ່ມີໂຆສນາເກ໭ນແລະບ່ຂາຍຂ້ອມູນຜູ້ໃຊ້. ງານຂອງຂ້ອນສະຫນັບສນຸນໂດຍທ່ານ ❤️.</string>
     <string name="upgrade_screen_why_title">ຂໍ້ດີ</string>
     <string name="upgrade_screen_subscription_trial_action">ເລີ່ມທົດລອງຟຣີ 14 ວັນ</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Atnaujinti į BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro siūlo geresnius rezultatus, daugiau funkcijų ir galimybių pažengusiems naudotojams.</string>
     <string name="upgrade_prompt_upgrade_action">Atnaujinti</string>
-    <string name="upgrade_screen_title">Atnaujinti į BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neturi reklamų ir neparduoda naudotojų duomenų. Mano darbas finansuojamas jūsų ❤️.</string>
     <string name="upgrade_screen_why_title">Privalumai</string>
     <string name="upgrade_screen_subscription_trial_action">Pradėti nemokamą 14 dienų bandomąjį laikotarpį</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -6,7 +6,6 @@
     <string name="upgrade_prompt_title">Jaunināt uz BSP Pro</string>
     <string name="upgrade_prompt_body">Bluetooth skaļuma pārvaldnieks Pro piedāvā labākus rezultātus, vairāk funkciju un opciju sapļrotājiem lietotājiem.</string>
     <string name="upgrade_prompt_upgrade_action">Jaunināt</string>
-    <string name="upgrade_screen_title">Jaunināt uz BSP Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth skaļuma pārvaldniekam nav reklāmu un tas nepardod lietotāju datus. Manu darbu finansiē jūs.</string>
     <string name="upgrade_screen_why_title">Priekšrocības</string>
     <string name="upgrade_screen_subscription_trial_action">Sāciet bezmaksas 14 dienu izmēģinājumu</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Надгради на BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro нуди подобри резултати, повеќе функции и опции за напредни корисници.</string>
     <string name="upgrade_prompt_upgrade_action">Надградба</string>
-    <string name="upgrade_screen_title">Надгради на BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклами и не продава кориснички податоци. Мојата работа е финансирана од вас ❤️.</string>
     <string name="upgrade_screen_why_title">Предности</string>
     <string name="upgrade_screen_subscription_trial_action">Започнете бесплатен пробен период од 14 дена</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro മികക്കല് മിക്ക ഫലം, പവർ ഉപയോക്താക്കൾക്ക് കൂടുതൽ ഫീച്ചർം ഓപ്ഷനുകളും നൽകുന്നു.</string>
     <string name="upgrade_prompt_upgrade_action">അപ്ഗ്രേഡുചെയ്യുക</string>
-    <string name="upgrade_screen_title">BVM Pro യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager പ്രജ്ഞാപനങ്ങൾ ഇല്ല, ഉപയോക്തൃ ഡേറ്റ വിൽക്കുന്നില്ല. എന്റെ ജോലി നിങ്ങൾ വഴി ധനസഹായം കിട്ടുന്നു ❤️.</string>
     <string name="upgrade_screen_why_title">പ്രയോജനങ്ങൾ</string>
     <string name="upgrade_screen_subscription_trial_action">സൗജന്യ 14-ദിവസ ട്രയൽ ആരംഭിക്കുക</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro рүү шилжээх</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro илүү үр дүн, илүү онцлог ба шинжлэх хэрэглэгчиддүгээр илүү сонголтыг саналддаг.</string>
     <string name="upgrade_prompt_upgrade_action">Сайжруулах</string>
-    <string name="upgrade_screen_title">BVM Pro рүү шилжээх</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager сурталчилгаагүй бөгөөд хэрэглэгчийн өгөгдлийг зардаггүй. Миний ажиллыг та нараар санхүүжнэ ❤️.</string>
     <string name="upgrade_screen_why_title">Давуу талууд</string>
     <string name="upgrade_screen_subscription_trial_action">14 хоногийн үнэ төлбөргүй туршилт эхлүүлэх</string>

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro वर अपग्रेड करा</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro शक्तिशाली वापरकर्त्यांसाठी चांगले परिणाम, अधिक वैशिष्ट्ये आणि पर्याय देते.</string>
     <string name="upgrade_prompt_upgrade_action">अपग्रेड करा</string>
-    <string name="upgrade_screen_title">BVM Pro वर अपग्रेड करा</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ला कोणतीही अॅड नाही आणि वापरकर्त्यांचा डेटा विकत नाही. माझे काम तुम्ही उचलवून अर्थपुरवठा केलेली आहे ❤️.</string>
     <string name="upgrade_screen_why_title">फायदे</string>
     <string name="upgrade_screen_subscription_trial_action">मोफत 14-दिवसांची चाचणी सुरू करा</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Naik taraf ke BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro menawarkan hasil yang lebih baik, lebih banyak ciri dan pilihan untuk pengguna berkuasa.</string>
     <string name="upgrade_prompt_upgrade_action">Naik taraf</string>
-    <string name="upgrade_screen_title">Naik taraf ke BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tiada iklan dan tidak menjual data pengguna. Kerja saya dibiayai oleh anda ❤️.</string>
     <string name="upgrade_screen_why_title">Kelebihan</string>
     <string name="upgrade_screen_subscription_trial_action">Mulakan percubaan 14 hari percuma</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro သို့ အဆင့်မြှင့်ပါ</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro သည် ပိုမိုကောင်းမွန်သော ရလဒ်များ၊ ပိုမိုများပြားသော လုပ်ဆောင်ချက်များနှင့် ကျွမ်းကျင်အသုံးပြုသူများအတွက် ရွေးချယ်စရာများကို ပေးပါသည်။</string>
     <string name="upgrade_prompt_upgrade_action">အဆင့်မြှင့်ပါ</string>
-    <string name="upgrade_screen_title">BVM Pro သို့ အဆင့်မြှင့်ပါ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager တွင် ကြော်ငြာများမရှိပါ၊ အသုံးပြုသူဒေတာများကိုလည်း မရောင်းချပါ။ ကျွန်ုပ်၏အလုပ်ကို သင်မှ ငွေကြေးထောက်ပံ့ထားပါသည် ❤️။</string>
     <string name="upgrade_screen_why_title">အကျိုးကျေးဇူးများ</string>
     <string name="upgrade_screen_subscription_trial_action">၁၄ ရက် အခမဲ့အစမ်းသုံးခြင်း စတင်မည်</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro मा अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ले शक्तिशाली प्रयोगकर्ताहरूका लागि राम्रो परिणाम, थप फिचरहरू र विकल्पहरू प्रदान गर्दछ।</string>
     <string name="upgrade_prompt_upgrade_action">अपग्रेड गर्नुहोस्</string>
-    <string name="upgrade_screen_title">BVM Pro मा अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager मा कुनै विज्ञापन छैन र यसले प्रयोगकर्ताको डेटा बাंड्दैन। मेरो काम तपाईंले गर्नुभएको आर्थिक सहयोगबाट चलिरहेको छ ❤️।</string>
     <string name="upgrade_screen_why_title">फाइदाहरू</string>
     <string name="upgrade_screen_subscription_trial_action">14-दिनको निःशुल्क परीक्षण सुरु गर्नुहोस्</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Upgrade naar BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro biedt betere resultaten, meer functies en opties voor hoofdgebruikers.</string>
     <string name="upgrade_prompt_upgrade_action">Upgraden</string>
-    <string name="upgrade_screen_title">Upgrade naar BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager bevat geen advertenties en verkoopt geen gebruikersgegevens. Mijn werk wordt door jou gefinancierd ❤️.</string>
     <string name="upgrade_screen_why_title">Voordelen</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis proefperiode van 14 dagen</string>

--- a/app/src/gplay/res/values-no/strings.xml
+++ b/app/src/gplay/res/values-no/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Oppgrader til BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro tilbyr bedre resultater, flere funksjoner og alternativer for avanserte brukere.</string>
     <string name="upgrade_prompt_upgrade_action">Oppgrader</string>
-    <string name="upgrade_screen_title">Oppgrader til BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen annonser og selger ikke brukerdata. Arbeidet mitt er finansiert av deg ❤️.</string>
     <string name="upgrade_screen_why_title">Fordeler</string>
     <string name="upgrade_screen_subscription_trial_action">Start 14-dagers gratis prøveperiode</string>

--- a/app/src/gplay/res/values-pcm-rNG/strings.xml
+++ b/app/src/gplay/res/values-pcm-rNG/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Upgrade to BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro dey give better results, more features and options for power users.</string>
     <string name="upgrade_prompt_upgrade_action">Upgrade</string>
-    <string name="upgrade_screen_title">Upgrade to BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no get ads and no dey sell user data. My work dey financed by you.</string>
     <string name="upgrade_screen_why_title">Advantages</string>
     <string name="upgrade_screen_subscription_trial_action">Start free 14-day trial</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Uaktualnij do BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferuje lepsze wyniki, więcej funkcji i opcji dla zaawansowanych użytkowników.</string>
     <string name="upgrade_prompt_upgrade_action">Ulepszenie</string>
-    <string name="upgrade_screen_title">Uaktualnij do BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nie zawiera reklam i nie sprzedaje danych użytkowników. Moja praca jest finansowana przez ciebie ❤️.</string>
     <string name="upgrade_screen_why_title">Zalety</string>
     <string name="upgrade_screen_subscription_trial_action">Rozpocznij bezpłatny 14-dniowy okres próbny</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Atualizar para BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferece melhores resultados, mais recursos e opções para usuários avançados.</string>
     <string name="upgrade_prompt_upgrade_action">Atualizar</string>
-    <string name="upgrade_screen_title">Atualizar para BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados do usuário. Meu trabalho é financiado por você ❤️.</string>
     <string name="upgrade_screen_why_title">Vantagens</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito de 14 dias</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Atualizar para BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferece melhores resultados, mais funcionalidades e opções para utilizadores avançados.</string>
     <string name="upgrade_prompt_upgrade_action">Atualizar</string>
-    <string name="upgrade_screen_title">Atualizar para BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados dos utilizadores. O meu trabalho é financiado por si ❤️.</string>
     <string name="upgrade_screen_why_title">Vantagens</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito de 14 dias</string>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Upgradar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro offra megliers resultats, pli blers featura ed opziuns per utilisaders avanzads.</string>
     <string name="upgrade_prompt_upgrade_action">Actualisar</string>
-    <string name="upgrade_screen_title">Upgradar a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n\'ha nagins annunzis e na venda betg las datas dals utilisaders. Mia lavur vegn finanziada da tai ❤️.</string>
     <string name="upgrade_screen_why_title">Avantatgs</string>
     <string name="upgrade_screen_subscription_trial_action">Cumenzar prova gratuita da 14 dis</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Actualizează la BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferă rezultate mai bune, mai multe funcții şi opțiuni pentru utilizatorii avanсați.</string>
     <string name="upgrade_prompt_upgrade_action">Actualizează</string>
-    <string name="upgrade_screen_title">Actualizează la BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nu are reclame şi nu vinde datele utilizatorilor. Munca mea este finanțată de tine ❤️.</string>
     <string name="upgrade_screen_why_title">Avantaje</string>
     <string name="upgrade_screen_subscription_trial_action">Începeți trial-ul gratuit 14 zile</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Обновить до BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro предлагает лучшие результаты, больше функций и опций для опытных пользователей.</string>
     <string name="upgrade_prompt_upgrade_action">Обновление</string>
-    <string name="upgrade_screen_title">Обновить до BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не содержит рекламы и не продаёт данные пользователей. Моя работа финансируется вами ❤️.</string>
     <string name="upgrade_screen_why_title">Преимущества</string>
     <string name="upgrade_screen_subscription_trial_action">Начать 14-дневный бесплатный период</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Addobba a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferit risultados mègius, prus caraterìsticas e optziones pro utentes avantzados.</string>
     <string name="upgrade_prompt_upgrade_action">Agiornare</string>
-    <string name="upgrade_screen_title">Addobba a BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non tenet publitzidade e non bendet datos de sos utentes. Su traballu meu est finantziadu dae bois ❤️.</string>
     <string name="upgrade_screen_why_title">Vantàgios</string>
     <string name="upgrade_screen_subscription_trial_action">Cumintza sa proa de badas de 14 dies</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro වෙත උත්‍යෝජනය කරන්න</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro වඩා හොඳ ප්‍රතිඵල, වැඩි විශේෂාංග සහ බලවත් පරිශීලකයින් සඳහා විකල්ප ලබා දෙයි.</string>
     <string name="upgrade_prompt_upgrade_action">වැඩිදියුණු කරන්න</string>
-    <string name="upgrade_screen_title">BVM Pro වෙත උත්‍යෝජනය කරන්න</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager හි දැන්වීම් නොමැති අතර පරිශීලක දත්ත විකුණන්නේ නැත. මගේ වැඩ ඔබ විසින් මූල්‍යාධාර සපයයි ❤️.</string>
     <string name="upgrade_screen_why_title">වාසි</string>
     <string name="upgrade_screen_subscription_trial_action">දින 14ක නොමිලේ අත්හදා බැලීම ආරම්භ කරන්න</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Prejsť na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ponúka lepšie výsledky, viac funkcií a možností pre náročných používateľov.</string>
     <string name="upgrade_prompt_upgrade_action">Upgrade</string>
-    <string name="upgrade_screen_title">Prejsť na BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nemá žiadne reklamy a nepredáva používateľské údaje. Moja práca je financovaná vami ❤️.</string>
     <string name="upgrade_screen_why_title">Výhody</string>
     <string name="upgrade_screen_subscription_trial_action">Spustite bezplatnú 14-dňovú skúšobnú verziu</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Nadgradite na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ponuja boljše rezultate, več funkcij in možnosti za napredne uporabnike.</string>
     <string name="upgrade_prompt_upgrade_action">Nadgradi</string>
-    <string name="upgrade_screen_title">Nadgradite na BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nima oglasov in ne prodaja uporabniških podatkov. Moje delo financirate vi ❤️.</string>
     <string name="upgrade_screen_why_title">Prednosti</string>
     <string name="upgrade_screen_subscription_trial_action">Začni 14-dnevni preizkus</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Përmirëso në BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofron rezultate më të mira, më shumë veçori dhe opsione për përdoruesit e fuqishëm.</string>
     <string name="upgrade_prompt_upgrade_action">Përmirëso</string>
-    <string name="upgrade_screen_title">Përmirëso në BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nuk ka reklama dhe nuk shet të dhënat e përdoruesit. Puna ime financohet nga ju ❤️.</string>
     <string name="upgrade_screen_why_title">Avantazhet</string>
     <string name="upgrade_screen_subscription_trial_action">Filloni provën falas 14-ditore</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Надогради на BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro нуди боље резултате, више функција и опција за искусне кориснике.</string>
     <string name="upgrade_prompt_upgrade_action">Надогради</string>
-    <string name="upgrade_screen_title">Надогради на BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклама и не продаје корисничке податке. Мој рад финансираш ти ❤️.</string>
     <string name="upgrade_screen_why_title">Предности</string>
     <string name="upgrade_screen_subscription_trial_action">Започни бесплатни 14-дневни пробни период</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Uppgradera till BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro erbjuder bättre resultat, fler funktioner och alternativ för avancerade användare.</string>
     <string name="upgrade_prompt_upgrade_action">Uppgradera</string>
-    <string name="upgrade_screen_title">Uppgradera till BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har inga annonser och säljer inte användardata. Mitt arbete finansieras av dig ❤️.</string>
     <string name="upgrade_screen_why_title">Fördelar</string>
     <string name="upgrade_screen_subscription_trial_action">Starta gratis 14-dagars test</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Boresha hadi BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro inatoa matokeo bora zaidi, vipengele vingi zaidi na chaguzi kwa watumiaji wa hali ya juu.</string>
     <string name="upgrade_prompt_upgrade_action">Boresha</string>
-    <string name="upgrade_screen_title">Boresha hadi BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager haina matangazo na haiuzi data ya mtumiaji. Kazi yangu inafadhiliwa na wewe ❤️.</string>
     <string name="upgrade_screen_why_title">Faida</string>
     <string name="upgrade_screen_subscription_trial_action">Anza majaribio ya bure ya siku 14</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Proக்கு மேம்படுத்து</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro சிறந்த தர்வ்ூதல்கள், மேலும் அனுபவம், மேலும் அமைப்்புகள் மற்றும் சக்தியான பயனர்களுக்கான விருப்பங்களை வாயில் வளர்கிறது.</string>
     <string name="upgrade_prompt_upgrade_action">மேம்படுத்து</string>
-    <string name="upgrade_screen_title">BVM Proக்கு மேம்படுத்து</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager விளம்பரங்கள் இல்லாதது மற்றும் பயனர் தரவுகளை விற்கவிற்கை இல்லை. என் பணியின் நிதியம் உங்களால் வழங்கப்படுகிறது.</string>
     <string name="upgrade_screen_why_title">நன்மைகள்</string>
     <string name="upgrade_screen_subscription_trial_action">இலவச 14-நாள் சோதனையைத் தொடங்கு</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro కి అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro మెరుగైన ఫలితాలు, మరిన్ని ఫీచర్లు మరియు పవర్ యూజర్ల కోసం ఆప్షన్లను అందిస్తుంది.</string>
     <string name="upgrade_prompt_upgrade_action">అప్‌గ్రేడ్ చేయండి</string>
-    <string name="upgrade_screen_title">BVM Pro కి అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager కి ప్రకటనలు లేవు మరియు వినియోగదారు డేటాను విక్రయించదు. నా పని మీరు ఆర్థిక సహాయం చేస్తున్నారు ❤️.</string>
     <string name="upgrade_screen_why_title">ప్రయోజనాలు</string>
     <string name="upgrade_screen_subscription_trial_action">ఉచిత 14-రోజుల ట్రయల్ ప్రారంభించండి</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">อัปเกรดเป็น BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ให้ผลลัพธ์ที่ดีกว่า ฟีเจอร์เพิ่มเติม และตัวเลือกสำหรับผู้ใช้ขั้นสูง</string>
     <string name="upgrade_prompt_upgrade_action">อัปเกรด</string>
-    <string name="upgrade_screen_title">อัปเกรดเป็น BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ไม่มีโฆษณาและไม่ขายข้อมูลผู้ใช้ งานของฉันได้รับการสนับสนุนทางการเงินจากคุณ ❤️</string>
     <string name="upgrade_screen_why_title">ข้อดี</string>
     <string name="upgrade_screen_subscription_trial_action">เริ่มทดลองใช้ฟรี 14 วัน</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro\'ya Yükselt</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro, uzman kullanıcılar için daha iyi sonuçlar, daha fazla özellik ve seçenek sunar.</string>
     <string name="upgrade_prompt_upgrade_action">Yükselt</string>
-    <string name="upgrade_screen_title">BVM Pro\'ya Yükselt</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklam içermez ve kullanıcı verilerini satmaz. Çalışmalarım sizler tarafından finanse edilmektedir ❤️.</string>
     <string name="upgrade_screen_why_title">Avantajlar</string>
     <string name="upgrade_screen_subscription_trial_action">14 günlük ücretsiz denemeyi başlatın</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Оновити до BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro пропонує кращі результати, більше функцій та опцій для досвідчених користувачів.</string>
     <string name="upgrade_prompt_upgrade_action">Підвищити статус</string>
-    <string name="upgrade_screen_title">Оновити до BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не має реклами та не продає дані користувачів. Моя робота фінансується вами ❤️.</string>
     <string name="upgrade_screen_why_title">Переваги</string>
     <string name="upgrade_screen_subscription_trial_action">Розпочати безкоштовний 14-денний пробний період</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro میں اپ گریڈ کریں</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro بہتر نتائج، زیادہ خصوصیات اور پاور یوزرز کے لیے آپشنز پیش کرتا ہے۔</string>
     <string name="upgrade_prompt_upgrade_action">اپ گریڈ کریں</string>
-    <string name="upgrade_screen_title">BVM Pro میں اپ گریڈ کریں</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager میں کوئی اشتہار نہیں ہے اور یہ صارف کا ڈیٹا فروخت نہیں کرتا۔ میرا کام آپ کی وجہ سے فنڈ ہوتا ہے ❤️۔</string>
     <string name="upgrade_screen_why_title">فوائد</string>
     <string name="upgrade_screen_subscription_trial_action">14 دن کی مفت آزمائش شروع کریں</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">BVM Pro ga o\'tish</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro quvvatli foydalanuvchilar uchun yaxshiroq natijalar, ko\'proq funksiyalar va opsiyalar taklif qiladi.</string>
     <string name="upgrade_prompt_upgrade_action">Yangilash</string>
-    <string name="upgrade_screen_title">BVM Pro ga o\'tish</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklamasiz va foydalanuvchi ma\'lumotlarini sotmaydi. Mening ishim siz tomonidan moliyalashtiriladi ❤️.</string>
     <string name="upgrade_screen_why_title">Afzalliklar</string>
     <string name="upgrade_screen_subscription_trial_action">Bepul 14 kunlik sinovni boshlang</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Nâng cấp lên BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro mang lại kết quả tốt hơn, nhiều tính năng và tùy chọn hơn cho người dùng.</string>
     <string name="upgrade_prompt_upgrade_action">Nâng cấp</string>
-    <string name="upgrade_screen_title">Nâng cấp lên BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager không có quảng cáo và không bán dữ liệu người dùng. Công việc của tôi được tài trợ bởi bạn ❤️.</string>
     <string name="upgrade_screen_why_title">Lợi thế</string>
     <string name="upgrade_screen_subscription_trial_action">Bắt đầu dùng thử 14 ngày miễn phí</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">升级至 BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro 为高级用户提供更好的效果、更多的功能和选项。</string>
     <string name="upgrade_prompt_upgrade_action">升级</string>
-    <string name="upgrade_screen_title">升级至 BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 没有广告，也不出售用户数据。我的工作由您资助 ❤️。</string>
     <string name="upgrade_screen_why_title">优点</string>
     <string name="upgrade_screen_subscription_trial_action">开始 14 天免费试用</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">升級到 BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro 為進階用戶提供更好的效果、更多功能和選項。</string>
     <string name="upgrade_prompt_upgrade_action">升級</string>
-    <string name="upgrade_screen_title">升級到 BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不出售用戶數據。我的工作由你支持 ❤️。</string>
     <string name="upgrade_screen_why_title">優點</string>
     <string name="upgrade_screen_subscription_trial_action">開始 14 天免費試用</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">升級至 BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro 提供更佳的結果、更多的功能和選項，適用於進階使用者。</string>
     <string name="upgrade_prompt_upgrade_action">升級</string>
-    <string name="upgrade_screen_title">升級至 BVM Pro</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不會出售使用者資料。我的工作由你贊助 ❤️。</string>
     <string name="upgrade_screen_why_title">優點</string>
     <string name="upgrade_screen_subscription_trial_action">開始 14 天免費試用</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -7,7 +7,6 @@
     <string name="upgrade_prompt_title">Buyekeza kuya ku-BVM Pro</string>
     <string name="upgrade_prompt_body">I-Bluetooth Volume Manager Pro inikezela imiphumela engcono, izici ezengeziwe nezinketho zabasebenzisi abaphakeme.</string>
     <string name="upgrade_prompt_upgrade_action">Thuthukisa</string>
-    <string name="upgrade_screen_title">Buyekeza kuya ku-BVM Pro</string>
     <string name="upgrade_screen_preamble">I-Bluetooth Volume Manager ayinazo izikhangiso futhi ayithengisi idatha yabasebenzisi. Umsebenzi wami uxhaswa nguwe ❤️.</string>
     <string name="upgrade_screen_why_title">Izinzuzo</string>
     <string name="upgrade_screen_subscription_trial_action">Qala ukuhlola kwamahhala kwezinsuku eziyi-14</string>

--- a/app/src/gplay/res/values/colors.xml
+++ b/app/src/gplay/res/values/colors.xml
@@ -1,3 +1,0 @@
-<resources>
-    <color name="colorUpgraded">#00b8d4</color>
-</resources>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -10,7 +10,8 @@
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro offers better results, more features and options for power users.</string>
     <string name="upgrade_prompt_upgrade_action">Upgrade</string>
 
-    <string name="upgrade_screen_title">Upgrade to BVM Pro</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Upgrade to %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager has no ads and doesn\'t sell user data. My work is financed by you ❤️.</string>
     <string name="upgrade_screen_why_title">Advantages</string>
     <string name="upgrade_screen_subscription_trial_action">Start free 14-day trial</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -69,7 +69,7 @@
     <string name="upgrade_screen_offers_title">Upgrade options</string>
     <string name="upgrade_screen_offers_body">Both options unlock the exact same Pro features — pick whichever suits you.</string>
     <string name="upgrade_screen_offers_unavailable_title">Prices unavailable</string>
-    <string name="upgrade_screen_offers_unavailable_message">Google Play didn\'t return any prices right now. Give it a moment and tap retry.</string>
+    <string name="upgrade_screen_offers_unavailable_message">Prices couldn\'t be loaded right now. Check Google Play and try again in a moment.</string>
     <string name="upgrade_screen_benefits_body">• Unlimited devices\n• Custom connection actions\n• Theme customization\n• Advanced volume controls\n• Support future development ❤️</string>
     <string name="upgrade_screen_subscription_offer_title">Yearly subscription</string>
     <string name="upgrade_screen_subscription_offer_body">Starts with a free trial, then renews yearly. Cancel anytime in Google Play.</string>

--- a/app/src/main/java/eu/darken/bluemusic/common/error/ErrorDialog.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/error/ErrorDialog.kt
@@ -61,7 +61,7 @@ fun ErrorDialog(throwable: Throwable, onDismiss: () -> Unit) {
 
                 localizedError.fixAction?.let { action ->
                     TextButton(onClick = onDismiss) {
-                        Text(stringResource(R.string.general_cancel_action))
+                        Text(stringResource(R.string.general_dismiss_action))
                     }
                     Spacer(modifier = Modifier.width(8.dp))
                     TextButton(

--- a/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeContent.kt
@@ -4,6 +4,7 @@ import androidx.annotation.StringRes
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.PaddingValues
@@ -19,7 +20,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.twotone.CheckCircle
-import androidx.compose.material.icons.twotone.Stars
 import androidx.compose.material.icons.twotone.WarningAmber
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
@@ -42,6 +42,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
@@ -49,9 +50,13 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.compose.BlueMusicIcon
+import eu.darken.bluemusic.common.compose.Preview2
+import eu.darken.bluemusic.common.compose.PreviewWrapper
 
 internal object UpgradeScreenTags {
     const val LOADING = "upgrade_loading"
@@ -78,10 +83,14 @@ internal object UpgradeScreenTags {
     const val GPLAY_GRACE_SPINNER = "upgrade_gplay_grace_spinner"
     const val GPLAY_GRACE_RESTORE = "upgrade_gplay_grace_restore"
 
-    // Acquisition-header mood (replaces the sdm mascot's happy/grumpy states: BlueMusic has no
-    // mascot). Calm badge while nothing is wrong, attention badge once a grace episode aged.
+    // Acquisition-header mood. The calm state is the app icon itself, the attention state a warning
+    // badge once a grace episode aged. Both tags stay on the STANDALONE header — the hero card
+    // brings its own, flavor-neutral icon tag.
     const val GPLAY_HEADER_CALM = "upgrade_gplay_header_calm"
     const val GPLAY_HEADER_ATTENTION = "upgrade_gplay_header_attention"
+
+    const val HERO = "upgrade_hero"
+    const val HERO_ICON = "upgrade_hero_icon"
 }
 
 // Composed app title with the flavor postfix highlighted while the upgrade is active — the same
@@ -198,9 +207,9 @@ internal fun UpgradeScreenContent(
     }
 }
 
-// BlueMusic has no mascot: the acquisition header is a themed status badge instead of the sdm
-// mascot. [happy] carries the same mood the mascot used to — a calm Pro badge while nothing is
-// wrong, an attention badge once a grace episode has aged into its diagnostics stage.
+// The standalone header carries the same mood the fleet's mascot does: the app icon while nothing
+// is wrong, a warning badge once a grace episode has aged into its diagnostics stage. That warning
+// badge is the ONLY place a non-icon graphic survives — everywhere else the icon is the mascot.
 @Composable
 internal fun UpgradeHeader(
     modifier: Modifier = Modifier,
@@ -214,36 +223,152 @@ internal fun UpgradeHeader(
             color = MaterialTheme.colorScheme.secondaryContainer.copy(alpha = 0.35f),
             shape = CircleShape,
         ) {
-            Icon(
-                imageVector = if (happy) Icons.TwoTone.Stars else Icons.TwoTone.WarningAmber,
-                contentDescription = null,
-                tint = if (happy) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
-                modifier = Modifier
-                    .padding(20.dp)
-                    .size(56.dp)
-                    .testTag(if (happy) UpgradeScreenTags.GPLAY_HEADER_CALM else UpgradeScreenTags.GPLAY_HEADER_ATTENTION),
-            )
+            if (happy) {
+                BlueMusicIcon(
+                    size = 56.dp,
+                    modifier = Modifier
+                        .padding(20.dp)
+                        .testTag(UpgradeScreenTags.GPLAY_HEADER_CALM),
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.TwoTone.WarningAmber,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.error,
+                    modifier = Modifier
+                        .padding(20.dp)
+                        .size(56.dp)
+                        .testTag(UpgradeScreenTags.GPLAY_HEADER_ATTENTION),
+                )
+            }
         }
     }
 }
 
+private val HERO_GAP = 16.dp
+
+// Below this much room for the copy the side-by-side split stops paying for itself: measured on a
+// 320dp screen at 200% font, the row wrapped the preamble over 10 lines (breaking a word mid-way)
+// and came out TALLER than stacking, which needs 6. Scaled by fontScale because the squeeze comes
+// from text size as much as from screen width — at 200% font even a normal-width phone must stack.
+private val HERO_MIN_TEXT_WIDTH = 150.dp
+
+// The screen opener: app icon and preamble in one card instead of a floating badge stacked on a
+// separate text box. Side-by-side keeps the icon at eye level with the copy it introduces, and buys
+// back the vertical space the standalone header used to spend above the fold — but only while the
+// copy still has room to breathe, hence the stacked fallback.
 @Composable
-internal fun UpgradePreambleCard(
+internal fun UpgradeHeroCard(
     text: String,
     modifier: Modifier = Modifier,
+    iconSize: Dp = 88.dp,
     colors: CardColors = CardDefaults.elevatedCardColors(),
 ) {
     ElevatedCard(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag(UpgradeScreenTags.HERO),
         colors = colors,
     ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.bodyMedium,
+        BoxWithConstraints(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(16.dp),
-        )
+                .padding(8.dp)
+                .padding(end = 8.dp),
+        ) {
+            val minTextWidth = HERO_MIN_TEXT_WIDTH * LocalDensity.current.fontScale
+            if (maxWidth - iconSize - HERO_GAP < minTextWidth) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                ) {
+                    BlueMusicIcon(
+                        size = iconSize,
+                        modifier = Modifier.testTag(UpgradeScreenTags.HERO_ICON),
+                    )
+                    Text(
+                        text = text,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
+            } else {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(HERO_GAP),
+                ) {
+                    BlueMusicIcon(
+                        size = iconSize,
+                        modifier = Modifier.testTag(UpgradeScreenTags.HERO_ICON),
+                    )
+                    Text(
+                        text = text,
+                        style = MaterialTheme.typography.bodyMedium,
+                        modifier = Modifier.weight(1f),
+                    )
+                }
+            }
+        }
+    }
+}
+
+// Preview copy matches the shipped preamble in length: the icon/text split only reads correctly if
+// the text wraps like it does in the app.
+private const val PREVIEW_PREAMBLE =
+    "Bluetooth Volume Manager has no ads and doesn't sell user data. My work is financed by you ❤️."
+
+@Preview2
+@Composable
+private fun UpgradeHeroCardPreview() {
+    PreviewWrapper {
+        Column(modifier = Modifier.padding(16.dp)) {
+            UpgradeHeroCard(text = PREVIEW_PREAMBLE)
+        }
+    }
+}
+
+// Preview2 only varies light/dark, so it can never reach the stacked branch. These two pin the
+// thresholds that flip it: a narrow screen, and a normal-width screen at 200% font. 280dp, not
+// 320dp: at 320dp the text still gets ~160dp once the paddings come off, so the row survives.
+@Preview(showBackground = true, name = "Compact width", widthDp = 280)
+@Preview(showBackground = true, name = "Huge font", fontScale = 2f)
+@Composable
+private fun UpgradeHeroCardCompactPreview() {
+    PreviewWrapper {
+        Column(modifier = Modifier.padding(16.dp)) {
+            UpgradeHeroCard(text = PREVIEW_PREAMBLE)
+        }
+    }
+}
+
+// Both flavors tint the hero: FOSS on primaryContainer, GPLAY on secondaryContainer. Neither is
+// the composable's default, so the default-colored preview above would not catch a contrast
+// regression on the colors that actually ship.
+@Preview2
+@Composable
+private fun UpgradeHeroCardTintedPreview() {
+    PreviewWrapper {
+        Column(
+            modifier = Modifier.padding(16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+        ) {
+            UpgradeHeroCard(
+                text = PREVIEW_PREAMBLE,
+                colors = CardDefaults.elevatedCardColors(
+                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onPrimaryContainer,
+                ),
+            )
+            UpgradeHeroCard(
+                text = PREVIEW_PREAMBLE,
+                colors = CardDefaults.elevatedCardColors(
+                    containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                    contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+                ),
+            )
+        }
     }
 }
 

--- a/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeContent.kt
@@ -2,6 +2,7 @@ package eu.darken.bluemusic.upgrade.ui
 
 import androidx.annotation.StringRes
 import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -21,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.twotone.CheckCircle
 import androidx.compose.material.icons.twotone.WarningAmber
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CenterAlignedTopAppBar
@@ -29,6 +31,7 @@ import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
@@ -587,5 +590,60 @@ internal fun UpgradeInlineStateCard(
             color = MaterialTheme.colorScheme.onErrorContainer,
         )
         content()
+    }
+}
+
+@Preview2
+@Composable
+private fun UpgradeInlineStateCardPreview() {
+    PreviewWrapper {
+        Column(modifier = Modifier.padding(16.dp)) {
+            UpgradeInlineStateCard(
+                title = "Prices unavailable",
+                body = "Prices couldn't be loaded right now. Check Google Play and try again in a moment.",
+                icon = Icons.TwoTone.WarningAmber,
+            ) {
+                OutlinedButton(
+                    onClick = {},
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        disabledContentColor = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.38f),
+                    ),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.onErrorContainer),
+                ) {
+                    Text("Retry")
+                }
+            }
+        }
+    }
+}
+
+// The latched state the card shows after the retry was tapped: the contrast of a DISABLED button on
+// errorContainer is the part the default theming gets wrong, so it needs its own preview.
+@Preview2
+@Composable
+private fun UpgradeInlineStateCardDisabledActionPreview() {
+    PreviewWrapper {
+        Column(modifier = Modifier.padding(16.dp)) {
+            UpgradeInlineStateCard(
+                title = "Prices unavailable",
+                body = "Prices couldn't be loaded right now. Check Google Play and try again in a moment.",
+                icon = Icons.TwoTone.WarningAmber,
+            ) {
+                OutlinedButton(
+                    onClick = {},
+                    enabled = false,
+                    modifier = Modifier.fillMaxWidth(),
+                    colors = ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                        disabledContentColor = MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.38f),
+                    ),
+                    border = BorderStroke(1.dp, MaterialTheme.colorScheme.onErrorContainer.copy(alpha = 0.1f)),
+                ) {
+                    Text("Retry")
+                }
+            }
+        }
     }
 }

--- a/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeContent.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
@@ -85,15 +84,42 @@ internal object UpgradeScreenTags {
     const val GPLAY_HEADER_ATTENTION = "upgrade_gplay_header_attention"
 }
 
-// Composed app title with the flavor postfix highlighted in the upgraded color while Pro is
-// active — the same treatment the dashboard title uses.
+// Composed app title with the flavor postfix highlighted while the upgrade is active — the same
+// "BVM Pro" the dashboard shows, in the theme's tertiary role instead of a raw brand hex.
+// Appended, not split out of a single composed string: a substring search would silently lose the
+// highlight in every locale whose translation words the composed name differently, while the short
+// brand name is untranslated and the postfix is its own resource in every locale.
 @Composable
 internal fun upgradeScreenTitle(upgraded: Boolean): AnnotatedString = buildAnnotatedString {
-    append(stringResource(R.string.app_name))
+    append(stringResource(R.string.app_name_short))
     append(" ")
-    if (upgraded) pushStyle(SpanStyle(color = colorResource(R.color.colorUpgraded)))
+    if (upgraded) pushStyle(SpanStyle(color = MaterialTheme.colorScheme.tertiary))
     append(stringResource(R.string.app_name_upgrade_postfix))
     if (upgraded) pop()
+}
+
+// Marker char for brand-title splicing: formatted into the translated pattern via the normal
+// Android format path (so %1$s vs %s, argument reordering, and %% all behave), then replaced
+// with the styled brand. U+FFFC (object replacement) cannot occur in a real translation.
+internal const val BRAND_TITLE_MARKER = "￼"
+
+internal fun spliceBrandTitle(formatted: String, brand: AnnotatedString): AnnotatedString = buildAnnotatedString {
+    var rest = formatted
+    var found = false
+    while (true) {
+        val idx = rest.indexOf(BRAND_TITLE_MARKER)
+        if (idx < 0) break
+        found = true
+        append(rest.substring(0, idx))
+        append(brand)
+        rest = rest.substring(idx + BRAND_TITLE_MARKER.length)
+    }
+    append(rest)
+    if (!found) {
+        // Defensive: a translation that lost its placeholder still shows the brand.
+        append(" ")
+        append(brand)
+    }
 }
 
 @Composable

--- a/app/src/testFoss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFossTest.kt
+++ b/app/src/testFoss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFossTest.kt
@@ -1,12 +1,50 @@
 package eu.darken.bluemusic.upgrade.core
 
+import eu.darken.bluemusic.common.datastore.DataStoreValue
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
+import java.io.IOException
 import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
 
 class UpgradeRepoFossTest : BaseTest() {
+
+    private val record = FossUpgrade(
+        upgradedAt = Instant.EPOCH,
+        upgradeType = FossUpgrade.Type.GITHUB_SPONSORS,
+    )
+
+    private fun createUpgradeValue(cacheFlow: Flow<FossUpgrade?>) = mockk<DataStoreValue<FossUpgrade?>>().apply {
+        every { flow } returns cacheFlow
+        coEvery { update(any()) } returns DataStoreValue.Updated(old = null, new = record)
+    }
+
+    // Real dispatchers, not a test scheduler: the shareIn sharing coroutine and the collectors have
+    // to actually interleave here, and the whole point is that a failure settles instead of hanging.
+    private fun createRepo(appScope: CoroutineScope, upgradeValue: DataStoreValue<FossUpgrade?>) = UpgradeRepoFoss(
+        scope = appScope,
+        fossCache = mockk<FossCache>().apply { every { upgrade } returns upgradeValue },
+        webpageTool = mockk(),
+    )
 
     @Test
     fun `upgrade info maps the pro status and the foss type`() {
@@ -28,6 +66,149 @@ class UpgradeRepoFossTest : BaseTest() {
             isPro shouldBe true
             upgradedAt shouldBe Instant.EPOCH
             fossUpgradeType shouldBe FossUpgrade.Type.GITHUB_SPONSORS
+        }
+    }
+
+    @Test
+    fun `a failing cache read surfaces as a settled error Info instead of hanging`(): Unit = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val repo = createRepo(scope, createUpgradeValue(flow { throw IOException("cache broken") }))
+
+            withTimeout(10_000) {
+                repo.upgradeInfo.first().apply {
+                    // Type and message: a bare non-null check would also pass on a swallow-and-wrap.
+                    error.shouldBeInstanceOf<IOException>().message shouldBe "cache broken"
+                    isPro shouldBe false
+                    // The UI must be able to render this: an unsettled error is an endless spinner.
+                    isSettled shouldBe true
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a late cache failure keeps the last known entitlement`(): Unit = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val repo = createRepo(scope, createUpgradeValue(flow {
+                emit(record)
+                throw IOException("cache broken later")
+            }))
+
+            withTimeout(10_000) {
+                val infos = repo.upgradeInfo.take(2).toList()
+
+                infos[0].apply {
+                    isPro shouldBe true
+                    error shouldBe null
+                }
+                // The entitlement we already saw must survive the read failure - a revoked Pro
+                // status would kick a paying supporter back to the pitch.
+                infos[1].apply {
+                    isPro shouldBe true
+                    error.shouldBeInstanceOf<IOException>()
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a successful persist revives an error-stuck upgradeInfo`(): Unit = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            // First subscription fails, later ones read fine: the store recovered, but the shared
+            // flow is still replaying the error Info to everyone.
+            val subscriptions = AtomicInteger(0)
+            val upgradeValue = createUpgradeValue(flow {
+                if (subscriptions.getAndIncrement() == 0) throw IOException("cache broken")
+                emit(record)
+            })
+            val repo = createRepo(scope, upgradeValue)
+            // Default backoff (30s and up): the revival must NOT be the retry loop waking up.
+
+            val received = Channel<UpgradeRepo.Info>(Channel.UNLIMITED)
+            scope.launch { repo.upgradeInfo.collect { received.send(it) } }
+
+            withTimeout(10_000) {
+                received.receive().error.shouldBeInstanceOf<IOException>()
+
+                // No explicit refresh() from the test: persist has to do the reviving itself,
+                // otherwise the user's unlock never reaches the screen they are looking at.
+                repo.persistUpgrade() shouldBe true
+
+                received.receive().apply {
+                    isPro shouldBe true
+                    error shouldBe null
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `the automatic retry recovers once the store heals`(): Unit = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val subscriptions = AtomicInteger(0)
+            val upgradeValue = createUpgradeValue(flow {
+                if (subscriptions.getAndIncrement() == 0) throw IOException("cache broken")
+                emit(record)
+            })
+            val repo = createRepo(scope, upgradeValue)
+            // Nobody is going to tap anything: the backoff loop itself has to bring the entitlement
+            // back. Shrunk so the test doesn't sit out the shipped 30s first delay.
+            repo.retryDelayMs = { 10L }
+
+            withTimeout(10_000) {
+                val infos = repo.upgradeInfo.take(2).toList()
+
+                infos[0].error.shouldBeInstanceOf<IOException>()
+                // No refresh(), no persist() - the automatic attempt after the backoff did this.
+                infos[1].apply {
+                    isPro shouldBe true
+                    error shouldBe null
+                }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `refresh recovers immediately instead of waiting out the backoff`(): Unit = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            val subscriptions = AtomicInteger(0)
+            val upgradeValue = createUpgradeValue(flow {
+                if (subscriptions.getAndIncrement() == 0) throw IOException("cache broken")
+                emit(record)
+            })
+            val repo = createRepo(scope, upgradeValue)
+            // Longer than the test could ever wait: if refresh() did not cancel the in-flight
+            // backoff, this test would time out - which is exactly the old shape's dead window.
+            repo.retryDelayMs = { 10 * 60_000L }
+
+            val received = Channel<UpgradeRepo.Info>(Channel.UNLIMITED)
+            scope.launch { repo.upgradeInfo.collect { received.send(it) } }
+
+            withTimeout(10_000) {
+                received.receive().error.shouldBeInstanceOf<IOException>()
+
+                repo.refresh()
+
+                received.receive().apply {
+                    isPro shouldBe true
+                    error shouldBe null
+                }
+            }
+        } finally {
+            scope.cancel()
         }
     }
 }

--- a/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeScreenTest.kt
@@ -25,10 +25,10 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
-    // The build-branded title: app_name plus the flavor postfix, exactly what the shared title
-    // helper composes. Asserted from resources, never as a hardcoded literal.
+    // The build-branded title: the short app name plus the flavor postfix, exactly what the shared
+    // title helper composes. Asserted from resources, never as a hardcoded literal.
     private val composedFlavorTitle: String
-        get() = "${context.getString(R.string.app_name)} ${context.getString(R.string.app_name_upgrade_postfix)}"
+        get() = "${context.getString(R.string.app_name_short)} ${context.getString(R.string.app_name_upgrade_postfix)}"
 
     @Test
     fun `renders the pitch content without a duplicated app bar title`() {

--- a/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeScreenTest.kt
+++ b/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeScreenTest.kt
@@ -44,6 +44,11 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithText(firstFeatureLine(context, R.string.upgrade_screen_why_body)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_sponsor_action_hint)).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(1)
+        // Preamble and app icon ship together in the pitch hero card: one hero, one icon, and no
+        // leftover standalone header above it.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO_ICON).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_HEADER_CALM).assertCountEquals(0)
     }
 
     @Test
@@ -73,6 +78,9 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_preamble)).assertCountEquals(0)
+        // Status views have no preamble to pair the icon with: standalone header, no hero card.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_HEADER_CALM).assertCountEquals(1)
     }
 
     @Test
@@ -109,6 +117,9 @@ class FossUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_DONATE).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SHOW_OPTIONS).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.FOSS_SPONSOR).assertCountEquals(0)
+        // Status views have no preamble to pair the icon with: standalone header, no hero card.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_HEADER_CALM).assertCountEquals(1)
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/bluemusic/common/error/ComposeErrorDialogTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/common/error/ComposeErrorDialogTest.kt
@@ -1,0 +1,114 @@
+package eu.darken.bluemusic.common.error
+
+import android.content.Context
+import android.provider.Settings
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.flow.SingleEventFlow
+import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The shared error dialog: an error that offers a way out gets its own action plus a dismiss, and
+ * everything else must keep the acknowledge-only shape — [ErrorEventHandler] backs every screen.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ComposeErrorDialogTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private class FakeErrorSource : ErrorEventSource {
+        override val errorEvents = SingleEventFlow<Throwable>()
+    }
+
+    private fun showError(error: Throwable) {
+        val source = FakeErrorSource()
+        composeRule.setContent {
+            PreviewWrapper {
+                ErrorEventHandler(source)
+            }
+        }
+        // Buffered channel: the event survives until the handler's collector attaches.
+        source.errorEvents.tryEmit(error)
+        composeRule.waitForIdle()
+    }
+
+    @Test
+    fun `a fixable error offers its action next to a dismiss`() {
+        showError(GplayServiceUnavailableException(RuntimeException("Play hiccup")))
+
+        composeRule.onNodeWithText(context.getString(R.string.upgrades_gplay_unavailable_error_title)).assertExists()
+        composeRule.onNodeWithText(context.getString(R.string.upgrades_gplay_unavailable_error_description))
+            .assertExists()
+        composeRule.onNodeWithText("Google Play").assertExists()
+        composeRule.onNodeWithText(context.getString(R.string.general_dismiss_action)).assertExists()
+        // Nothing is being cancelled or merely acknowledged here.
+        composeRule.onAllNodesWithText(context.getString(R.string.general_cancel_action)).assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(android.R.string.ok)).assertCountEquals(0)
+    }
+
+    @Test
+    fun `the fix action opens Google Play's app info and closes the dialog`() {
+        showError(GplayServiceUnavailableException(RuntimeException("Play hiccup")))
+
+        composeRule.onNodeWithText("Google Play").performClick()
+        composeRule.waitForIdle()
+
+        val started = shadowOf(composeRule.activity).nextStartedActivity.shouldNotBeNull()
+        started.action shouldBe Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+        started.data.toString() shouldBe "package:com.android.vending"
+        // The user acted: leaving the dialog up would greet them again on the way back.
+        composeRule.onAllNodesWithText("Google Play").assertCountEquals(0)
+    }
+
+    @Test
+    fun `dismissing closes the dialog without launching anything`() {
+        showError(GplayServiceUnavailableException(RuntimeException("Play hiccup")))
+
+        composeRule.onNodeWithText(context.getString(R.string.general_dismiss_action)).performClick()
+        composeRule.waitForIdle()
+
+        composeRule.onAllNodesWithText(context.getString(R.string.general_dismiss_action)).assertCountEquals(0)
+        shadowOf(composeRule.activity).nextStartedActivity shouldBe null
+    }
+
+    @Test
+    fun `an ordinary error keeps the acknowledge-only dialog`() {
+        // The handler is shared by every screen: the fix/dismiss pair must stay exclusive to errors
+        // that actually carry a fix action.
+        showError(RuntimeException("something went wrong"))
+
+        composeRule.onNodeWithText(context.getString(android.R.string.ok)).assertExists()
+        composeRule.onAllNodesWithText(context.getString(R.string.general_dismiss_action)).assertCountEquals(0)
+        composeRule.onAllNodesWithText("Google Play").assertCountEquals(0)
+    }
+
+    @Test
+    fun `the unavailable-billing error carries a fix action`() {
+        val localized = GplayServiceUnavailableException(RuntimeException("Play hiccup")).getLocalizedError()
+
+        localized.fixActionLabel?.get(context) shouldBe "Google Play"
+        localized.fixAction.shouldNotBeNull()
+    }
+}

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/BrandTitleSpliceTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/BrandTitleSpliceTest.kt
@@ -1,0 +1,73 @@
+package eu.darken.bluemusic.upgrade.ui
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+/**
+ * The brand is spliced into the already-formatted translation, so the styled postfix has to land on
+ * the right offsets no matter where the pattern put the placeholder.
+ */
+class BrandTitleSpliceTest : BaseTest() {
+
+    private val brandColor = Color.Red
+
+    // "BVM Pro" with the postfix (4..7) colored, like upgradeScreenTitle(upgraded = true).
+    private val brand: AnnotatedString = buildAnnotatedString {
+        append("BVM ")
+        pushStyle(SpanStyle(color = brandColor))
+        append("Pro")
+        pop()
+    }
+
+    @Test
+    fun `marker in the middle shifts the styled postfix by the prefix`() {
+        val result = spliceBrandTitle("Upgrade to $BRAND_TITLE_MARKER", brand)
+
+        result.text shouldBe "Upgrade to BVM Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe brandColor
+        result.spanStyles.single().start shouldBe 15
+        result.spanStyles.single().end shouldBe 18
+        result.text.substring(15, 18) shouldBe "Pro"
+    }
+
+    @Test
+    fun `marker at the start keeps the postfix offsets inside the brand`() {
+        val result = spliceBrandTitle("$BRAND_TITLE_MARKER holen", brand)
+
+        result.text shouldBe "BVM Pro holen"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().start shouldBe 4
+        result.spanStyles.single().end shouldBe 7
+        result.text.substring(4, 7) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a duplicated marker renders the brand twice`() {
+        val result = spliceBrandTitle("$BRAND_TITLE_MARKER und $BRAND_TITLE_MARKER", brand)
+
+        result.text shouldBe "BVM Pro und BVM Pro"
+        result.spanStyles.size shouldBe 2
+        result.spanStyles[0].start shouldBe 4
+        result.spanStyles[0].end shouldBe 7
+        result.spanStyles[1].start shouldBe 16
+        result.spanStyles[1].end shouldBe 19
+        result.text.substring(16, 19) shouldBe "Pro"
+    }
+
+    @Test
+    fun `a translation that lost the placeholder still shows the brand`() {
+        val result = spliceBrandTitle("Upgrade to Pro", brand)
+
+        result.text shouldBe "Upgrade to Pro BVM Pro"
+        result.spanStyles.size shouldBe 1
+        result.spanStyles.single().item.color shouldBe brandColor
+        result.spanStyles.single().start shouldBe 19
+        result.spanStyles.single().end shouldBe 22
+    }
+}

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -101,6 +101,11 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.ACTIONS).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_preamble)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_why_title)).assertCountEquals(1)
+        // Preamble and app icon ship together in the hero card outside grace: one hero, one icon,
+        // so a leftover standalone header next to the hero would fail here.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO_ICON).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_HEADER_CALM).assertCountEquals(0)
     }
 
     @Test
@@ -213,6 +218,10 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
             .assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrades_gplay_unavailable_error_title))
             .assertCountEquals(0)
+        // Still the acquisition presentation: hero card with the app icon, no standalone header.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO_ICON).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_HEADER_CALM).assertCountEquals(0)
     }
 
     @Test
@@ -483,6 +492,9 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
             .assertCountEquals(1)
         composeRule.onAllNodesWithText(appNameWithPostfixedHeroBody(R.string.upgrade_screen_owned_hero_sub_body))
             .assertCountEquals(0)
+        // Owners get the ownership hero instead of the pitch hero: no acquisition preamble card.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_preamble)).assertCountEquals(0)
     }
 
     @Test
@@ -542,11 +554,13 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_GRACE).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_grace_title)).assertCountEquals(1)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_grace_body_short)).assertCountEquals(1)
-        // "Confirming…" is backed by motion during the quiet stage; the mascot stays cheerful.
+        // "Confirming…" is backed by motion during the quiet stage; the header stays calm.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_GRACE_SPINNER).assertCountEquals(1)
-        // BlueMusic has no mascot: the calm header badge carries the "nothing is wrong" mood.
+        // Grace has no preamble to pair the icon with, so the app icon stays a standalone header
+        // and carries the "nothing is wrong" mood — no hero card here.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_HEADER_CALM).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_HEADER_ATTENTION).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(0)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_GRACE_RESTORE).assertCountEquals(0)
         // The grace card owns restore via its two-stage disclosure — the generic restore section
         // must not undercut the calm quiet stage with its own restore CTA.
@@ -599,6 +613,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         // The aged copy asks the user to act: the header switches to the attention badge.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_HEADER_ATTENTION).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_HEADER_CALM).assertCountEquals(0)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.HERO).assertCountEquals(0)
         // The aged episode is treated as likely-permanent: the offers come back so an expired
         // subscriber can switch without waiting out the full grace window. Still no sales pitch.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertCountEquals(1)

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -1,7 +1,10 @@
 package eu.darken.bluemusic.upgrade.ui
 
 import android.content.Context
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertCountEquals
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
@@ -32,10 +35,61 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
     private val context: Context
         get() = ApplicationProvider.getApplicationContext()
 
-    private fun appNameWithPostfixedHeroBody(bodyRes: Int): String = context.getString(
-        bodyRes,
-        "${context.getString(R.string.app_name)} ${context.getString(R.string.app_name_upgrade_postfix)}",
+    // "BVM Pro" — the composed brand the screen renders for owners, grace users and the pitch.
+    private val appNameWithPostfix: String
+        get() = "${context.getString(R.string.app_name_short)} ${context.getString(R.string.app_name_upgrade_postfix)}"
+
+    private fun appNameWithPostfixedHeroBody(bodyRes: Int): String = context.getString(bodyRes, appNameWithPostfix)
+
+    // What the acquisition top bar must render: the translated pitch pattern with the composed
+    // brand formatted into it.
+    private val acquisitionTitle: String
+        get() = context.getString(R.string.upgrade_screen_title_template, appNameWithPostfix)
+
+    private fun acquisitionState() = GplayUpgradeUiState.Loaded(
+        subscriptionAction = SubscriptionAction.STANDARD,
+        subscriptionEnabled = true,
+        subscriptionPrice = "$12.99",
+        iapEnabled = true,
+        iapPrice = "$24.99",
     )
+
+    @Test
+    fun `acquisition titles the screen with the brand inside the pitch sentence`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(uiState = acquisitionState())
+        }
+
+        composeRule.onAllNodesWithText(acquisitionTitle).assertCountEquals(1)
+    }
+
+    @Test
+    fun `the acquisition title colors exactly the brand postfix`() {
+        // The highlight is a theme role, not a color resource: capture it from the very composition
+        // under test instead of re-deriving it.
+        var expectedTertiary = Color.Unspecified
+        composeRule.setUpgradeContent {
+            expectedTertiary = MaterialTheme.colorScheme.tertiary
+            UpgradeScreen(uiState = acquisitionState())
+        }
+
+        // The pitch splices in the SAME styled brand the status title uses: the upgraded color must
+        // land on the postfix only, never on the surrounding sentence.
+        val rendered = composeRule.onNodeWithText(acquisitionTitle)
+            .fetchSemanticsNode()
+            .config[SemanticsProperties.Text]
+            .single()
+        val postfix = context.getString(R.string.app_name_upgrade_postfix)
+
+        rendered.text shouldBe acquisitionTitle
+        rendered.spanStyles.size shouldBe 1
+        val span = rendered.spanStyles.single()
+        span.item.color shouldBe expectedTertiary
+        rendered.text.substring(span.start, span.end) shouldBe postfix
+        // Pins the range rather than just its content: only one candidate position exists.
+        rendered.text.indexOf(postfix) shouldBe span.start
+        rendered.text.lastIndexOf(postfix) shouldBe span.start
+    }
 
     @Test
     fun `loading state shows progress and hides actions`() {
@@ -373,7 +427,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_MANAGE_SUB).assertCountEquals(1)
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertCountEquals(0)
         composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_owned_sub_renewing_body)).assertCountEquals(1)
-        composeRule.onAllNodesWithText("${context.getString(R.string.app_name)} ${context.getString(R.string.app_name_upgrade_postfix)}").assertCountEquals(1)
+        composeRule.onAllNodesWithText(appNameWithPostfix).assertCountEquals(1)
         // The congrats hero names the variant.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_OWNED_HERO).assertCountEquals(1)
         composeRule.onAllNodesWithText(appNameWithPostfixedHeroBody(R.string.upgrade_screen_owned_hero_sub_body))
@@ -498,7 +552,7 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         // must not undercut the calm quiet stage with its own restore CTA.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertCountEquals(0)
         // Grace users are still Pro: neutral status title, not the acquisition pitch title.
-        composeRule.onAllNodesWithText("${context.getString(R.string.app_name)} ${context.getString(R.string.app_name_upgrade_postfix)}").assertCountEquals(1)
+        composeRule.onAllNodesWithText(appNameWithPostfix).assertCountEquals(1)
         // A young episode is treated as a blip: calm status only — no offers, no sales pitch.
         // The offers return with the aged (diagnostics) stage.
         composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertCountEquals(0)


### PR DESCRIPTION
## What changed

FOSS version: a failed supporter-status read no longer flips a known supporter back to the free pitch while the app retries — the last confirmed status stays visible with the error attached, retries keep running automatically, and a successful unlock now reaches the screen immediately instead of waiting out a retry delay of up to five minutes.

Both versions: the upgrade screens now lead with the app icon in a combined intro card (replacing the star badge) that adapts to narrow screens and large fonts. The titles are unified on the brand the dashboard shows: "Upgrade to BVM Pro" with "Pro" in the theme's highlight color — colored in every language, and the same color the dashboard uses instead of a separate hardcoded hex. The FOSS and Play versions finally list the same upgrade advantages under the same heading. The error dialog's extra button says "Dismiss" instead of "Cancel" (nothing was being cancelled), and the retry button on the "Prices unavailable" card now matches the card it sits on.

For translators: the upgrade-screen title moved to a pattern around the brand name and the FOSS advantages text changed, so those strings will show English until re-translated.

## Technical Context

- The FOSS `upgradeInfo` retry loop moved inside a `refreshTrigger.flatMapLatest` block and gained last-known-entitlement preservation: error emissions ride on the previously seen status instead of a blank one, `refresh()` (also fired after a successful persist) cancels an in-flight backoff delay and resubscribes immediately, and the loop now rethrows cancellation (it previously swallowed it). The backoff formula is unchanged but seam-injectable, so the new tests drive automatic recovery and refresh-cancels-backoff without sleeping through the real schedule.
- The title mechanism is deliberately an append of two resources (untranslated short brand + per-locale postfix) rather than a substring split of the composed name: a split silently loses the highlight in every locale whose translation words the name differently — which is exactly the state of 14 locales' data today. The dashboard's own split-based rendering is untouched; its data quirk goes to the translation-content pass.
- The acquisition title splices the styled brand into a translated template via a marker resolved through Android's formatter. The old title key was retired base+locales together (ExtraTranslation runs at its fatal default here).
- The unused `colorUpgraded` resources were removed entirely — both flavors' `colors.xml` contained nothing else.
- Review guidance: the hero card renders under exactly the prior conditions (grace keeps the standalone header — now the app icon for the calm mood, the warning badge for aged episodes — and owners keep the congrats hero). The dialog previously had zero test coverage; the new suite pins the localized rendering, the Google Play settings intent, dismiss-launches-nothing, and the OK-only default path.
