### PR TITLE
Remove unused upgrade strings from the shared resources

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -364,8 +364,6 @@
     <string name="description_premium_required_this_extra_option">This extra option requires the premium version of this app.</string>
     <string name="description_premium_upgrade_explanation">Get the premium version to enable additional features and support development.</string>
     <string name="label_premium_version_required">Premium version required</string>
-    <string name="upgrade_feature_requires_pro">This feature requires the premium version</string>
-    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
     <string name="description_intro_purpose">This app allows your Android device to remember the volume of different Bluetooth devices.</string>
     <string name="description_intro_premium">If you like this app, consider upgrading to the premium version. It supports development and gets you a few extra features.</string>
     <string name="upgrade_benefit_unlimited_devices">Unlimited device profiles</string>


### PR DESCRIPTION
## What changed

No user-facing behavior change. Removes two upgrade-screen strings from the shared base English file that were already overridden by both build flavors, so they were never shown to anyone.

## Technical Context

- `upgrade_feature_requires_pro` and `upgrade_prompt_upgrade_action` are defined in both flavors (`Requires BVM Pro` / `Requires BVM FOSS`), which shadowed the shared copies in every build — the removed strings were unreachable in FOSS and Google Play alike.
- Beyond dead weight, this was a latent regression: a flavor's `values/strings.xml` override only wins for the *default* qualifier. Had Crowdin translated these keys into `main/values-XX/` before the flavor files caught up, Android's resource resolution would have picked the localized shared string over the flavor's untranslated default, leaking the generic wording into both flavors on every translated device. The equivalent break was hit for real in a sibling app, where a flavor-specific string was moved into shared `main` and the next translation sync activated it.
- Base English only — the 77 translated copies under `main/values-*/` are Crowdin-owned and get pruned on the next sync.
- Verified: 796 FOSS and 1050 Google Play unit tests pass, `lintVitalFossRelease` and `lintVitalGplayRelease` both clean.
