### PR TITLE
Fix rare crashes and dialog spam around store errors

### DIFF
--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFoss.kt
@@ -58,6 +58,9 @@ class UpgradeRepoFoss @Inject constructor(
     // a successful persist could take up to five minutes to reach collectors.
     override val upgradeInfo: Flow<UpgradeRepo.Info> = refreshTrigger
         .flatMapLatest {
+            // Per-inner-subscription failure-episode counter. A refresh resubscription builds a new
+            // inner flow and therefore starts a fresh counter.
+            var episodeAttempts = 0L
             fossCache.upgrade.flow
                 .map { data ->
                     if (data == null) {
@@ -72,13 +75,27 @@ class UpgradeRepoFoss @Inject constructor(
                 }
                 // Same coroutine as the throw below, so the ordering is guaranteed. Only
                 // successfully mapped elements pass here — retry emissions go straight downstream
-                // and never record themselves as a last known state.
-                .onEach { lastKnownInfo = it }
-                .retryWhen { error, attempt ->
-                    if (error is CancellationException) return@retryWhen false
-                    log(TAG, WARN) { "upgradeInfo read failed (attempt=$attempt): ${error.asLog()}" }
-                    emit((lastKnownInfo ?: Info()).copy(error = error))
-                    delay(retryDelayMs(attempt))
+                // and never record themselves as a last known state. A successful read also ends the
+                // current failure episode, so the next failure reports and backs off from scratch.
+                .onEach {
+                    lastKnownInfo = it
+                    episodeAttempts = 0L
+                }
+                .retryWhen { cause, _ ->
+                    if (cause is CancellationException) throw cause
+                    log(TAG, WARN) { "upgradeInfo read failed (attempt=$episodeAttempts): ${cause.asLog()}" }
+                    // Once per failure episode, not once per attempt: the FOSS ViewModel raises an
+                    // error dialog for every non-Pro error emission, and a per-attempt emission
+                    // would re-raise that dialog on every backoff wake-up. An episode is a run of
+                    // CONSECUTIVE failures ending on a successful read (a refresh resubscription
+                    // starts a fresh inner flow and counter), so a later, separate episode reports
+                    // itself again instead of failing silently. The library's own attempt parameter
+                    // is deliberately unused: it counts every retry of the whole inner collection
+                    // and never resets on a successful emission, which would both mute every episode
+                    // after the first and resume the backoff at an already escalated index.
+                    if (episodeAttempts == 0L) emit((lastKnownInfo ?: Info()).copy(error = cause))
+                    delay(retryDelayMs(episodeAttempts))
+                    episodeAttempts++
                     true
                 }
         }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/GplayServiceUnavailableException.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/GplayServiceUnavailableException.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.upgrade.core.billing
 
+import android.app.Activity
 import android.content.ActivityNotFoundException
 import android.content.Intent
 import android.net.Uri
@@ -21,20 +22,27 @@ class GplayServiceUnavailableException(cause: Throwable) :
         description = R.string.upgrades_gplay_unavailable_error_description.toCaString(),
         fixActionLabel = "Google Play".toCaString(),
         fixAction = { activity ->
-            try {
-                val intent = Intent().apply {
-                    action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
-                    data = Uri.fromParts("package", GPLAY_PKG, null)
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                }
+            val intent = Intent().apply {
+                action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+                data = Uri.fromParts("package", GPLAY_PKG, null)
+            }
 
+            try {
                 activity.startActivity(intent)
             } catch (e: ActivityNotFoundException) {
-                log(ERROR) { "Can't launch settings intent for Google Play: $e" }
-                Toast.makeText(activity, "Google Play is not installed", Toast.LENGTH_SHORT).show()
+                onLaunchFailed(activity, e)
+            } catch (e: SecurityException) {
+                // Play can be installed but unreachable: disabled app, work/restricted profile or a
+                // ROM that guards the settings screen. The launch is denied, not unresolvable.
+                onLaunchFailed(activity, e)
             }
         }
     )
+
+    private fun onLaunchFailed(activity: Activity, e: Exception) {
+        log(ERROR) { "Can't launch settings intent for Google Play: $e" }
+        Toast.makeText(activity, R.string.upgrades_gplay_not_installed_message, Toast.LENGTH_SHORT).show()
+    }
 
     companion object {
         private const val GPLAY_PKG = "com.android.vending"

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -63,6 +63,8 @@
     <string name="upgrades_gplay_network_error_description">Unable to connect to Google Play. Please check your internet connection and try again.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play is unavailable</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager can\'t connect to Google Play. Is Google Play installed and up to date? Is your Google Account logged in? Try clearing the cache of the Google Play app and rebooting your device.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play is not installed.</string>
     <string name="upgrades_no_purchases_found_check_account">No purchases found. Are you using the right account?</string>
 
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->

--- a/app/src/main/java/eu/darken/bluemusic/common/error/ErrorDialog.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/error/ErrorDialog.kt
@@ -21,12 +21,29 @@ import androidx.compose.ui.unit.dp
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.bluemusic.common.debug.logging.asLog
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
 
 @Composable
 fun ErrorDialog(throwable: Throwable, onDismiss: () -> Unit) {
     val context = LocalContext.current
     val activity = context as? Activity
     val localizedError = throwable.localized(context)
+
+    fun dispatchAndDismiss(action: (Activity) -> Unit) {
+        // Error actions are arbitrary third-party code (intent launches, navigation): a throw here
+        // would crash the UI thread from inside a click handler, and skipping onDismiss() would
+        // leave the dialog latched on the current error with no way out.
+        try {
+            activity?.let(action)
+        } catch (e: Exception) {
+            log(TAG, ERROR) { "Error action failed: ${e.asLog()}" }
+        } finally {
+            onDismiss()
+        }
+    }
 
     AlertDialog(
         onDismissRequest = onDismiss,
@@ -50,7 +67,7 @@ fun ErrorDialog(throwable: Throwable, onDismiss: () -> Unit) {
         confirmButton = {
             Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End) {
                 localizedError.infoAction?.let { action ->
-                    TextButton(onClick = { activity?.let { action.invoke(it) } }) {
+                    TextButton(onClick = { dispatchAndDismiss(action) }) {
                         Text(
                             localizedError.infoActionLabel?.get(context)
                                 ?: stringResource(R.string.general_show_details_action)
@@ -64,12 +81,7 @@ fun ErrorDialog(throwable: Throwable, onDismiss: () -> Unit) {
                         Text(stringResource(R.string.general_dismiss_action))
                     }
                     Spacer(modifier = Modifier.width(8.dp))
-                    TextButton(
-                        onClick = {
-                            activity?.let { action.invoke(it) }
-                            onDismiss()
-                        }
-                    ) {
+                    TextButton(onClick = { dispatchAndDismiss(action) }) {
                         Text(
                             localizedError.fixActionLabel?.get(context)
                                 ?: stringResource(android.R.string.ok)
@@ -83,6 +95,8 @@ fun ErrorDialog(throwable: Throwable, onDismiss: () -> Unit) {
         }
     )
 }
+
+private val TAG = logTag("Error", "Dialog")
 
 @Preview2
 @Composable

--- a/app/src/test/java/eu/darken/bluemusic/common/error/ComposeErrorDialogGuardTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/common/error/ComposeErrorDialogGuardTest.kt
@@ -1,0 +1,106 @@
+package eu.darken.bluemusic.common.error
+
+import android.app.Activity
+import androidx.activity.ComponentActivity
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import eu.darken.bluemusic.common.ca.toCaString
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The dialog's fix/info dispatch runs arbitrary third-party code: an action that blows up must
+ * never take the UI - or the dialog's exit - down with it.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ComposeErrorDialogGuardTest : BaseTest() {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    private var dismissals = 0
+
+    private class ThrowingFixError(private val onFix: (Activity) -> Unit) : Exception(), HasLocalizedError {
+        override fun getLocalizedError() = LocalizedError(
+            throwable = this,
+            label = ERROR_TITLE.toCaString(),
+            description = ERROR_BODY.toCaString(),
+            fixActionLabel = FIX_LABEL.toCaString(),
+            fixAction = onFix,
+        )
+    }
+
+    private class ThrowingInfoError(private val onInfo: (Activity) -> Unit) : Exception(), HasLocalizedError {
+        override fun getLocalizedError() = LocalizedError(
+            throwable = this,
+            label = ERROR_TITLE.toCaString(),
+            description = ERROR_BODY.toCaString(),
+            infoActionLabel = INFO_LABEL.toCaString(),
+            infoAction = onInfo,
+        )
+    }
+
+    private fun show(error: Throwable) {
+        composeRule.setContent {
+            PreviewWrapper {
+                ErrorDialog(
+                    throwable = error,
+                    onDismiss = { dismissals++ },
+                )
+            }
+        }
+        composeRule.waitForIdle()
+    }
+
+    @Test
+    fun `a throwing fix action still closes the dialog`() {
+        var invoked = false
+        show(
+            ThrowingFixError {
+                // Flag first: the assertion below has to distinguish "action ran and threw" from
+                // "action was never dispatched".
+                invoked = true
+                throw IllegalStateException("fix action exploded")
+            }
+        )
+
+        composeRule.onNodeWithText(FIX_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        invoked shouldBe true
+        // Exactly one dismissal: the throw must neither swallow it nor double it.
+        dismissals shouldBe 1
+    }
+
+    @Test
+    fun `a throwing info action still closes the dialog`() {
+        var invocations = 0
+        show(
+            ThrowingInfoError {
+                invocations++
+                throw IllegalStateException("info action exploded")
+            }
+        )
+
+        composeRule.onNodeWithText(INFO_LABEL).performClick()
+        composeRule.waitForIdle()
+
+        invocations shouldBe 1
+        // The info action dismisses too: a latched dialog would greet the user again on the way back.
+        dismissals shouldBe 1
+    }
+}
+
+private const val ERROR_TITLE = "Test error title"
+private const val ERROR_BODY = "Test error description"
+private const val FIX_LABEL = "Fix it"
+private const val INFO_LABEL = "Tell me more"

--- a/app/src/testFoss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFossTest.kt
+++ b/app/src/testFoss/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoFossTest.kt
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 import java.io.IOException
 import java.time.Instant
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicInteger
 
 class UpgradeRepoFossTest : BaseTest() {
@@ -206,6 +207,121 @@ class UpgradeRepoFossTest : BaseTest() {
                     isPro shouldBe true
                     error shouldBe null
                 }
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `a second failure episode surfaces its own error`(): Unit = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            // Fail, recover, fail again, recover - all within ONE inner subscription chain. The
+            // library's retry attempt counter never resets on a successful emission, so gating on it
+            // would leave the second episode completely silent: the UI would never learn.
+            val subscriptions = AtomicInteger(0)
+            val upgradeValue = createUpgradeValue(flow {
+                when (subscriptions.getAndIncrement()) {
+                    0 -> throw IOException("cache broken")
+                    1 -> {
+                        emit(record)
+                        throw IOException("cache broken again")
+                    }
+
+                    else -> emit(record)
+                }
+            })
+            val repo = createRepo(scope, upgradeValue)
+            repo.retryDelayMs = { 10L }
+
+            val received = Channel<UpgradeRepo.Info>(Channel.UNLIMITED)
+            scope.launch { repo.upgradeInfo.collect { received.send(it) } }
+
+            withTimeout(10_000) {
+                val infos = mutableListOf<UpgradeRepo.Info>()
+
+                // Episode 1: the very first read fails.
+                infos.add(received.receive())
+                infos[0].error.shouldBeInstanceOf<IOException>()
+
+                // Recovery, then the read that starts episode 2.
+                infos.add(received.receive())
+                infos[1].apply {
+                    isPro shouldBe true
+                    error shouldBe null
+                }
+
+                // Episode 2 has to report itself too. It rides lastKnownInfo, so the entitlement
+                // seen right before it survives the failure.
+                infos.add(received.receive())
+                infos[2].apply {
+                    error.shouldBeInstanceOf<IOException>()
+                    isPro shouldBe true
+                }
+
+                // And the loop keeps healing afterwards.
+                infos.add(received.receive())
+                infos[3].apply {
+                    isPro shouldBe true
+                    error shouldBe null
+                }
+
+                // Exactly one error report per episode: neither muted nor re-raised per wake-up.
+                infos.count { it.error != null } shouldBe 2
+            }
+        } finally {
+            scope.cancel()
+        }
+    }
+
+    @Test
+    fun `each failure episode reports once and backs off from scratch`(): Unit = runBlocking {
+        val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+        try {
+            // Fail, fail, recover-then-fail: two consecutive failures make one episode, the healthy
+            // read in between ends it.
+            val subscriptions = AtomicInteger(0)
+            val upgradeValue = createUpgradeValue(flow {
+                when (subscriptions.getAndIncrement()) {
+                    0, 1 -> throw IOException("cache broken")
+                    2 -> {
+                        emit(record)
+                        throw IOException("cache broken again")
+                    }
+
+                    else -> emit(record)
+                }
+            })
+            val repo = createRepo(scope, upgradeValue)
+            // Every backoff index the loop asks for, in order. Written from the sharing coroutine
+            // and read from the test one.
+            val backoffIndices = CopyOnWriteArrayList<Long>()
+            repo.retryDelayMs = { attempt ->
+                backoffIndices.add(attempt)
+                10L
+            }
+
+            val received = Channel<UpgradeRepo.Info>(Channel.UNLIMITED)
+            scope.launch { repo.upgradeInfo.collect { received.send(it) } }
+
+            withTimeout(10_000) {
+                val infos = List(4) { received.receive() }
+
+                // Both episode-1 failures really happened, yet only the first one reached a
+                // collector - a per-attempt emission would re-raise the error dialog on every
+                // backoff wake-up.
+                infos.take(2).count { it.error != null } shouldBe 1
+                infos[1].apply {
+                    isPro shouldBe true
+                    error shouldBe null
+                }
+                infos[2].error.shouldBeInstanceOf<IOException>()
+
+                // The escalating index restarts at 0 for episode 2. Reading the library's own
+                // attempt parameter instead would have asked for index 2 here, i.e. resumed the
+                // backoff at an already escalated delay.
+                backoffIndices.toList() shouldBe listOf(0L, 1L, 0L)
             }
         } finally {
             scope.cancel()

--- a/app/src/testGplay/java/eu/darken/bluemusic/common/error/ComposeErrorDialogTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/common/error/ComposeErrorDialogTest.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.common.error
 
 import android.content.Context
+import android.content.Intent
 import android.provider.Settings
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.assertCountEquals
@@ -78,6 +79,9 @@ class ComposeErrorDialogTest : BaseTest() {
         val started = shadowOf(composeRule.activity).nextStartedActivity.shouldNotBeNull()
         started.action shouldBe Settings.ACTION_APPLICATION_DETAILS_SETTINGS
         started.data.toString() shouldBe "package:com.android.vending"
+        // NEW_TASK on an activity context detaches Play's app info from our task: the user loses the
+        // back path to the screen they came from and the settings screen lingers in recents.
+        (started.flags and Intent.FLAG_ACTIVITY_NEW_TASK) shouldBe 0
         // The user acted: leaving the dialog up would greet them again on the way back.
         composeRule.onAllNodesWithText("Google Play").assertCountEquals(0)
     }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/GplayFixActionTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/GplayFixActionTest.kt
@@ -1,0 +1,59 @@
+package eu.darken.bluemusic.upgrade.core.billing
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import eu.darken.bluemusic.R
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Robolectric
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowToast
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+
+/**
+ * The error dialog's "Google Play" button on devices where the launch never lands: a refused or
+ * unresolvable intent has to end in a toast, not a crash. The intent shape itself is pinned by
+ * [eu.darken.bluemusic.common.error.ComposeErrorDialogTest].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class GplayFixActionTest : BaseTest() {
+
+    /** Play is installed but unreachable: disabled app, restricted profile or a guarding ROM. */
+    class DeniedLaunchActivity : Activity() {
+        override fun startActivity(intent: Intent): Unit = throw SecurityException("Permission Denial")
+    }
+
+    /** No app settings screen resolves the intent at all, e.g. a stripped-down ROM. */
+    class UnresolvedLaunchActivity : Activity() {
+        override fun startActivity(intent: Intent): Unit = throw ActivityNotFoundException("No Activity found")
+    }
+
+    private val fixAction: (Activity) -> Unit
+        get() = GplayServiceUnavailableException(RuntimeException("Play hiccup"))
+            .getLocalizedError().fixAction.shouldNotBeNull()
+
+    private fun <T : Activity> assertNotInstalledToast(clazz: Class<T>) {
+        val activity = Robolectric.buildActivity(clazz).setup().get()
+
+        fixAction.invoke(activity)
+
+        ShadowToast.getTextOfLatestToast() shouldBe
+            activity.getString(R.string.upgrades_gplay_not_installed_message)
+    }
+
+    @Test
+    fun `a denied launch shows the not-installed toast instead of crashing`() {
+        assertNotInstalledToast(DeniedLaunchActivity::class.java)
+    }
+
+    @Test
+    fun `an unresolvable launch shows the not-installed toast instead of crashing`() {
+        assertNotInstalledToast(UnresolvedLaunchActivity::class.java)
+    }
+}


### PR DESCRIPTION
## What changed

The error dialog's buttons can no longer crash the app. If tapping "Google Play" (or the details action) hits something unexpected — Google Play missing, disabled, or blocked on the device — the app now shows a short notice instead of crashing, and the dialog closes properly. Google Play's app-info screen also opens inside the app's own task, so pressing Back returns to the screen you came from.

On the FOSS build, a failing store connection now shows the error dialog once per failure episode instead of re-raising it every 30 seconds to 5 minutes for as long as the upgrade screen stays open — and the retry backoff starts from scratch after a recovery instead of resuming at an escalated delay.

## Technical Context

- The "Google Play" fix action launched its settings intent with `FLAG_ACTIVITY_NEW_TASK` from an activity context — that detaches the settings screen from our task. Dropped; a test pins its absence.
- The launch was only guarded against `ActivityNotFoundException`; a `SecurityException` (disabled Play, restricted profile, guarding ROM) crashed the app. Both now route to one fallback: an error log plus a translatable toast (previously hardcoded English).
- Both dialog action dispatches are wrapped in try/catch/finally: error actions run arbitrary code, and a throw from a click handler would crash the UI thread and leave the dialog latched. The details action now also dismisses (previously it left the dialog open; there are currently no info-action producers, so no user-visible change today — this aligns the dialog with the sibling apps).
- The episode fix deliberately ignores `retryWhen`'s own `attempt` parameter: it never resets on a successful emission, which would both mute every episode after the first and resume the backoff escalated. A per-subscription counter reset on each successful read replaces it; regression tests pin the once-per-episode emission and the exact backoff-index sequence across an episode boundary.
- Guard tests live in `app/src/test` (shared code — both flavor test legs run them) and drive the public dialog directly with a dismissal counter, proving exactly-once dismissal.
