### PR TITLE
Ask happy users for a Play Store review

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -335,6 +335,9 @@ dependencies {
     "gplayImplementation"("com.android.billingclient:billing:8.3.0")
     "gplayImplementation"("com.android.billingclient:billing-ktx:8.3.0")
 
+    "gplayImplementation"("com.google.android.play:review:2.0.2")
+    "gplayImplementation"("com.google.android.play:review-ktx:2.0.2")
+
     implementation("io.github.z4kn4fein:semver:3.0.0")
 
     "screenshotTestImplementation"(platform("androidx.compose:compose-bom:2026.02.00"))

--- a/app/src/foss/java/eu/darken/bluemusic/common/review/FossReviewTool.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/common/review/FossReviewTool.kt
@@ -1,0 +1,31 @@
+package eu.darken.bluemusic.common.review
+
+import android.app.Activity
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class FossReviewTool @Inject constructor() : ReviewTool {
+
+
+    override val state: Flow<ReviewTool.State> = flowOf(ReviewTool.State())
+
+    override suspend fun dismiss() {
+        log(TAG, INFO) { "dismiss()" }
+        // NOOP
+    }
+
+    override suspend fun reviewNow(activity: Activity) {
+        log(TAG, INFO) { "reviewNow($activity)" }
+        // NOOP
+    }
+
+    companion object {
+        private val TAG = logTag("Review", "Tool", "FOSS")
+    }
+}

--- a/app/src/foss/java/eu/darken/bluemusic/common/review/ReviewModule.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/common/review/ReviewModule.kt
@@ -1,0 +1,16 @@
+package eu.darken.bluemusic.common.review
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReviewModule {
+
+    @Binds
+    @Singleton
+    abstract fun reviewTool(tool: FossReviewTool): ReviewTool
+}

--- a/app/src/gplay/java/eu/darken/bluemusic/common/review/GplayReviewTool.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/common/review/GplayReviewTool.kt
@@ -1,0 +1,207 @@
+package eu.darken.bluemusic.common.review
+
+import android.app.Activity
+import com.google.android.play.core.ktx.launchReview
+import com.google.android.play.core.ktx.requestReview
+import com.google.android.play.core.review.ReviewInfo
+import com.google.android.play.core.review.ReviewManager
+import eu.darken.bluemusic.common.coroutine.AppScope
+import eu.darken.bluemusic.common.datastore.value
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
+import eu.darken.bluemusic.common.debug.logging.asLog
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.common.flow.replayingShare
+import eu.darken.bluemusic.common.flow.throttleLatest
+import eu.darken.bluemusic.common.upgrade.UpgradeRepo
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.sync.Mutex
+import java.time.Duration
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+import kotlin.system.measureTimeMillis
+
+@Singleton
+class GplayReviewTool @Inject constructor(
+    @param:AppScope private val appScope: CoroutineScope,
+    private val settings: ReviewSettings,
+    private val manager: ReviewManager,
+    upgradeRepo: UpgradeRepo,
+) : ReviewTool {
+
+    // Test seam: the probe backoff runs on AppScope (a real dispatcher), so a virtual-time test
+    // cannot advance the production bound. Same pattern as UpgradeRepoGplay.launchTimeoutMs.
+    internal var probeRetryDelay: Duration = PROBE_RETRY_DELAY
+
+    // Local bookkeeping only: decided without talking to Play, so an ineligible user never
+    // triggers a Play round-trip.
+    private val isLocallyEligible: Flow<Boolean> = combine(
+        settings.lastDismissed.flow,
+        settings.reviewedAt.flow,
+        upgradeRepo.upgradeInfo,
+    ) { lastDismissed, reviewedAt, upgradeInfo ->
+        val now = Instant.now()
+
+        // Free trial is 14 days, only ask for review after the user has paid something
+        val hasPaidForPro = Duration.between(upgradeInfo.upgradedAt ?: now, now) > Duration.ofDays(21)
+        val isSnoozed = Duration.between(lastDismissed ?: Instant.EPOCH, now) < Duration.ofDays(14)
+        val hasReviewed = reviewedAt != null
+
+        log(TAG) { "Eligibility: hasPaidForPro=$hasPaidForPro (${upgradeInfo.upgradedAt})" }
+        log(TAG) { "Eligibility: isSnoozed=$isSnoozed ($lastDismissed), hasReviewed=$hasReviewed ($reviewedAt)" }
+
+        hasPaidForPro && !isSnoozed && !hasReviewed
+    }
+        .distinctUntilChanged()
+        // Upstream of the shares below: an exception there would kill the sharing coroutine on
+        // AppScope (crashing the process) instead of reaching any downstream `catch`.
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "Eligibility failed: ${e.asLog()}" }
+            emit(false)
+        }
+
+    // Only probed once the user is eligible: Play counts requests against the app's quota, and an
+    // `isNoOp` answer is Play's deliberate verdict, i.e. an answer and not a failure to retry.
+    private val isReviewAvailable: Flow<Boolean> = isLocallyEligible
+        .flatMapLatest { eligible ->
+            if (!eligible) return@flatMapLatest flowOf(false)
+
+            flow {
+                for (attempt in 1..PROBE_ATTEMPTS) {
+                    val info = try {
+                        manager.requestReview()
+                    } catch (e: CancellationException) {
+                        throw e
+                    } catch (e: Exception) {
+                        log(TAG, WARN) { "Probe $attempt/$PROBE_ATTEMPTS failed: ${e.asLog()}" }
+                        if (attempt < PROBE_ATTEMPTS) delay(probeRetryDelay.toMillis())
+                        continue
+                    }
+                    log(TAG) { "Probe $attempt/$PROBE_ATTEMPTS returned ${info.desc()}" }
+                    emit(info.canShow)
+                    return@flow
+                }
+                // Re-probed when eligibility changes or on the next process start
+                log(TAG, WARN) { "Probe gave up after $PROBE_ATTEMPTS attempts" }
+                emit(false)
+            }
+        }
+        .replayingShare(appScope)
+
+    override val state: Flow<ReviewTool.State> = combine(
+        isLocallyEligible,
+        isReviewAvailable,
+        settings.reviewedAt.flow,
+    ) { eligible, available, reviewedAt ->
+        log(TAG) { "State: eligible=$eligible, available=$available, reviewedAt=$reviewedAt" }
+        ReviewTool.State(
+            shouldAskForReview = eligible && available,
+            hasReviewed = reviewedAt != null,
+        )
+    }
+        .throttleLatest(500)
+        .onStart { emit(ReviewTool.State()) }
+        .catch { e ->
+            if (e is CancellationException) throw e
+            log(TAG, ERROR) { "State failed: ${e.asLog()}" }
+            emit(ReviewTool.State())
+        }
+        .replayingShare(appScope)
+
+    // Single-flight: a second tap must not queue up behind the first, or Play's flow would be
+    // launched again the moment the user returns from it.
+    private val reviewLock = Mutex()
+
+    override suspend fun dismiss() {
+        log(TAG, INFO) { "dismiss()" }
+        settings.lastDismissed.value(Instant.now())
+    }
+
+    override suspend fun reviewNow(activity: Activity) {
+        log(TAG, INFO) { "reviewNow($activity)" }
+
+        if (!reviewLock.tryLock()) {
+            log(TAG, WARN) { "reviewNow(...) is already in progress, skipping" }
+            return
+        }
+
+        try {
+            // ReviewInfo is short lived, Google wants it requested shortly before the launch,
+            // a token cached at process start is likely stale by the time the user taps.
+            val reviewInfo = try {
+                manager.requestReview()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // A transient failure is not user intent: don't snooze the card, the next tap retries
+                log(TAG, ERROR) { "Failed to get a fresh ReviewInfo: ${e.asLog()}" }
+                return
+            }
+            log(TAG) { "reviewNow(...): Fresh ${reviewInfo.desc()}" }
+
+            if (!reviewInfo.canShow) {
+                // Play's quota verdict, asking again right away would be pointless
+                log(TAG, WARN) { "Play says we can't show the prompt, snoozing" }
+                settings.lastDismissed.value(Instant.now())
+                return
+            }
+
+            if (activity.isFinishing || activity.isDestroyed) {
+                log(TAG, WARN) { "Activity is gone, aborting: $activity" }
+                return
+            }
+
+            val reviewTime = measureTimeMillis {
+                try {
+                    manager.launchReview(activity, reviewInfo)
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
+                    log(TAG, ERROR) { "Failed to launch review flow: ${e.asLog()}" }
+                    return
+                }
+            }
+            log(TAG) { "Review completed after ${reviewTime}ms" }
+
+            if (Duration.ofMillis(reviewTime) >= Duration.ofSeconds(2)) {
+                log(TAG, INFO) { "Marking review as completed" }
+                settings.reviewedAt.value(Instant.now())
+            } else {
+                log(TAG, INFO) { "Review was too quick, counting as dismiss" }
+                settings.lastDismissed.value(Instant.now())
+            }
+        } finally {
+            reviewLock.unlock()
+        }
+    }
+
+    private val ReviewInfo.canShow: Boolean
+        get() = when {
+            toString().contains("isNoOp=true") -> false
+            else -> true
+        }
+
+    private fun ReviewInfo.desc(): String {
+        return "ReviewInfo(canShow=$canShow, ${toString()})"
+    }
+
+    companion object {
+        private val TAG = logTag("Review", "Tool", "Gplay")
+        private const val PROBE_ATTEMPTS = 3
+        private val PROBE_RETRY_DELAY = Duration.ofSeconds(30)
+    }
+}

