### PR TITLE
Fix crashes and hangs when debug log recording fails to start

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/common/debug/logging/FileLogger.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/debug/logging/FileLogger.kt
@@ -2,9 +2,11 @@ package eu.darken.bluemusic.common.debug.logging
 
 import android.util.Log
 import eu.darken.bluemusic.common.debug.Bugs
+import eu.darken.bluemusic.common.error.addSuppressedSafely
 import java.io.File
 import java.io.FileOutputStream
 import java.io.IOException
+import java.io.OutputStream
 import java.io.OutputStreamWriter
 import java.time.Instant
 
@@ -12,38 +14,58 @@ import java.time.Instant
 class FileLogger(private val logFile: File) : Logging.Logger {
     private var logWriter: OutputStreamWriter? = null
 
+    // Test seam for deterministic fault injection: a failing open is otherwise only reachable through
+    // filesystem permissions, which this very start repairs and a root test runner ignores.
+    internal var streamFactory: (File) -> OutputStream = { FileOutputStream(it, true) }
+
+    /**
+     * Throws if the writer could not be initialized. Swallowing the failure here would install a
+     * logger that silently writes nowhere, and the recorder would report a successful start for a
+     * recording that can never produce a log file.
+     */
     @Suppress("SetWorldWritable", "SetWorldReadable")
     @Synchronized
     fun start() {
         if (logWriter != null) return
         Log.i(TAG, "Starting logger for " + logFile.path)
-        try {
-            val parentDir = logFile.parentFile!!
-            if (parentDir.isFile) parentDir.delete()
 
-            logFile.parentFile!!.mkdirs()
-            if (logFile.createNewFile()) Log.i(TAG, "File logger writing to ${logFile.path}")
-            if (logFile.setReadable(true, false)) Log.i(TAG, "Debug run log read permission set")
-            if (logFile.setWritable(true, false)) Log.i(TAG, "Debug run log write permission set")
+        val parentDir = logFile.parentFile!!
+        if (parentDir.isFile) parentDir.delete()
+        parentDir.mkdirs()
+
+        // Only a log file THIS start created may be deleted again when it fails: a session being
+        // resumed already holds the recording the user made, and dropping it on a failed restart
+        // destroys the very data they were collecting.
+        val createdHere = logFile.createNewFile()
+        if (createdHere) Log.i(TAG, "File logger writing to ${logFile.path}")
+        if (logFile.setReadable(true, false)) Log.i(TAG, "Debug run log read permission set")
+        if (logFile.setWritable(true, false)) Log.i(TAG, "Debug run log write permission set")
+
+        val writer = try {
+            OutputStreamWriter(streamFactory(logFile))
         } catch (e: IOException) {
-            Log.e(TAG, "Log writer failed to init log file", e)
-            e.printStackTrace()
+            Log.e(TAG, "Log writer failed to open $logFile", e)
+            if (createdHere) logFile.delete()
+            throw e
         }
 
         try {
-            logWriter = OutputStreamWriter(FileOutputStream(logFile, true))
-            logWriter!!.write("=== BEGIN ${Bugs.processTag} ===\n")
-            logWriter!!.write("Logfile: $logFile\n")
-            logWriter!!.flush()
-            Log.i(TAG, "File logger started.")
+            writer.write("=== BEGIN ${Bugs.processTag} ===\n")
+            writer.write("Logfile: $logFile\n")
+            writer.flush()
         } catch (e: IOException) {
             Log.e(TAG, "Log writer failed to start", e)
-            e.printStackTrace()
-
-            logFile.delete()
-            if (logWriter != null) logWriter!!.close()
+            try {
+                writer.close()
+            } catch (closeError: IOException) {
+                e.addSuppressedSafely(closeError)
+            }
+            if (createdHere) logFile.delete()
+            throw e
         }
 
+        logWriter = writer
+        Log.i(TAG, "File logger started.")
     }
 
     @Synchronized

--- a/app/src/main/java/eu/darken/bluemusic/common/debug/logging/Logging.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/debug/logging/Logging.kt
@@ -63,8 +63,10 @@ object Logging {
     }
 
     fun remove(logger: Logger) {
-        log(TAG, INFO) { "Removing: $logger" }
+        // Deregister first: a logger being torn down still receives anything we log before that, and
+        // if it throws on that line it would stay installed forever.
         synchronized(internalLoggers) { internalLoggers.remove(logger) }
+        log(TAG, INFO) { "Removed: $logger" }
     }
 
     fun logInternal(

--- a/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/core/Recorder.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/core/Recorder.kt
@@ -5,6 +5,7 @@ import eu.darken.bluemusic.common.debug.logging.Logging
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.common.error.addSuppressedSafely
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import java.io.File
@@ -20,25 +21,56 @@ class Recorder @Inject constructor() {
     var path: File? = null
         private set
 
-    suspend fun start(path: File) = mutex.withLock {
+    /**
+     * Nothing is published and no logger is installed until the writer is live: a failing
+     * [FileLogger.start] would otherwise leave this recorder claiming to record into a file that
+     * receives nothing.
+     */
+    suspend fun start(path: File): Unit = mutex.withLock {
         if (fileLogger != null) return@withLock
+
+        val logger = FileLogger(path)
+        logger.start()
+
         this.path = path
-        fileLogger = FileLogger(path)
-        fileLogger?.let {
-            it.start()
-            Logging.install(it)
-            log(TAG, INFO) { "Now logging to file!" }
-        }
+        fileLogger = logger
+
+        Logging.install(logger)
+        log(TAG, INFO) { "Now logging to file!" }
     }
 
-    suspend fun stop() = mutex.withLock {
-        fileLogger?.let {
-            log(TAG, INFO) { "Stopping file-logger-tree: $it" }
-            Logging.remove(it)
-            it.stop()
+    /**
+     * Every teardown step runs, no matter what the ones before it did: the logger leaves the
+     * registry BEFORE any diagnostic it would still receive itself, the published state is cleared
+     * in the outermost finally, and only then is the first failure rethrown with the later ones
+     * suppressed onto it. This recorder must never stay globally installed while the module reports
+     * it as stopped.
+     */
+    suspend fun stop(): Unit = mutex.withLock {
+        val logger = fileLogger
+        var failure: Throwable? = null
+
+        fun step(block: () -> Unit) {
+            try {
+                block()
+            } catch (e: Throwable) {
+                val previous = failure
+                if (previous == null) failure = e else previous.addSuppressedSafely(e)
+            }
+        }
+
+        try {
+            if (logger != null) {
+                step { Logging.remove(logger) }
+                step { log(TAG, INFO) { "Stopped file-logger-tree: $logger" } }
+                step { logger.stop() }
+            }
+        } finally {
             fileLogger = null
             this.path = null
         }
+
+        failure?.let { throw it }
     }
 
     companion object {

--- a/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModule.kt
@@ -14,21 +14,26 @@ import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
 import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.common.error.addSuppressedSafely
 import eu.darken.bluemusic.common.flow.DynamicStateFlow
 import eu.darken.bluemusic.common.upgrade.UpgradeDiagnostics
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.plus
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
 import androidx.annotation.VisibleForTesting
 import java.io.File
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Provider
 import javax.inject.Singleton
@@ -51,6 +56,11 @@ class RecorderModule @Inject constructor(
     // the durations are wall-clock/monotonic, so virtual time cannot drive them.
     internal var wallClock: () -> Long = System::currentTimeMillis
     internal var monotonicClock: () -> Long = android.os.SystemClock::elapsedRealtime
+
+    // Serializes the public request surface, observation included: two callers racing the same
+    // transition would otherwise each await a state the other one is about to overwrite, and report
+    // each other's outcome instead of their own attempt's.
+    private val startStopLock = Mutex()
 
     @Volatile
     internal var currentLogDir: File? = null
@@ -84,6 +94,28 @@ class RecorderModule @Inject constructor(
 
     private suspend fun reconcileState(state: State) {
         if (!state.isRecording && state.shouldRecord) {
+            startRecording()
+        } else if (!state.shouldRecord && state.isRecording) {
+            val recorder = state.recorder ?: return
+            stopRecording(recorder)
+        }
+    }
+
+    /**
+     * Everything a start attempt does is inside the guard, the work that decides WHERE to record
+     * included: a throw anywhere in here used to escape this collector and kill it for the rest of
+     * the process — the recorder kept writing where nothing could stop it, the trigger file survived
+     * to re-attempt the dead session on every launch, and [startRecorder] waited for a state nobody
+     * would ever publish again.
+     */
+    private suspend fun startRecording() {
+        // Rollback bookkeeping, all of it derived from what actually happened on disk: only a
+        // trigger file and a session dir THIS attempt brought into existence may be removed again.
+        var candidateRecorder: Recorder? = null
+        var createdTrigger = false
+        var createdSessionDir: File? = null
+
+        try {
             // Keyed on the trigger file, NOT on directory reuse: a completed session dir survives
             // stopping, so findExistingSessionDir() also matches an ordinary repeat recording. Only
             // a trigger that already existed before this start sequence means the process died
@@ -91,83 +123,184 @@ class RecorderModule @Inject constructor(
             val isProcessResume = triggerFile.exists()
 
             val existingDir = findExistingSessionDir()
-            val sessionDir = existingDir ?: createSessionDir()
+            val sessionDir = existingDir ?: createSessionDir().also { createdSessionDir = it }
             val logFile = File(sessionDir, "core.log")
-            val newRecorder = recorderProvider.get()
+
+            // Bound BEFORE start() so a throw from inside start() still has something to roll back.
+            val newRecorder = recorderProvider.get().also { candidateRecorder = it }
             newRecorder.start(logFile)
 
-            try {
-                triggerFile.createNewFile()
+            // The return value is the only honest answer to "did this attempt create it": a trigger
+            // that was already there belongs to the session being resumed.
+            createdTrigger = triggerFile.createNewFile()
 
-                if (existingDir != null) {
-                    log(TAG, INFO) { "Resuming recording in existing session: ${existingDir.name}" }
-                }
-                log(TAG, INFO) { "Build.Fingerprint: ${Build.FINGERPRINT}" }
-                log(TAG, INFO) { "BuildConfig.Versions: ${BuildConfigWrap.VERSION_DESCRIPTION}" }
-
-                try {
-                    // Billing complaints usually arrive as debug logs: having the local entitlement
-                    // record in the header saves a support round-trip. Bounded on top of that: debug
-                    // recording is what a user reaches for when the app is ALREADY misbehaving, so a
-                    // source that never answers (a stuck DataStore file lock, a billing store that
-                    // doesn't respond) must not hold up the start of the recording either.
-                    val read = withTimeoutOrNull(headerReadTimeoutMs) { HeaderRead(upgradeDiagnostics.debugInfo()) }
-                    when {
-                        read == null -> log(TAG, WARN) {
-                            "Upgrade diagnostics unavailable, read did not finish within ${headerReadTimeoutMs}ms"
-                        }
-                        // Completion is tracked separately from the value: a flavor that legitimately has
-                        // nothing to report (FOSS) returns null and gets no line at all, not an "unavailable".
-                        read.value != null -> log(TAG, INFO) { "Upgrade diagnostics: ${read.value}" }
-                    }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    // Diagnostics only — a broken read must not stop the recorder from starting.
-                    log(TAG, WARN) { "Upgrade diagnostics unavailable: ${e.asLog()}" }
-                }
-
-                val recordingStartedAt = if (existingDir != null) {
-                    existingDir.lastModified()
-                } else {
-                    wallClock()
-                }
-
-                this@RecorderModule.currentLogDir = sessionDir
-
-                internalState.updateBlocking {
-                    copy(
-                        recorder = newRecorder,
-                        currentLogDir = sessionDir,
-                        recordingStartedAt = recordingStartedAt,
-                        // A fresh start that reuses an old session dir gets BOTH bases: the mtime
-                        // wall stamp above and this monotonic one. The heuristic prefers the
-                        // monotonic base, so the stale mtime never decides a live recording.
-                        recordingStartedAtMonotonic = if (isProcessResume) null else monotonicClock(),
-                    )
-                }
-            } catch (e: Exception) {
-                // The recorder is already live but not yet committed to the state: an exception escaping
-                // the header would abandon it where stopRecorder() can't reach it.
-                withContext(NonCancellable) {
-                    try {
-                        newRecorder.stop()
-                    } catch (stopError: Exception) {
-                        e.addSuppressed(stopError)
-                    }
-                    this@RecorderModule.currentLogDir = null
-                }
-                throw e
+            if (existingDir != null) {
+                log(TAG, INFO) { "Resuming recording in existing session: ${existingDir.name}" }
             }
-        } else if (!state.shouldRecord && state.isRecording) {
-            state.recorder!!.stop()
+            log(TAG, INFO) { "Build.Fingerprint: ${Build.FINGERPRINT}" }
+            log(TAG, INFO) { "BuildConfig.Versions: ${BuildConfigWrap.VERSION_DESCRIPTION}" }
 
+            try {
+                // Billing complaints usually arrive as debug logs: having the local entitlement
+                // record in the header saves a support round-trip. Bounded on top of that: debug
+                // recording is what a user reaches for when the app is ALREADY misbehaving, so a
+                // source that never answers (a stuck DataStore file lock, a billing store that
+                // doesn't respond) must not hold up the start of the recording either.
+                val read = withTimeoutOrNull(headerReadTimeoutMs) { HeaderRead(upgradeDiagnostics.debugInfo()) }
+                when {
+                    read == null -> log(TAG, WARN) {
+                        "Upgrade diagnostics unavailable, read did not finish within ${headerReadTimeoutMs}ms"
+                    }
+                    // Completion is tracked separately from the value: a flavor that legitimately has
+                    // nothing to report (FOSS) returns null and gets no line at all, not an "unavailable".
+                    read.value != null -> log(TAG, INFO) { "Upgrade diagnostics: ${read.value}" }
+                }
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // Diagnostics only — a broken read must not stop the recorder from starting.
+                log(TAG, WARN) { "Upgrade diagnostics unavailable: ${e.asLog()}" }
+            }
+
+            val recordingStartedAt = if (existingDir != null) {
+                existingDir.lastModified()
+            } else {
+                wallClock()
+            }
+
+            this@RecorderModule.currentLogDir = sessionDir
+
+            internalState.updateBlocking {
+                copy(
+                    recorder = newRecorder,
+                    currentLogDir = sessionDir,
+                    recordingStartedAt = recordingStartedAt,
+                    // A fresh start that reuses an old session dir gets BOTH bases: the mtime
+                    // wall stamp above and this monotonic one. The heuristic prefers the
+                    // monotonic base, so the stale mtime never decides a live recording.
+                    recordingStartedAtMonotonic = if (isProcessResume) null else monotonicClock(),
+                    startFailure = null,
+                )
+            }
+        } catch (e: Throwable) {
+            rollbackStart(e, candidateRecorder, createdTrigger, createdSessionDir)
+
+            logSafely { log(TAG, ERROR) { "Failed to start recording: ${e.asLog()}" } }
+
+            // Our own scope dying is the one failure that SHOULD take this collector with it.
+            // Anything else — a cancellation from inside the start work included — becomes an
+            // ordinary failure, because rethrowing it here wedges the module for the whole process.
+            currentCoroutineContext().ensureActive()
+
+            publishStartFailure(asStartFailure(e))
+        }
+    }
+
+    /**
+     * For the log lines that sit between cleanup and publication. The logging framework hands a
+     * logger's failure straight back to the caller, and any installed logger can fail — not just
+     * ours: an error line lost costs a diagnostic, an error line thrown costs the cleanup that was
+     * still to run, the state commit behind it, and with it this module for the rest of the process.
+     */
+    private inline fun logSafely(block: () -> Unit) {
+        try {
+            block()
+        } catch (ignore: Throwable) {
+        }
+    }
+
+    /**
+     * Total and uncancellable: every step runs regardless of what the ones before it did, so a start
+     * that failed — or was cancelled — half-way leaves nothing behind that this module can no longer
+     * reach. Cleanup failures are attached to the failure being reported instead of replacing it.
+     */
+    private suspend fun rollbackStart(
+        error: Throwable,
+        candidateRecorder: Recorder?,
+        createdTrigger: Boolean,
+        createdSessionDir: File?,
+    ) = withContext(NonCancellable) {
+        suspend fun step(block: suspend () -> Unit) {
+            try {
+                block()
+            } catch (cleanupError: Throwable) {
+                error.addSuppressedSafely(cleanupError)
+            }
+        }
+
+        // The recorder may be live while nothing points at it yet: left behind it keeps its globally
+        // installed loggers and stopRecorder() can never reach it.
+        step { candidateRecorder?.stop() }
+        // Only a trigger this attempt created: one that was already there is the resume marker of
+        // the session we were resuming.
+        step {
+            if (createdTrigger && triggerFile.exists() && !triggerFile.delete()) {
+                log(TAG, ERROR) { "Failed to delete trigger file after failed start" }
+            }
+        }
+        // Same rule for the directory: a resumed one holds the recording the user already made.
+        step {
+            createdSessionDir?.let { dir ->
+                if (dir.isDirectory && !dir.deleteRecursively()) {
+                    log(TAG, ERROR) { "Failed to delete session dir after failed start: $dir" }
+                }
+            }
+        }
+        // DebugSessionManager reads this field directly — a stale value advertises a session that no
+        // recorder is writing to.
+        step { this@RecorderModule.currentLogDir = null }
+    }
+
+    /**
+     * The last thing a failed start does, and it must not throw: shouldRecord is reset so this
+     * collector is re-armed for a retry instead of walking straight back into the failing branch,
+     * and the failure is committed so a waiting [startRecorder] observes it instead of waiting for a
+     * recording that is never coming.
+     */
+    private suspend fun publishStartFailure(failure: Throwable) {
+        try {
+            internalState.updateBlocking {
+                copy(
+                    shouldRecord = false,
+                    startFailure = failure,
+                    recorder = null,
+                    currentLogDir = null,
+                    recordingStartedAt = 0L,
+                    recordingStartedAtMonotonic = null,
+                )
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            logSafely { log(TAG, ERROR) { "Failed to publish the start failure: ${e.asLog()}" } }
+        }
+    }
+
+    /**
+     * Best effort, step by step: a stop that cannot complete must not strand everyone awaiting the
+     * transition either — [stopRecorder], [requestStopRecorder] and the UI's isRecording all wait
+     * for the cleared state, which is committed regardless and last.
+     */
+    private suspend fun stopRecording(recorder: Recorder) {
+        suspend fun step(label: String, block: suspend () -> Unit) {
+            try {
+                block()
+            } catch (e: Throwable) {
+                // Our own scope dying still propagates; anything else is logged and cleanup goes on.
+                currentCoroutineContext().ensureActive()
+                logSafely { log(TAG, ERROR) { "$label: ${e.asLog()}" } }
+            }
+        }
+
+        step("Failed to stop the recorder") { recorder.stop() }
+        step("Failed to delete trigger file") {
             if (triggerFile.exists() && !triggerFile.delete()) {
                 log(TAG, ERROR) { "Failed to delete trigger file" }
             }
+        }
+        step("Failed to clear the current log dir") { this@RecorderModule.currentLogDir = null }
 
-            this@RecorderModule.currentLogDir = null
-
+        try {
             internalState.updateBlocking {
                 copy(
                     recorder = null,
@@ -176,7 +309,29 @@ class RecorderModule @Inject constructor(
                     recordingStartedAtMonotonic = null,
                 )
             }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Throwable) {
+            logSafely { log(TAG, ERROR) { "Failed to publish the stopped state: ${e.asLog()}" } }
         }
+    }
+
+    /**
+     * A start failure that arrived as a [CancellationException] while this module's own scope was
+     * still alive — a bounded read inside the start work timing out, for example. Stored and
+     * rethrown unchanged it would make every caller treat it as THEIR cancellation: the launch that
+     * requested the start ends "normally" and the error handler that would have surfaced the failure
+     * never runs.
+     */
+    class RecorderStartFailedException(cause: Throwable) : IllegalStateException("Failed to start recording", cause)
+
+    /**
+     * Runs AFTER [ensureActive] has confirmed the scope is alive, so a cancellation seen here can
+     * only be a foreign one. Everything else is committed unchanged.
+     */
+    private fun asStartFailure(error: Throwable): Throwable = when (error) {
+        is CancellationException -> RecorderStartFailedException(error)
+        else -> error
     }
 
     /**
@@ -186,7 +341,7 @@ class RecorderModule @Inject constructor(
     private class HeaderRead<T>(val value: T)
 
     private fun createSessionDir(): File {
-        val timestamp = java.time.ZonedDateTime.now(java.time.ZoneOffset.UTC)
+        val timestamp = java.time.Instant.ofEpochMilli(wallClock()).atZone(java.time.ZoneOffset.UTC)
             .format(java.time.format.DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'"))
         val installIdPrefix = blueMusicId.id.take(8)
         val dirName = "bluemusic_${BuildConfigWrap.VERSION_NAME}_${timestamp}_$installIdPrefix"
@@ -201,11 +356,24 @@ class RecorderModule @Inject constructor(
         }
 
         val parent = primaryParent ?: File(context.cacheDir, "debug/logs").also { it.mkdirs() }
-        val sessionDir = File(parent, dirName)
-        sessionDir.mkdirs()
 
-        log(TAG) { "Created session dir: $sessionDir" }
-        return sessionDir
+        // mkdirs() reports false for a directory that already exists, so the candidate that wins is
+        // always one this call brought into existence. Adopting an existing one would hand the
+        // rollback of a failed start somebody else's logs to delete — and a bare exists() check
+        // cannot tell them apart here, because a session dir is deliberately reused across
+        // recordings via findExistingSessionDir(). The name is stamped to the second, so a
+        // collision means a leftover directory or a retry within the same second, not a long run.
+        for (attempt in 0..NAME_COLLISION_LIMIT) {
+            val candidate = File(parent, if (attempt == 0) dirName else "$dirName-$attempt")
+            if (candidate.mkdirs()) {
+                log(TAG) { "Created session dir: $candidate" }
+                return candidate
+            }
+            // Not a collision but an unusable parent directory: further suffixes cannot help.
+            if (!candidate.exists()) break
+        }
+
+        throw IOException("Failed to create a session dir for $dirName in $parent")
     }
 
     internal fun getLogDirectories(): List<File> = listOfNotNull(
@@ -217,39 +385,52 @@ class RecorderModule @Inject constructor(
         File(context.cacheDir, "debug/logs"),
     )
 
-    suspend fun startRecorder(): File {
+    suspend fun startRecorder(): File = startStopLock.withLock {
+        // Clearing the failure is part of the request: a stale one from an earlier attempt would
+        // otherwise be reported as the outcome of this one.
         internalState.updateBlocking {
-            copy(shouldRecord = true)
+            copy(shouldRecord = true, startFailure = null)
         }
-        return requireNotNull(internalState.flow.filter { it.isRecording }.first().currentLogDir) {
-            "Recording started but currentLogDir is null"
-        }
+        // A start that cannot succeed has to settle this wait too, or the caller sits here forever.
+        val settled = internalState.flow.first { it.isRecording || it.startFailure != null }
+        settled.startFailure?.let { throw it }
+
+        requireNotNull(settled.currentLogDir) { "Recording started but currentLogDir is null" }
     }
 
-    suspend fun stopRecorder(): File? {
+    suspend fun stopRecorder(): File? = startStopLock.withLock { stopRecorderLocked() }
+
+    /**
+     * Requires [startStopLock]. Reading the current session, publishing the request and observing
+     * the stop have to happen without another caller in between, or two callers report having
+     * stopped the same session — or one that is still running.
+     */
+    private suspend fun stopRecorderLocked(): File? {
         val currentDir = internalState.value().currentLogDir ?: return null
         internalState.updateBlocking {
             copy(shouldRecord = false)
         }
-        internalState.flow.filter { !it.isRecording }.first()
+        internalState.flow.first { !it.isRecording }
         return currentDir
     }
 
-    suspend fun requestStopRecorder(): StopResult {
+    suspend fun requestStopRecorder(): StopResult = startStopLock.withLock {
         val currentState = internalState.value()
-        if (!currentState.isRecording) return StopResult.NotRecording
+        if (!currentState.isRecording) return@withLock StopResult.NotRecording
 
-        val logDir = currentState.currentLogDir ?: return StopResult.NotRecording
+        if (currentState.currentLogDir == null) return@withLock StopResult.NotRecording
         val elapsed = currentState.recordingStartedAtMonotonic
             ?.let { monotonicClock() - it }             // live session: immune to wall-clock adjustments
             ?: (wallClock() - currentState.recordingStartedAt)  // resumed: only the mtime-derived wall start exists
         // Negative = wall clock moved backward across a resume; fail open (no warning) rather than
         // trap the user in TooShort.
-        if (elapsed in 0 until MIN_RECORDING_MS) return StopResult.TooShort
+        if (elapsed in 0 until MIN_RECORDING_MS) return@withLock StopResult.TooShort
 
-        stopRecorder()
-        val sessionId = DebugSessionManager.deriveSessionId(logDir)
-        return StopResult.Stopped(logDir, sessionId)
+        // The delegated stop decides what was stopped: reporting the dir read above would claim a
+        // stop that a concurrent caller had already performed.
+        val stoppedDir = stopRecorderLocked() ?: return@withLock StopResult.NotRecording
+        val sessionId = DebugSessionManager.deriveSessionId(stoppedDir)
+        StopResult.Stopped(stoppedDir, sessionId)
     }
 
     sealed class StopResult {
@@ -268,6 +449,13 @@ class RecorderModule @Inject constructor(
         // previous process or boot is meaningless. Nullable rather than 0L — 0 is a legal
         // elapsedRealtime near boot.
         val recordingStartedAtMonotonic: Long? = null,
+        /**
+         * Why the last start attempt did not produce a recording, cleared when a new one is
+         * requested. Carried as the Throwable itself: the state flow is distinctUntilChanged, so a
+         * failure has to produce a value distinct from its predecessor or a waiting [startRecorder]
+         * never wakes up — Throwable's reference equality provides that.
+         */
+        val startFailure: Throwable? = null,
     ) {
         val isRecording: Boolean
             get() = recorder != null
@@ -291,6 +479,13 @@ class RecorderModule @Inject constructor(
          * direct force-stop path, which has no duration check.
          */
         private const val MIN_RECORDING_MS = 10_000L
+
+        /**
+         * Suffixes tried when the timestamped session dir name is already taken. A handful is
+         * plenty: the name is stamped to the second, so a collision means a leftover directory or a
+         * retry within the same second, not a long run of them.
+         */
+        private const val NAME_COLLISION_LIMIT = 8
 
         // Budget for the header's diagnostics read.
         private const val HEADER_READ_TIMEOUT_MS = 5_000L

--- a/app/src/main/java/eu/darken/bluemusic/common/error/ThrowableExtensions.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/error/ThrowableExtensions.kt
@@ -40,3 +40,13 @@ fun Throwable.getStackTraceString(): String {
 
 fun Throwable.tryUnwrap(kClass: KClass<RuntimeException> = RuntimeException::class): Throwable =
     if (!kClass.isInstance(this)) this else cause ?: this
+
+/**
+ * Attaches a secondary failure to the one being reported. Cleanup can hand back the very throwable
+ * it is cleaning up after — a recorder broken in one way throws it on the start line and again on
+ * the teardown line — and [Throwable.addSuppressed] rejects self-suppression with an
+ * [IllegalArgumentException], which would abort the cleanup before the failure is ever reported.
+ */
+fun Throwable.addSuppressedSafely(other: Throwable) {
+    if (this !== other) addSuppressed(other)
+}

--- a/app/src/test/java/eu/darken/bluemusic/common/debug/logging/FileLoggerTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/common/debug/logging/FileLoggerTest.kt
@@ -1,0 +1,96 @@
+package eu.darken.bluemusic.common.debug.logging
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.io.File
+import java.io.IOException
+import java.io.OutputStream
+
+/**
+ * A start that cannot open its writer used to be swallowed: the recorder then reported a successful
+ * start for a recording that could never produce a log file, and it removed the log file on the way
+ * out — which included the log of a session being RESUMED, so a restart that failed threw away the
+ * recording the user had already collected.
+ *
+ * The failures are injected through [FileLogger.streamFactory] rather than through permission bits:
+ * [FileLogger.start] repairs the file permissions itself before opening the writer, and a root test
+ * runner ignores them entirely — an injected fault that the code under test can undo is no fault.
+ *
+ * Robolectric because the logger writes through android.util.Log.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class FileLoggerTest : BaseTest() {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    /** Fails in the window that decides the delete: the file exists by the time the open is attempted. */
+    private val unopenableStream: (File) -> OutputStream = { throw IOException("writer cannot be opened") }
+
+    /** The other window: the writer opens, and the header it writes never reaches the file. */
+    private val unwritableStream: (File) -> OutputStream = {
+        object : OutputStream() {
+            override fun write(b: Int) = throw IOException("header cannot be written")
+        }
+    }
+
+    @Test
+    fun `a failed start keeps a log it did not create`() {
+        val logFile = File(tempFolder.newFolder("resumed"), "core.log")
+        logFile.writeText("=== BEGIN ===\nthe recording the user already made\n")
+
+        shouldThrow<IOException> {
+            FileLogger(logFile).apply { streamFactory = unopenableStream }.start()
+        }
+
+        logFile.exists() shouldBe true
+        logFile.readText() shouldContain "the recording the user already made"
+    }
+
+    @Test
+    fun `a failed start removes the log file it created itself`() {
+        val logFile = File(tempFolder.newFolder("fresh"), "core.log")
+
+        shouldThrow<IOException> {
+            FileLogger(logFile).apply { streamFactory = unopenableStream }.start()
+        }
+
+        // Nothing was recorded into it and nothing else owns it: leaving the empty file behind makes
+        // the session look like a recording that produced an empty log.
+        logFile.exists() shouldBe false
+    }
+
+    @Test
+    fun `a header write that fails removes the log file this start created`() {
+        val logFile = File(tempFolder.newFolder("header"), "core.log")
+
+        shouldThrow<IOException> {
+            FileLogger(logFile).apply { streamFactory = unwritableStream }.start()
+        }
+
+        logFile.exists() shouldBe false
+    }
+
+    @Test
+    fun `a start that cannot open its writer surfaces the failure`() {
+        // The production open, no seam: swallowed, this installs a logger that writes nowhere while
+        // the recorder reports success.
+        val logFile = File(tempFolder.newFolder("blocked"), "core.log")
+        logFile.mkdirs()
+
+        shouldThrow<IOException> { FileLogger(logFile).start() }
+
+        // Not created by this start, so it is not removed either.
+        logFile.isDirectory shouldBe true
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderModuleTest.kt
@@ -2,24 +2,33 @@ package eu.darken.bluemusic.common.debug.recorder.core
 
 import android.content.Context
 import eu.darken.bluemusic.common.BlueMusicId
+import eu.darken.bluemusic.common.debug.logging.FileLogger
 import eu.darken.bluemusic.common.debug.logging.Logging
 import eu.darken.bluemusic.common.upgrade.UpgradeDiagnostics
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.longs.shouldBeLessThan
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.types.shouldBeInstanceOf
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -29,6 +38,7 @@ import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.coroutines.yield
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -43,6 +53,143 @@ import javax.inject.Provider
 import kotlin.system.measureTimeMillis
 
 class RecorderModuleTest : BaseTest() {
+
+    @TempDir
+    lateinit var tempDir: File
+
+    private val context: Context = mockk(relaxed = true)
+    private val blueMusicId: BlueMusicId = mockk()
+    private val upgradeDiagnostics: UpgradeDiagnostics = mockk()
+    private val recorderProvider: Provider<Recorder> = mockk()
+    private val mockRecorder: Recorder = mockk()
+
+    private lateinit var externalDir: File
+    private lateinit var cacheDir: File
+    private lateinit var externalLogDir: File
+
+    private val triggerFile: File
+        get() = File(externalDir, TRIGGER_FILE)
+
+    // Test-controlled clocks handed to the module's seams: the durations under test are
+    // wall-clock/monotonic, so virtual time cannot drive them. The wall clock is fixed, which also
+    // pins the session dir name - the collision walk is only observable with a stable name.
+    // Volatile: the concurrency suite advances them from the test thread while the module reads them
+    // on its own dispatcher threads.
+    @Volatile
+    private var wallNow = WALL_BASE
+
+    @Volatile
+    private var monotonicNow = MONOTONIC_BASE
+
+    @BeforeEach
+    fun setupFixture() {
+        externalDir = File(tempDir, "external").apply { mkdirs() }
+        cacheDir = File(tempDir, "cache").apply { mkdirs() }
+        externalLogDir = File(externalDir, "debug/logs").apply { mkdirs() }
+
+        every { context.getExternalFilesDir(null) } returns externalDir
+        every { context.cacheDir } returns cacheDir
+
+        every { blueMusicId.id } returns "abcdefgh12345678"
+        coEvery { upgradeDiagnostics.debugInfo() } returns "BillingCache(test)"
+
+        every { recorderProvider.get() } returns mockRecorder
+        coEvery { mockRecorder.start(any()) } returns Unit
+        coEvery { mockRecorder.stop() } returns Unit
+
+        wallNow = WALL_BASE
+        monotonicNow = MONOTONIC_BASE
+    }
+
+    private fun createModule(scope: CoroutineScope, dispatcher: CoroutineDispatcher) = RecorderModule(
+        context = context,
+        appScope = scope,
+        dispatcherProvider = TestDispatcherProvider(dispatcher),
+        blueMusicId = blueMusicId,
+        upgradeDiagnostics = upgradeDiagnostics,
+        recorderProvider = recorderProvider,
+    ).apply {
+        // The monotonic seam defaults to SystemClock.elapsedRealtime, an Android framework stub that
+        // throws in plain JVM tests. RecorderModuleDurationTest owns the duration heuristic; here the
+        // clocks only have to be readable and controllable.
+        wallClock = { wallNow }
+        monotonicClock = { monotonicNow }
+    }
+
+    private val logLines = CopyOnWriteArrayList<String>()
+    private val logCapture = object : Logging.Logger {
+        override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+            logLines.add(message)
+        }
+    }
+
+    /**
+     * Real dispatchers on purpose: these tests are about a failed or raced transition SETTLING, and
+     * virtual time would skip past a wedge rather than expose it — the header's read deadline is
+     * wall-clock too. The envelope is what turns a regression into a failure in seconds instead of a
+     * gradle worker stuck until the job timeout, which is what the pre-fix module did.
+     *
+     * The recorder is stopped in a nested finally BEFORE the scope goes: cancelling the scope alone
+     * does not uninstall a running recorder's globally installed [FileLogger]. This harness injects a
+     * mocked [Recorder], so nothing should install one at all — the accounting is what catches a
+     * change that starts doing so.
+     */
+    private fun withRealtimeModule(
+        headerTimeoutMs: Long = 300L,
+        block: suspend (RecorderModule) -> Unit,
+    ) {
+        val fileLoggersBefore = Logging.loggers.filterIsInstance<FileLogger>()
+        val moduleScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+        Logging.install(logCapture)
+        var module: RecorderModule? = null
+        try {
+            try {
+                val created = createModule(moduleScope, Dispatchers.IO)
+                created.headerReadTimeoutMs = headerTimeoutMs
+                module = created
+                runBlocking {
+                    withTimeout(TEST_ENVELOPE_MS) {
+                        // Settled before the test acts: the state flow only goes hot once the init
+                        // collector subscribes, and a request racing that start-up is not what any
+                        // of these tests are about.
+                        created.state.first()
+                        block(created)
+                    }
+                }
+            } finally {
+                module?.let {
+                    runBlocking {
+                        withTimeoutOrNull(TEST_ENVELOPE_MS) { runCatching { it.stopRecorder() } }
+                    }
+                }
+            }
+        } finally {
+            Logging.remove(logCapture)
+            moduleScope.cancel()
+            // A leaked logger must fail THIS test, not poison later ones. Remove stragglers after
+            // asserting so one failure cannot cascade.
+            val leaked = Logging.loggers.filterIsInstance<FileLogger>() - fileLoggersBefore.toSet()
+            leaked.forEach { Logging.remove(it) }
+            leaked shouldBe emptyList<FileLogger>()
+        }
+    }
+
+    /**
+     * A recorder started from the debug settings has no trigger file yet — and an unwritable external
+     * files dir makes creating it fail right after the recorder went live.
+     */
+    private fun blockTriggerFileCreation() {
+        val blockedParent = File(tempDir, "blocked").apply { createNewFile() }
+        every { context.getExternalFilesDir(null) } returns blockedParent
+    }
+
+    /** A session interrupted by process death: a dir with a log in it plus the trigger that marks it. */
+    private fun seedResumableSession(): File {
+        val sessionDir = File(externalLogDir, "bluemusic_1.0_20260309T120000Z_abcdefgh").apply { mkdirs() }
+        File(sessionDir, "core.log").writeText("the recording the user already made\n")
+        check(triggerFile.createNewFile()) { "Failed to seed the trigger file" }
+        return sessionDir
+    }
 
     @Nested
     inner class DefaultState {
@@ -69,6 +216,11 @@ class RecorderModuleTest : BaseTest() {
         @Test
         fun `currentLogPath is null`() {
             RecorderModule.State().currentLogPath shouldBe null
+        }
+
+        @Test
+        fun `startFailure is null`() {
+            RecorderModule.State().startFailure shouldBe null
         }
     }
 
@@ -172,92 +324,12 @@ class RecorderModuleTest : BaseTest() {
     @Nested
     inner class StartGuard {
 
-        @TempDir lateinit var tempDir: File
-
-        private val context: Context = mockk(relaxed = true)
-        private val blueMusicId: BlueMusicId = mockk()
-        private val upgradeDiagnostics: UpgradeDiagnostics = mockk()
-        private val recorderProvider: Provider<Recorder> = mockk()
-        private val mockRecorder: Recorder = mockk()
-
-        private lateinit var externalDir: File
-        private lateinit var cacheDir: File
-
-        @BeforeEach
-        fun setup() {
-            externalDir = File(tempDir, "external").apply { mkdirs() }
-            cacheDir = File(tempDir, "cache").apply { mkdirs() }
-
-            every { context.getExternalFilesDir(null) } returns externalDir
-            every { context.cacheDir } returns cacheDir
-
-            every { blueMusicId.id } returns "abcdefgh12345678"
-            coEvery { upgradeDiagnostics.debugInfo() } returns "BillingCache(test)"
-
-            every { recorderProvider.get() } returns mockRecorder
-            coEvery { mockRecorder.start(any()) } returns Unit
-            coEvery { mockRecorder.stop() } returns Unit
-        }
-
-        private fun createModule(scope: CoroutineScope, dispatcher: CoroutineDispatcher) = RecorderModule(
-            context = context,
-            appScope = scope,
-            dispatcherProvider = TestDispatcherProvider(dispatcher),
-            blueMusicId = blueMusicId,
-            upgradeDiagnostics = upgradeDiagnostics,
-            recorderProvider = recorderProvider,
-        ).apply {
-            // The monotonic seam defaults to SystemClock.elapsedRealtime, an Android framework stub
-            // that throws in plain JVM tests. Nothing here measures durations — RecorderModuleDurationTest
-            // does — these starts just must not trip over the default.
-            monotonicClock = { 0L }
-        }
-
-        private val logLines = CopyOnWriteArrayList<String>()
-        private val logCapture = object : Logging.Logger {
-            override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
-                logLines.add(message)
-            }
-        }
-
-        /**
-         * Real dispatchers on purpose: the header's read deadline is wall-clock, so a virtual-time
-         * test would skip past it instead of exercising it — an ignored seam has to fail this, not
-         * pass after the full production budget. The seam is set before [RecorderModule.startRecorder]
-         * so no header read can run against the production bound.
-         *
-         * The block runs inside its own deadline: a missing or mis-wired production bound must fail
-         * this test rather than wedge the gradle worker on a read that never answers.
-         */
-        private fun withRealtimeModule(
-            headerTimeoutMs: Long = 300L,
-            block: suspend (RecorderModule) -> Unit,
-        ) {
-            val moduleScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
-            Logging.install(logCapture)
-            try {
-                val module = createModule(moduleScope, Dispatchers.IO)
-                module.headerReadTimeoutMs = headerTimeoutMs
-                runBlocking { withTimeout(TEST_ENVELOPE_MS) { block(module) } }
-            } finally {
-                Logging.remove(logCapture)
-                moduleScope.cancel()
-            }
-        }
-
-        /** A recorder started from the debug settings has no trigger file yet — and an unwritable
-         * external files dir makes creating it fail right after the recorder went live. */
-        private fun blockTriggerFileCreation() {
-            val blockedParent = File(tempDir, "blocked").apply { createNewFile() }
-            every { context.getExternalFilesDir(null) } returns blockedParent
-        }
-
         @Test
         fun `a cancellation during the log header stops the uncommitted recorder`() = runTest {
             // The recorder is started before the header is written but only committed to the state
             // afterwards: a cancellation in between would orphan a running recorder that
             // stopRecorder() can never reach.
-            File(externalDir, "bluemusic_force_debug_run").createNewFile()
+            triggerFile.createNewFile()
             coEvery { upgradeDiagnostics.debugInfo() } coAnswers { awaitCancellation() }
 
             val dispatcher = UnconfinedTestDispatcher(testScheduler)
@@ -284,14 +356,14 @@ class RecorderModuleTest : BaseTest() {
             // currentLogDir is published before the state commit lands: a cancellation while the
             // commit is in flight would leave a running recorder behind a log dir that the state
             // never learns about.
-            File(externalDir, "bluemusic_force_debug_run").createNewFile()
+            triggerFile.createNewFile()
 
             val dispatcher = StandardTestDispatcher(testScheduler)
             val moduleScope = CoroutineScope(dispatcher + Job())
             val module = createModule(moduleScope, dispatcher)
 
             // Queued alongside the module's own coroutines: the first turn where currentLogDir is
-            // set is the one where reconcileState() is parked in the state commit.
+            // set is the one where the start is parked in the state commit.
             val canceller = launch {
                 var turns = 0
                 while (module.currentLogDir == null && turns++ < 1000) yield()
@@ -308,50 +380,35 @@ class RecorderModuleTest : BaseTest() {
         }
 
         @Test
-        fun `a failing log header stops the uncommitted recorder`() = runTest {
-            // Same window as above, but for ordinary failures of the header writes.
+        fun `a failing log header surfaces to the caller instead of hanging`() {
+            // Same window as the cancellation cases, but for an ordinary failure of the header
+            // writes: it reaches the caller, and the module stays usable.
             blockTriggerFileCreation()
 
-            val dispatcher = UnconfinedTestDispatcher(testScheduler)
-            var caught: Throwable? = null
-            val handler = CoroutineExceptionHandler { _, error -> caught = error }
-            val moduleScope = CoroutineScope(dispatcher + Job() + handler)
-            val module = createModule(moduleScope, dispatcher)
-            // The recorder is enabled from the debug settings, so there is no trigger file yet.
-            val starter = launch { module.startRecorder() }
-            advanceUntilIdle()
+            withRealtimeModule { module ->
+                shouldThrow<IOException> { module.startRecorder() }
 
-            caught.shouldBeInstanceOf<IOException>()
-            coVerify { mockRecorder.start(any()) }
-            coVerify { mockRecorder.stop() }
-            module.state.first().isRecording shouldBe false
-            module.currentLogDir shouldBe null
-
-            starter.cancel()
-            moduleScope.cancel()
+                coVerify { mockRecorder.start(any()) }
+                coVerify { mockRecorder.stop() }
+                val state = module.state.first()
+                state.isRecording shouldBe false
+                state.startFailure.shouldNotBeNull()
+                module.currentLogDir.shouldBeNull()
+            }
         }
 
         @Test
-        fun `a failing stop is reported with the original failure`() = runTest {
+        fun `a failing stop is reported with the original failure`() {
             // The stop is a best-effort cleanup: losing the reason the start failed would leave the
             // debug log with a mystery instead of the disk error that caused it.
             blockTriggerFileCreation()
             val stopError = IllegalStateException("recorder is wedged")
             coEvery { mockRecorder.stop() } throws stopError
 
-            val dispatcher = UnconfinedTestDispatcher(testScheduler)
-            var caught: Throwable? = null
-            val handler = CoroutineExceptionHandler { _, error -> caught = error }
-            val moduleScope = CoroutineScope(dispatcher + Job() + handler)
-            val module = createModule(moduleScope, dispatcher)
-            val starter = launch { module.startRecorder() }
-            advanceUntilIdle()
-
-            caught.shouldBeInstanceOf<IOException>()
-            caught!!.suppressed.toList() shouldBe listOf(stopError)
-
-            starter.cancel()
-            moduleScope.cancel()
+            withRealtimeModule { module ->
+                val caught = shouldThrow<IOException> { module.startRecorder() }
+                caught.suppressed.toList() shouldBe listOf(stopError)
+            }
         }
 
         /**
@@ -386,8 +443,336 @@ class RecorderModuleTest : BaseTest() {
             }
         }
     }
-}
 
-// Independent of the production bound: a missing or mis-wired one has to fail the test, not hang
-// the gradle worker.
-private const val TEST_ENVELOPE_MS = 10_000L
+    /**
+     * A start that fails must not take the state collector with it: that collector is the only thing
+     * that ever serves a start or stop request, so killing it wedges every later caller forever —
+     * while the recorder it abandoned keeps writing where nothing can reach it.
+     */
+    @Nested
+    inner class StartFailures {
+
+        @Test
+        fun `a failed start settles the request and leaves the collector alive`() {
+            coEvery { mockRecorder.start(any()) } throws IOException("recorder broken")
+
+            withRealtimeModule { module ->
+                shouldThrow<IOException> { module.startRecorder() }
+
+                val failed = module.state.first()
+                failed.isRecording shouldBe false
+                // Reset on failure, or the collector walks straight back into the start branch.
+                failed.shouldRecord shouldBe false
+                failed.startFailure.shouldNotBeNull()
+                failed.currentLogDir.shouldBeNull()
+                module.currentLogDir.shouldBeNull()
+                triggerFile.exists() shouldBe false
+
+                coEvery { mockRecorder.start(any()) } returns Unit
+
+                // Non-vacuity: with a rethrow the collector would be dead here and this would hang
+                // until the envelope kills the test.
+                val logDir = module.startRecorder()
+                logDir.exists() shouldBe true
+                val recording = module.state.first { it.isRecording }
+                recording.currentLogDir shouldBe logDir
+                // A stale failure must not be reported as the outcome of the attempt that succeeded.
+                recording.startFailure.shouldBeNull()
+                triggerFile.exists() shouldBe true
+            }
+        }
+
+        @Test
+        fun `a failed start rolls back the session dir it created`() {
+            coEvery { mockRecorder.start(any()) } throws IOException("recorder broken")
+
+            withRealtimeModule { module ->
+                shouldThrow<IOException> { module.startRecorder() }
+
+                // Publishing the failure kicks off a session scan, and an empty dir left here would
+                // be picked up as an orphan session that never held a recording.
+                externalLogDir.listFiles()?.toList().orEmpty().shouldBeEmpty()
+                triggerFile.exists() shouldBe false
+            }
+        }
+
+        @Test
+        fun `a failed start deletes the trigger file it created`() {
+            // Fails AFTER the trigger was written: a trigger left behind re-attempts the dead
+            // session on every single app launch.
+            withRealtimeModule { module ->
+                module.monotonicClock = { throw IOException("clock broken") }
+
+                shouldThrow<IOException> { module.startRecorder() }
+
+                triggerFile.exists() shouldBe false
+                externalLogDir.listFiles()?.toList().orEmpty().shouldBeEmpty()
+                module.currentLogDir.shouldBeNull()
+                module.state.first().startFailure.shouldNotBeNull()
+            }
+        }
+
+        @Test
+        fun `a failed resume keeps the markers of the session it was resuming`() {
+            // The boot path starts a recording without anyone calling startRecorder(): a trigger left
+            // from a previous run makes the module resume on construction. None of it was created by
+            // the failing attempt, so none of it may be rolled away.
+            val sessionDir = seedResumableSession()
+            coEvery { mockRecorder.start(any()) } throws IOException("recorder broken")
+
+            withRealtimeModule { module ->
+                module.state.first { it.startFailure != null }
+
+                module.state.first().isRecording shouldBe false
+                module.currentLogDir.shouldBeNull()
+                sessionDir.exists() shouldBe true
+                File(sessionDir, "core.log").readText() shouldBe "the recording the user already made\n"
+                triggerFile.exists() shouldBe true
+            }
+        }
+
+        /**
+         * A [CancellationException] out of the start work does NOT mean this module's scope is going
+         * away — a bounded read timing out looks exactly like this. Handed to the caller unchanged it
+         * would unwind THEM as if they had been cancelled, and the ViewModel error handler ignores
+         * cancellations: the user is told nothing at all.
+         */
+        @Test
+        fun `a foreign cancellation reaches the caller as a start failure`() {
+            coEvery { mockRecorder.start(any()) } throws CancellationException("bounded read gave up")
+
+            withRealtimeModule { module ->
+                val error = shouldThrow<RecorderModule.RecorderStartFailedException> { module.startRecorder() }
+                // The conversion is what matters, not which instance survived it: a cancellation
+                // travelling through the coroutine machinery may well arrive as a copy.
+                error.cause.shouldBeInstanceOf<CancellationException>()
+                module.state.first().startFailure.shouldBeInstanceOf<RecorderModule.RecorderStartFailedException>()
+
+                coEvery { mockRecorder.start(any()) } returns Unit
+
+                // Non-vacuity: with a rethrow the collector would be dead here.
+                val logDir = module.startRecorder()
+                module.state.first { it.isRecording }.currentLogDir shouldBe logDir
+            }
+        }
+
+        /**
+         * The stop side of the same window: everything awaiting the transition — stopRecorder(),
+         * requestStopRecorder(), the UI's isRecording — depends on the cleared state being committed
+         * even when the recorder itself cannot be shut down.
+         */
+        @Test
+        fun `a recorder that fails to stop still clears the recording state`() {
+            withRealtimeModule { module ->
+                val logDir = module.startRecorder()
+                triggerFile.exists() shouldBe true
+
+                coEvery { mockRecorder.stop() } throws IOException("log writer wedged")
+
+                module.stopRecorder() shouldBe logDir
+
+                val state = module.state.first()
+                state.isRecording shouldBe false
+                state.currentLogDir.shouldBeNull()
+                state.recordingStartedAt shouldBe 0L
+                module.currentLogDir.shouldBeNull()
+                triggerFile.exists() shouldBe false
+
+                coEvery { mockRecorder.stop() } returns Unit
+
+                // The module survived the failed stop and still serves the next request.
+                module.startRecorder().exists() shouldBe true
+            }
+        }
+
+        @Test
+        fun `a session name collision takes a new dir instead of adopting the existing one`() {
+            withRealtimeModule { module ->
+                val first = module.startRecorder()
+                module.stopRecorder() shouldBe first
+
+                // The mocked recorder writes no core.log, so the finished dir is not resumable and
+                // the create path runs straight into its name — the wall clock is fixed, so the
+                // second recording computes the very same one.
+                File(first, "core.log").exists() shouldBe false
+
+                val second = module.startRecorder()
+
+                // Adopting it would mark somebody else's directory as created-by-this-attempt, and a
+                // failed start would then delete it.
+                second.name shouldBe "${first.name}-1"
+                second.isDirectory shouldBe true
+                first.isDirectory shouldBe true
+                DebugSessionManager.deriveSessionId(second) shouldBe "ext:${second.name}"
+            }
+        }
+    }
+
+    /**
+     * The public request surface is serialized: without that, two callers racing the same transition
+     * observe each other's outcome — two of them report having stopped the same session, or a start
+     * request settles on a failure that belongs to somebody else's attempt.
+     *
+     * Every test here pins the first caller INSIDE the transition — parked in the mocked recorder's
+     * own start or stop, holding the lock — before the racers are launched, and checks they are still
+     * blocked before releasing it. Launching them side by side on [Dispatchers.IO] does not race
+     * anything: the transitions are short enough to serialize on their own, and the assertions would
+     * hold with the mutex removed.
+     */
+    @Nested
+    inner class Concurrency {
+
+        @Test
+        fun `four concurrent stop requests report exactly one stop`() {
+            val stopEntered = CompletableDeferred<Unit>()
+            val releaseStop = CompletableDeferred<Unit>()
+            coEvery { mockRecorder.stop() } coAnswers {
+                stopEntered.complete(Unit)
+                releaseStop.await()
+            }
+
+            withRealtimeModule { module ->
+                module.startRecorder()
+                monotonicNow += 20_000L
+
+                val results = coroutineScope {
+                    val first = async(Dispatchers.IO) { module.requestStopRecorder() }
+                    // The transition is in flight and its caller holds the lock: the state still
+                    // says "recording" while the stop it asked for has not committed.
+                    stopEntered.await()
+
+                    val racers = (1..3).map { async(Dispatchers.IO) { module.requestStopRecorder() } }
+                    delay(SETTLE_MS)
+                    // Without the lock they would read that stale "recording" and each report having
+                    // stopped the very same session.
+                    racers.forEach { it.isCompleted shouldBe false }
+
+                    releaseStop.complete(Unit)
+                    (listOf(first) + racers).awaitAll()
+                }
+
+                results.count { it is RecorderModule.StopResult.Stopped } shouldBe 1
+                results.count { it == RecorderModule.StopResult.NotRecording } shouldBe 3
+                module.state.first().isRecording shouldBe false
+            }
+        }
+
+        @Test
+        fun `a direct stop racing a stop request reports the stop exactly once`() {
+            val stopEntered = CompletableDeferred<Unit>()
+            val releaseStop = CompletableDeferred<Unit>()
+            coEvery { mockRecorder.stop() } coAnswers {
+                stopEntered.complete(Unit)
+                releaseStop.await()
+            }
+
+            withRealtimeModule { module ->
+                val logDir = module.startRecorder()
+                monotonicNow += 20_000L
+
+                val (direct, requested) = coroutineScope {
+                    val a = async(Dispatchers.IO) { module.stopRecorder() }
+                    // Same window, from the direct stop's side: it is parked in the recorder's stop
+                    // with the lock held when the request below arrives.
+                    stopEntered.await()
+
+                    val b = async(Dispatchers.IO) { module.requestStopRecorder() }
+                    delay(SETTLE_MS)
+                    b.isCompleted shouldBe false
+
+                    releaseStop.complete(Unit)
+                    a.await() to b.await()
+                }
+
+                val reports = listOfNotNull(direct).size +
+                    (if (requested is RecorderModule.StopResult.Stopped) 1 else 0)
+                reports shouldBe 1
+                (direct ?: (requested as RecorderModule.StopResult.Stopped).logDir) shouldBe logDir
+                module.state.first().isRecording shouldBe false
+            }
+        }
+
+        @Test
+        fun `concurrent failed starts each get their own attempt`() {
+            val firstStartEntered = CompletableDeferred<Unit>()
+            val releaseFirstStart = CompletableDeferred<Unit>()
+            coEvery { mockRecorder.start(any()) } coAnswers {
+                // Only the first attempt is held: the second one has to be free to run to completion
+                // once the lock is handed over to it.
+                if (firstStartEntered.complete(Unit)) releaseFirstStart.await()
+                throw IOException("recorder broken")
+            }
+
+            withRealtimeModule { module ->
+                coroutineScope {
+                    val first = async(Dispatchers.IO) { runCatching { module.startRecorder() } }
+                    firstStartEntered.await()
+
+                    val second = async(Dispatchers.IO) { runCatching { module.startRecorder() } }
+                    delay(SETTLE_MS)
+                    // Without the lock this request would fold into the attempt already running -
+                    // its shouldRecord=true is not a distinct state - and report that one's failure
+                    // as its own, which the attempt count below then contradicts.
+                    second.isCompleted shouldBe false
+
+                    releaseFirstStart.complete(Unit)
+
+                    // Serialized: neither request can clear the failure the other one is waiting for
+                    // and leave it hanging on a recording that is never coming.
+                    first.await().exceptionOrNull().shouldBeInstanceOf<IOException>()
+                    second.await().exceptionOrNull().shouldBeInstanceOf<IOException>()
+                }
+
+                // One attempt per request, not one shared outcome reported twice.
+                coVerify(exactly = 2) { mockRecorder.start(any()) }
+            }
+        }
+
+        @Test
+        fun `a stop request during an in-flight start waits for it`() {
+            val startEntered = CompletableDeferred<Unit>()
+            val releaseStart = CompletableDeferred<Unit>()
+            coEvery { mockRecorder.start(any()) } coAnswers {
+                startEntered.complete(Unit)
+                releaseStart.await()
+            }
+
+            withRealtimeModule { module ->
+                coroutineScope {
+                    val starting = async(Dispatchers.IO) { module.startRecorder() }
+                    startEntered.await()
+
+                    val stopping = async(Dispatchers.IO) { module.stopRecorder() }
+                    delay(SETTLE_MS)
+
+                    // Reading the state outside the lock answered "not recording" here, and the start
+                    // committed right afterwards — a recording the user had already asked to stop.
+                    stopping.isCompleted shouldBe false
+
+                    releaseStart.complete(Unit)
+
+                    val logDir = starting.await()
+                    stopping.await() shouldBe logDir
+                }
+
+                module.state.first().isRecording shouldBe false
+                module.currentLogDir.shouldBeNull()
+                triggerFile.exists() shouldBe false
+            }
+        }
+    }
+
+    companion object {
+        // Independent of any production bound: a wedged wait has to fail the test, not hang the
+        // gradle worker.
+        private const val TEST_ENVELOPE_MS = 10_000L
+
+        // Real time, not virtual: long enough for a transition that should NOT have happened to show
+        // itself, short enough to stay well inside the envelope.
+        private const val SETTLE_MS = 300L
+
+        private const val WALL_BASE = 1_800_000_000_000L
+        private const val MONOTONIC_BASE = 100_000L
+        private const val TRIGGER_FILE = "bluemusic_force_debug_run"
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/common/debug/recorder/core/RecorderTest.kt
@@ -1,0 +1,110 @@
+package eu.darken.bluemusic.common.debug.recorder.core
+
+import eu.darken.bluemusic.common.debug.logging.Logging
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import kotlinx.coroutines.runBlocking
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.io.File
+import java.io.IOException
+
+/**
+ * The REAL recorder, with the faults injected into the file it records to and into the logging its
+ * own teardown emits — no double, no manual cleanup. Both directions have to hold: a start that
+ * cannot open its log must leave nothing behind that claims to be recording, and a stop must run
+ * every teardown step regardless of what the ones before it did, because the module commits
+ * "stopped" state around it and a logger left installed keeps writing into a session everybody else
+ * considers finished.
+ *
+ * Robolectric because the file logger writes through android.util.Log.
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class RecorderTest : BaseTest() {
+
+    @get:Rule
+    val tempFolder = TemporaryFolder()
+
+    /** Fails on every line it receives while armed — the loggers being torn down are receivers. */
+    private class Saboteur : Logging.Logger {
+        @Volatile
+        var armed = false
+
+        override fun log(priority: Logging.Priority, tag: String, message: String, metaData: Map<String, Any>?) {
+            if (armed) throw IllegalStateException("Simulated logger failure")
+        }
+    }
+
+    /**
+     * The registry is global: a recorder or saboteur left installed by a FAILING assertion here keeps
+     * receiving every line every later test in this process emits — the regression under test would
+     * then cascade into unrelated failures instead of being the one thing that went red. Run
+     * unconditionally, and after the assertions, so it can never substitute for them.
+     */
+    private fun restoreRegistry(recorder: Recorder, loggersBefore: List<Logging.Logger>) {
+        runCatching { runBlocking { recorder.stop() } }
+        (Logging.loggers - loggersBefore.toSet()).forEach { Logging.remove(it) }
+    }
+
+    @Test
+    fun `a start that cannot open its log leaves nothing behind`() {
+        val loggersBefore = Logging.loggers
+        // A directory where the log file belongs: the writer cannot be opened for it.
+        val logFile = File(tempFolder.newFolder("session"), "core.log").also { it.mkdirs() }
+        val recorder = Recorder()
+
+        try {
+            shouldThrow<IOException> { runBlocking { recorder.start(logFile) } }
+
+            // Nothing is published until the writer is live, or the recorder claims to record into a
+            // file that receives nothing — and stopRecorder() would report a session with no log.
+            recorder.isRecording shouldBe false
+            recorder.path.shouldBeNull()
+            Logging.loggers shouldBe loggersBefore
+        } finally {
+            // A start that unexpectedly succeeded installed a FileLogger that nothing else removes.
+            restoreRegistry(recorder, loggersBefore)
+        }
+    }
+
+    @Test
+    fun `a stop whose logging fails still tears the recorder down`() {
+        val loggersBefore = Logging.loggers
+        val logFile = File(tempFolder.newFolder("session"), "core.log")
+        val recorder = Recorder()
+        val saboteur = Saboteur()
+
+        try {
+            runBlocking { recorder.start(logFile) }
+            Logging.install(saboteur)
+            saboteur.armed = true
+
+            // The first failure is reported, not swallowed — but only after everything ran.
+            shouldThrow<IllegalStateException> { runBlocking { recorder.stop() } }
+
+            saboteur.armed = false
+            Logging.remove(saboteur)
+
+            // Nothing was uninstalled by hand in between: this is stop()'s own guarantee.
+            Logging.loggers shouldBe loggersBefore
+            recorder.isRecording shouldBe false
+            recorder.path.shouldBeNull()
+            // The end marker is written by the file logger's own stop, so the writer was closed too
+            // instead of being left open on a session that is reported as finished.
+            logFile.readText() shouldContain "=== END ==="
+        } finally {
+            // Disarmed first: a saboteur still armed would throw out of the very cleanup below.
+            saboteur.armed = false
+            restoreRegistry(recorder, loggersBefore)
+        }
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/main/ui/settings/support/SupportScreenViewModelTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/ui/settings/support/SupportScreenViewModelTest.kt
@@ -1,0 +1,60 @@
+package eu.darken.bluemusic.main.ui.settings.support
+
+import eu.darken.bluemusic.common.debug.recorder.core.DebugSession
+import eu.darken.bluemusic.common.debug.recorder.core.DebugSessionManager
+import eu.darken.bluemusic.common.debug.recorder.core.RecorderModule
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
+
+/**
+ * Starting a debug recording can fail — and used to fail silently: the module rethrew into its own
+ * scope instead of answering the caller, so this ViewModel's launch never completed and the user
+ * kept staring at a toggle that did nothing. The failure has to arrive at [errorEvents], which is
+ * what the screen renders its error overlay from.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SupportScreenViewModelTest : BaseTest() {
+
+    private val sessionManager: DebugSessionManager = mockk(relaxed = true)
+
+    private fun TestScope.viewModel(): SupportScreenViewModel {
+        every { sessionManager.recorderState } returns flowOf(RecorderModule.State())
+        every { sessionManager.sessions } returns flowOf(emptyList<DebugSession>())
+        return SupportScreenViewModel(
+            dispatcherProvider = TestDispatcherProvider(UnconfinedTestDispatcher(testScheduler)),
+            navCtrl = mockk(relaxed = true),
+            webpageTool = mockk(relaxed = true),
+            sessionManager = sessionManager,
+        )
+    }
+
+    @Test
+    fun `a failed start reaches the error events instead of vanishing`() = runTest {
+        val boom = IOException("recorder broken")
+        coEvery { sessionManager.startRecording() } throws boom
+
+        val vm = viewModel()
+        val error = async { vm.errorEvents.first() }
+        runCurrent()
+
+        vm.startDebugLog()
+        advanceUntilIdle()
+
+        error.await() shouldBe boom
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/main/ui/settings/support/contact/ContactSupportViewModelTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/ui/settings/support/contact/ContactSupportViewModelTest.kt
@@ -1,0 +1,62 @@
+package eu.darken.bluemusic.main.ui.settings.support.contact
+
+import android.content.Context
+import eu.darken.bluemusic.common.debug.recorder.core.DebugSession
+import eu.darken.bluemusic.common.debug.recorder.core.DebugSessionManager
+import eu.darken.bluemusic.common.debug.recorder.core.RecorderModule
+import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runCurrent
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.TestDispatcherProvider
+import java.io.IOException
+
+/**
+ * The contact form's own entry into the recorder: a start that cannot succeed used to leave this
+ * launch hanging forever, so the consent dialog was answered and then nothing happened at all. The
+ * failure has to arrive at [errorEvents], which is what the screen renders its error overlay from.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class ContactSupportViewModelTest : BaseTest() {
+
+    private val sessionManager: DebugSessionManager = mockk(relaxed = true)
+
+    private fun TestScope.viewModel(): ContactSupportViewModel {
+        every { sessionManager.recorderState } returns flowOf(RecorderModule.State())
+        every { sessionManager.sessions } returns flowOf(emptyList<DebugSession>())
+        return ContactSupportViewModel(
+            navCtrl = mockk(relaxed = true),
+            dispatcherProvider = TestDispatcherProvider(UnconfinedTestDispatcher(testScheduler)),
+            context = mockk<Context>(relaxed = true),
+            sessionManager = sessionManager,
+            emailTool = mockk(relaxed = true),
+            webpageTool = mockk(relaxed = true),
+        )
+    }
+
+    @Test
+    fun `a failed start reaches the error events instead of vanishing`() = runTest {
+        val boom = IOException("recorder broken")
+        coEvery { sessionManager.startRecording() } throws boom
+
+        val vm = viewModel()
+        val error = async { vm.errorEvents.first() }
+        runCurrent()
+
+        vm.doStartRecording()
+        advanceUntilIdle()
+
+        error.await() shouldBe boom
+    }
+}


### PR DESCRIPTION
## What changed

A failed debug-log recording start no longer crashes the app — and no longer turns into a crash loop on every launch via the leftover trigger file. The failure shows as a normal error dialog and the next attempt works. Several data-loss edges are closed: a failed restart can no longer delete the recording you already made, and a failed start can no longer delete an earlier session that happened to share its folder name.

## Technical Context

- A throw in the start branch escaped the reactive collector onto the handler-less app scope — a process crash; where the process survived, the collector was dead and `startRecorder()` hung forever. The persisted trigger file re-entered the same failing start at every launch.
- Fix shape (shared with the sibling apps): whole-branch guard, failure committed to state (`startFailure`), `shouldRecord` reset, total rollback under `NonCancellable` (only artifacts this attempt created are deleted — resumed sessions preserved; "created" is derived from actual `createNewFile`/`mkdirs` results, and a session-folder name collision walks suffixed names instead of adopting an unrelated folder), then `ensureActive()` — genuine scope cancellation propagates while a dependency's `CancellationException` is wrapped in `RecorderStartFailedException` so ViewModel error handlers fire.
- The stop branch had the same collector-killing class and is now best-effort per step. Error-path logging is guarded too: the logging bus hands a logger's failure back to the caller, so an unrelated throwing logger could otherwise kill the reconciliation right before the failure state publishes.
- `Recorder.start()` now starts its file logger before publishing itself as active; `Recorder.stop()` tears down every step and rethrows the first failure after cleanup. `Logging.remove()` deregisters before logging so a throwing logger can't prevent its own removal. `FileLogger.start()` surfaces failures and deletes only files it created.
- Start/stop/request APIs are serialized by a mutex covering the whole transition including observation; the concurrency tests park the first caller inside the transition and prove the racers block — each test fails if the mutex is removed. Consumer tests prove a failed start reaches both settings screens' error events.