--- a/app/src/gplay/java/eu/darken/bluemusic/common/review/ReviewModule.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/common/review/ReviewModule.kt
@@ -1,0 +1,27 @@
+package eu.darken.bluemusic.common.review
+
+import android.content.Context
+import com.google.android.play.core.review.ReviewManager
+import com.google.android.play.core.review.ReviewManagerFactory
+import dagger.Binds
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+abstract class ReviewModule {
+
+    @Binds
+    @Singleton
+    abstract fun reviewTool(tool: GplayReviewTool): ReviewTool
+
+    companion object {
+        @Provides
+        @Singleton
+        fun reviewManager(@ApplicationContext context: Context): ReviewManager = ReviewManagerFactory.create(context)
+    }
+}

--- a/app/src/gplay/java/eu/darken/bluemusic/common/review/ReviewSettings.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/common/review/ReviewSettings.kt
@@ -1,0 +1,40 @@
+package eu.darken.bluemusic.common.review
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.bluemusic.common.datastore.createValue
+import eu.darken.bluemusic.common.debug.logging.logTag
+import kotlinx.serialization.json.Json
+import java.time.Instant
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class ReviewSettings @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    json: Json,
+) {
+
+    private val Context.dataStore by preferencesDataStore(name = "settings_review_gplay")
+
+    val dataStore: DataStore<Preferences>
+        get() = context.dataStore
+
+    // onErrorFallbackToDefault is off: corrupt data has to surface instead of silently resetting the
+    // snooze/reviewed bookkeeping to "never".
+    val lastDismissed = dataStore.createValue<Instant?>(
+        "review.dismissedAt", null, json,
+        onErrorFallbackToDefault = false,
+    )
+    val reviewedAt = dataStore.createValue<Instant?>(
+        "review.reviewedAt", null, json,
+        onErrorFallbackToDefault = false,
+    )
+
+    companion object {
+        internal val TAG = logTag("Review", "Settings", "Gplay")
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/common/review/ReviewTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/common/review/ReviewTool.kt
@@ -1,0 +1,18 @@
+package eu.darken.bluemusic.common.review
+
+import android.app.Activity
+import kotlinx.coroutines.flow.Flow
+
+interface ReviewTool {
+
+    val state: Flow<State>
+
+    data class State(
+        val shouldAskForReview: Boolean = false,
+        val hasReviewed: Boolean = false,
+    )
+
+    suspend fun dismiss()
+
+    suspend fun reviewNow(activity: Activity)
+}

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
@@ -75,12 +75,15 @@ import eu.darken.bluemusic.devices.ui.dashboard.rows.DeviceSpeakerHintCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.DndAccessHintCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.EmptyDevicesCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.NotificationPermissionHintCard
+import eu.darken.bluemusic.devices.ui.dashboard.rows.ReviewCard
 import eu.darken.bluemusic.devices.ui.dashboard.rows.device.ManagedDeviceItem
 
 @Composable
 fun DevicesScreenHost(vm: DashboardViewModel = hiltViewModel()) {
 
     val state by vm.state.collectAsStateWithLifecycle()
+
+    val activity = LocalContext.current as? android.app.Activity
 
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
@@ -109,6 +112,8 @@ fun DevicesScreenHost(vm: DashboardViewModel = hiltViewModel()) {
             onRequestBluetoothPermission = {
                 vm.action(DashboardAction.RequestBluetoothPermission)
             },
+            onReview = activity?.let { { vm.reviewNow(it) } },
+            onReviewDismiss = { vm.reviewDismiss() },
         )
     }
 }
@@ -122,6 +127,8 @@ fun DevicesScreen(
     onNavigateToSettings: () -> Unit,
     onNavigateToUpgrade: () -> Unit,
     onRequestBluetoothPermission: () -> Unit,
+    onReview: (() -> Unit)? = null,
+    onReviewDismiss: () -> Unit = {},
 ) {
     val listState = rememberLazyListState()
     val isScrolledDown by remember {
@@ -231,6 +238,15 @@ fun DevicesScreen(
                     DeviceSpeakerHintCard(
                         onDismiss = { onDeviceAction(DashboardAction.DismissSpeakerHint) },
                         onAdd = { onDeviceAction(DashboardAction.AddSpeakerDevice) }
+                    )
+                }
+            }
+
+            if (state.showReviewCard) {
+                item {
+                    ReviewCard(
+                        onReview = onReview,
+                        onDismiss = onReviewDismiss
                     )
                 }
             }

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.devices.ui.dashboard
 
+import android.app.Activity
 import android.content.Intent
 import dagger.hilt.android.lifecycle.HiltViewModel
 import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
@@ -13,6 +14,7 @@ import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.common.navigation.Nav
 import eu.darken.bluemusic.common.navigation.NavigationController
 import eu.darken.bluemusic.common.permissions.PermissionHelper
+import eu.darken.bluemusic.common.review.ReviewTool
 import eu.darken.bluemusic.common.ui.ViewModel4
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.common.upgrade.isProForUi
@@ -30,6 +32,7 @@ import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeModeTool
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
@@ -47,6 +50,7 @@ class DashboardViewModel @Inject constructor(
     private val devicesSettings: DevicesSettings,
     private val deviceCreator: NewDeviceCreator,
     private val speakerProvider: SpeakerDeviceProvider,
+    private val reviewTool: ReviewTool,
     dispatcherProvider: DispatcherProvider,
     navCtrl: NavigationController,
     appRepo: AppRepo,
@@ -139,7 +143,16 @@ class DashboardViewModel @Inject constructor(
         dndAccessHintFlow,
         devicesSettings.lockedDevices.flow,
         generalSettings.isSpeakerHintDismissed.flow,
-    ) { upgradeInfo, bluetoothState, devicesWithApps, batteryHint, overlayHint, notificationHint, dndHint, lockedDevices, speakerHintDismissed ->
+        // The review prompt is a nice-to-have: a failing review backend must never take the whole
+        // dashboard down with it, so it falls back to "don't ask".
+        reviewTool.state.catch { e ->
+            if (e is kotlinx.coroutines.CancellationException) throw e
+            emit(ReviewTool.State())
+        },
+    ) { upgradeInfo, bluetoothState, devicesWithApps, batteryHint, overlayHint, notificationHint, dndHint, lockedDevices, speakerHintDismissed, review ->
+        val showSpeakerHint = !speakerHintDismissed &&
+            devicesWithApps.any { it.device.type != SourceDevice.Type.PHONE_SPEAKER } &&
+            devicesWithApps.none { it.device.type == SourceDevice.Type.PHONE_SPEAKER }
         State(
             isProVersion = upgradeInfo.isPro,
             isBluetoothEnabled = bluetoothState.isEnabled,
@@ -153,9 +166,18 @@ class DashboardViewModel @Inject constructor(
             showNotificationPermissionHint = notificationHint.shouldShow,
             showDndAccessHint = dndHint.shouldShow,
             dndAccessIntent = dndHint.intent,
-            showSpeakerHint = !speakerHintDismissed &&
-                devicesWithApps.any { it.device.type != SourceDevice.Type.PHONE_SPEAKER } &&
-                devicesWithApps.none { it.device.type == SourceDevice.Type.PHONE_SPEAKER },
+            showSpeakerHint = showSpeakerHint,
+            // Lowest priority card: only asked for on an otherwise quiet dashboard, i.e. no hint or
+            // permission card is competing for attention and the user actually has devices set up.
+            showReviewCard = review.shouldAskForReview &&
+                bluetoothState.hasPermission &&
+                bluetoothState.isEnabled &&
+                !batteryHint.shouldShow &&
+                !overlayHint.shouldShow &&
+                !dndHint.shouldShow &&
+                !notificationHint.shouldShow &&
+                !showSpeakerHint &&
+                devicesWithApps.isNotEmpty(),
         )
     }.asStateFlow()
 
@@ -179,6 +201,7 @@ class DashboardViewModel @Inject constructor(
         val showDndAccessHint: Boolean = false,
         val dndAccessIntent: Intent? = null,
         val showSpeakerHint: Boolean = false,
+        val showReviewCard: Boolean = false,
     ) {
         // Convenience property for backwards compatibility
         val devices: List<ManagedDevice> get() = devicesWithApps.map { it.device }
@@ -190,6 +213,18 @@ class DashboardViewModel @Inject constructor(
     fun onUpgradeClicked() = launch {
         log(tag) { "onUpgradeClicked()" }
         navTo(Nav.Main.Upgrade(manage = upgradeRepo.isProForUi()))
+    }
+
+    // Play's in-app review flow needs the hosting Activity, which never belongs in a [DashboardAction]
+    // value. Kept symmetrical with its dismiss counterpart, same shape as [onUpgradeClicked].
+    fun reviewNow(activity: Activity) = launch {
+        log(tag) { "reviewNow($activity)" }
+        reviewTool.reviewNow(activity)
+    }
+
+    fun reviewDismiss() = launch {
+        log(tag) { "reviewDismiss()" }
+        reviewTool.dismiss()
     }
 
     fun action(action: DashboardAction) = launch {

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/ReviewCard.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/ReviewCard.kt
@@ -1,0 +1,99 @@
+package eu.darken.bluemusic.devices.ui.dashboard.rows
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.compose.BlueMusicIcon
+import eu.darken.bluemusic.common.compose.Preview2
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+
+/**
+ * Asks the user to leave a review. [onReview] is null when no hosting Activity is available, Play's
+ * in-app review flow can't be launched without one, so the action is shown disabled instead.
+ */
+@Composable
+fun ReviewCard(
+    onReview: (() -> Unit)?,
+    onDismiss: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp)
+            .animateContentSize(),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BlueMusicIcon(
+                    size = 40.dp,
+                    contentDescription = null,
+                )
+                Spacer(modifier = Modifier.width(12.dp))
+                Text(
+                    text = stringResource(R.string.review_app_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSecondaryContainer
+                )
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(stringResource(R.string.review_app_dismiss_action))
+                }
+                Spacer(modifier = Modifier.width(8.dp))
+                Button(
+                    onClick = { onReview?.invoke() },
+                    enabled = onReview != null,
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Text(stringResource(R.string.review_app_review_action))
+                }
+            }
+        }
+    }
+}
+
+@Preview2
+@Composable
+fun ReviewCardPreview() {
+    PreviewWrapper {
+        ReviewCard(
+            onReview = {},
+            onDismiss = {}
+        )
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -447,6 +447,9 @@
     <string name="device_speaker_hint_title">Volumes after disconnect</string>
     <string name="device_speaker_hint_message">Want your volumes restored when a Bluetooth device disconnects? Add \"Device speaker\" as a managed device — its volumes are applied when audio switches back to your phone.</string>
     <string name="device_speaker_hint_action">Add</string>
+    <string name="review_app_body">Would you like to leave BVM a review? ❤️</string>
+    <string name="review_app_review_action">Review</string>
+    <string name="review_app_dismiss_action">Maybe later</string>
 
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Purchase cancelled</string>

--- a/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreenReviewTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreenReviewTest.kt
@@ -1,0 +1,93 @@
+package eu.darken.bluemusic.devices.ui.dashboard
+
+import android.app.Activity
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.assertIsEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.bluetooth.core.MockDevice
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class DashboardScreenReviewTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val reviewAction: String
+        get() = context.getString(R.string.review_app_review_action)
+    private val dismissAction: String
+        get() = context.getString(R.string.review_app_dismiss_action)
+
+    private fun reviewState() = DashboardViewModel.State(
+        devicesWithApps = listOf(
+            DashboardViewModel.DeviceWithApps(MockDevice().toManagedDevice(isConnected = true), emptyList())
+        ),
+        isBluetoothEnabled = true,
+        hasBluetoothPermission = true,
+        showReviewCard = true,
+    )
+
+    @Test
+    fun `both review actions reach the screen callbacks`() {
+        var reviewed = 0
+        var dismissed = 0
+        composeRule.setContent {
+            PreviewWrapper {
+                DashboardScreenUnderTest(
+                    onReview = { reviewed++ },
+                    onReviewDismiss = { dismissed++ },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(reviewAction).performClick()
+        composeRule.onNodeWithText(dismissAction).performClick()
+
+        reviewed shouldBe 1
+        dismissed shouldBe 1
+    }
+
+    @Test
+    fun `an Activity host enables the review action`() {
+        var reviewed = 0
+        composeRule.setContent {
+            // Same idiom the Host uses to obtain the Activity Play's flow needs.
+            val activity = LocalContext.current as? Activity
+            PreviewWrapper {
+                DashboardScreenUnderTest(
+                    onReview = activity?.let { { reviewed++ } },
+                    onReviewDismiss = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(reviewAction).assertIsEnabled().performClick()
+
+        reviewed shouldBe 1
+    }
+
+    @Composable
+    private fun DashboardScreenUnderTest(
+        onReview: (() -> Unit)?,
+        onReviewDismiss: () -> Unit,
+    ) {
+        DevicesScreen(
+            state = reviewState(),
+            onAddDevice = {},
+            onDeviceConfig = {},
+            onDeviceAction = {},
+            onNavigateToSettings = {},
+            onNavigateToUpgrade = {},
+            onRequestBluetoothPermission = {},
+            onReview = onReview,
+            onReviewDismiss = onReviewDismiss,
+        )
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModelTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.devices.ui.dashboard
 
+import android.app.Activity
 import eu.darken.bluemusic.bluetooth.core.BluetoothRepo
 import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.bluetooth.core.SourceDeviceWrapper
@@ -9,6 +10,7 @@ import eu.darken.bluemusic.common.datastore.DataStoreValue
 import eu.darken.bluemusic.common.navigation.Nav
 import eu.darken.bluemusic.common.navigation.NavigationController
 import eu.darken.bluemusic.common.permissions.PermissionHelper
+import eu.darken.bluemusic.common.review.ReviewTool
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.devices.core.DeviceAddr
 import eu.darken.bluemusic.devices.core.DeviceRepo
@@ -18,6 +20,7 @@ import eu.darken.bluemusic.devices.core.NewDeviceCreator
 import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
 import eu.darken.bluemusic.main.core.GeneralSettings
 import io.kotest.matchers.shouldBe
+import io.mockk.coJustRun
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
@@ -54,6 +57,8 @@ class DashboardViewModelTest : BaseTest() {
 
     private lateinit var deviceCreator: NewDeviceCreator
     private lateinit var speakerProvider: SpeakerDeviceProvider
+    private lateinit var reviewTool: ReviewTool
+    private lateinit var reviewStates: MutableStateFlow<ReviewTool.State>
 
     private lateinit var batteryHintDismissed: DataStoreValue<Boolean>
     private lateinit var android10HintDismissed: DataStoreValue<Boolean>
@@ -75,6 +80,15 @@ class DashboardViewModelTest : BaseTest() {
         deviceCreator = mockk(relaxed = true)
         speakerProvider = mockk(relaxed = true)
         every { speakerProvider.address } returns SPEAKER_ADDR
+
+        // Explicit, never relaxed: a relaxed ReviewTool would hand out an empty state flow and
+        // silently turn every "the card is shown" assertion into a false negative.
+        reviewStates = MutableStateFlow(ReviewTool.State())
+        reviewTool = mockk<ReviewTool>().apply {
+            every { state } returns reviewStates
+            coJustRun { dismiss() }
+            coJustRun { reviewNow(any()) }
+        }
 
         devicesFlow = MutableStateFlow(emptyList())
         every { deviceRepo.devices } returns devicesFlow
@@ -133,6 +147,7 @@ class DashboardViewModelTest : BaseTest() {
         devicesSettings = devicesSettings,
         deviceCreator = deviceCreator,
         speakerProvider = speakerProvider,
+        reviewTool = reviewTool,
         dispatcherProvider = TestDispatcherProvider(UnconfinedTestDispatcher(testScheduler)),
         navCtrl = navCtrl,
         appRepo = appRepo,
@@ -339,6 +354,84 @@ class DashboardViewModelTest : BaseTest() {
 
         coVerify { speakerHintDismissed.update(capture(updateSlot)) }
         updateSlot.captured(false) shouldBe true
+    }
+
+    /**
+     * Every gate the review card sits behind, satisfied at once. The negative tests below each flip
+     * exactly one of them, so a gate that silently stops mattering surfaces as a failure.
+     */
+    private fun quietDashboard() {
+        every { bluetoothRepo.state } returns MutableStateFlow(
+            BluetoothRepo.State(isEnabled = true, hasPermission = true, devices = emptySet())
+        )
+        every { permissionHelper.getBatteryOptimizationHint(any()) } returns
+                PermissionHelper.PermissionHint(shouldShow = false)
+        every { permissionHelper.getOverlayPermissionHint(any(), any()) } returns
+                PermissionHelper.PermissionHint(shouldShow = false)
+        every { permissionHelper.getNotificationPermissionHint(any()) } returns
+                PermissionHelper.PermissionHint(shouldShow = false)
+        every { permissionHelper.getDndAccessHint(any(), any()) } returns
+                PermissionHelper.PermissionHint(shouldShow = false)
+        // The shared fixture leaves the speaker hint active as soon as a device exists.
+        every { speakerHintDismissed.flow } returns MutableStateFlow(true)
+        devicesFlow.value = listOf(device())
+        reviewStates.value = ReviewTool.State(shouldAskForReview = true)
+    }
+
+    @Test
+    fun `the review card shows on a quiet dashboard`() = runTest(UnconfinedTestDispatcher()) {
+        quietDashboard()
+
+        viewModel().state.filterNotNull().first().showReviewCard shouldBe true
+    }
+
+    @Test
+    fun `the review card yields to a permission hint`() = runTest(UnconfinedTestDispatcher()) {
+        quietDashboard()
+        every { permissionHelper.getNotificationPermissionHint(any()) } returns
+                PermissionHelper.PermissionHint(shouldShow = true)
+
+        viewModel().state.filterNotNull().first().showReviewCard shouldBe false
+    }
+
+    @Test
+    fun `the review card stays hidden while bluetooth is off`() = runTest(UnconfinedTestDispatcher()) {
+        quietDashboard()
+        every { bluetoothRepo.state } returns MutableStateFlow(
+            BluetoothRepo.State(isEnabled = false, hasPermission = true, devices = emptySet())
+        )
+
+        viewModel().state.filterNotNull().first().showReviewCard shouldBe false
+    }
+
+    @Test
+    fun `the review card stays hidden without any managed device`() = runTest(UnconfinedTestDispatcher()) {
+        quietDashboard()
+        devicesFlow.value = emptyList()
+
+        viewModel().state.filterNotNull().first().showReviewCard shouldBe false
+    }
+
+    @Test
+    fun `dismissing the review card delegates to the review tool`() = runTest(UnconfinedTestDispatcher()) {
+        viewModel().reviewDismiss()
+        advanceUntilIdle()
+
+        coVerify { reviewTool.dismiss() }
+    }
+
+    @Test
+    fun `the review action forwards the hosting activity unchanged`() = runTest(UnconfinedTestDispatcher()) {
+        val activity = mockk<Activity>()
+        val activitySlot = slot<Activity>()
+
+        viewModel().reviewNow(activity)
+        advanceUntilIdle()
+
+        // Play's flow is launched on whatever Activity the screen handed over, a substitute would
+        // put the review dialog on the wrong window.
+        coVerify { reviewTool.reviewNow(capture(activitySlot)) }
+        activitySlot.captured shouldBe activity
     }
 
     companion object {

--- a/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/rows/ReviewCardTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/rows/ReviewCardTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.bluemusic.devices.ui.dashboard.rows
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class ReviewCardTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val body: String
+        get() = context.getString(R.string.review_app_body)
+    private val reviewAction: String
+        get() = context.getString(R.string.review_app_review_action)
+    private val dismissAction: String
+        get() = context.getString(R.string.review_app_dismiss_action)
+
+    @Test
+    fun `the card renders the ask and both actions`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                ReviewCard(onReview = {}, onDismiss = {})
+            }
+        }
+
+        composeRule.onNodeWithText(body).assertIsDisplayed()
+        composeRule.onNodeWithText(reviewAction).assertIsDisplayed()
+        composeRule.onNodeWithText(dismissAction).assertIsDisplayed()
+    }
+
+    @Test
+    fun `both actions report back to the caller`() {
+        var reviewed = 0
+        var dismissed = 0
+        composeRule.setContent {
+            PreviewWrapper {
+                ReviewCard(onReview = { reviewed++ }, onDismiss = { dismissed++ })
+            }
+        }
+
+        composeRule.onNodeWithText(reviewAction).performClick()
+        composeRule.onNodeWithText(dismissAction).performClick()
+
+        reviewed shouldBe 1
+        dismissed shouldBe 1
+    }
+
+    @Test
+    fun `the review action is disabled without a hosting activity`() {
+        var dismissed = 0
+        composeRule.setContent {
+            PreviewWrapper {
+                ReviewCard(onReview = null, onDismiss = { dismissed++ })
+            }
+        }
+
+        // Play's flow can't be launched without an Activity, but the card still has to be dismissable.
+        composeRule.onNodeWithText(reviewAction).assertIsNotEnabled()
+        composeRule.onNodeWithText(dismissAction).performClick()
+
+        dismissed shouldBe 1
+    }
+}

--- a/app/src/testGplay/java/eu/darken/bluemusic/common/review/GplayReviewToolTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/common/review/GplayReviewToolTest.kt
@@ -1,0 +1,288 @@
+package eu.darken.bluemusic.common.review
+
+import android.app.Activity
+import com.google.android.gms.tasks.OnFailureListener
+import com.google.android.gms.tasks.OnSuccessListener
+import com.google.android.gms.tasks.Task
+import com.google.android.gms.tasks.Tasks
+import com.google.android.play.core.review.ReviewInfo
+import com.google.android.play.core.review.ReviewManager
+import eu.darken.bluemusic.common.datastore.DataStoreValue
+import eu.darken.bluemusic.common.upgrade.UpgradeRepo
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.withTimeoutOrNull
+import kotlinx.serialization.SerializationException
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+import testhelpers.coroutine.runTest2
+import testhelpers.datastore.FakeDataStoreValue
+import java.time.Duration
+import java.time.Instant
+
+class GplayReviewToolTest : BaseTest() {
+
+    private val manager = mockk<ReviewManager>()
+    private val settings = mockk<ReviewSettings>()
+    private val upgradeRepo = mockk<UpgradeRepo>()
+    private lateinit var lastDismissedMock: DataStoreValue<Instant?>
+    private lateinit var reviewedAtMock: DataStoreValue<Instant?>
+
+    // The `.value(new)` writes go through `update`, which the fake answers and records.
+    private fun rwSetting(initial: Instant?): DataStoreValue<Instant?> = FakeDataStoreValue(initial).mock
+
+    // The tool's own scope has to run on the test scheduler, otherwise the probe backoff and the
+    // state throttle would burn real time.
+    private fun TestScope.tool(
+        upgradedAt: Instant? = Instant.now().minus(Duration.ofDays(30)),
+        lastDismissed: Instant? = null,
+        reviewedAt: Instant? = null,
+    ): GplayReviewTool {
+        lastDismissedMock = rwSetting(lastDismissed)
+        reviewedAtMock = rwSetting(reviewedAt)
+        every { settings.lastDismissed } returns lastDismissedMock
+        every { settings.reviewedAt } returns reviewedAtMock
+
+        val upgradeInfo = mockk<UpgradeRepo.Info>()
+        every { upgradeInfo.upgradedAt } returns upgradedAt
+        every { upgradeRepo.upgradeInfo } returns flowOf(upgradeInfo)
+
+        return GplayReviewTool(
+            appScope = backgroundScope,
+            settings = settings,
+            manager = manager,
+            upgradeRepo = upgradeRepo,
+        ).apply { probeRetryDelay = Duration.ofSeconds(1) }
+    }
+
+    private fun reviewInfo(canShow: Boolean = true): ReviewInfo {
+        val info = mockk<ReviewInfo>()
+        // There is no public accessor for the isNoOp flag, the tool sniffs the toString().
+        every { info.toString() } returns when {
+            canShow -> "ReviewInfo{pendingIntent=PendingIntent{1}, isNoOp=false}"
+            else -> "ReviewInfo{pendingIntent=null, isNoOp=true}"
+        }
+        return info
+    }
+
+    private fun activity(finishing: Boolean = false, destroyed: Boolean = false) = mockk<Activity>().apply {
+        every { isFinishing } returns finishing
+        every { isDestroyed } returns destroyed
+    }
+
+    private fun launchOk(): Task<Void?> = Tasks.forResult(null)
+
+    // The `onStart` seed is not a computed state, every assertion has to await the first real one.
+    private suspend fun GplayReviewTool.computedState() = state.drop(1).first()
+
+    @Test fun `an eligible user is asked for a review`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool().computedState().apply {
+            shouldAskForReview shouldBe true
+            hasReviewed shouldBe false
+        }
+    }
+
+    @Test fun `a user who has not paid for pro long enough is never probed`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(upgradedAt = Instant.now().minus(Duration.ofDays(3)))
+            .computedState().shouldAskForReview shouldBe false
+
+        // Eligibility is decided locally first: Play's request quota is only spent on candidates.
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a recently dismissed card is not shown again`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+
+        tool(lastDismissed = Instant.now().minus(Duration.ofDays(3)))
+            .computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 0) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `reviewNow launches with a freshly requested ReviewInfo`() = runTest2 {
+        // ReviewInfo is short lived, the token used for the launch must not be the one the
+        // availability probe obtained (potentially hours) earlier.
+        val probeInfo = reviewInfo()
+        val freshInfo = reviewInfo()
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forResult(probeInfo),
+            Tasks.forResult(freshInfo),
+        )
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        tool.computedState().shouldAskForReview shouldBe true
+        tool.reviewNow(activity)
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+        verify(exactly = 1) { manager.launchReviewFlow(activity, freshInfo) }
+        verify(exactly = 0) { manager.launchReviewFlow(activity, probeInfo) }
+    }
+
+    @Test fun `a failed fresh request keeps the card and persists nothing`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // A transient failure is not user intent, the next tap has to be able to retry.
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a fresh isNoOp answer snoozes the card`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo(canShow = false))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        // isNoOp is Play's quota verdict, asking again right away would be pointless.
+        coVerify(exactly = 1) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a failed launch persists nothing and does not escape`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns Tasks.forException(RuntimeException("launch failed"))
+        val tool = tool()
+
+        tool.reviewNow(activity())
+
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `a dead activity aborts the launch without persisting`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+
+        // The fresh request is a Play round-trip, the activity can be gone by the time it returns.
+        tool.reviewNow(activity(finishing = true))
+
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `overlapping reviewNow calls launch the flow only once`() = runTest2 {
+        // Park the first call on an unresolved Play request, so the second genuinely overlaps it.
+        val successListener = slot<OnSuccessListener<in ReviewInfo>>()
+        val pendingRequest = mockk<Task<ReviewInfo>>().apply {
+            every { isComplete } returns false
+            every { addOnSuccessListener(capture(successListener)) } returns this
+            every { addOnFailureListener(any<OnFailureListener>()) } returns this
+        }
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            pendingRequest,
+            // A second request would resolve instantly, so a broken guard shows up as a launch.
+            Tasks.forResult(reviewInfo()),
+        )
+        every { manager.launchReviewFlow(any(), any()) } returns launchOk()
+        val tool = tool()
+        val activity = activity()
+
+        val first = launch { tool.reviewNow(activity) }
+        advanceUntilIdle()
+
+        tool.reviewNow(activity)
+
+        successListener.captured.onSuccess(reviewInfo())
+        first.join()
+
+        // Without the single-flight guard the second tap would run its own request+launch, and
+        // Play's flow would pop up again the moment the user returned from the first one.
+        verify(exactly = 1) { manager.requestReviewFlow() }
+        verify(exactly = 1) { manager.launchReviewFlow(any(), any()) }
+    }
+
+    @Test fun `a probe that fails once still resolves within the retry budget`() = runTest2 {
+        every { manager.requestReviewFlow() } returnsMany listOf(
+            Tasks.forException(RuntimeException("Play unavailable")),
+            Tasks.forResult(reviewInfo()),
+        )
+
+        tool().computedState().shouldAskForReview shouldBe true
+
+        verify(exactly = 2) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `a probe that keeps failing hides the card`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forException(RuntimeException("Play unavailable"))
+
+        tool().computedState().shouldAskForReview shouldBe false
+
+        verify(exactly = 3) { manager.requestReviewFlow() }
+    }
+
+    @Test fun `corrupt review settings fall back to the default state`() = runTest2 {
+        every { manager.requestReviewFlow() } returns Tasks.forResult(reviewInfo())
+        lastDismissedMock = rwSetting(null)
+        // A malformed stored timestamp throws when the DataStore flow is read.
+        reviewedAtMock = mockk<DataStoreValue<Instant?>>().apply {
+            every { flow } returns flow { throw SerializationException("corrupt") }
+        }
+        every { settings.lastDismissed } returns lastDismissedMock
+        every { settings.reviewedAt } returns reviewedAtMock
+
+        val upgradeInfo = mockk<UpgradeRepo.Info>()
+        every { upgradeInfo.upgradedAt } returns Instant.now().minus(Duration.ofDays(30))
+        every { upgradeRepo.upgradeInfo } returns flowOf(upgradeInfo)
+
+        val tool = GplayReviewTool(
+            appScope = backgroundScope,
+            settings = settings,
+            manager = manager,
+            upgradeRepo = upgradeRepo,
+        )
+
+        // The failure has to be absorbed upstream of the share: on the shared coroutine it would go
+        // to AppScope (no handler, i.e. a process crash) and never reach a downstream collector.
+        tool.computedState() shouldBe ReviewTool.State()
+    }
+
+    @Test fun `cancellation during reviewNow is not swallowed`() = runTest2 {
+        every { manager.requestReviewFlow() } throws CancellationException("scope died")
+        val tool = tool()
+
+        shouldThrow<CancellationException> { tool.reviewNow(activity()) }
+
+        // A cancelled coroutine is not a Play failure: no launch, no bookkeeping.
+        verify(exactly = 0) { manager.launchReviewFlow(any(), any()) }
+        coVerify(exactly = 0) { lastDismissedMock.update(any()) }
+        coVerify(exactly = 0) { reviewedAtMock.update(any()) }
+    }
+
+    @Test fun `cancellation during the probe is not swallowed into the retry path`() = runTest2 {
+        every { manager.requestReviewFlow() } throws CancellationException("scope died")
+        val tool = tool()
+
+        // Cancellation takes the probe down with its scope, no verdict is ever computed (virtual
+        // time, so the timeout costs nothing).
+        val computed = withTimeoutOrNull(Duration.ofMinutes(1).toMillis()) { tool.computedState() }
+
+        computed shouldBe null
+        // The general failure path would have burned all 3 attempts and settled on "unavailable".
+        verify(exactly = 1) { manager.requestReviewFlow() }
+    }
+}

--- a/app/src/testGplay/java/eu/darken/bluemusic/common/review/ReviewSettingsTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/common/review/ReviewSettingsTest.kt
@@ -1,0 +1,74 @@
+package eu.darken.bluemusic.common.review
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.common.datastore.value
+import eu.darken.bluemusic.common.serialization.SerializationModule
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.SerializationException
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+import testhelpers.BaseTest
+import testhelpers.TestApplication
+import java.time.Instant
+
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [33], application = TestApplication::class)
+class ReviewSettingsTest : BaseTest() {
+
+    // The app's Json, not a bare `Json {}`: `java.time.Instant` is only serializable here through
+    // the contextual InstantSerializer this module registers.
+    private val json = SerializationModule().json()
+
+    // One test method on purpose: ReviewSettings is a @Singleton whose DataStore is bound to the
+    // Context property delegate, and DataStore forbids two active instances on the same file.
+    @Test
+    fun `the review timestamps round-trip through the real DataStore`() = runTest {
+        // Real time and real I/O: the DataStore does its work off the test scheduler.
+        withContext(Dispatchers.IO) {
+            val context = ApplicationProvider.getApplicationContext<Context>()
+
+            // Real DataStore, no mocks: this catches a mismatch between what the Instant serializer
+            // writes and what the reader expects to find.
+            val settings = ReviewSettings(context, json)
+
+            settings.lastDismissed.value() shouldBe null
+            settings.reviewedAt.value() shouldBe null
+
+            // ISO-8601 with nanosecond precision, nothing is truncated on the way through.
+            val dismissedAt = Instant.parse("2023-11-14T22:13:20.000000001Z")
+            val reviewedAt = Instant.parse("2023-11-14T22:15:23.456789123Z")
+
+            settings.lastDismissed.value(dismissedAt)
+            settings.reviewedAt.value(reviewedAt)
+
+            settings.lastDismissed.value() shouldBe dismissedAt
+            settings.reviewedAt.value() shouldBe reviewedAt
+
+            // Writing null clears the key instead of storing a literal "null" that would then be
+            // decoded on the next read.
+            settings.lastDismissed.value(null)
+            settings.lastDismissed.value() shouldBe null
+            settings.dataStore.data.first().contains(DISMISSED_KEY) shouldBe false
+
+            // onErrorFallbackToDefault is off, so corrupt data surfaces instead of silently
+            // resetting the snooze/reviewed bookkeeping to "never".
+            settings.dataStore.edit { it[REVIEWED_KEY] = "not-a-timestamp" }
+            shouldThrow<SerializationException> { settings.reviewedAt.value() }
+        }
+    }
+
+    companion object {
+        private val DISMISSED_KEY = stringPreferencesKey("review.dismissedAt")
+        private val REVIEWED_KEY = stringPreferencesKey("review.reviewedAt")
+    }
+}


### PR DESCRIPTION
## What changed

BVM can now ask satisfied Pro users for a Play Store review. Users who have been Pro for more than 3 weeks may see a small card on the dashboard asking for a review — only while the dashboard is completely quiet (Bluetooth on and permitted, no hint or permission cards, at least one device set up). "Review" opens Google Play's own in-app review sheet, "Maybe later" hides the card for two weeks, and once a review was left the card never returns. FOSS builds are unaffected.

## Technical Context

- Port of the fleet's review-prompt design (SD Maid SE origin; the CAPod merge is the direct donor — the backend is byte-identical modulo package): `ReviewTool` interface with a FOSS no-op and a gplay implementation.
- Eligibility is computed locally first; Play is only probed for eligible users (quota-friendly), and the launch always requests a fresh `ReviewInfo`. Review timestamps persist via the app's contextual `InstantSerializer` (same mechanism as `CurriculumVitae`), strict-decode.
- Includes the fleet's crash-guard: corrupt review preferences fail closed upstream of `replayingShare` instead of terminating the shared flow inside the app scope (a crash no downstream `catch` can intercept — pinned by a regression test that reproduces the failure with the guard removed).
- The quiet gate covers all eight dashboard prompts (permission, Bluetooth-off, battery/overlay/DND/notification hints, speaker hint, empty-device CTA) so the review card never stacks with anything asking for action.
- Review actions are plain ViewModel methods rather than `DashboardAction` members — an `Activity` reference doesn't belong in an action payload (same shape as the existing upgrade click handling).
- Strings are English-only for now and join the next translation pass. On the release carrying this, every Pro user past the 21-day mark becomes eligible at once — a one-time wave of review cards is expected.
