### PR TITLE
Fix broken bullet-list formatting and mistranslated labels

### DIFF
--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager het geen advertensies nie en verkoop nie gebruikersdata nie. Voortgesette ontwikkeling word slegs deur jou moontlik gemaak.</string>
     <string name="upgrade_screen_how_title">Hoe om te help</string>
     <string name="upgrade_screen_how_body">Word \'n beskermheer en borg ontwikkeling! Tik die knoppie hieronder om alle ekstra funksies te aktiveer en my GitHub Sponsors profiel oop te maak.</string>
+    <string name="upgrade_screen_why_title">Voordele</string>
+    <string name="upgrade_screen_why_body">• Onbeperkte toestelle\n• Aangepaste verbindingsaksies\n• Temaapaswing\n• Gevorderde volumekontroles\n• Ondersteuning van oopbronsontwikkeling 🧙</string>
     <string name="upgrade_screen_sponsor_action">Borg ontwikkeling</string>
     <string name="upgrade_screen_sponsor_action_hint">Die alternatief is advertensies, analitiek en Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Dankie dat jy oopbron ontwikkeling ondersteun ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Bekyk jou ondersteunerstatus</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Jy is op die gratis weergawe</string>
+    <string name="upgrade_screen_status_free_body">Word \'n ondersteuner om die ekstra funksies te ontsluit en voortgesette ontwikkeling te sponsorseer.</string>
+    <string name="upgrade_screen_status_free_action">Sien opgraadopsies</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Dankie vir jou ondersteuning</string>
     <string name="upgrade_screen_supporter_status_body">Jy het alle ekstra kenmerke ontsluit deur oopbronontwikkeling te ondersteun.</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ምንም እዋዀት ይረጋል፣ የተገባይ ውሂብንነም አይሸጥም። የተቆተቀወ ቅብት በእርስዎን ብቼድ ይተቀጥላል።</string>
     <string name="upgrade_screen_how_title">እንዴት መርዳት እንደሚችሉ</string>
     <string name="upgrade_screen_how_body">ደጋፊ ይሁኑ እና ልማትን ይደግፉ! ሁሉንም ተጨማሪ ባህሪያት ለማንቃት እና የእኔን GitHub Sponsors መገለጫ ለመክፈት ከታች ያለውን ቁልፍ ይንኩ።</string>
+    <string name="upgrade_screen_why_title">ጥቅሞች</string>
+    <string name="upgrade_screen_why_body">• ገደብ ነጻ መሳሪያዎች\n• ተስተካካሪ ግንኙነት ድርጊቶች\n• ገጽታ ማበጀት\n• የላቀ ድምጽ ቁጥጥር\n• ዓለም አቀፍ ልማት ድጋፍ 🧙</string>
     <string name="upgrade_screen_sponsor_action">ልማትን ይደግፉ</string>
     <string name="upgrade_screen_sponsor_action_hint">አማራጩ ማስታወቂያዎች፣ ትንታኔዎች እና Google Play ናቸው 🙁</string>
     <string name="upgrade_screen_thanks_toast">ክፍት ምንጭ ልማትን ስለደገፉ እናመሰግናለን ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">ደጋፊ ሁኔታዎን ይመልከቱ</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">ነፃ ወለታ ወደ ይህ ደርሰዋል።</string>
+    <string name="upgrade_screen_status_free_body">ድጋሪ ተላ ተጨማሪ ሞያዎች ሽቅ ለማድረግ ወደፊት ልማት ድጋፍ.</string>
+    <string name="upgrade_screen_status_free_action">የሻመ ምርጫዎች ይመልከቱ</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">ድጋፋችሁ ስለወሰዳችሁ አመሰግናለሁ</string>
     <string name="upgrade_screen_supporter_status_body">ነጻ ምንጭ ልማትን በድጋፍ ሁሉንም ተጨማሪ ባህሪያት አንስተሳሉ።</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">لا يعرض Bluetooth Volume Manager أية إعلانات ولا يبيع بيانات المستخدم. التطوير المستمر ممكن فقط بدعمكم.</string>
     <string name="upgrade_screen_how_title">كيف أساعدك</string>
     <string name="upgrade_screen_how_body">كن داعما وراعيا للتطوير! انقر على الزر أدناه لتفعيل جميع الميزات الإضافية وفتح ملفي الخاص برعاة GitHub.</string>
+    <string name="upgrade_screen_why_title">المميزات</string>
+    <string name="upgrade_screen_why_body">• عدد غير محدود من الأجهزة\n• إجراءات اتصال مخصصة\n• تخصيص المظهر\n• عناصر تحكم صوت متقدمة\n• دعم تطوير المصادر المفتوحة 🧙</string>
     <string name="upgrade_screen_sponsor_action">ادعم التطوير</string>
     <string name="upgrade_screen_sponsor_action_hint">البديل هو الإعلانات والتحليلات و Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">شكراً على دعمك لتطوير المصادر المفتوحة ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">عرض حالة الداعم الخاصة بك</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">أنت على النسخة المجانية</string>
+    <string name="upgrade_screen_status_free_body">أصبح مؤيدًا لفتح الميزات الإضافية وتمويل التطوير المستمر.</string>
+    <string name="upgrade_screen_status_free_action">شاهد خيارات الترقية</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">شكرًا لدعمك</string>
     <string name="upgrade_screen_supporter_status_body">لقد فتحت جميع الميزات الإضافية بدعمك لتطوير المصدر المفتوح.</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-də reklam yoxdur və istifadəçi məlumatlarını satmır. Davamlı inkışaf yalnız sizin sayənizdə mümkündür.</string>
     <string name="upgrade_screen_how_title">Necə kömək etmək</string>
     <string name="upgrade_screen_how_body">Himayədar olun və inkişafı sponsor edin! Bütün əlavə xüsusiyyətləri aktivləşdirmək və mənim GitHub Sponsors profilimi açmaq üçün aşağıdakı düyməni toxunun.</string>
+    <string name="upgrade_screen_why_title">Üstünlüklər</string>
+    <string name="upgrade_screen_why_body">• Sınırsız cihazlar\n• Fərdi bağlantı əməliyyatları\n• Tema fərdiləşdirmə\n• Qabaqcıl səs idarəetmə\n• Açıq mənbə inkişafına dəstək 🧙</string>
     <string name="upgrade_screen_sponsor_action">İnkişafı sponsor edin</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativ reklamlar, analitika və Google Play-dir 🙁</string>
     <string name="upgrade_screen_thanks_toast">Açıq mənbə inkişafını dəstəklədiyiniz üçün təşəkkür edirik ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Dəstəkçi statusunuza baxın</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Siz pulsuz versiyada olursunuz</string>
+    <string name="upgrade_screen_status_free_body">Əlavə xüsusiyyətləri açmaq və davam edən inkişafı sponsorlamaq üçün tərəfdar olun.</string>
+    <string name="upgrade_screen_status_free_action">Yüksəltmə seçimlərini görün</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Dəstəyiniz üçün təşəkkürlər</string>
     <string name="upgrade_screen_supporter_status_body">Açıq mənbə inkişafını dəstəklədiyiniz üçün bütün əlavə funksiyaların kilidini açdınız.</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не мае рэкламы і не прадае дадзеныя карыстальнікаў. Працягнення разработкі магчыма толькі дзякуючы вам.</string>
     <string name="upgrade_screen_how_title">Як дапамагчы</string>
     <string name="upgrade_screen_how_body">Станьце спонсарам распрацоўкі! Націсніце кнопку ніжэй, каб актывіраваць усе дадатковыя функцыі і адкрыць мой профіль на GitHub Sponsors.</string>
+    <string name="upgrade_screen_why_title">Перавагі</string>
+    <string name="upgrade_screen_why_body">• Неабмежаваныя прылады\n• Налады злучэння\n• Персоналізацыя тэмы\n• Прасунутыя элементы кантролю гучнасці\n• Падтрымка разпрацоўкі з адкрытым кодам 🧙</string>
     <string name="upgrade_screen_sponsor_action">Падтрымаць распрацоўку</string>
     <string name="upgrade_screen_sponsor_action_hint">Альтэрнатыва - рэклама, аналітыка і Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Дзякуй за падтрымку распрацоўкі з адкрытым зыходным кодам ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Праглядзець ваш статус спонсара</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Вы на бясплатнай версіі</string>
+    <string name="upgrade_screen_status_free_body">Станьце прыхільнікам, каб разблакіраваць дадатковыя функцыі і падтрымаць бягучы развіццё.</string>
+    <string name="upgrade_screen_status_free_action">Глядзіце опцыі паліпшэння</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Дзякуй за вашу падтрымку</string>
     <string name="upgrade_screen_supporter_status_body">Вы разблакіравалі ўсе дадатковыя функцыі, падтрымаўшы распрацоўку адкрытага кода.</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager няма реклами и не продава потребителски данни. Непрекъснатото развитие е възможно само благодарение на вас.</string>
     <string name="upgrade_screen_how_title">Как да помогнете</string>
     <string name="upgrade_screen_how_body">Станете покровител и спонсорирайте разработката! Докоснете бутона по-долу, за да активирате всички допълнителни функции и да отворите моя GitHub Sponsors профил.</string>
+    <string name="upgrade_screen_why_title">Предимства</string>
+    <string name="upgrade_screen_why_body">• Неограничени устройства\n• Персонализирани действия при свързване\n• Персонализиране на темата\n• Разширени контроли на звука\n• Подкрепа на разработката с отворен код 🧙</string>
     <string name="upgrade_screen_sponsor_action">Спонсорирайте разработката</string>
     <string name="upgrade_screen_sponsor_action_hint">Алтернативата са реклами, анализи и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Благодаря ви, че подкрепяте разработката с отворен код ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Вижте статуса си на поддържник</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Вие сте на безплатната версия</string>
+    <string name="upgrade_screen_status_free_body">Станете подкрепител, за да отключите допълнителните функции и да спонсорирате продължаващото развитие.</string>
+    <string name="upgrade_screen_status_free_action">Вижте опциите за надграждане</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Благодарим за подкрепата</string>
     <string name="upgrade_screen_supporter_status_body">Отключихте всички допълнителни функции, като подкрепихте разработката с отворен код.</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-এ কোনো বিজ্ঞাপন নেই এবং ব্যবহারকারীর তথ্য বিক্রি করে না। চলমান উন্নয়ন শুধুমাত্র আপনার দ্বারা সম্ভব।</string>
     <string name="upgrade_screen_how_title">কিভাবে সাহায্য করতে পারি</string>
     <string name="upgrade_screen_how_body">একটি পৃষ্ঠপোষক এবং স্পনসর উন্নয়ন হয়ে! সমস্ত অতিরিক্ত বৈশিষ্ট্য সক্রিয় করতে নীচের বোতামটি আলতো চাপুন এবং আমার GitHub স্পনসর প্রোফাইল খুলুন।</string>
+    <string name="upgrade_screen_why_title">সুবিধাসমূহ</string>
+    <string name="upgrade_screen_why_body">• সীমাহীন ডিভাইস\n• কাস্টম সংযোগ ক্রিয়া\n• থিম কাস্টমাইজেশন\n• উন্নত ভলিউম নিয়ন্ত্রণ\n• ওপেন-সোর্স উন্নয়ন সমর্থন 🧙</string>
     <string name="upgrade_screen_sponsor_action">স্পনসর ডেভলপমেন্ট</string>
     <string name="upgrade_screen_sponsor_action_hint">বিকল্প হল বিজ্ঞাপন, বিশ্লেষণ এবং Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ওপেন সোর্স ডেভেলপমেন্ট সমর্থন করার জন্য আপনাকে ধন্যবাদ ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">আপনার সমর্থক স্ট্যাটাস দেখুন</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">আপনি বিনামূল্যে সংস্করণে আছেন</string>
+    <string name="upgrade_screen_status_free_body">একজন সমর্থক হন অতিরিক্ত বৈশিষ্ট্য আনলক করতে এবং অব্যাহত উন্নয়নে স্পন্সর করতে।</string>
+    <string name="upgrade_screen_status_free_action">আপগ্রেড বিকল্প দেখুন</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">আপনার সহায়তার জন্য ধন্যবাদ</string>
     <string name="upgrade_screen_supporter_status_body">ওপেন-সোর্স ডেভেলপমেন্টকে সহায়তা করে আপনি সমস্ত অতিরিক্ত বৈশিষ্ট্য আনলক করেছেন।</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no té anuncis i no ven dades d’usuari. El desenvolupament continuat només és possible gràcies a vosaltres.</string>
     <string name="upgrade_screen_how_title">Com ajudar</string>
     <string name="upgrade_screen_how_body">Convertiu-vos en mecenes i patrocinadors del desenvolupament! Toqueu el botó següent per activar totes les funcions addicionals i obrir el meu perfil de patrocinadors del GitHub.</string>
+    <string name="upgrade_screen_why_title">Avantatges</string>
+    <string name="upgrade_screen_why_body">• Dispositius il·limitats\n• Accions de connexió personalitzades\n• Personalització del tema\n• Controls de volum avançats\n• Suport del desenvolupament de codi obert 🧙</string>
     <string name="upgrade_screen_sponsor_action">Desenvolupament del patrocinador</string>
     <string name="upgrade_screen_sponsor_action_hint">L\'alternativa són els anuncis, les analítiques i Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gràcies per donar suport al desenvolupament de codi obert ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Consulteu el vostre estat de col·laborador</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Estàs en la versió gratuïta</string>
+    <string name="upgrade_screen_status_free_body">Converteix-te en un partidari per desbloquejar les funcions addicionals i patrocinar el desenvolupament continu.</string>
+    <string name="upgrade_screen_status_free_action">Veure opcions d\'actualització</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Gràcies pel vostre suport</string>
     <string name="upgrade_screen_supporter_status_body">Heu desbloquejat totes les funcions addicionals per donar suport al desenvolupament de codi obert.</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neobsahuje žádné reklamy a neprodává data uživatelů. Další vývoj je možný pouze díky vám.</string>
     <string name="upgrade_screen_how_title">Jak pomoci</string>
     <string name="upgrade_screen_how_body">Staňte se patronem a sponzorem vývoje! Klepnutím na tlačítko níže aktivujete všechny další funkce a otevřete můj profil sponzora na GitHubu.</string>
+    <string name="upgrade_screen_why_title">Výhody</string>
+    <string name="upgrade_screen_why_body">• Neomezená zařízení\n• Vlastní akce připojení\n• Přizpůsobení motivu\n• Pokročilé ovládání hlasitosti\n• Podpora vývoje open-source 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponzorovat vývoj</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativou jsou reklamy, analytika a Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Děkujeme vám za podporu vývoje open-source ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Zobrazit stav podporovatele</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Používáte bezplatnou verzi</string>
+    <string name="upgrade_screen_status_free_body">Staňte se podporovatelem, abyste odemkli další funkce a podpořili pokračujicí vývoj.</string>
+    <string name="upgrade_screen_status_free_action">Zobrazit možnosti upgradu</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Díky za vaši podporu</string>
     <string name="upgrade_screen_supporter_status_body">Podporou open-source vývoje jste si odemkli všechny extra funkce.</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen reklamer og sælger ikke brugerdata. Fortsat udvikling er kun muliggjort af dig.</string>
     <string name="upgrade_screen_how_title">Sådan hjælper du</string>
     <string name="upgrade_screen_how_body">Bliv patron og sponsorér udvikling! Tryk på knappen nedenfor for at aktivere alle ekstra funktioner og åbne min GitHub-sponsorprofil.</string>
+    <string name="upgrade_screen_why_title">Fordele</string>
+    <string name="upgrade_screen_why_body">• Ubegrænsede enheder\n• Brugerdefinerede forbindelingshandlinger\n• Temakustomisering\n• Avancerede lydstyrkereguleringer\n• Støtte til open source-udvikling 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsorudvikling</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativet er annoncer, analyser og Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Tak, fordi du støtter open source-udvikling ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Se din supporter-status</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Du er på den gratis version</string>
+    <string name="upgrade_screen_status_free_body">Bliv tilhænger for at låse op for de ekstra funktioner og sponsorere fortsat udvikling.</string>
+    <string name="upgrade_screen_status_free_action">Se opgraderingsmuligheder</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Tak for din støtte</string>
     <string name="upgrade_screen_supporter_status_body">Du har låst op for alle ekstra funktioner ved at støtte open source-udvikling.</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager enthält keine Werbung und verkauft keine Nutzerdaten. Die Weiterentwicklung wird nur durch dich ermöglicht.</string>
     <string name="upgrade_screen_how_title">Wie kann ich helfen?</string>
     <string name="upgrade_screen_how_body">Werde Förderer und unterstütze Entwicklung! Klicke auf die Schaltfläche unten, um alle zusätzlichen Funktionen zu aktivieren und mein GitHub-Sponsorenprofil zu öffnen.</string>
+    <string name="upgrade_screen_why_title">Vorteile</string>
+    <string name="upgrade_screen_why_body">• Unbegrenzte Anzahl an Geräten\n• Benutzerdefinierte Verbindungsaktionen\n• Design-Anpassung\n• Erweiterte Lautstärkeregelung\n• Open-Source-Entwicklung unterstützen 🧙</string>
     <string name="upgrade_screen_sponsor_action">Weiterentwicklung unterstützen</string>
     <string name="upgrade_screen_sponsor_action_hint">Die Alternative sind Anzeigen, Analysen und Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Vielen Dank für Deine Unterstützung der Open-Source-Entwicklung ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Deinen Unterstützerstatus ansehen</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Du hast die kostenlose Version</string>
+    <string name="upgrade_screen_status_free_body">Werde Sponsor um zusätzlichen Funktionen freizuschalten und die App-Entwicklung zu unterstützen.</string>
+    <string name="upgrade_screen_status_free_action">Upgrade-Optionen ansehen</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Danke für deine Unterstützung</string>
     <string name="upgrade_screen_supporter_status_body">Du hast alle Zusatzfunktionen freigeschaltet, indem du die Open-Source-Entwicklung unterstützt hast.</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Το Bluetooth Volume Manager δεν έχει διαφημίσεις και δεν πωλεί δεδομένα χρηστών. Η συνεχής ανάπτυξη είναι δυνατή μόνο χάρη σε εσάς.</string>
     <string name="upgrade_screen_how_title">Πώς να βοηθήσετε</string>
     <string name="upgrade_screen_how_body">Γίνετε patron και χορηγήστε την ανάπτυξη! Πατήστε το κουμπί παρακάτω για να ενεργοποιήσετε όλα τα επιπλέον χαρακτηριστικά και ανοίξτε το προφίλ μου GitHub Sponsors.</string>
+    <string name="upgrade_screen_why_title">Πλεονεκτήματα</string>
+    <string name="upgrade_screen_why_body">• Απεριόριστες συσκευές\n• Προσαρμοσμένες ενέργειες σύνδεσης\n• Προσαρμογή θέματος\n• Προχωρημένα χειριστήρια έντασης\n• Υποστήριξη ανάπτυξης ανοιχτού κώδικα 🧙</string>
     <string name="upgrade_screen_sponsor_action">Χορηγήστε την ανάπτυξη</string>
     <string name="upgrade_screen_sponsor_action_hint">Η εναλλακτική λύση είναι οι διαφημίσεις, τα αναλυτικά και το Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Σας ευχαριστούμε που υποστηρίζετε την ανάπτυξη ανοιχτού κώδικα ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Δες την κατάσταση υποστηρικτή σου</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Είστε στην δωρεάν έκδοση</string>
+    <string name="upgrade_screen_status_free_body">Γίνετε υποστηρικτής για να ξεκλειδώσετε τα επιπλέον χαρακτηριστικά και να υποστηρίξετε τη συνεχιζόμενη ανάπτυξη.</string>
+    <string name="upgrade_screen_status_free_action">Δείτε τις επιλογές αναβάθμισης</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Ευχαριστούμε για την υποστήριξή σου</string>
     <string name="upgrade_screen_supporter_status_body">Ξεκλείδωσες όλα τα επιπλέον χαρακτηριστικά υποστηρίζοντας την ανάπτυξη ανοιχτού κώδικα.</string>

--- a/app/src/foss/res/values-eo-rUY/strings.xml
+++ b/app/src/foss/res/values-eo-rUY/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ne havas reklamojn kaj ne vendas uzantoajn datumojn. Daŭra disvolvado estas ebligita nur de vi.</string>
     <string name="upgrade_screen_how_title">Kiel helpi</string>
     <string name="upgrade_screen_how_body">Fiĝiĝu patrono kaj sponsoru disvolvadon! Frapi la butonon malsupre por aktivigi ĉiujn ekstra funkciojn kaj malfermi mian GitHub Sponsors-profilon.</string>
+    <string name="upgrade_screen_why_title">Avantaĝoj</string>
+    <string name="upgrade_screen_why_body">• Senlimaj aparatoj\n• Agordaj konekt-agoj\n• Tema agordo\n• Progresa laudo-kontrolo\n• Subteno al malfermkoda disvolviĝo 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsori disvolvadon</string>
     <string name="upgrade_screen_sponsor_action_hint">La alternativo estas reklamoj, analizoj kaj Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Dankon pro subteno de malfermita kodo ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Vidu vian subtenantan staton</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Vi estas en la senpaga versio</string>
+    <string name="upgrade_screen_status_free_body">Fariĝu subtenanto por malŝlosi la kromajn funkciojn kaj subteni la daŭran disvolviĝon.</string>
+    <string name="upgrade_screen_status_free_action">Vidi ĝisdatigo-variantojn</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Dankon pro via subteno</string>
     <string name="upgrade_screen_supporter_status_body">Vi malŝlosis ĉiujn aldonajn funkciojn per subteno de malfermitkoda programado.</string>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende datos de usuario. El desarrollo continuo solo es posible gracias a vos.</string>
     <string name="upgrade_screen_how_title">Como ayudar</string>
     <string name="upgrade_screen_how_body">¡Conviértete en patrocinador y patrocina el desarrollo! Toque el botón de abajo para activar todas las funciones adicionales y abrir mi perfil de Patrocinadores de GitHub.</string>
+    <string name="upgrade_screen_why_title">Ventajas</string>
+    <string name="upgrade_screen_why_body">• Dispositivos ilimitados\n• Acciones de conexión personalizadas\n• Personalización de temas\n• Controles de volumen avanzados\n• Apoya el desarrollo de código abierto 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsorear el desarrollo</string>
     <string name="upgrade_screen_sponsor_action_hint">Las alternativas son anuncios, analíticas y Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo de código abierto ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Mirá tu estado de colaborador</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Estás en la versión gratuita</string>
+    <string name="upgrade_screen_status_free_body">Convertite en patrocinador para desbloquear funciones adicionales y patrocinar el desarrollo continuo.</string>
+    <string name="upgrade_screen_status_free_action">Ver opciones de actualización</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Gracias por tu apoyo</string>
     <string name="upgrade_screen_supporter_status_body">Desbloqueaste todas las funciones extra al apoyar el desarrollo de código abierto.</string>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene publicidad y no vende datos de usuarios. El desarrollo continuo solo es posible gracias a ti.</string>
     <string name="upgrade_screen_how_title">Cómo ayudar</string>
     <string name="upgrade_screen_how_body">¡Conviértete en un patrocinador y apoya el desarrollo constante de la aplicación! Presiona el botón a continuación para activar todas las funciones adicionales además de abrir mi perfil de Patrocinadores en GitHub.</string>
+    <string name="upgrade_screen_why_title">Ventajas</string>
+    <string name="upgrade_screen_why_body">• Dispositivos ilimitados\n• Acciones de conexión personalizadas\n• Personalización de tema\n• Controles de volumen avanzados\n• Apoya el desarrollo de código abierto 🧙</string>
     <string name="upgrade_screen_sponsor_action">Patrocinador el proyecto</string>
     <string name="upgrade_screen_sponsor_action_hint">La alternativa son los anuncios, las analíticas y Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo libre ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Consulta tu estado de colaborador</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Estás usando la versión gratuita</string>
+    <string name="upgrade_screen_status_free_body">Convíertete en patrocinador para desbloquear funciones adicionales y patrocinar el desarrollo continuo.</string>
+    <string name="upgrade_screen_status_free_action">Ver opciones de actualización</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Gracias por tu apoyo</string>
     <string name="upgrade_screen_supporter_status_body">Desbloqueaste todas las funciones adicionales al apoyar el desarrollo de código abierto.</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende los datos de los usuarios. El desarrollo continuo solo es posible gracias a ti.</string>
     <string name="upgrade_screen_how_title">Como ayudar</string>
     <string name="upgrade_screen_how_body">¡Conviértete en patrocinador y patrocina el desarrollo! Toque el botón de abajo para activar todas las funciones adicionales y abrir mi perfil de Patrocinadores de GitHub.</string>
+    <string name="upgrade_screen_why_title">Ventajas</string>
+    <string name="upgrade_screen_why_body">• Dispositivos ilimitados\n• Acciones de conexión personalizadas\n• Personalización de temas\n• Controles de volumen avanzados\n• Apoya el desarrollo de código abierto 🧙</string>
     <string name="upgrade_screen_sponsor_action">Patrocinadores</string>
     <string name="upgrade_screen_sponsor_action_hint">La alternativa son los anuncios, las analíticas y Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo del código abierto ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Consulta tu estado de colaborador</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Estás en la versión gratuita</string>
+    <string name="upgrade_screen_status_free_body">Conviértete en un apoyo para desbloquear las características adicionales y patrocinar el desarrollo continuo.</string>
+    <string name="upgrade_screen_status_free_action">Ver opciones de actualización</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Gracias por tu apoyo</string>
     <string name="upgrade_screen_supporter_status_body">Has desbloqueado todas las funciones adicionales al apoyar el desarrollo de código abierto.</string>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manageris pole reklaame ja see ei müü kasutajaandmeid. Jätkuv arendamine on võimalik vaid teie abil.</string>
     <string name="upgrade_screen_how_title">Kuidas aidata?</string>
     <string name="upgrade_screen_how_body">Hakake toetajaks ja rahastage arendamist. Kõikide lisavõimaluste kasutamiseks ja minu GitHub Sponsors profiili avamiseks puudutage alumist nuppu.</string>
+    <string name="upgrade_screen_why_title">Eelised</string>
+    <string name="upgrade_screen_why_body">• Piiramatu seadmete arv\n• Kohandatud ühendustegevused\n• Kujunduse kohandamine\n• Täpsemad helitugevuse juhtelemendid\n• Toeta avatud lähtekoodiga arendust 🧙</string>
     <string name="upgrade_screen_sponsor_action">Rahastage arendamist</string>
     <string name="upgrade_screen_sponsor_action_hint">Teiseks võimaluseks on reklaamid, analüüs ja Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Aitäh, et toetate avatud lähtekoodiga arendamist ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Vaata oma toetaja staatust</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Kasutad tasuta versiooni</string>
+    <string name="upgrade_screen_status_free_body">Saa toetajaks, et avada lisafunktsioonid ja rahastada jätkuvat arengut.</string>
+    <string name="upgrade_screen_status_free_action">Vaadake täiendamise valikuid</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Täname toetuse eest</string>
     <string name="upgrade_screen_supporter_status_body">Oled avanud kõik lisafunktsioonid, toetades avatud lähtekoodiga arendust.</string>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ek ez du iragarkirik eta ez du erabiltzailearen daturik saltzen. Garapenarekin jarraitzea zuk soilik egiten da posible.</string>
     <string name="upgrade_screen_how_title">Nola lagundu</string>
     <string name="upgrade_screen_how_body">Izan babesle eta garapen babeslari! Egin klik beheko botoian eginbide gehigarri guztiak aktibatzeko eta nire GitHub Sponsors profila irekitzeko.</string>
+    <string name="upgrade_screen_why_title">Abantailak</string>
+    <string name="upgrade_screen_why_body">• Mugarik gabeko gailuak\n• Konexio ekintza pertsonalizatuak\n• Tema pertsonalizazioa\n• Bolumen kontrol aurreratuak\n• Kode librea garapen laguntza 🧙</string>
     <string name="upgrade_screen_sponsor_action">Garapena babestu</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatiboa iragarkinak, analisiak eta Google Play dira 🙁</string>
     <string name="upgrade_screen_thanks_toast">Eskerrik asko iturburu irekiko garapena babesten duzulako ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Ikusi zure laguntzaile-egoera</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Bertsioan libre zaude</string>
+    <string name="upgrade_screen_status_free_body">Supporter bihurtu gehigarri ezaugarriak desblokeatzeko eta jarraitutako garapena lagundu.</string>
+    <string name="upgrade_screen_status_free_action">Hobekuntza aukerak ikusi</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Eskerrik asko zure laguntzagatik</string>
     <string name="upgrade_screen_supporter_status_body">Ezaugarri gehigarri guztiak desblokeatu dituzu iturburu irekiko garapena babestuz.</string>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">مدیر صدای بلوتوث تبلیغات ندارد و داده‌های کاربر را نمی‌فروشد. توسعه مداوم تنها با کمک شما ممکن می‌شود.</string>
     <string name="upgrade_screen_how_title">چگونه کمک کنیم</string>
     <string name="upgrade_screen_how_body">به حامی تبدیل شوید و توسعه را حمایت کنید! برای فعال کردن همه ویژگی‌های اضافی و باز کردن نمایه GitHub Sponsors من، روی دکمه زیر ضربه بزنید.</string>
+    <string name="upgrade_screen_why_title">مزایا</string>
+    <string name="upgrade_screen_why_body">• دستگاه‌های نامحدود\n• اقدامات اتصال سفارشی\n• سفارشی‌سازی تم\n• کنترل‌های صدای پیشرفته\n• حمایت از توسعه متن‌باز 🧙</string>
     <string name="upgrade_screen_sponsor_action">حامی توسعه دهنده</string>
     <string name="upgrade_screen_sponsor_action_hint">جایگزین تبلیغات، تجزیه و تحلیل و Google Play 🙁 هستند</string>
     <string name="upgrade_screen_thanks_toast">از شما برای حمایت از توسعه منبع باز سپاسگزاریم ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">وضعیت حامی خود را مشاهده کنید</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">شما در نسخه رایگان هستید</string>
+    <string name="upgrade_screen_status_free_body">به یک حامی تبدیل شوید تا ویژگی‌های اضافی را باز کنید و توسعه مستمر را حمایت کنید.</string>
+    <string name="upgrade_screen_status_free_action">مشاهده گزینه‌های ارتقا</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">با تشکر از حمایت شما</string>
     <string name="upgrade_screen_supporter_status_body">با حمایت از توسعه متن‌باز، تمام امکانات اضافی را باز کرده‌اید.</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerissa ei ole mainoksia eikä se myy käyttäjätietoja. Jatkuva kehitys on mahdollista vain sinun avullasi.</string>
     <string name="upgrade_screen_how_title">Kuinka auttaa</string>
     <string name="upgrade_screen_how_body">Ryhdy tukijaksi ja sponsoroi kehitystä! Napauta alla olevaa painiketta aktivoidaksesi kaikki lisäominaisuudet ja avataksesi GitHub Sponsors -profiilini.</string>
+    <string name="upgrade_screen_why_title">Edut</string>
+    <string name="upgrade_screen_why_body">• Rajattomat laitteet\n• Mukautetut yhteyden toiminnot\n• Teeman mukauttaminen\n• Kehittyneet äänenvoimakkuuden säädöt\n• Avoimen lähdekoodin kehityksen tukeminen 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsoroi kehitystä</string>
     <string name="upgrade_screen_sponsor_action_hint">Vaihtoehto on mainokset, analytiikka ja Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Kiitos avoimen lähdekoodin kehityksen tukemisesta ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Katso tukijatilasi</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Käytät ilmaista versiota</string>
+    <string name="upgrade_screen_status_free_body">Liity tukijaksi avataksesi lisäominaisuudet ja tukeaksesi jatkokehitystä.</string>
+    <string name="upgrade_screen_status_free_action">Katso päivitysvaihtoehdot</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Kiitos tuestasi</string>
     <string name="upgrade_screen_supporter_status_body">Olet avannut kaikki lisäominaisuudet tukemalla avoimen lähdekoodin kehitystä.</string>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Walang mga ads ang Bluetooth Volume Manager at hindi nagbebenta ng data ng user. Ang patuloy na development ay posible lamang dahil sa inyo.</string>
     <string name="upgrade_screen_how_title">Paano tumulong</string>
     <string name="upgrade_screen_how_body">Maging patron at mag-sponsor ng development! I-tap ang button sa ibaba para ma-activate ang lahat ng extra features at buksan ang aking GitHub Sponsors profile.</string>
+    <string name="upgrade_screen_why_title">Mga Benepisyo</string>
+    <string name="upgrade_screen_why_body">• Walang hanggang devices\n• Custom na aksyon sa koneksyon\n• Customization ng tema\n• Advanced na kontrol sa volume\n• Suportahan ang open-source development 🧙</string>
     <string name="upgrade_screen_sponsor_action">Mag-sponsor ng development</string>
     <string name="upgrade_screen_sponsor_action_hint">Ang alternative ay ads, analytics at Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Salamat sa pagsuporta sa open-source development ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Tingnan ang iyong supporter status</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Nasa free version ka</string>
+    <string name="upgrade_screen_status_free_body">Maging supporter upang i-unlock ang mga karagdagang feature at mag-sponsor ng patuloy na development.</string>
+    <string name="upgrade_screen_status_free_action">Tingnan ang mga opsyon sa upgrade</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Salamat sa iyong suporta</string>
     <string name="upgrade_screen_supporter_status_body">Na-unlock mo na ang lahat ng extra na feature sa pagsuporta sa open-source development.</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n’affiche pas de publicités et ne vend pas les données des utilisateurs. La poursuite du développement n’est possible que grâce à vous.</string>
     <string name="upgrade_screen_how_title">Comment aider</string>
     <string name="upgrade_screen_how_body">Devenez mécène et commanditez le développement d’Octi. Touchez le bouton ci-dessous pour activer les fonctions supplémentaires et ouvrir mon profil « GitHub Sponsors ».</string>
+    <string name="upgrade_screen_why_title">Avantages</string>
+    <string name="upgrade_screen_why_body">• Appareils illimités\n• Actions de connexion personnalisées\n• Personnalisation du thème\n• Contrôles de volume avancés\n• Soutenir le développement open-source 🧙</string>
     <string name="upgrade_screen_sponsor_action">Commanditer le développement</string>
     <string name="upgrade_screen_sponsor_action_hint">L’alternative est des publicités, des analyses et Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Merci de soutenir le développement libre ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Consultez votre statut de contributeur</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Vous êtes sur la version gratuite</string>
+    <string name="upgrade_screen_status_free_body">Devenez un supporter pour déverrouiller les fonctionnalités supplémentaires et soutenir le développement continu.</string>
+    <string name="upgrade_screen_status_free_action">Voir les options de mise à niveau</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Merci pour votre soutien</string>
     <string name="upgrade_screen_supporter_status_body">Vous avez débloqué toutes les fonctionnalités supplémentaires en soutenant le développement open source.</string>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non ten anuncios e non vende datos de usuario. O desenvolvemento continuo só é posible grazas a ti.</string>
     <string name="upgrade_screen_how_title">Como axudar</string>
     <string name="upgrade_screen_how_body">Convértete en mecenas e patrocina o desenvolvemento! Toca o botón de abaixo para activar todas as características extra e abrir o meu perfil de GitHub Sponsors.</string>
+    <string name="upgrade_screen_why_title">Vantaxes</string>
+    <string name="upgrade_screen_why_body">• Dispositivos ilimitados\n• Accións de conexión personalizadas\n• Personalización de tema\n• Controles de volume avanzados\n• Apoiar o desenvolvemento de código aberto 🧙</string>
     <string name="upgrade_screen_sponsor_action">Patrocinar desenvolvemento</string>
     <string name="upgrade_screen_sponsor_action_hint">A alternativa son anuncios, análises e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Grazas por apoiar o desenvolvemento de código aberto ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Ver o teu estado de colaborador</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Estás na versión gratuíta</string>
+    <string name="upgrade_screen_status_free_body">Convértete nun apoiador para desbloquear as características extra e patrocinar o desenvolvemento continuo.</string>
+    <string name="upgrade_screen_status_free_action">Ver opcións de actualización</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Grazas polo teu apoio</string>
     <string name="upgrade_screen_supporter_status_body">Desbloqueaches todas as funcións extra por apoiar o desenvolvemento de código aberto.</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager में कोई विज्ञापन नहीं है और वह उपयोगकर्ता डेटा नहीं बेचता। निरंतर विकास केवल आपकी वजह से संभव है।</string>
     <string name="upgrade_screen_how_title">कैसे सहायता करें</string>
     <string name="upgrade_screen_how_body">संरक्षक बनें और विकास को प्रायोजित करें! सभी अतिरिक्त सुविधाओं को सक्रिय करने और मेरी GitHub Sponsors प्रोफ़ाइल खोलने के लिए नीचे दिए गए बटन को टैप करें।</string>
+    <string name="upgrade_screen_why_title">लाभ</string>
+    <string name="upgrade_screen_why_body">• असीमित डिवाइस\n• कस्टम कनेक्शन क्रियाएँ\n• थीम अनुकूलन\n• उन्नत वॉल्यूम नियंत्रण\n• ओपन-सोर्स विकास का समर्थन 🧙</string>
     <string name="upgrade_screen_sponsor_action">विकास को प्रायोजक करें</string>
     <string name="upgrade_screen_sponsor_action_hint">विज्ञापन, एनालिटिक्स और गूगल प्ले ये सभी वैकल्पिक है🙁</string>
     <string name="upgrade_screen_thanks_toast">ओपन-सोर्स विकास ❤️ का समर्थन करने के लिए धन्यवाद</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">अपनी समर्थक स्थिति देखें</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">आप मुफ्त संस्करण पर हैं</string>
+    <string name="upgrade_screen_status_free_body">अतिरिक्त सुविधाओं को अनलॉक करने और निरंतर विकास को प्रायोजित करने के लिए एक समर्थक बनें।</string>
+    <string name="upgrade_screen_status_free_action">अपग्रेड विकल्प देखें</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">आपके समर्थन के लिए धन्यवाद</string>
     <string name="upgrade_screen_supporter_status_body">ओपन-सोर्स विकास का समर्थन करके आपने सभी अतिरिक्त सुविधाएं अनलॉक कर ली हैं।</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nema oglasa i ne prodaje korisničke podatke. Kontinuirani razvoj omogućen je samo zbog vas.</string>
     <string name="upgrade_screen_how_title">Kako pomoći</string>
     <string name="upgrade_screen_how_body">Postanite pokrovitelj i sponzorirajte razvoj! Dodirnite gumb ispod da biste aktivirali sve dodatne značajke i otvorili moj GitHub sponzorski profil.</string>
+    <string name="upgrade_screen_why_title">Prednosti</string>
+    <string name="upgrade_screen_why_body">• Neograničeni uređaji\n• Prilagođene akcije povezivanja\n• Prilagodba teme\n• Napredne kontrole glasnoće\n• Podrška razvoju otvorenog koda 🧙</string>
     <string name="upgrade_screen_sponsor_action">Podržite razvoj</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativa su oglasi, analitika i Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Hvala vam što podržavate razvoj otvorenog koda ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Pogledajte svoj status podupiratelja</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Koristite besplatnu verziju</string>
+    <string name="upgrade_screen_status_free_body">Postanite pobornik da otključate dodatne značajke i sponzorirate nastavak razvoja.</string>
+    <string name="upgrade_screen_status_free_action">Pogledajte opcije nadogradnje</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Hvala na podršci</string>
     <string name="upgrade_screen_supporter_status_body">Otključali ste sve dodatne značajke podržavajući razvoj otvorenog koda.</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">A Bluetooth Volume Manager nem tartalmaz hirdetéseket, és nem értékesít felhasználói adatokat. A folyamatos fejlesztést csak te teszed lehetővé.</string>
     <string name="upgrade_screen_how_title">Hogyan lehet segíteni</string>
     <string name="upgrade_screen_how_body">Legyen patron támogató és szponzorálja a fejlesztést! Kattintson az alábbi gombra az összes extra funkció aktiválásához és a GitHub Sponsors profilom megnyitásához.</string>
+    <string name="upgrade_screen_why_title">Előnyök</string>
+    <string name="upgrade_screen_why_body">• Korlátlan eszközök\n• Egyéni csatlakozási műveletek\n• Téma testreszabása\n• Speciális hangerő-vezérlés\n• Támogass nyílt forráskódú fejlesztést 🧙</string>
     <string name="upgrade_screen_sponsor_action">Szponzori fejlesztés</string>
     <string name="upgrade_screen_sponsor_action_hint">Az alternatívák a hirdetések, az elemzések és a Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Köszönjük, hogy támogatod a nyílt forráskódú fejlesztést ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Támogatói állapotod megtekintése</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Az ingyenes verzión vagy</string>
+    <string name="upgrade_screen_status_free_body">Támogass minket az extra funkciók feloldásához és a fejlesztés támogatásához.</string>
+    <string name="upgrade_screen_status_free_action">Frissítési lehetőségek megtekintése</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Köszönjük a támogatásod</string>
     <string name="upgrade_screen_supporter_status_body">A nyílt forráskódú fejlesztés támogatásával feloldottad az összes extra funkciót.</string>

--- a/app/src/foss/res/values-hy-rAM/strings.xml
+++ b/app/src/foss/res/values-hy-rAM/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ում գովազդներ չկան և ուժղատության տվյալներ չի վարարկում։ Միայն դզեր կողմից ե հնարավոր շարունակ զարգացումն։</string>
     <string name="upgrade_screen_how_title">Ինչպես օգնել</string>
     <string name="upgrade_screen_how_body">Դարձեք հովանավոր և հովանավորեք զարգացումը: Սեղմեք ստորև գտնվող կոճակը՝ բոլոր լրացուցիչ գործառույթները ակտիվացնելու և իմ GitHub Sponsors պրոֆիլը բացելու համար:</string>
+    <string name="upgrade_screen_why_title">Առավելություններ</string>
+    <string name="upgrade_screen_why_body">• Անսահմանափակ սարքեր\n• Հատուկ միացման գործողություններ\n• Թեմայի հարմարեցում\n• Ընդլայնված ծավալի կառավարում\n• Բաց կոդի մշակման աջակցություն 🧙</string>
     <string name="upgrade_screen_sponsor_action">Հովանավորել զարգացումը</string>
     <string name="upgrade_screen_sponsor_action_hint">Այլընտրանքը գովազդներն են, վերլուծությունը և Google Play-ը 🙁</string>
     <string name="upgrade_screen_thanks_toast">Շնորհակալություն բաց կոդով զարգացումը աջակցելու համար ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Դիտեք ձեր աջակցողի կարգավիճակը</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Դուք անվճար տարբերակի վրա եք</string>
+    <string name="upgrade_screen_status_free_body">Դառնեք աջակցող։ լրացուցիչ հատկանիշները հանելու և շարունակական մշակումը սատարելու համար։</string>
+    <string name="upgrade_screen_status_free_action">Տեսեք արդիացման տարբերակները</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Շնորհակալություն ձեր աջակցության համար</string>
     <string name="upgrade_screen_supporter_status_body">Բացել եք բոլոր լրացուցիչ հնարավորությունները՝ աջակցելով բաց կոդով զարգացմանը։</string>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tidak menampilkan iklan dan tidak menjual data pengguna. Pengembangan yang berkelanjutan hanya bisa dilakukan berkat Anda.</string>
     <string name="upgrade_screen_how_title">Cara membantu</string>
     <string name="upgrade_screen_how_body">Jadilah pelindung dan sponsor pengembangan! Ketuk tombol di bawah untuk mengaktifkan semua fitur tambahan dan membuka profil GitHub Sponsors saya.</string>
+    <string name="upgrade_screen_why_title">Kelebihan</string>
+    <string name="upgrade_screen_why_body">• Perangkat tak terbatas\n• Tindakan koneksi kustom\n• Kustomisasi tema\n• Kontrol volume lanjutan\n• Dukung pengembangan sumber terbuka 🧙</string>
     <string name="upgrade_screen_sponsor_action">Pengembangan sponsor</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatifnya adalah iklan, analitik, dan Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Terima kasih karena telah mendukung pengembangan sumber terbuka ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Lihat status pendukung Anda</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Anda berada di versi gratis</string>
+    <string name="upgrade_screen_status_free_body">Jadilah pendukung untuk membuka fitur tambahan dan mensponsori pengembangan berkelanjutan.</string>
+    <string name="upgrade_screen_status_free_action">Lihat opsi upgrade</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Terima kasih atas dukungan Anda</string>
     <string name="upgrade_screen_supporter_status_body">Anda telah membuka semua fitur tambahan dengan mendukung pengembangan open-source.</string>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager birtir engar auglýsingar og selur ekki notendagögn. Áframhaldandi þróun er eingungu möguleg þökk sé þér.</string>
     <string name="upgrade_screen_how_title">Hvernig á að hjálpa</string>
     <string name="upgrade_screen_how_body">Vertu styrktaraðili og styrktu þróun! Ýttu á hnappinn hér að neðan til að virkja alla viðbótareiginleika og opna GitHub Sponsors prófílinn minn.</string>
+    <string name="upgrade_screen_why_title">Kostir</string>
+    <string name="upgrade_screen_why_body">• Ótakmörk tæki\n• Sérsniðnar tengingaðgerðir\n• Sérsniðning útlits\n• Ítarleg hljóðstyrk stjórnun\n• Stuðningur við opna hugbúnaðarþróun 🧙</string>
     <string name="upgrade_screen_sponsor_action">Styrkja þróun</string>
     <string name="upgrade_screen_sponsor_action_hint">Valkosturinn eru auglýsingar, greiningar og Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Takk fyrir að styðja opna hugbúnaðarþróun ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Skoða stuðningsstöðu þína</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Þú ert á ókeypis útgáfunni</string>
+    <string name="upgrade_screen_status_free_body">Vertu stuðningsaðili til að opna aukaeiginleika og styðja áframhaldandi þróun.</string>
+    <string name="upgrade_screen_status_free_action">Sjá uppfærslumöguleika</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Takk fyrir stuðninginn</string>
     <string name="upgrade_screen_supporter_status_body">Þú hefur opnað alla aukaeiginleika með því að styðja þróun opins hugbúnaðar.</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non contiene pubblicità e non vende i dati degli utenti. Lo sviluppo continuo è possibile solo grazie a te.</string>
     <string name="upgrade_screen_how_title">Come aiutare</string>
     <string name="upgrade_screen_how_body">Diventa un sostenitore e sponsorizza lo sviluppo! Clicca il pulsante qui sotto per attivare tutte le funzioni extra e apri il mio profilo Sponsor Github.</string>
+    <string name="upgrade_screen_why_title">Vantaggi</string>
+    <string name="upgrade_screen_why_body">• Dispositivi illimitati\n• Azioni di connessione personalizzate\n• Personalizzazione del tema\n• Controlli del volume avanzati\n• Supporto dello sviluppo open-source 🧙</string>
     <string name="upgrade_screen_sponsor_action">Finanzia lo sviluppo</string>
     <string name="upgrade_screen_sponsor_action_hint">L\'alternativa sono annunci, analytics e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Grazie per aver supportato lo sviluppo open-source ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Visualizza il tuo stato di sostenitore</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Sei sulla versione gratuita</string>
+    <string name="upgrade_screen_status_free_body">Diventa un sostenitore per sbloccare le funzioni extra e sponsorizzare lo sviluppo continuo.</string>
+    <string name="upgrade_screen_status_free_action">Vedi le opzioni di upgrade</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Grazie per il tuo supporto</string>
     <string name="upgrade_screen_supporter_status_body">Hai sbloccato tutte le funzionalità extra sostenendo lo sviluppo open-source.</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ללא מודעות ואינה מוכרת נתוני משתמשים. המשך הפיתוח מתאפשר רק על ידך.</string>
     <string name="upgrade_screen_how_title">איך לעזור</string>
     <string name="upgrade_screen_how_body">הפוך לפטרון ונותן חסות לפיתוח! הקש על הכפתור למטה כדי להפעיל את כל התכונות הנוספות ולפתוח את פרופיל הספונסרים בגיטהאב שלי.</string>
+    <string name="upgrade_screen_why_title">יתרונות</string>
+    <string name="upgrade_screen_why_body">• מכשירים בלתי מוגבלים\n• פעולות חיבור מותאמות\n• התאמה של ערכת נושא\n• בקרות עוצמת קול מתקדמות\n• תמיכה בפיתוח קוד-פתוח 🧙</string>
     <string name="upgrade_screen_sponsor_action">תמוך בפיתוח</string>
     <string name="upgrade_screen_sponsor_action_hint">האלטרנטיבה הן מודעות, אנליטיקס ו-Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">תודה שתמכת בפיתוח קוד פתוח ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">הצגת סטטוס התומך שלכם</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">אתה בגרסה החינמית</string>
+    <string name="upgrade_screen_status_free_body">הפוך לתומך כדי לשחרר את התכונות הנוספות ולתמוך בפיתוח מתמשך.</string>
+    <string name="upgrade_screen_status_free_action">ראה אפשרויות שדרוג</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">תודה על התמיכה שלכם</string>
     <string name="upgrade_screen_supporter_status_body">פתחתם את כל התכונות הנוספות בזכות התמיכה בפיתוח קוד פתוח.</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerは広告がなく、ユーザーデータを販売しません。継続的な開発は、あなたのおかげで成り立っています。</string>
     <string name="upgrade_screen_how_title">協力するには</string>
     <string name="upgrade_screen_how_body">パトロンとスポンサーの開発になりましょう！下のボタンをタップすると、すべての追加機能が有効になり、GitHub Sponsors プロファイルを開きます。</string>
+    <string name="upgrade_screen_why_title">メリット</string>
+    <string name="upgrade_screen_why_body">• 無制限のデバイス\n• カスタム接続アクション\n• テーマのカスタマイズ\n• 高度なボリュームコントロール\n• オープンソース開発をサポート 🧙</string>
     <string name="upgrade_screen_sponsor_action">開発支援者</string>
     <string name="upgrade_screen_sponsor_action_hint">代替は広告や分析そしてGoogle Playになります</string>
     <string name="upgrade_screen_thanks_toast">オープンソースでの開発に協力してくれてありがとうございます ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">サポーターステータスを確認</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">無料版をご利用中です</string>
+    <string name="upgrade_screen_status_free_body">サポーターになって追加機能をロック解除し、開発の継続をご支援ください。</string>
+    <string name="upgrade_screen_status_free_action">アップグレードオプションを確認する</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">ご支援ありがとうございます</string>
     <string name="upgrade_screen_supporter_status_body">オープンソース開発を支援することで、すべての追加機能をアンロックしました。</string>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager რეკლამაგარეშია და მომხმარეთა მონაცემებს არ ყიდის. განვითარებად განვითარება მხოლოდ მხოლოდ შესაძლებელია ერთიადად თქვენით.</string>
     <string name="upgrade_screen_how_title">როგორ დაგეხმაროთ</string>
     <string name="upgrade_screen_how_body">გახდით მფარველი და სპონსორობა გაუწიეთ განვითარებას! შეეხეთ ქვემოთ მოცემულ ღილაკს, რათა ააქტიუროთ ყველა დამატებითი ფუნქცია და გახსნათ ჩემი GitHub Sponsors პროფილი.</string>
+    <string name="upgrade_screen_why_title">უპირატესობები</string>
+    <string name="upgrade_screen_why_body">• შეუზღუდავი მოწყობილობები\n• მორგებული კავშირის მოქმედებები\n• თემის მორგება\n• დაწვრილებული ხმის კონტროლი\n• ღია წყაროს განვითარების ხელშეწყობა 🧙</string>
     <string name="upgrade_screen_sponsor_action">სპონსორის განვითარება</string>
     <string name="upgrade_screen_sponsor_action_hint">ალტერნატივა არის რეკლამა, ანალიტიკა და Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">გმადლობთ ღია კოდის განვითარების მხარდაჭერისთვის ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">იხილეთ თქვენი მხარდამჭერის სტატუსი</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">თქვენ უფასო ვერსიას იყენებთ</string>
+    <string name="upgrade_screen_status_free_body">გახდით მხარდამჭერი რათა გახსნათ დამატებითი ფუნქციები და ხელი შეუწყოთ განვითარებას.</string>
+    <string name="upgrade_screen_status_free_action">იხილეთ განახლების ვარიანტები</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">მადლობა მხარდაჭერისთვის</string>
     <string name="upgrade_screen_supporter_status_body">ღია კოდის განვითარების მხარდაჭერით გახსენთ ყველა დამატებითი ფუნქცია.</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager មិនមានការផ្សាយពាណិជ្ជកម្ម ហើយមិនលក់ទិន្នន័យអ្នកប្រើប្រាស់ទេ។ ការអភិវឌ្ឍន៍ជាបន្ត​បន្ទាប់ត្រូវបានធ្វើឱ្យអាចធ្វើទៅបានតែដោយអ្នកប្រើ។</string>
     <string name="upgrade_screen_how_title">របៀបជួយ</string>
     <string name="upgrade_screen_how_body">ក្លាយជាអ្នកឧបត្ថម្ភ និងឧបត្ថម្ភការអភិវឌ្ឍន៍! ចុចប៊ូតុងខាងក្រោមដើម្បីធ្វើឱ្យមុខងារបន្ថែមទាំងអស់សកម្ម និងបើកប្រវត្តិរូប GitHub Sponsors របស់ខ្ញុំ។</string>
+    <string name="upgrade_screen_why_title">អត្ថប្រយោជន៍</string>
+    <string name="upgrade_screen_why_body">• ឧបករណ៍មិនមានដែនកំណត់\n• សកម្មភាពភ្ជាប់ដែលផ្ទាល់ខ្លួន\n• ការលៃតម្រូវរូបរាង\n• ការគ្រប់គ្រងសម្លេងលម្អិត\n• គាំទ្របង្ក្រឹងការអភិវឌ្ឍន៍កម្មវិធីលើក 🧙</string>
     <string name="upgrade_screen_sponsor_action">ឧបត្ថម្ភការអភិវឌ្ឍន៍</string>
     <string name="upgrade_screen_sponsor_action_hint">ជម្រើសផ្សេងគឺការផ្សាយពាណិជ្ជកម្ម ការវិភាគ និង Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">សូមអរគុណសម្រាប់ការគាំទ្រការអភិវឌ្ឍន៍ប្រភពបើកចំហ ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">មើលស្ថានភាពអ្នកគាំទ្ររបស់អ្នក</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">អ្នកគឺស្ថិតក្នុងកំណែឥតគិតថ្លៃ</string>
+    <string name="upgrade_screen_status_free_body">ក្លាយជាអ្នកគាំព ដើម្បីដោះលែកលក្ខណៈពិសេសលម្អ និងឧបត្ថម្ភការលូតលាស់របស់កម្មវិធី។</string>
+    <string name="upgrade_screen_status_free_action">មើលជម្រើសលើកកម្ពស់</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">សូមអរគុណសម្រាប់ការគាំទ្ររបស់អ្នក</string>
     <string name="upgrade_screen_supporter_status_body">អ្នកបានដោះសោលក្ខណៈពិសេសបន្ថែមទាំងអស់ ដោយការគាំទ្រការអភិវឌ្ឍន៍កូដបើកចំហា។</string>

--- a/app/src/foss/res/values-kmr-rTR/strings.xml
+++ b/app/src/foss/res/values-kmr-rTR/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">BVM reklamê nake. Geşedana berdewam tenê bi we gengaz e.</string>
     <string name="upgrade_screen_how_title">Çawa bipşixe</string>
     <string name="upgrade_screen_how_body">Bibin patronek û geşedanê sponsor bikin!</string>
+    <string name="upgrade_screen_why_title">Avantaj</string>
+    <string name="upgrade_screen_why_body">• Amûrên bê sînor\n• Aksiyonên peywendîyê yên taybet\n• Guzerandinê reng\n• Kontrolên helûskên pêşketî\n• Piştgiriya pêşveçûna netewî ya alib 🧙</string>
     <string name="upgrade_screen_sponsor_action">Geşedanê sponsor bike</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatif reklam, analitik û Google Play ye</string>
     <string name="upgrade_screen_thanks_toast">Spas ji bo pishtgiriya çavkaniya vekirî</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Statûya piştgirêrê xwe bibînin</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Tu li ser vêjean azad yî</string>
+    <string name="upgrade_screen_status_free_body">Bibe alîkar da ku taybetmendiyên zêde vekî û pêşveçûna berdewam alîkar bike.</string>
+    <string name="upgrade_screen_status_free_action">Vebijarkên bihevkirinê bibîn</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Spasî li piştgirîya we</string>
     <string name="upgrade_screen_supporter_status_body">We bi piştgirî dan pêşevekiriya çavkanîya vekirî hemû taybetmendiyên zêde tê destxistîn.</string>

--- a/app/src/foss/res/values-kn-rIN/strings.xml
+++ b/app/src/foss/res/values-kn-rIN/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ಜಾಹೀರಾತುಗಳಿಲ್ಲ ಮತ್ತು ಬಳಕೆದಾರರ ಡೇಟಾ ಮಾರಾಟುವುದಿಲ್ಲ. ನಿಮ್ಮಿಂದ ಮಾತ್ರ ನಿರಂತರ ಅಭಿವರ್ಧನೆ ಸಾಧ್ಯ.</string>
     <string name="upgrade_screen_how_title">ಸಹಾಯ ಮಾಡುವ ವಿಧಾನ</string>
     <string name="upgrade_screen_how_body">ಪ್ರಾಯೋಜಕರಾಗಿ ಅಭಿವರ್ಧನೆಯನ್ನು ಬೆಂಬಲಿಸಿ! ಎಲ್ಲಾ ಹೆಚ್ಚಿನ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಸಕ್ರಿಯಗೊಳಿಸಲು ಮತ್ತು ನನ್ನ GitHub Sponsors ಪ್ರೋಫೈಲ್ ತೆರೆಯಲು ಕೆಳಗಿನ ಬಟನ ಟ್ಯಾಪ್ ಮಾಡಿ.</string>
+    <string name="upgrade_screen_why_title">ಪ್ರಯೋಜನಗಳು</string>
+    <string name="upgrade_screen_why_body">• ಅಸೀಮಿತ ಸಾಧನಗಳು\n• ಕಸ್ಟಮ್ ಸಂಪರ್ಕ ಕ್ರಿಯೆಗಳು\n• ಥೀಮ್ ಅನುಕೂಲನ\n• ಮುಂದುವರಿದ ವಾಲ್ಯೂಮ್ ನಿಯಂತ್ರಣಗಳು\n• ಮುಕ್ತ-ಮೂಲ ಅಭಿವೃದ್ಧಿಯನ್ನು ಬೆಂಬಲಿಸಿ 🧙</string>
     <string name="upgrade_screen_sponsor_action">ಅಭಿವರ್ಧನೆಗೆ ಪ್ರಾಯೋಜಕತವನ್ನು ನೀಡಿ</string>
     <string name="upgrade_screen_sponsor_action_hint">ಪರ್ಯಾಯ ಜಾಹೀರಾತುಗಳು, ವಿಶ್ಲೇಷಣೆ ಮತ್ತು Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ಓಪನ್-ಸೋರ್ಸ್ ಅಭಿವರ್ಧನೆಗೆ ಬೆಂಬಲಿಸಿದ್ದಕ್ಕೆ ಧನ್ಯವಾದಗಳು ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">ನಿಮ್ಮ ಬೆಂಬಲಕಾರ ಸ್ಥಿತಿಯನ್ನು ವೀಕ್ಷಿಸಿ</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">ನೀವು ಉಚಿತ ಆವೃತ್ತಿಯಲ್ಲಿ ಇದ್ದೀರಿ</string>
+    <string name="upgrade_screen_status_free_body">ಅತಿರಿಕ್ತ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಅನ್‌ಲಾಕ್ ಮಾಡಲು ಮತ್ತು ಮುಂದುವರಿದ ಅಭಿವೃದ್ಧಿಯನ್ನು ಪ್ರಾಯೋಜಿಸಲು ಸಮರ್ಥಕ ಆಗಿ.</string>
+    <string name="upgrade_screen_status_free_action">ಅಪ್‌ಗ್ರೇಡ್ ಆಯ್ಕೆಗಳನ್ನು ನೋಡಿ</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">ನಿಮ್ಮ ಬೆಂಬಲಕ್ಕಾಗಿ ಧನ್ಯವಾದ</string>
     <string name="upgrade_screen_supporter_status_body">ನೀವು ಓಪನ್-ಸೋರ್ಸ್ ಅಭಿವೃದ್ಧಿಯನ್ನು ಬೆಂಬಲಿಸುವ ಮೂಲಕ ಎಲ್ಲಾ ಹೆಚ್ಚುವರಿ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಅನ್‌ಲಾಕ್ ಮಾಡಿದ್ದೀರಿ.</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager는 광고가 없고 유저 데이터를 팔지 않습니다. 지속적인 개발은 여러분이 있기에 가능합니다.</string>
     <string name="upgrade_screen_how_title">도움 주기</string>
     <string name="upgrade_screen_how_body">후원자가 되어 개발을 지원하세요! 아래 버튼을 눌러 Github Sponsors 프로필을 열고 추가 기능을 잠금해제하세요.</string>
+    <string name="upgrade_screen_why_title">장점</string>
+    <string name="upgrade_screen_why_body">• 무제한 기기\n• 맞춤 연결 작업\n• 테마 맞춤설정\n• 고급 볼륨 제어\n• 오픈소스 개발 지원 🧙</string>
     <string name="upgrade_screen_sponsor_action">개발 후원하기</string>
     <string name="upgrade_screen_sponsor_action_hint">다른 방식은 광고, 데이터 수집, 그리고 플레이 스토어입니다 🙁</string>
     <string name="upgrade_screen_thanks_toast">오픈소스 개발을 지원해주셔서 감사합니다 ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">후원자 상태 보기</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">무료 버전을 사용 중입니다</string>
+    <string name="upgrade_screen_status_free_body">후원자가 되어 추가 기능의 잠금을 해제하고 지속적인 개발을 지원하세요.</string>
+    <string name="upgrade_screen_status_free_action">업그레이드 옵션 보기</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">성원에 감사드립니다</string>
     <string name="upgrade_screen_supporter_status_body">오픈소스 개발을 지원해 주셔서 모든 추가 기능이 잠금 해제되었습니다.</string>

--- a/app/src/foss/res/values-ky-rKG/strings.xml
+++ b/app/src/foss/res/values-ky-rKG/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager жарнамаларсыз жана пайдалануучулардын мәлиматын сатпайт. Үзгөлтүрүлгөн ишкерлениш тек сиздин аркасында мүмкүн.</string>
     <string name="upgrade_screen_how_title">Калай жардам берүүгө</string>
     <string name="upgrade_screen_how_body">Патрон болуңуз жана ишкерленишти колдоо! Бардык кошумча функцияларды активдөө жана жеке астындагы GitHub Sponsors профилимди ачуу үчүн төмөндөгү баскычты таптаңыз.</string>
+    <string name="upgrade_screen_why_title">Артыкчылыктар</string>
+    <string name="upgrade_screen_why_body">• Чексиз түзмөктөр\n• Жөндөмдүү туташуу аракеттери\n• Тема ишкечтелери\n• Өнүккөн үндү башкаруу\n• Ачык баштапкы коддун өнүктүүлүгүнө колдоо 🧙</string>
     <string name="upgrade_screen_sponsor_action">Ишкерленишти спонсорлоо</string>
     <string name="upgrade_screen_sponsor_action_hint">Альтернатив жарнамалар, аналитика жана Google Play болот 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ачык код ишкерленишти колдоодогунуңуз үчүн рахмат ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Колдоочу статусун көрүңүз</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Сиз бесплатка версиясында болосуз</string>
+    <string name="upgrade_screen_status_free_body">Кошумча функцияларды ачуу жана улантылган өнүктүүлүккө колдоо көрсөтүү үчүн колдоочу болуңуз.</string>
+    <string name="upgrade_screen_status_free_action">Жогорулоо опцияларын карап чыгыңыз</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Колдооңуз үчүн рахмат</string>
     <string name="upgrade_screen_supporter_status_body">Ачык коддуу чулууну колдоо аркылуу сиз бардык кошумча функцияларды ачтыңыз.</string>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ບ່ມີໂຆສນາແລະບ່ຂາຍຂ້ອມູນຜູ້ໃຊ້. ການພັດທນາຕ່ອເນື່ອງເປັນໄປໄດ້ໂດຍມີທ່ານເທ່ານັ້ນ.</string>
     <string name="upgrade_screen_how_title">ວິທີການຊ່ວຍເຫຼືອ</string>
     <string name="upgrade_screen_how_body">ກາຍເປັນຜູ້ອຸປະຖໍາ ແລະ ໃຫ້ການສະໜັບສະໜູນການພັດທະນາ! ກົດປຸ່ມຂ້າງລຸ່ມເພື່ອເປີດໃຊ້ງານຄຸນສົມບັດເພີ່ມເຕີມທັງໝົດ ແລະ ເປີດໂປຣໄຟລ໌ GitHub Sponsors ຂອງຂ້ອຍ.</string>
+    <string name="upgrade_screen_why_title">ຂໍ້ດີ</string>
+    <string name="upgrade_screen_why_body">• ອຸປະກອນທີ່ບໍ່ມີຂອບເຂດ\n• ການດໍາເນີນການເຊື່ອມຕໍ່ທີ່ກຳນົດເອງ\n• ການປັບແຕ່ງຫຼອຂໍ້\n• ການຄວບຄຸມສຽງທີ່ກ້າວໜ້າ\n• ສະໜັບສະໜູນການພັດທະນາຊອບແວເປິດເຜີຍ 🧙</string>
     <string name="upgrade_screen_sponsor_action">ສະໜັບສະໜູນການພັດທະນາ</string>
     <string name="upgrade_screen_sponsor_action_hint">ທາງເລືອກແມ່ນໂຄສະນາ, ການວິເຄາະ ແລະ Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ຂອບໃຈສໍາລັບການສະໜັບສະໜູນການພັດທະນາແຫຼ່ງເປີດ ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">ເບິ່ງສະຖານະຜູ້ສະໝັບສະໝູນຂອງທ່ານ</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">ທ່ານຍູ່ໃນຮູບແບບຟຣີ</string>
+    <string name="upgrade_screen_status_free_body">ກາຍເປັນຜູ້ສະໜັບສະໜູນເພື່ອປົ່ອຍໃຫ້ຟີເຈີພິສະ ແລະສະໜັບສະໜູນການພັດທະນາຕໍ່ໄປ.</string>
+    <string name="upgrade_screen_status_free_action">ເບິ່ງຕົວເລືອກການອັບເກຣດ</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">ຂອບໃຈສຳລັບການສະໝັບສະໝູນຂອງທ່ານ</string>
     <string name="upgrade_screen_supporter_status_body">ທ່ານໄດ້ປົດລັອກຄຸນສົມບັດພິເສດທັງໝົດໂດຍການສະໝັບສະໝູນການພັດທະນາລະໝັດເປີດ.</string>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neturi reklamų ir neparduoda naudotojų duomenų. Tolesnė plėtra įmanoma tik dėka jūsų.</string>
     <string name="upgrade_screen_how_title">Kaip padėti</string>
     <string name="upgrade_screen_how_body">Tapkite globėju ir rėmėju plėtros! Palieskite žemiau esantį mygtuką, kad suaktyvintumėte visas papildomas funkcijas ir atidarytumėte mano GitHub Sponsors profilį.</string>
+    <string name="upgrade_screen_why_title">Privalumai</string>
+    <string name="upgrade_screen_why_body">• Neribota įrenginių skaičius\n• Pasirinktiniai ryšio veiksmai\n• Temos pritaikymas\n• Pažangūs garso valdymo nustatymai\n• Parama atvirojo kodo plėtrai 🧙</string>
     <string name="upgrade_screen_sponsor_action">Remti plėtrą</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatyva yra reklamos, analitika ir Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ačiū, kad remiате atvirojo kodo plėtrą ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Peržiūrėkite savo rėmėjo būseną</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Jūs naudojatės nemokama versija</string>
+    <string name="upgrade_screen_status_free_body">Tapkite šalininku, norėdami atrakinti papildomus pranašumus ir rėmti tolesnę plėtrą.</string>
+    <string name="upgrade_screen_status_free_action">Peržiūrėti atnaujinimo parinktis</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Dėkojame už paramą</string>
     <string name="upgrade_screen_supporter_status_body">Atrakinote visas papildomas funkcijas remdami atvirojo kodo kūrimą.</string>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name_upgraded">BSP FOSS</string>
     <string name="upgrade_feature_requires_pro">Nepieciešams BSP FOSS</string>
     <string name="upgrade_prompt_title">Jaunināt uz BSP FOSS</string>
     <string name="upgrade_prompt_body">Atslēdz papildu iespējas un kļūsti par aizbildni, lai atbalstītu izstrādes nepārtrauktību!</string>
@@ -8,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth skaļuma pārvaldniekā nav reklāmu, un tas nepārdod lietotāju datus. Izstrādes nepārtrauktība ir iespējama tikai pateicoties jums.</string>
     <string name="upgrade_screen_how_title">Kā palīdzēt</string>
     <string name="upgrade_screen_how_body">Kļūstiet par aizbildni un sponsorējiet attīstību! Pieskarieties pogas zemāk, lai aktivizētu visas papildu funkcijas un atvērtu manu GitHub Sponsors profilu.</string>
+    <string name="upgrade_screen_why_title">Priekšrocības</string>
+    <string name="upgrade_screen_why_body">• Neierobežoti ierīces\n• Pielāgoti savienojuma darbības\n• Tēmas pielāgošana\n• Papildu skaļuma vadības iespējas\n• Atbalstīt atvērtā koda attīstību 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsorēt attīstību</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatīva ir reklāmas, analītika un Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Paldies par atklātā koda attīstības atbalstīšanu ❤️</string>
@@ -15,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Skatīt savu atbalstītāja statusu</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Jūs esat bezmaksas versijā</string>
+    <string name="upgrade_screen_status_free_body">Kļūstiet atbalstītājs, lai atbloķētu papildu funkcijas un sponsorētu turpināto attīstību.</string>
+    <string name="upgrade_screen_status_free_action">Skatīt jaunināšanas opcijas</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Paldies par atbalstu</string>
     <string name="upgrade_screen_supporter_status_body">Tu esi atbloķējis visas papildu funkcijas, atbalstot atvērtā koda izstrādi.</string>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклами и не продава кориснички податоци. Континуираниот развој е можен само благодарение на вас.</string>
     <string name="upgrade_screen_how_title">Како да помогнете</string>
     <string name="upgrade_screen_how_body">Станете покровител и спонзорирајте го развојот! Допрете го копчето подолу за да ги активирате сите дополнителни функции и да го отворите мојот GitHub Sponsors профил.</string>
+    <string name="upgrade_screen_why_title">Предности</string>
+    <string name="upgrade_screen_why_body">• Неограничени уреди\n• Прилагодени акции за поврзување\n• Прилагодување на изглед\n• Напредни контроли за звук\n• Поддршка на развој на отворен код 🧙</string>
     <string name="upgrade_screen_sponsor_action">Спонзорирај развој</string>
     <string name="upgrade_screen_sponsor_action_hint">Алтернативата се реклами, аналитика и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ви благодариме што го поддржувате развојот на отворен код ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Погледнете го вашиот статус на поддржувач</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Вие сте на бесплатната верзија</string>
+    <string name="upgrade_screen_status_free_body">Станете поддржувач за да добиете дополнителни функции и спонзорирајте продолжен развој.</string>
+    <string name="upgrade_screen_status_free_action">Видете опции за надградба</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Ви благодариме за поддршката</string>
     <string name="upgrade_screen_supporter_status_body">Ги отклучивте сите додатни функции со поддржување на развојот со отворен код.</string>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager പ്രജ്ഞാപനങ്ങൾ ഇല്ല, ഉപയോക്തൃ ഡേറ്റ വിൽക്കുന്നില്ല. ഐക്കമാന വികസനം നിങ്ങൾ വഴി മാത്രം സാധ്യമാകുന്നു.</string>
     <string name="upgrade_screen_how_title">എങ്ങനെ സഹായിക്കാം</string>
     <string name="upgrade_screen_how_body">പാട്രോൺ ആകുകയും വികസനം സ്പോൺസർ ചെയ്യുകയും ചെയ്യുക! എല്ലാ അധിക സവിശേഷതകളും സജീവമാക്കാനും എന്റെ GitHub Sponsors പ്രൊഫൈൽ തുറക്കാനും താഴെയുള്ള ബട്ടൺ ടാപ്പ് ചെയ്യുക.</string>
+    <string name="upgrade_screen_why_title">പ്രയോജനങ്ങൾ</string>
+    <string name="upgrade_screen_why_body">• പരിധിയില്ലാത്ത ഡിവൈസുകൾ\n• കസ്റ്റം കണക്ഷൻ പ്രവർത്തനങ്ങൾ\n• തീം അനുകൂലീകരണം\n• വിപുലമായ വോളിയം നിയന്ത്രണങ്ങൾ\n• തുറന്ന സ്രോത വികസനം പിന്തുണയ്ക്കുക 🧙</string>
     <string name="upgrade_screen_sponsor_action">വികസനം സ്പോൺസർ ചെയ്യുക</string>
     <string name="upgrade_screen_sponsor_action_hint">പരസ്യങ്ങൾ, അനലിറ്റിക്‌സ്, ഗൂഗിൾ പ്ലേ എന്നിവയാണ് ബദൽ🙁</string>
     <string name="upgrade_screen_thanks_toast">ഓപ്പൺ സോഴ്‌സ് വികസനത്തെ പിന്തുണച്ചതിന് നന്ദി ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">നിങ്ങളുടെ സപ്പോർടർ സ്റ്റാറ്റസ് കാണുക</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">നിങ്ങൾ സ്വതന്ത്ര പതിപ്പ് ഉപയോഗിക്കുന്നു</string>
+    <string name="upgrade_screen_status_free_body">അതിരിക്ത സവിശേഷതകൾ അൺലോക്ക് ചെയ്യുന്നതിനും തുടർന്നുള്ള വികസനം പിന്തുണയ്ക്കുന്നതിനും ഒരു സപ്പോർട്ടർ ആകുക.</string>
+    <string name="upgrade_screen_status_free_action">അപ്ഗ്രേഡ് ഐച്ഛികതകൾ കാണുക</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">നിങ്ങളുടെ പിന്തുണയ്ക്കുള്ള നന്ദി</string>
     <string name="upgrade_screen_supporter_status_body">തുറന്ന സോഴ്സ് വികസനത്തെ പിന്തുണച്ച് നിങ്ങൾ എല്ലാ അധിക സവിശേഷതകളും അൻലോക്ക് ചെയ്തിരിക്കുന്നു.</string>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager сурталчилгаагүй бөгөөд хэрэглэгчийн өгөгдлийг зардаггүй. Цаашид хөгжлөлт зөвхөн тань боломжтой болгог.</string>
     <string name="upgrade_screen_how_title">Хэрхэн тусламж үзүүлэх</string>
     <string name="upgrade_screen_how_body">Ивээн тэтгэгч болж хөгжлийг дэмжээрэй! Бүх нэмэлт боломжуудыг идэвхжүүлж, миний GitHub Sponsors профайлыг нээхийн тулд доорх товчийг дарна уу.</string>
+    <string name="upgrade_screen_why_title">Давуу талууд</string>
+    <string name="upgrade_screen_why_body">• Хязгааргүй төхөөрөмж\n• Өөрчлөлттэй холболтын үйлдэл\n• Сэдвийн өөрчлөлт\n• Дэвшилтэт эзлэхүүнийг удирдах\n• Нээлттэй эх кодын хөгжүүлэлтийг дэмжих 🧙</string>
     <string name="upgrade_screen_sponsor_action">Хөгжлийг дэмжих</string>
     <string name="upgrade_screen_sponsor_action_hint">Өөр сонголт бол зар сурталчилгаа, шинжилгээ, Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Нээлттэй эхийн хөгжлийг дэмжсэнд баярлалаа ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Дэмжигчийн статусаа үзэх</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Та үнэгүй хувилбарт байна</string>
+    <string name="upgrade_screen_status_free_body">Дэмжигч болж нэмэлт функцүүдийг нээж, хөгжүүлэлтийг үргэлжүүлэхийг дэмжинэ үү.</string>
+    <string name="upgrade_screen_status_free_action">Шаруулах сонголтуудыг харах</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Таны дэмжлэгт баярлалаа</string>
     <string name="upgrade_screen_supporter_status_body">Та нээлттэй эхийн хөгжүүлэлтийг дэмжсэнээр бүх нэмэлт функцийг нээсэн байна.</string>

--- a/app/src/foss/res/values-mr-rIN/strings.xml
+++ b/app/src/foss/res/values-mr-rIN/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ला कोणतीही अॅड नाही आणि वापरकर्त्यांचा डेटा विकत नाही. सतत विकास केवळ तुमच्यामुळेही शक्य आहे.</string>
     <string name="upgrade_screen_how_title">कसे मदत करावी</string>
     <string name="upgrade_screen_how_body">प्रायोजक व्हा आणि विकासाला पाठिंबा द्या! सर्व अतिरिक्त वैशिष्ट्ये सक्रिय करण्यासाठी खालील बटण टॅप करा आणि माझे GitHub Sponsors प्रोफाइल उघडा.</string>
+    <string name="upgrade_screen_why_title">फायदे</string>
+    <string name="upgrade_screen_why_body">• असीम डिव्हाइस\n• कस्टम कनेक्शन क्रिया\n• थीम कस्टमाइजेशन\n• उन्नत व्हॉल्यूम नियंत्रण\n• मुक्त-स्रोत विकासाचे समर्थन 🧙</string>
     <string name="upgrade_screen_sponsor_action">विकासाला पाठिंबा द्या</string>
     <string name="upgrade_screen_sponsor_action_hint">पर्याय म्हणजे अॅड, अॅनालिटिक्स आणि Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ओपन-सोर्स विकासाला पाठिंबा दिल्याबद्दल धन्यवाद ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">आपली समर्थक स्थिती पहा</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">तुम्ही मुक्त आवृत्तीवर आहात</string>
+    <string name="upgrade_screen_status_free_body">अतिरिक्त वैशिष्ट्ये अनलॉक करण्यासाठी आणि सतत विकासला प्रायोजन देण्यासाठी समर्थक व्हा.</string>
+    <string name="upgrade_screen_status_free_action">अपग्रेड पर्याय पहा</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">आपल्या समर्थनाबद्दल धन्यवाद</string>
     <string name="upgrade_screen_supporter_status_body">ओपन-सोर्स विकासाला समर्थन देऊन आपण सर्व अतिरिक्त वैशिष्ट्ये अनलॉक केली आहेत.</string>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tiada iklan dan tidak menjual data pengguna. Pembangunan berterusan hanya boleh dilakukan dengan sokongan anda.</string>
     <string name="upgrade_screen_how_title">Bagaimana untuk membantu</string>
     <string name="upgrade_screen_how_body">Menjadi penaung dan penaja pembangunan! Ketik butang di bawah untuk mengaktifkan semua ciri tambahan dan buka profil Penaja GitHub saya.</string>
+    <string name="upgrade_screen_why_title">Kelebihan</string>
+    <string name="upgrade_screen_why_body">• Peranti tanpa had\n• Tindakan sambungan khusus\n• Penyesuaian tema\n• Kawalan volum maju\n• Sokongan pembangunan sumber terbuka 🧙</string>
     <string name="upgrade_screen_sponsor_action">Pembangunan penaja</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatifnya ialah iklan, analitik dan Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Terima kasih kerana menyokong pembangunan sumber terbuka ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Lihat status penyokong anda</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Anda berada di versi percuma</string>
+    <string name="upgrade_screen_status_free_body">Jadilah penyokong untuk membuka fitur tambahan dan menaja pembangunan yang berterusan.</string>
+    <string name="upgrade_screen_status_free_action">Lihat pilihan peningkatan</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Terima kasih atas sokongan anda</string>
     <string name="upgrade_screen_supporter_status_body">Anda telah membuka semua ciri tambahan dengan menyokong pembangunan sumber terbuka.</string>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager တွင် ကြော်ငြာများမရှိပြီး အသုံးပြုသူဒေတာများကိုလည်း မရောင်းချပါ။ ဆက်လက်ဖွံ့ဖြိုးတိုးတက်မှုသည် သင့ေကြောင့်သာသာ ဖြစ်နိုင်သည်။</string>
     <string name="upgrade_screen_how_title">ကူညီနည်းလမ်း</string>
     <string name="upgrade_screen_how_body">ကူညီသူဖြစ်ပြီး ဖွံ့ဖြိုးတိုးတက်မှုကို ကမကထပံ့ပိုးပါ! အပိုဝန်ဆောင်မှုများအားလုံးကို ဖွင့်ပြီး ကျွန်ုပ်၏ GitHub Sponsors ပရိုဖိုင်းကို ဖွင့်ရန် အောက်ပါခလုတ်ကို နှိပ်ပါ။</string>
+    <string name="upgrade_screen_why_title">အကျိုးကျေးဇူးများ</string>
+    <string name="upgrade_screen_why_body">• အကန့်အသတ်မရှိသော စက်ပစ္စည်းများ\n• စိတ်ကြိုက်ချိတ်ဆက်မှု လုပ်ဆောင်ချက်များ\n• ပုံစံအင်္ဂါ စိတ်ကြိုက်ပြင်ဆင်ခြင်း\n• အဆင့်မြင့်အသံအတိုးအကျယ်ထိန်းချုပ်မှုများ\n• အဖွင့်အရင်းအမြစ်ထုတ်ပြန်မှု ထောက်ခံခြင်း 🧙</string>
     <string name="upgrade_screen_sponsor_action">ဖွံ့ဖြိုးတိုးတက်မှုကို ကမကထပံ့ပိုးရန်</string>
     <string name="upgrade_screen_sponsor_action_hint">အခြားရွေးချယ်စရာမှာ ကြော်ငြာများ၊ ခွဲခြမ်းစိတ်ဖြာခြင်းနှင့် Google Play တို့ဖြစ်သည် 🙁</string>
     <string name="upgrade_screen_thanks_toast">ပွင့်လင်းရင်းမြစ် ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးပေးသည့်အတွက် ကျေးဇူးတင်ပါသည် ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">သင်၏တောက်ခံသူအဆင့်ကိုကြည့်ရှုပါ</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">သင်သည် အခမဲ့ဗားရှင်းတွင် ရှိပါသည်</string>
+    <string name="upgrade_screen_status_free_body">အကြံအပြင်ဆောင်ရွက်သူ ဖြစ်လာပြီး ထပ်ဆောင်းအင်္ဂါရပ်များကိုအသုံးပြုနိုင်စေရန်နှင့် ဆက်တိုက်တည်ဆောက်ခြင်းအားပံ့ပိုးပါ</string>
+    <string name="upgrade_screen_status_free_action">အဆင့်မြှင့်တင်ခြင်းရွေးချယ်မှုများကို ကြည့်ရှုပါ</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">သင်၏တောက်ခံမှုအတွက်ကျေးဇူးတင်ပါသည်</string>
     <string name="upgrade_screen_supporter_status_body">သင်သည် အဖွင့်အရင်းအမြစ်ဆော့ဝဲလ်တီထွင်မှုကို တောက်ခံခြင်းဖြင့် အပိုင်းအခြင်းအားလုံး ဖွင့်လှစ်ခဲ့ပါပြီ။</string>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager मा कुनै विज्ञापन छैन र यसले प्रयोगकर्ताको डेटा बাंड्दैन। निरन्तर विकास केवल तपाईंले गर्नुभएको सहयोगबाट मात्र संभव भएको छ।</string>
     <string name="upgrade_screen_how_title">कसरी मद्दत गर्ने</string>
     <string name="upgrade_screen_how_body">संरक्षक बन्नुहोस् र विकासलाई प्रायोजन गर्नुहोस्! सबै अतिरिक्त सुविधाहरू सक्रिय पार्न र मेरो GitHub Sponsors प्रोफाइल खोल्न तलको बटन ट्याप गर्नुहोस्।</string>
+    <string name="upgrade_screen_why_title">फाइदाहरू</string>
+    <string name="upgrade_screen_why_body">• असीमित उपकरणहरू\n• अनुकूल जडान कार्यहरू\n• विषयवस्तु अनुकूलन\n• उन्नत भलिउम नियन्त्रण\n• खुला स्रोत विकास समर्थन 🧙</string>
     <string name="upgrade_screen_sponsor_action">विकासलाई प्रायोजन गर्नुहोस्</string>
     <string name="upgrade_screen_sponsor_action_hint">विकल्प विज्ञापन, विश्लेषण र Google Play हुन् 🙁</string>
     <string name="upgrade_screen_thanks_toast">खुला स्रोत विकासलाई समर्थन गरेकोमा धन्यवाद ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">आफ्नो समर्थक स्थिति हेर्नुहोस्</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">तपाई नि: शुल्क संस्करण मा हुनुहुन्छु</string>
+    <string name="upgrade_screen_status_free_body">अतिरिक्त सुविधाहरू अनलक गर्न र निरन्तर विकास प्रायोजन गर्न समर्थक बन्नुहोस्।</string>
+    <string name="upgrade_screen_status_free_action">अपग्रेड विकल्पहरू देख्नुहोस्</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">तपाईंको समर्थनको लागि धन्यवाद</string>
     <string name="upgrade_screen_supporter_status_body">तपाईंले खुला-स्रोत विकास समर्थन गरेर सबै अतिरिक्त सुविधाहरू अनलक गर्नुभएको छ।</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager bevat geen advertenties en verkoopt geen gebruikersgegevens. Verdere ontwikkeling wordt alleen door jou mogelijk gemaakt.</string>
     <string name="upgrade_screen_how_title">Hoe kun je helpen</string>
     <string name="upgrade_screen_how_body">Word mecenas en sponsor ontwikkelaar! Tik op de onderstaande knop om alle extra functies te activeren en mijn GitHub Sponsors-profiel te openen.</string>
+    <string name="upgrade_screen_why_title">Voordelen</string>
+    <string name="upgrade_screen_why_body">• Onbeperkte apparaten\n• Aangepaste verbindingsacties\n• Thema-aanpassingen\n• Geavanceerde volumeregelingen\n• Ondersteun open-source-ontwikkeling 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsor ontwikkeling</string>
     <string name="upgrade_screen_sponsor_action_hint">Het alternatief zijn advertenties, analyses en Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Bedankt voor het ondersteunen van open-sourceontwikkeling ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Bekijk je ondersteunersstatus</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Je bent op de gratis versie</string>
+    <string name="upgrade_screen_status_free_body">Word een supporter om extra functies vrij te maken en verdere ontwikkeling te sponsoren.</string>
+    <string name="upgrade_screen_status_free_action">Bekijk upgrade-opties</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Bedankt voor je ondersteuning</string>
     <string name="upgrade_screen_supporter_status_body">Je hebt alle extra functies ontgrendeld door open-source-ontwikkeling te ondersteunen.</string>

--- a/app/src/foss/res/values-no/strings.xml
+++ b/app/src/foss/res/values-no/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen annonser og selger ikke brukerdata. Fortsatt utvikling er bare mulig ved hjelp av deg.</string>
     <string name="upgrade_screen_how_title">Hvordan hjelpe</string>
     <string name="upgrade_screen_how_body">Bli en patron og støtt utviklingen! Trykk på knappen under for å aktivere alle ekstra funksjoner og åpne sponsorprofilen min på GitHub.</string>
+    <string name="upgrade_screen_why_title">Fordeler</string>
+    <string name="upgrade_screen_why_body">• Ubegrensede enheter\n• Egendefinerte tilkoblingshandlinger\n• Tematilpasning\n• Avanserte volumkontroller\n• Støtt åpen kildekodeutvikling 🧙</string>
     <string name="upgrade_screen_sponsor_action">Støtt utviklingen</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativet er annonser, analyser og Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Takk for at du støtter utviklingen som har åpen kildekode ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Se din støtterstatus</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Du bruker den gratis versjonen</string>
+    <string name="upgrade_screen_status_free_body">Bli en støttespiller for å låse opp ekstra funksjoner og sponse fortsatt utvikling.</string>
+    <string name="upgrade_screen_status_free_action">Se oppgraderingsalternativer</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Takk for din støtte</string>
     <string name="upgrade_screen_supporter_status_body">Du har låst opp alle ekstrafunksjoner ved å støtte utvikling av åpen kildekode.</string>

--- a/app/src/foss/res/values-pcm-rNG/strings.xml
+++ b/app/src/foss/res/values-pcm-rNG/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no get ads and no dey sell user data. Continued development na only possible because of you.</string>
     <string name="upgrade_screen_how_title">How to help</string>
     <string name="upgrade_screen_how_body">Become patron and sponsor development! Tap di button below to activate all extra features and open my GitHub Sponsors profile.</string>
+    <string name="upgrade_screen_why_title">Advantages</string>
+    <string name="upgrade_screen_why_body">• Unlimited devices\n• Make your own connection actions\n• Change your theme\n• Top volume controls\n• Support open-source development 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsor development</string>
     <string name="upgrade_screen_sponsor_action_hint">Di alternative na ads, analytics and Google Play</string>
     <string name="upgrade_screen_thanks_toast">Thank you for supporting open-source development</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">See your supporter status</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">You dey use free version</string>
+    <string name="upgrade_screen_status_free_body">Become supporter make you unlock extra features and help development continue.</string>
+    <string name="upgrade_screen_status_free_action">See ways to upgrade</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Thank you for your support</string>
     <string name="upgrade_screen_supporter_status_body">You don unlock all extra features because you support open-source development.</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nie ma reklam i nie sprzedaje danych użytkowników. Dalszy rozwój jest możliwy tylko dzięki tobie.</string>
     <string name="upgrade_screen_how_title">Jak pomóc</string>
     <string name="upgrade_screen_how_body">Zostań patronem i wspieraj rozwój! Dotknij przycisku poniżej, aby aktywować wszystkie dodatkowe funkcje i otworzyć mój profil GitHub Sponsors.</string>
+    <string name="upgrade_screen_why_title">Zalety</string>
+    <string name="upgrade_screen_why_body">• Nieograniczona liczba urządzeń\n• Niestandardowe akcje połączenia\n• Dostosowywanie motywu\n• Zaawansowane kontroli głośności\n• Wspieranie rozwoju oprogramowania open-source 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsoruj rozwój</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatywą są reklamy, analityka i Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Dziękuję za wsparcie rozwoju oprogramowania otwarto źródłowego❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Zobacz status swojego wsparcia</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Jesteś na darmowej wersji</string>
+    <string name="upgrade_screen_status_free_body">Zostań wspierającym, aby odblokować dodatkowe funkcje i sponsorować dalszy rozwój.</string>
+    <string name="upgrade_screen_status_free_action">Zobacz opcje aktualizacji</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Dziękujemy za wsparcie</string>
     <string name="upgrade_screen_supporter_status_body">Odblokowałeś wszystkie dodatkowe funkcje dzięki wsparciu rozwoju open source.</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados do usuário. O desenvolvimento contínuo só é possível graças a você.</string>
     <string name="upgrade_screen_how_title">Como ajudar</string>
     <string name="upgrade_screen_how_body">Torne-se um patrocinador e financie o desenvolvimento! Clique no botão abaixo para ativar todos os recursos extras e abrir meu perfil Github Sponsors.</string>
+    <string name="upgrade_screen_why_title">Vantagens</string>
+    <string name="upgrade_screen_why_body">• Dispositivos ilimitados\n• Ações de conexão personalizadas\n• Personalização de tema\n• Controles de volume avançados\n• Apoie o desenvolvimento de código aberto 🧙</string>
     <string name="upgrade_screen_sponsor_action">Desenvolvimento do patrocinador</string>
     <string name="upgrade_screen_sponsor_action_hint">A alternativa são anúncios, análises e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Obrigado por apoiar o desenvolvimento de código aberto ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Visualizar seu status de apoiador</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Você está na versão gratuita</string>
+    <string name="upgrade_screen_status_free_body">Torne-se um apoiador para desbloquear os recursos extras e patrocinar o desenvolvimento contínuo.</string>
+    <string name="upgrade_screen_status_free_action">Ver opções de upgrade</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Obrigado pelo seu apoio</string>
     <string name="upgrade_screen_supporter_status_body">Você desbloqueou todos os recursos extras ao apoiar o desenvolvimento de código aberto.</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados dos utilizadores. O desenvolvimento contínuo só é possível graças a si.</string>
     <string name="upgrade_screen_how_title">Como ajudar</string>
     <string name="upgrade_screen_how_body">Torne-se um patrono e patrocine o desenvolvimento! Clique no botão abaixo para ativar todas as funcionalidades extra e abrir o meu perfil nos Patrocinadores GitHub.</string>
+    <string name="upgrade_screen_why_title">Vantagens</string>
+    <string name="upgrade_screen_why_body">• Dispositivos ilimitados\n• Ações de ligação personalizadas\n• Personalização de tema\n• Controlos de volume avançados\n• Apoiar o desenvolvimento de código aberto 🧙</string>
     <string name="upgrade_screen_sponsor_action">Patrocine o desenvolvimento</string>
     <string name="upgrade_screen_sponsor_action_hint">A alternativa são anúncios, análises e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Obrigado por apoiar o desenvolvimento de código aberto ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Ver o teu estado de apoiante</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Tem a versão gratuita</string>
+    <string name="upgrade_screen_status_free_body">Torne-se um apoiante para desbloquear as funcionalidades extra e apoiar o desenvolvimento contínuo.</string>
+    <string name="upgrade_screen_status_free_action">Ver opções de atualização</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Obrigado pelo teu apoio</string>
     <string name="upgrade_screen_supporter_status_body">Desbloqueaste todas as funcionalidades extra ao apoiares o desenvolvimento open-source.</string>

--- a/app/src/foss/res/values-rm/strings.xml
+++ b/app/src/foss/res/values-rm/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n\'ha naginas reclamas e na vend betg datas d\'utilisaders. Il svilup ulterior è mo pussaivel grazia a tai.</string>
     <string name="upgrade_screen_how_title">Tge che ti pos far</string>
     <string name="upgrade_screen_how_body">Daventescha in patronu e sustegna il svilup! Tocca il buttun sut per activar tut las funcziuns extras e vrar mai il profil GitHub Sponsors.</string>
+    <string name="upgrade_screen_why_title">Avantaschas</string>
+    <string name="upgrade_screen_why_body">• Apparails sensa limit\n• Acziuns da cunnexiun persunalisadas\n• Persunalisaziun dal tema\n• Controllas da volumen avanzads\n• Sustegn dal svilup open-source 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sustegnair il svilup</string>
     <string name="upgrade_screen_sponsor_action_hint">L\'alternativa è reclamas, analytics e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Grazia per sustegnair il svilup open-source ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Mira tia status da supporter</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Ti es en la versiun gratuita</string>
+    <string name="upgrade_screen_status_free_body">Dveinta sustengida per debliedar las funcziuns extras e sustegn il svilup cuntinuai.</string>
+    <string name="upgrade_screen_status_free_action">Vescha las opziuns da promomn</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Grazia per tia sapport</string>
     <string name="upgrade_screen_supporter_status_body">Tu has debloccà totas las funczias extras perquai che tu supporter il svilup da software open-source.</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nu are reclame şi nu vinde datele utilizatorilor. Continuarea dezvoltării este posibilă numai datorită ție.</string>
     <string name="upgrade_screen_how_title">Cum să ajuți</string>
     <string name="upgrade_screen_how_body">Deveniți un patron și o dezvoltare a sponsorului! Apăsați butonul de mai jos pentru a activa toate caracteristicile suplimentare și deschideți profilul meu GitHub Sponsors.</string>
+    <string name="upgrade_screen_why_title">Avantaje</string>
+    <string name="upgrade_screen_why_body">• Dispozitive nelimitate\n• Acțiuni de conexiune personalizate\n• Personalizare temă\n• Comenzi volum avansate\n• Suportă dezvoltarea open-source 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsorizează dezvoltarea</string>
     <string name="upgrade_screen_sponsor_action_hint">O alternativă sunt reclamele, analizele și Google Play🙁</string>
     <string name="upgrade_screen_thanks_toast">Mulțumesc că îmi suporți această dezvoltare open-source❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Verifică starea ta de suporter</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Ești pe versiunea gratuită</string>
+    <string name="upgrade_screen_status_free_body">Devino susținător pentru a debloca funcțiile suplimentare și a sponsoriza dezvoltarea continuă.</string>
+    <string name="upgrade_screen_status_free_action">Vezi opțiuni de upgrade</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Mulțumim pentru sprijinul tău</string>
     <string name="upgrade_screen_supporter_status_body">Ai deblocat toate funcțiile extra sprijinind dezvoltarea open-source.</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не содержит рекламы и не продаёт данные пользователей. Дальнейшее развитие возможно только благодаря вам.</string>
     <string name="upgrade_screen_how_title">Как помочь</string>
     <string name="upgrade_screen_how_body">Станьте спонсором и поддержите разработку! Нажмите кнопку ниже, чтобы активировать все дополнительные функции и открыть мой профиль GitHub Sponsors.</string>
+    <string name="upgrade_screen_why_title">Преимущества</string>
+    <string name="upgrade_screen_why_body">• Неограниченное количество устройств\n• Пользовательские действия при подключении\n• Настройка темы\n• Расширенные элементы управления громкостью\n• Поддержка разработки с открытым исходным кодом 🧙</string>
     <string name="upgrade_screen_sponsor_action">Спонсировать разработку</string>
     <string name="upgrade_screen_sponsor_action_hint">Альтернатива — реклама, аналитика и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Спасибо за поддержку разработки с открытым исходным кодом ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Посмотреть статус поддержки</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Вы используете бесплатную версию</string>
+    <string name="upgrade_screen_status_free_body">Поддержите нас, чтобы разблокировать дополнительные функции и спонсировать дальнейшую разработку.</string>
+    <string name="upgrade_screen_status_free_action">Посмотреть варианты обновления</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Спасибо за вашу поддержку</string>
     <string name="upgrade_screen_supporter_status_body">Вы разблокировали все дополнительные функции, поддержав разработку open-source проекта.</string>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tenet pubblicidade e no vendet datos de s\'usuàriu. S\'isvilupu continuadu est possìbile solamente gràtzias a tene.</string>
     <string name="upgrade_screen_how_title">Comente agiudare</string>
     <string name="upgrade_screen_how_body">Diventa patronu e sponsoriza s\'isvilupu! Tocca su butone in bassu pro ativare totu sas funtzionalidades addizionales e abèrrere su profilu meu de GitHub Sponsors.</string>
+    <string name="upgrade_screen_why_title">Vantàgios</string>
+    <string name="upgrade_screen_why_body">• Dispositivos illimitaus\n• Atziones de connessione personalizadas\n• Personalizatzione de tema\n• Controlos de volume avanzados\n• Suportu at su isvilluppu open-source 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsoriza s\'isvilupu</string>
     <string name="upgrade_screen_sponsor_action_hint">S\'alternativa sunt sa pubblicidade, s\'anàlisi e Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Gràtzias pro sustènnere s\'isvilupu de còdighe abertu ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Bili su tuo istadu de suportador</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Ses in sa bertzione libera</string>
+    <string name="upgrade_screen_status_free_body">Diventa unu suportatore pro a disblocca sa funtzionalidades estras e finantza s\'isvilluppu continuadu.</string>
+    <string name="upgrade_screen_status_free_action">Bide optziones de umpadu</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Grazie pro tuo suportu</string>
     <string name="upgrade_screen_supporter_status_body">Has desbloccadu totu sas funzionalidades extras suportande su sviluppu open-source.</string>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager හි දැන්වීම් නොමැති අතර පරිශීලක දත්ත අලේවි නොකරයි. අකට් සඹ්වර්ධනය ඔබ නිසා පමණක් හෙකියාවක්.</string>
     <string name="upgrade_screen_how_title">උදව් කරන්නේ කෙසේද</string>
     <string name="upgrade_screen_how_body">අනුග්‍රාහකයෙකු වී සංවර්ධනයට අනුග්‍රහ කරන්න! සියලු අමතර විශේෂාංග සක්‍රිය කර මගේ GitHub Sponsors පැතිකඩ විවෘත කිරීමට පහත බොත්තම ස්පර්ශ කරන්න.</string>
+    <string name="upgrade_screen_why_title">වාසි</string>
+    <string name="upgrade_screen_why_body">• සීමාවිරහිත උපාංගයන්\n• අභිරුචි සංයෝගනය ක්‍රියා\n• තේමා අභිරුචිකරණ\n• උසස් ශබ්ද පාලන\n• විවෘත මූලාශ්‍ර සංවර්ධනය සහාය කරන්න 🧙</string>
     <string name="upgrade_screen_sponsor_action">සංවර්ධනයට අනුග්‍රහය දෙන්න</string>
     <string name="upgrade_screen_sponsor_action_hint">විකල්පය දැන්වීම්, විශ්ලේෂණ සහ Google Play වේ 🙁</string>
     <string name="upgrade_screen_thanks_toast">විවෘත මූලාශ්‍ර සංවර්ධනයට සහාය දීම ගැන ස්තූතියි ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">ඔබගේ සහායක තත්වය බලන්න</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">ඔබ නිරීක්ෂණ සංස්කරණයට සිටින්න</string>
+    <string name="upgrade_screen_status_free_body">අතිරේක විශේෂාංගයන් අගුළු හරින්න සහ අඛණ්ඩ සංවර්ධනය සහාය කරන්නකු සිටින්න.</string>
+    <string name="upgrade_screen_status_free_action">උත්තරණ විකල්පයන් බලන්න</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">ඔබගේ සහයොගයට ස්තුතිවන්තයි</string>
     <string name="upgrade_screen_supporter_status_body">ඔබ විවර්තන-මූලාශ්‍ර සංවර්ධනයට සහය දැක්වීමෙන් සියලු අතිරේක විශේෂාග අවත් කළ හැකි වී.</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nemá žiadne reklamy a nepredáva údaje používateľov. Neustály vývoj umožňujete len vy.</string>
     <string name="upgrade_screen_how_title">Ako pomôcť</string>
     <string name="upgrade_screen_how_body">Staňte sa patrónom a sponzorujte rozvoj! Klepnutím na tlačidlo nižšie aktivujete všetky ďalšie funkcie a otvoríte môj profil sponzorov GitHub.</string>
+    <string name="upgrade_screen_why_title">Výhody</string>
+    <string name="upgrade_screen_why_body">• Neobmedzené zariadenia\n• Vlastné akcie pripojenia\n• Prispôsobenie témy\n• Pokročilé ovládanie hlasitosti\n• Podpora vývoja otvoreného kódu 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponzorovaný vývoj</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternatívou sú reklamy, analytika a Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ďakujem za podporu vývoja open-source ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Zobraziť svoj stav podporovateľa</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Ste na bezplatnej verzii</string>
+    <string name="upgrade_screen_status_free_body">Staňte sa podporovateľom, aby ste odomkli ďalšie funkcie a podporili ďalší vývoj.</string>
+    <string name="upgrade_screen_status_free_action">Pozrite si možnosti upgradu</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Ďakujeme za vašu podporu</string>
     <string name="upgrade_screen_supporter_status_body">Odomkli ste všetky extra funkcie podporou vývoja otvoreného zdrojového kódu.</string>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nima oglasov in ne prodaja uporabniških podatkov. Nadaljnji razvoj je omogočen samo z vašo podporo.</string>
     <string name="upgrade_screen_how_title">Kako pomagati.</string>
     <string name="upgrade_screen_how_body">Postanite pokrovitelj in prispevajte k razvoju!  Dotaknite se spodnjega gumba, da omogočite dodatne funkcije in odprete moj pokroviteljski profil na GitHubu.</string>
+    <string name="upgrade_screen_why_title">Prednosti</string>
+    <string name="upgrade_screen_why_body">• Neomejene naprave\n• Prilagojene možnosti priklopitve\n• Prilagajanje teme\n• Napredni nadzori glasnosti\n• Podpora razvoju odprtokodnega programa 🧙</string>
     <string name="upgrade_screen_sponsor_action">Podpri razvoj</string>
     <string name="upgrade_screen_sponsor_action_hint">Druga možnost so oglasi, analitika in Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Hvala za podporo odprtokodnemu razvoju ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Oglejte si status podpornika</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Ste na brezplačni različici</string>
+    <string name="upgrade_screen_status_free_body">Postanite podpornik, da odklenete dodatne funkcije in sponzorirate nadaljnji razvoj.</string>
+    <string name="upgrade_screen_status_free_action">Oglejte si možnosti nadgradnje</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Hvala za vašo podporo</string>
     <string name="upgrade_screen_supporter_status_body">Odklenili ste vse dodatne funkcije s podporo razvoju odprtokodnega programja.</string>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nuk ka reklama dhe nuk shet të dhënat e përdoruesit. Zhvillimi i vazhdueshëm bëhet i mundur vetëm nga ju.</string>
     <string name="upgrade_screen_how_title">Si të ndihmoj</string>
     <string name="upgrade_screen_how_body">Bëhuni një mbrojtës dhe sponsor i zhvillimit! Prekni butonin më poshtë për të aktivizuar të gjitha veçoritë shtesë dhe për të hapur profilin tim të sponsorëve të GitHub.</string>
+    <string name="upgrade_screen_why_title">Avantazhet</string>
+    <string name="upgrade_screen_why_body">• Pajisje të pakufizuara\n• Veprime të personalizuara të lidhjes\n• Përshtatje e temës\n• Kontrolle të avancuara të volumit\n• Mbështetni zhvillimin në burim të hapur 🧙</string>
     <string name="upgrade_screen_sponsor_action">Zhvillimi i sponsorëve</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativa janë reklamat, analitika dhe Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Faleminderit për mbështetjen e zhvillimit me burim të hapur ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Shikoni statusin e mbështetësit tuaj</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Ju jeni në versionin falas</string>
+    <string name="upgrade_screen_status_free_body">Bëhuni mbështetës për të zhbllokuar veçoritë shtesë dhe për të sponsorizuar zhvillimin e vazhdueshëm.</string>
+    <string name="upgrade_screen_status_free_action">Shikoni opsionet e përmirësimit</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Faleminderit për mbështetjen tuaj</string>
     <string name="upgrade_screen_supporter_status_body">Ju keni shkyçur të gjitha veçoritë shtesë duke mbështetur zhvillimin e burimit të hapur.</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклама и не продаје корисничке податке. Наставак развоја могућ је само захваљујући теби.</string>
     <string name="upgrade_screen_how_title">Како помоћи</string>
     <string name="upgrade_screen_how_body">Постаните покровитељ и спонзоришите развој! Додирните дугме испод да активирате све додатне функције и отворите мој GitHub Sponsors профил.</string>
+    <string name="upgrade_screen_why_title">Предности</string>
+    <string name="upgrade_screen_why_body">• Неограничени уређаји\n• Прилагођене акције повезивања\n• Прилагођавање теме\n• Напредне контроле јачине звука\n• Подршка развоју отвореног кода 🧙</string>
     <string name="upgrade_screen_sponsor_action">Спонзориши развој</string>
     <string name="upgrade_screen_sponsor_action_hint">Алтернатива су рекламе, аналитика и Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Хвала вам што подржавате развој отвореног кода ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Прегледајте статус подржавача</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Користиш бесплатну верзију</string>
+    <string name="upgrade_screen_status_free_body">Постани подржавац да отклучаш додатне функције и спонзоришеш наставак развоја.</string>
+    <string name="upgrade_screen_status_free_action">Погледај опције надградње</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Хвала на подршци</string>
     <string name="upgrade_screen_supporter_status_body">Откључали сте све додатне функције подржавањем развоја отвореног кода.</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har inga annonser och säljer inte användardata. Fortsätt utveckling är endast möjlig tack vare dig.</string>
     <string name="upgrade_screen_how_title">Hur du kan hjälpa</string>
     <string name="upgrade_screen_how_body">Bli en beskyddare och sponsra utvecklingen! Tryck på knappen nedan för att aktivera alla extra funktioner och öppna min GitHub Sponsors-profil.</string>
+    <string name="upgrade_screen_why_title">Fördelar</string>
+    <string name="upgrade_screen_why_body">• Obegränsade enheter\n• Anpassade anslutningsåtgärder\n• Temakustomisering\n• Avancerad volymkontroll\n• Stöd för utveckling av öppen källkod 🧙</string>
     <string name="upgrade_screen_sponsor_action">Sponsra utvecklingen</string>
     <string name="upgrade_screen_sponsor_action_hint">Alternativet är annonser, analys och Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Tack för att du stöder utveckling med öppen källkod ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Visa din stödjestatus</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Du använder gratisversionen</string>
+    <string name="upgrade_screen_status_free_body">Bli en supporter för att låsa upp extrafunktioner och sponsra fortsatt utveckling.</string>
+    <string name="upgrade_screen_status_free_action">Se uppgraderingsalternativ</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Tack för ditt stöd</string>
     <string name="upgrade_screen_supporter_status_body">Du har låst upp alla extra funktioner genom att stödja utveckling av öppen källkod.</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -20,6 +20,7 @@
     <string name="settings_upgrade_status_desc">Tazama hali yako ya mchangiaji</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Wewe uko kwa toleo la bure</string>
+    <string name="upgrade_screen_status_free_body">Kuwa mfadhili ili kufungua vipengele vya ziada na kuunga mkono maendeleo endelevu.</string>
     <string name="upgrade_screen_status_free_action">Angalia chaguo za kuboreshwa</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Asante kwa msaada wako</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager haina matangazo na haiuzi data ya mtumiaji. Maendeleo yanayoendelea yanawezeshwa tu na wewe.</string>
     <string name="upgrade_screen_how_title">Jinsi ya kusaidia</string>
     <string name="upgrade_screen_how_body">Kuwa mfumo na mfadhili wa maendeleo! Gusa kitufe kilicho hapa chini ili kuwezesha vipengele vyote vya ziada na kufungua wasifu wangu wa GitHub Sponsors.</string>
+    <string name="upgrade_screen_why_title">Faida</string>
+    <string name="upgrade_screen_why_body">• Vifaa bila kikomo\n• Hatua za kuunganisha zilizobadilishwa\n• Ubadilishaji wa mandhari\n• Vidhibiti vya sauti vya juu\n• Kuunga mkono maendeleo ya chanzo wazi 🧙</string>
     <string name="upgrade_screen_sponsor_action">Faidhi maendeleo</string>
     <string name="upgrade_screen_sponsor_action_hint">Mbadala ni matangazo, uchambuzi na Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Asante kwa kuunga mkono maendeleo ya chanzo wazi ❤️</string>
@@ -16,6 +18,9 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Tazama hali yako ya mchangiaji</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Wewe uko kwa toleo la bure</string>
+    <string name="upgrade_screen_status_free_action">Angalia chaguo za kuboreshwa</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Asante kwa msaada wako</string>
     <string name="upgrade_screen_supporter_status_body">Umefungua vipengele vyote vya ziada kwa kusaidia maendeleo ya chanzo huria.</string>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager விளம்பரங்கள் இல்லாதது மற்றும் பயனர் தரவுகளை விற்கவிற்கை இல்லை. தொடர்ந்த மேம்பாடு உங்களால் மட்டுமே சாத்தியமாகிறது.</string>
     <string name="upgrade_screen_how_title">எப்படி உதவுவது</string>
     <string name="upgrade_screen_how_body">புரவலராக மாறி மேம்பாட்டை ஸ்பான்சர் செய்யுங்கள்! அனைத்து கூடுதல் அம்சங்களையும் செயல்படுத்த மற்றும் எனது GitHub Sponsors சுயவிவரத்தைத் திறக்க கீழே உள்ள பொத்தானைத் தட்டவும்.</string>
+    <string name="upgrade_screen_why_title">நன்மைகள்</string>
+    <string name="upgrade_screen_why_body">• வரம்பற்ற சாதனங்கள்\n• தனிப்பயன் இணைப்பு செயல்கள்\n• கருப்பொருள் தனிப்பயனாக்கம்\n• முன்னேற்ற ஒலி கட்டுப்பாடுகள்\n• திறன்மூல வளர்ச்சிக்கு ஆதரவு 🧙</string>
     <string name="upgrade_screen_sponsor_action">மேம்பாட்டை ஸ்பான்சர் செய்யுங்கள்</string>
     <string name="upgrade_screen_sponsor_action_hint">மாற்று விளம்பரங்கள், பகுப்பாய்வுகள் மற்றும் Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">திறந்த மூல மேம்பாட்டை ஆதரித்ததற்கு நன்றி ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">உங்கள் ஆதரவாளர் நிலையைக் காணவும்</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">நீங்கள் இலவச பதிப்பில் உள்ளீர்கள்</string>
+    <string name="upgrade_screen_status_free_body">கூடுதல் அம்சங்களைத் திறக்க மற்றும் தொடரும் வளர்ச்சியை ஆதரிக்க ஆதரவாளர் ஆகவும்.</string>
+    <string name="upgrade_screen_status_free_action">மேம்படுத்தல் விருப்பங்களைப் பார்க்கவும்</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">உங்கள் ஆதரவுக்கு நன்றி</string>
     <string name="upgrade_screen_supporter_status_body">திறந்த மூல மென்பொருள் மேம்பாட்டை ஆதரிப்பதன் மூலம் நீங்கள் அனைத்து கூடுதல் அம்சங்களையும் திறக்க முடிந்துவிட்டீர்கள்.</string>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager కి ప్రకటనలు లేవు మరియు వినియోగదారు డేటాను అమ్మదు. నిరంతర అభివృద్ధి మీ వల్లనే సాధ్యం.</string>
     <string name="upgrade_screen_how_title">ఎలా సహాయం చేయాలి</string>
     <string name="upgrade_screen_how_body">పేట్రన్ అవ్వండి మరియు అభివృద్ధిని స్పాన్సర్ చేయండి! అన్ని అదనపు ఫీచర్లను యాక్టివేట్ చేయడానికి మరియు నా GitHub Sponsors ప్రొఫైల్‌ను తెరవడానికి దిగువ బటన్‌ను నొక్కండి.</string>
+    <string name="upgrade_screen_why_title">ప్రయోజనాలు</string>
+    <string name="upgrade_screen_why_body">• సీమాహీన పరికరాలు\n• కస్టమ్ కనెక్షన్ చర్యలు\n• థీమ్ కస్టమైజేషన్\n• అధునాతన వాల్యూమ్ నియంత్రణలు\n• ఓపెన్-సోర్స్ అభివృద్ధికి సపోర్ట్ చేయండి 🧙</string>
     <string name="upgrade_screen_sponsor_action">అభివృద్ధిని స్పాన్సర్ చేయండి</string>
     <string name="upgrade_screen_sponsor_action_hint">ప్రత్యామనాయం ప్రకటనలు, అనలిటిక్స్ మరియు Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ఓపెన్ సోర్స్ అభివృద్ధికి మద్దతు ఇచ్చినందుకు ధన్యవాదాలు ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">మీ సపోర్టర్ స్థితిని చూడండి</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">మీరు ఉచిత సంస్కరణలో ఉన్నారు</string>
+    <string name="upgrade_screen_status_free_body">సపోర్టర్ అయ్యి అదనపు ఫీచర్‌లను అన్‌లాక్ చేసుకోండి మరియు కొనసాగిన అభివృద్ధికి సపోర్ట్ చేయండి.</string>
+    <string name="upgrade_screen_status_free_action">అప్‌గ్రేడ్ ఎంపికలను చూడండి</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">మీ సపోర్టు కోసం ధన్యవాదాలు</string>
     <string name="upgrade_screen_supporter_status_body">ఓపెన్-సోర్స్ డెవలప్‌మెంట్‌కు సపోర్ట్ చేయడం ద్వారా మీరు అన్ని అదనపు ఫీచర్‌లను అన్‌లాక్ చేసారు.</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ไม่มีโฆษณาและไม่ขายข้อมูลผู้ใช้ การพัฒนาอย่างต่อเนื่องเป็นไปได้เพียงเพราะคุณเท่านั้น</string>
     <string name="upgrade_screen_how_title">วิธีการช่วยเหลือ</string>
     <string name="upgrade_screen_how_body">เป็นผู้อุปถัมภ์และสปอนเซอร์การพัฒนา! แตะปุ่มด้านล่างเพื่อเปิดใช้ฟีเจอร์เพิ่มเติมทั้งหมดและเปิดโปรไฟล์ GitHub Sponsors ของฉัน</string>
+    <string name="upgrade_screen_why_title">ข้อดี</string>
+    <string name="upgrade_screen_why_body">• อุปกรณ์ไม่จำกัด\n• การดำเนินการเชื่อมต่อที่กำหนดเอง\n• ปรับแต่งธีม\n• ตัวควบคุมระดับเสียงขั้นสูง\n• สนับสนุนการพัฒนาโอเพนซอร์ส 🧙</string>
     <string name="upgrade_screen_sponsor_action">สปอนเซอร์การพัฒนา</string>
     <string name="upgrade_screen_sponsor_action_hint">ทางเลือกคือโฆษณา การวิเคราะห์ และ Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">ขอบคุณสำหรับการสนับสนุนการพัฒนาโอเพ่นซอร์ส ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">ดูสถานะผู้สนับสนุนของคุณ</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">คุณใช้เวอร์ชันฟรี</string>
+    <string name="upgrade_screen_status_free_body">กลายเป็นผู้สนับสนุนเพื่อปลดล็อกฟีเจอร์เพิ่มเติมและสนับสนุนการพัฒนาอย่างต่อเนื่อง</string>
+    <string name="upgrade_screen_status_free_action">ดูตัวเลือกอัปเกรด</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">ขอบคุณสำหรับการสนับสนุนของคุณ</string>
     <string name="upgrade_screen_supporter_status_body">คุณได้ปลดล็อกฟีเจอร์พิเศษทั้งหมดโดยการสนับสนุนการพัฒนาโอเพนซอร์ส</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklam içermez ve kullanıcı verilerini satmaz. Sürekli gelişim yalnızca sizin sayenizde mümkündür.</string>
     <string name="upgrade_screen_how_title">Nasıl yardım edilir</string>
     <string name="upgrade_screen_how_body">Haminiz olun ve gelişime sponsor olun! Tüm ekstra özellikleri etkinleştirmek ve GitHub Sponsorları profilimi açmak için aşağıdaki düğmeye dokunun.</string>
+    <string name="upgrade_screen_why_title">Avantajlar</string>
+    <string name="upgrade_screen_why_body">• Sınırsız cihaz\n• Özel bağlantı eylemleri\n• Tema özelleştirmesi\n• Gelişmiş ses kontrolü\n• Açık kaynak geliştirmeyi destekleyin 🧙</string>
     <string name="upgrade_screen_sponsor_action">Gelişime sponsor ol</string>
     <string name="upgrade_screen_sponsor_action_hint">Bunun alternatifi reklamlar, analizler ve Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Açık kaynak gelişimini desteklediğiniz için teşekkür ederiz ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Destekçi durumunuzu görüntüleyin</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Ücretsiz sürümü kullanıyorsunuz</string>
+    <string name="upgrade_screen_status_free_body">Ek özelliklerin kilidini açmak ve geliştirmeyi desteklemek için desteççi olun.</string>
+    <string name="upgrade_screen_status_free_action">Yükseltme seçeneklerini görün</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Desteğiniz için teşekkür ederiz</string>
     <string name="upgrade_screen_supporter_status_body">Açık kaynak geliştirmeyi destekleyerek tüm ekstra özelliklerin kilidini açtınız.</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не має реклами й не продає дані користувачів. Подальший розвиток можливий лише завдяки вам.</string>
     <string name="upgrade_screen_how_title">Як допомогти</string>
     <string name="upgrade_screen_how_body">Стань меценатом і спонсором розробки! Торкніться кнопки нижче, щоб активувати всі додаткові функції та відкрити мій профіль спонсорів GitHub.</string>
+    <string name="upgrade_screen_why_title">Переваги</string>
+    <string name="upgrade_screen_why_body">• Необмежена кількість пристроїв\n• Користувацькі дії при підключенні\n• Налаштування теми\n• Розширене управління гучністю\n• Підтримка розвитку відкритого коду 🧙</string>
     <string name="upgrade_screen_sponsor_action">Розвиток спонсорів</string>
     <string name="upgrade_screen_sponsor_action_hint">Альтернативою є реклама, аналітика та Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Дякуємо за підтримку розробки з відкритим кодом ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Переглянути свій статус прихильника</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Ви використовуєте безплатну версію</string>
+    <string name="upgrade_screen_status_free_body">Станьте спонсором, щоб розблокувати додаткові функції та підтримати подальший розвиток.</string>
+    <string name="upgrade_screen_status_free_action">Переглянути варіанти оновлення</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Дякуємо за вашу підтримку</string>
     <string name="upgrade_screen_supporter_status_body">Ви розблокували всі додаткові функції, підтримавши розробку відкритого коду.</string>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager میں کوئی اشتہار نہیں ہے اور یہ صارف کا ڈیٹا فروخت نہیں کرتا۔ جاری ترقی صرف آپ کی وجہ سے ممکن ہے۔</string>
     <string name="upgrade_screen_how_title">کیسے مدد کریں</string>
     <string name="upgrade_screen_how_body">سرپرست بنیں اور ترقی کو اسپانسر کریں! تمام اضافی خصوصیات کو فعال کرنے اور میری GitHub Sponsors پروفائل کھولنے کے لیے نیچے دیا گیا بٹن دبائیں۔</string>
+    <string name="upgrade_screen_why_title">فوائد</string>
+    <string name="upgrade_screen_why_body">• لامحدود آلات\n• کسٹم کنکشن ایکشنز\n• تھیم کی تبدیلی\n• اعلیٰ حجم کنٹرول\n• اوپن سورس کی ترقی میں معاونت 🧙</string>
     <string name="upgrade_screen_sponsor_action">ترقی کو اسپانسر کریں</string>
     <string name="upgrade_screen_sponsor_action_hint">متبادل اشتہارات، تجزیات اور Google Play ہیں 🙁</string>
     <string name="upgrade_screen_thanks_toast">اوپن سورس ڈیولپمنٹ کی حمایت کرنے کا شکریہ ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">اپنی سپورٹر حالت دیکھیں</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">آپ مفت ورژن پر ہیں</string>
+    <string name="upgrade_screen_status_free_body">حمایتی بن کر اضافی خصوصیات کو کھولیں اور مسلسل ترقی کی سرپرستی کریں۔</string>
+    <string name="upgrade_screen_status_free_action">اپ گریڈ کے اختیارات دیکھیں</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">آپ کی سپورٹ کے لیے شکریہ</string>
     <string name="upgrade_screen_supporter_status_body">آپ نے اوپن سورس ڈوئیلپ منٹ کی سپورٹ کر کے تمام اضافی خصوصیات کو کھول دیا ہے۔</string>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklamasiz va foydalanuvchi ma\'lumotlarini sotmaydi. Rivojlanishning davom etishi faqat siz tufayli mumkin.</string>
     <string name="upgrade_screen_how_title">Qanday yordam berish</string>
     <string name="upgrade_screen_how_body">Homiy bo\'ling va rivojlanishni sponsorlik qiling! Barcha qo\'shimcha xususiyatlarni faollashtirish va GitHub Sponsors profilimni ochish uchun quyidagi tugmani bosing.</string>
+    <string name="upgrade_screen_why_title">Afzalliklar</string>
+    <string name="upgrade_screen_why_body">• Cheksiz qurilmalar\n• Maxsus ulanish harakatlari\n• Tema sozlanmasi\n• Ilg\'or ovoz boshqarish\n• Ochiq manba ishlanmasini qo\'llab-quvvatlash 🧙</string>
     <string name="upgrade_screen_sponsor_action">Rivojlanishni sponsorlik qilish</string>
     <string name="upgrade_screen_sponsor_action_hint">Muqobil reklama, tahlil va Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ochiq manba rivojlanishini qo\'llab-quvvatlaganingiz uchun rahmat ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Tarafdor statusini ko\'ring</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Siz bepul versiyadasiz</string>
+    <string name="upgrade_screen_status_free_body">Qo\'shimcha imkoniyatlarni ochish va ishlanmani qo\'llab-quvvatlash uchun homiy bo\'ling.</string>
+    <string name="upgrade_screen_status_free_action">Yangilash variantlarini ko\'ring</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Qo\'llab-quvvatlashingiz uchun rahmat</string>
     <string name="upgrade_screen_supporter_status_body">Siz ochiq kodli taraqqiyotni qo\'llab-quvvatlab, barcha qo\'shimcha xususiyatlarni ochib oldingiz.</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager không có quảng cáo và không bán dữ liệu người dùng. Việc tiếp tục phát triển chỉ có thể thực hiện được nhờ bạn.</string>
     <string name="upgrade_screen_how_title">Làm thế nào để giúp đỡ</string>
     <string name="upgrade_screen_how_body">Trở thành người bảo trợ và tài trợ phát triển! Nhấp vào nút bên dưới để kích hoạt tất cả các tính năng bổ sung và mở hồ sơ Nhà tài trợ GitHub của tôi.</string>
+    <string name="upgrade_screen_why_title">Lợi thế</string>
+    <string name="upgrade_screen_why_body">• Thiết bị không giới hạn\n• Tùy chỉnh hành động kết nối\n• Tùy chỉnh chủ đề\n• Điều khiển âm lượng nâng cao\n• Hỗ trợ phát triển mã nguồn mở 🧙</string>
     <string name="upgrade_screen_sponsor_action">Tài trợ nhà phát triển</string>
     <string name="upgrade_screen_sponsor_action_hint">Giải pháp thay thế là quảng cáo, phân tích và Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Cảm ơn bạn đã hỗ trợ phát triển mã nguồn mở ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Xem trạng thái người ủng hộ của bạn</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Bạn đang sử dụng phiên bản miễn phí</string>
+    <string name="upgrade_screen_status_free_body">Trở thành một người ủng hộ để mở khóa các tính năng bổ sung và tài trợ phát triển tiếp tục.</string>
+    <string name="upgrade_screen_status_free_action">Xem các tùy chọn nâng cấp</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Cảm ơn sự ủng hộ của bạn</string>
     <string name="upgrade_screen_supporter_status_body">Bạn đã mở khóa tất cả các tính năng bổ sung nhờ ủng hộ phát triển mã nguồn mở.</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 没有广告，也不出售用户数据。持续开发只因有您的支持。</string>
     <string name="upgrade_screen_how_title">如何帮助我们</string>
     <string name="upgrade_screen_how_body">成为赞助者并支持我们的开发！点击下面的按钮激活所有额外功能并打开我的 GitHub 赞助者资料。</string>
+    <string name="upgrade_screen_why_title">优点</string>
+    <string name="upgrade_screen_why_body">• 无限制设备\n• 自定义连接操作\n• 主题自定义\n• 高级音量控制\n• 支持开源开发 🧙</string>
     <string name="upgrade_screen_sponsor_action">赞助开发</string>
     <string name="upgrade_screen_sponsor_action_hint">取而代之的是广告、分析和 Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">感谢您支持开源开发 ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">查看您的支持者状态</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">你使用的是免费版本</string>
+    <string name="upgrade_screen_status_free_body">成为支持者以解锁额外功能并赞助继续开发。</string>
+    <string name="upgrade_screen_status_free_action">查看升级选项</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">感谢您的支持</string>
     <string name="upgrade_screen_supporter_status_body">您通过支持开源开发已解锁所有额外功能。</string>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不出售用戶數據。持續開發只有靠你的支持才成為可能。</string>
     <string name="upgrade_screen_how_title">如何協助</string>
     <string name="upgrade_screen_how_body">成為贊助者並贊助開發！輕觸下面的按鈕，啟用所有額外功能，並開啟我的 Github 贊助者設定檔。</string>
+    <string name="upgrade_screen_why_title">優點</string>
+    <string name="upgrade_screen_why_body">• 無限裝置\n• 自訂連線動作\n• 主題自訂\n• 進階音量控制\n• 支持開源開發 🧙</string>
     <string name="upgrade_screen_sponsor_action">贊助開發</string>
     <string name="upgrade_screen_sponsor_action_hint">替代品為廣告、分析和 Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">感謝您對開放原始碼開發的支持 ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">查看您的支援者狀態</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">你正在使用免費版本</string>
+    <string name="upgrade_screen_status_free_body">成為支持者以解鎖額外功能並贊助持續開發。</string>
+    <string name="upgrade_screen_status_free_action">查看升級選項</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">感謝您的支持</string>
     <string name="upgrade_screen_supporter_status_body">您已通過支持開源開發來解鎖所有額外功能。</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不會出售使用者資料。持續的開發由你們所支援。</string>
     <string name="upgrade_screen_how_title">如何協助</string>
     <string name="upgrade_screen_how_body">成為贊助者並贊助開發！輕觸下面的按鈕，啟用所有額外功能，並開啟我的 Github 贊助者設定檔。</string>
+    <string name="upgrade_screen_why_title">優點</string>
+    <string name="upgrade_screen_why_body">• 無限制設備\n• 自訂連接操作\n• 主題自訂\n• 進階音量控制\n• 支持開源開發 🧙</string>
     <string name="upgrade_screen_sponsor_action">贊助開發</string>
     <string name="upgrade_screen_sponsor_action_hint">替代品為廣告、分析和 Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">感謝您對開放原始碼開發的支持 ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">查看您的支持者狀態</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">你正在使用免費版本</string>
+    <string name="upgrade_screen_status_free_body">成為支持者，解鎖額外功能並贊助持續開發。</string>
+    <string name="upgrade_screen_status_free_action">查看升級選項</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">感謝您的支持</string>
     <string name="upgrade_screen_supporter_status_body">您已透過支持開源開發而解鎖所有額外功能。</string>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -9,6 +9,8 @@
     <string name="upgrade_screen_preamble">I-Bluetooth Volume Manager ayinazo izikhangiso futhi ayithengisi idatha yabasebenzisi. Ukuthuthukiswa okuqhubekayo kwenziwa kuphela nguwe.</string>
     <string name="upgrade_screen_how_title">Indlela yokusiza</string>
     <string name="upgrade_screen_how_body">Yiba ngumnikazi futhi uxhase ukuthuthukiswa! Thepha inkinobho engezansi ukuze unike amandla zonke izici ezengeziwe futhi uvule iphrofayili yami ye-GitHub Sponsors.</string>
+    <string name="upgrade_screen_why_title">Izinzuzo</string>
+    <string name="upgrade_screen_why_body">• Imizila engenali\n• Izenzo zokuxhuma zezithubutuhu\n• Ukwenyusa imibono\n• Ukulawula umthwali ophumelele\n• Okusekela ukuthuthuka kwe-open-source 🧙</string>
     <string name="upgrade_screen_sponsor_action">Xhasa ukuthuthukiswa</string>
     <string name="upgrade_screen_sponsor_action_hint">Enye indlela izikhangiso, ukuhlaziya ne-Google Play 🙁</string>
     <string name="upgrade_screen_thanks_toast">Ngiyabonga ngokusekela ukuthuthukiswa komthombo ovulekile ❤️</string>
@@ -16,6 +18,10 @@
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
     <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Buka isimo sakho se-supporter</string>
+    <!-- Free status view -->
+    <string name="upgrade_screen_status_free_title">Ungakho ichasiyoni engenalo intengo</string>
+    <string name="upgrade_screen_status_free_body">Yiba ongolutho ukuvula izici ezengeziwe futhi ukhuthaze nokuqhubeka nokuthuthuka.</string>
+    <string name="upgrade_screen_status_free_action">Bona okukhethwa kokukhulisa</string>
     <!-- Supporter status view -->
     <string name="upgrade_screen_supporter_status_title">Ngiyabonga ngokusekela kwakho</string>
     <string name="upgrade_screen_supporter_status_body">Uvule lonke izici ezongeza ngokusekela umthuthukiso we-open-source.</string>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Opgradeer na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro bied beter resultate, meer funksies en opsies vir kraggebruikers.</string>
     <string name="upgrade_prompt_upgrade_action">Gradeer Op</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Opgradeer na %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager het geen advertensies nie en verkoop nie gebruikersdata nie. My werk word deur jou gefinansier ❤️.</string>
     <string name="upgrade_screen_why_title">Voordele</string>
     <string name="upgrade_screen_subscription_trial_action">Begin gratis 14-dag proef</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Kan nie aan Google Play koppel nie. Kyk asseblief jou internetverbinding en probeer weer.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play is nie beskikbaar nie</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan nie aan Google Play koppel nie. Is Google Play geïnstalleer en opgedateer? Is jou Google-rekening aangemeld? Probeer om die kas van die Google Play-toepassing skoon te maak en jou toestel herlaai.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kon Google Play nie oopmaak nie. Dit kan vermis, gedeaktiveer of beperkt wees op hierdie toestel.</string>
     <string name="upgrades_no_purchases_found_check_account">Geen aankope gevind nie. Gebruik jy die regte rekening?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opgraadopsies</string>
+    <string name="upgrade_screen_offers_body">Beide opsies ontsluit presies dieselfde Pro-funksies — kies watter een jou pas.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Pryse nie beskikbaar nie</string>
+    <string name="upgrade_screen_offers_unavailable_message">Pryse kon nou nie gelaai word nie. Kyk in Google Play en probeer oor \'n oomblik weer.</string>
+    <string name="upgrade_screen_benefits_body">• Onbeperkte toestelle\n• Aangepaste verbindingsaksies\n• Temaapaswing\n• Gevorderde volumekontroles\n• Ondersteuning van toekomstige ontwikkeling ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Jaarlikse inskripsie</string>
+    <string name="upgrade_screen_subscription_offer_body">Begin met \'n gratis proefperiode, dan werk dit jaarlik by. Kanselleer enige tyd in Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Werk jaarlik by. Kanselleer enige tyd in Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Lewenslange ontgrendeling</string>
+    <string name="upgrade_screen_iap_offer_body">Betaal eenkeer en besit Pro vir altyd.</string>
+    <string name="upgrade_screen_owned_hero_title">Jy is Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Jy besit %1$s vir altyd.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Jou %1$s-inskripsie is aktief.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Jou inskripsie is nie ingestel om te vernuwe nie, so jy kan nou na die eenmalige aankoop oorskakel. Let op: dit is \'n aparte las wat jou inskripsie nie sal kanselleer of terugbetaal nie, so gebruik dieselfde Google-rekening vir albei.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Kanselleer jou vernuwende inskripsie eers in Google Play, dan kan jy na die eenmalige aankoop oorskakel.</string>
+    <string name="upgrade_screen_restore_body">Het jy al Pro op hierdie rekening gekoop? Vra Google Play om jou aankope na te gaan.</string>
+    <string name="upgrade_screen_restore_checked_message">Ons het Google Play gevra om hierdie rekening se aankope na te gaan en het niks gevind nie.</string>
+    <string name="upgrade_screen_restore_contact_hint">Nog steeds vasgesit? Kontak ons vanaf dieselfde Google-rekening waarmee jy gekoop het, voeg jou Google Play-ordernommer in, en ons sal dit reggemaak.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Ons kon nie betyds met Google Play klaar maak nie, so ons weet nog steeds nie jou aankopestatus nie — wag \'n oomblik en probeer weer.</string>
+    <string name="upgrades_gplay_billing_error_label">Aankoopprobleem</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play het \'n probleem gerapporteer: %1$s. Probeer dit later weer of herlaai jou toestel.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Aanbod nie beskikbaar nie</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play het hierdie item nou nie aangebied nie. Dit mag nog nie vir jou rekening of streek beskikbaar wees nie — probeer asseblief later weer.</string>
 </resources>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">ወደ BVM Pro ክበቱ</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ለተጨማሪ ተመርጸውዎች፣ ተጨማሪ ብካዾች፥ እና የፐወር ተጠቃሚዎችን ይደግጋል።</string>
     <string name="upgrade_prompt_upgrade_action">አሻሽል</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">ወደ %1$s ሻመ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ምንም እዋዀት ይረጋል፣ የተገባይ ውሂብንነም አይሸጥም። የ።ቡቡ፡ በ።ቡቡ፠ ዘርድ የካዘለኂው ❤️።</string>
     <string name="upgrade_screen_why_title">ጥቅሞች</string>
     <string name="upgrade_screen_subscription_trial_action">ነፃ የ14 ቀን ሙከራ ይጀምሩ</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">ከGoogle Play ጋር ለመገናኘት አልተቻለም። እባክዎ የኢንተርኔት ግንኙነትዎን ምልከቱ እና እንደገና ይሞክሩ።</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play አይገኝም</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ወደ Google Play መገናኘት አይቻል። Google Play የተገጀተ እና ወደ ላይ የተዘመኘትነ? የGoogle አካወንት የነጩ ክ? Google Play አፕሊኬስንን በሜᇍ ካስቀጁ መሣሪያውን አስለስለስ ያስፈለግላ።</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play መክፈት አልተቻለም። በዚህ መሳሪያ ላይ ሊሆን ይችላል የሌለ፣ ተሰናክሎ ወይም ተገድቦ።</string>
     <string name="upgrades_no_purchases_found_check_account">ምንም ግዢዎች አልተገኙም። ትክክለኛውን መለያ እየተጠቀሙ ነው?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">የሻመ ምርጫዎች</string>
+    <string name="upgrade_screen_offers_body">ሁለቱም ምርጫዎች ተመሳሳይ Pro ሞያዎችን ይከፍታሉ — የሚስማሙ ይምረጡ።</string>
+    <string name="upgrade_screen_offers_unavailable_title">ክፋይ ተደራሽ አይደለም</string>
+    <string name="upgrade_screen_offers_unavailable_message">ክፋይ ገና ሊጫን አይችልም. Google Play ሞኩር ወደ ውሎ ሞክር.</string>
+    <string name="upgrade_screen_benefits_body">• ገደብ ነጻ መሳሪያዎች\n• ተስተካካሪ ግንኙነት ድርጊቶች\n• ገጽታ ማበጀት\n• የላቀ ድምጽ ቁጥጥር\n• ወደፊት ልማት ድጋፍ ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">ዓመታዊ ደንገስ</string>
+    <string name="upgrade_screen_subscription_offer_body">ነፃ ሙከራ ሊያስተዋወቅ, ከዚያም ዓመት ነግ ታደድ. Google Play ውስጥ ማቋረጥ ይችሉ.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">ዓመት ነግ ታደድ. Google Play ውስጥ ማቋረጥ ይችሉ.</string>
+    <string name="upgrade_screen_iap_offer_title">ሕይወት ሙሉ ሽቅ</string>
+    <string name="upgrade_screen_iap_offer_body">አንድ ጊዜ ክፈል Pro ሕይወት ሙሉ ይሆን።</string>
+    <string name="upgrade_screen_owned_hero_title">እርስዎ Pro ነዎት! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">እርስዎ %1$s ሕይወት ሙሉ ይይዝሉ።</string>
+    <string name="upgrade_screen_owned_hero_sub_body">እርስዎ %1$s ደንገስ ንቁ ነው።</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">ወደ ደንገስ አሁን ማሪትዎ ተዘጋጅ አለ, ስለዚህ ወደ አንድ ጊዜ ግዢ ቀይር ይችሉ. ተጠንቂ: ይህ አንድ የተለየ ክፈያ ሂሳብ ወይም refund ደንገስ, ስለዚህ ሁለቱም ተመሳሳይ Google ሂሳብ ይጠቀም.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">ወደ Google Play ረድኤት ደንገስ ልከ ዝቅ ማቋረጥ, ከዚያም ወደ አንድ ጊዜ ግዢ ቀይር ይችሉ.</string>
+    <string name="upgrade_screen_restore_body">Pro አስቀድሞ ገዝተሃል? Google Play ን ድጋሰ-ጽሕ ግዢዎ ይጠይቁ.</string>
+    <string name="upgrade_screen_restore_checked_message">Google Play ድጋሰ-ጽሕ ዓይነት ለእዚህ ሒሳብ ግዢ ስላልገኘን።</string>
+    <string name="upgrade_screen_restore_contact_hint">ገና ተወኙ? ራስዎን ከ ተመሳሳይ Google ሂሳብ ጋር ወደ ገበታ ይግቡ, Google Play ጥያቄ ቁጥር ያካትቱ, እና ልታደርገው ሞወ.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play ጊዜ ውስጥ ፍትሔ ረዝመ ስላልቻልን, ሁሉ ግዢ ሁኔታ አያውቁ — ጊዜ ሰጥ እና ሞክር.</string>
+    <string name="upgrades_gplay_billing_error_label">ግዢ ችግር</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ችግር ሪፖርት: %1$s. ወደ ውሎ ሞክር ወይም መሳሪያ ዱር.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ቅናሽ ተደራሽ አይደለም</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ይህ ዓይነት አሁን ሊሰጥ አይችልም. ይህ ሊሆን ይችላል አንተ ሂሳብ ወይም ክልል አሁንም — ቀጥለን ለመሞከር ይሞክሩ.</string>
 </resources>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">الترقية إلى BVM Pro</string>
     <string name="upgrade_prompt_body">BVM Pro يمنحك نتائج أفضل، ومزيداً من المميزات والخيارات للمستخدمين المحترفين.</string>
     <string name="upgrade_prompt_upgrade_action">تحديث</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">الترقية إلى %1$s</string>
     <string name="upgrade_screen_preamble">لا يعرض Bluetooth Volume Manager أية إعلانات ولا يبيع بيانات المستخدم. يتم تمويل عملي من قِبَلكم ❤️.</string>
     <string name="upgrade_screen_why_title">المميزات</string>
     <string name="upgrade_screen_subscription_trial_action">بدء التجربة المجانية لمدة 14 يوماً</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">تعذر الاتصال بـ Google Play. يُرجى التحقق من اتصالك بالإنترنت والمحاولة مرة أخرى.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play غير متاح</string>
     <string name="upgrades_gplay_unavailable_error_description">يتعذر على Bluetooth Volume Manager الاتصال بـ Google Play. هل تم تثبيت Google Play وتحديثه؟ هل تم تسجيل الدخول إلى حسابك في Google؟ حاول مسح ذاكرة التخزين المؤقت لتطبيق Google Play وإعادة تشغيل جهازك.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">لم يتمكن من فتح متجر Google Play. قد يكون مفقودًا أو معطلاً أو مقيدًا على هذا الجهاز.</string>
     <string name="upgrades_no_purchases_found_check_account">لم يتم العثور على عملية الشراء. هل تستخدم حساب Google الصحيح؟</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">خيارات الترقية</string>
+    <string name="upgrade_screen_offers_body">كلا الخيارين يفتحان نفس ميزات Pro بالضبط — اختر ما يناسبك.</string>
+    <string name="upgrade_screen_offers_unavailable_title">الأسعار غير متاحة</string>
+    <string name="upgrade_screen_offers_unavailable_message">لا يمكن تحميل الأسعار الآن. تحقق من Google Play وحاول مرة أخرى في لحظة.</string>
+    <string name="upgrade_screen_benefits_body">• عدد غير محدود من الأجهزة\n• إجراءات اتصال مخصصة\n• تخصيص المظهر\n• عناصر تحكم صوت متقدمة\n• دعم التطوير المستقبلي ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">اشتراك سنوي</string>
+    <string name="upgrade_screen_subscription_offer_body">يبدأ بفترة تجريبية مجانية، ثم يتجدد سنويًا. ألغِ الاشتراك في أي وقت عبر Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">يتجدد سنويًا. ألغِ الاشتراك في أي وقت عبر Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">فتح مدى الحياة</string>
+    <string name="upgrade_screen_iap_offer_body">ادفع مرة واحدة وامتلك Pro للأبد.</string>
+    <string name="upgrade_screen_owned_hero_title">أنت Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">تمتلك %1$s للأبد.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">اشتراك %1$s الخاص بك نشط.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">اشتراكك غير مضبوط على التجديد، لذا يمكنك التبديل إلى الشراء لمرة واحدة الآن. تنبيه: إنها رسوم منفصلة لن تلغي أو ترد اشتراكك، لذا استخدم نفس حساب Google لكليهما.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">ألغِ اشتراكك المتجدد في Google Play أولاً، ثم يمكنك التبديل إلى الشراء لمرة واحدة.</string>
+    <string name="upgrade_screen_restore_body">هل اشتريت Pro بالفعل على هذا الحساب؟ اطلب من Google Play التحقق مرة أخرى من مشترياتك.</string>
+    <string name="upgrade_screen_restore_checked_message">طلبنا من Google Play التحقق مرة أخرى من مشتريات هذا الحساب ولم نجد أي منها.</string>
+    <string name="upgrade_screen_restore_contact_hint">هل تواجه مشكلة؟ اتصل بنا من نفس حساب Google الذي اشتريت به، وأضف رقم طلبك من Google Play، وسنقوم بحل المشكلة.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">لم نتمكن من إنهاء التحقق من Google Play في الوقت المناسب، لذا لا نزال لا نعرف حالة شرائك — أعطِ الأمر لحظة ثم حاول مرة أخرى.</string>
+    <string name="upgrades_gplay_billing_error_label">مشكلة في الشراء</string>
+    <string name="upgrades_gplay_billing_error_description">أبلغت Google Play عن مشكلة: %1$s. حاول مرة أخرى لاحقًا أو أعد تشغيل جهازك.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">العرض غير متاح</string>
+    <string name="upgrades_gplay_offer_unavailable_description">لم تقدم Google Play هذا العنصر الآن. قد لا يكون متاحًا لحسابك أو منطقتك حتى الآن — يرجى المحاولة مرة أخرى لاحقًا.</string>
 </resources>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro-ya yüksəldin</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro daha yaxşı nəticələr, daha çox xüsusiyyətlər və güc istifadəçiləri üçün seçimlər təklif edir.</string>
     <string name="upgrade_prompt_upgrade_action">Yüksəlt</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Yüksəlt %1$s-ə</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-də reklam yoxdur və istifadəçi məlumatlarını satmır. Mənim işim sizin tərəfindən maliyyələşdirilir ❤️.</string>
     <string name="upgrade_screen_why_title">Üstünlüklər</string>
     <string name="upgrade_screen_subscription_trial_action">Pulsuz 14 günlük sınağa başlayın</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play-ə qoşulmaq mümkün olmadı. Zəhmət olmasa internet bağlantınızı yoxlayın və yenidən cəhd edin.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play əlçatan deyil</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play-ə qoşula bilmir. Google Play quraşdırılıb və yenilənib? Google Hesabınıza daxil olubsunuz? Google Play tətbiqinin keşini təmizləməyə və cihazınızı yenidən başlatmağa çalışın.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play açıla bilmədi. Cihazda olmaya bilər, deaktiv edilmiş və ya məhdudlaşdırılmış ola bilər.</string>
     <string name="upgrades_no_purchases_found_check_account">Heç bir alış tapılmadı. Düzgün hesabdan istifadə edirsiniz?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Yüksəltmə seçimləri</string>
+    <string name="upgrade_screen_offers_body">Hər iki seçim eyni Pro xüsusiyyətlərin kilidini açır — sizə ən uyğun olanını seçin.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Qiymətlər əlçatan deyil</string>
+    <string name="upgrade_screen_offers_unavailable_message">Qiymətlər indi yüklənə bilmədi. Google Play-i yoxlayın və bir andan sonra yenidən cəhd edin.</string>
+    <string name="upgrade_screen_benefits_body">• Sınırsız cihazlar\n• Fərdi bağlantı əməliyyatları\n• Tema fərdiləşdirmə\n• Qabaqcıl səs idarəetmə\n• Gələcək inkişafına dəstək ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">İllik abonəlik</string>
+    <string name="upgrade_screen_subscription_offer_body">Pulsuz sınaqla başlayır, sonra hər il yenilənir. İstənilən vaxt Google Play-də ləğv edin.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Hər il yenilənir. İstənilən vaxt Google Play-də ləğv edin.</string>
+    <string name="upgrade_screen_iap_offer_title">Ömürlük açılış</string>
+    <string name="upgrade_screen_iap_offer_body">Bir dəfə ödəyin və Pro-nu əbədi olaraq sahibləşin.</string>
+    <string name="upgrade_screen_owned_hero_title">Siz Pro-sunuz! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Siz %1$s-ni əbədi olaraq sahibləşirsiniz.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Sizin %1$s abonəliyi fəal.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Sizin abonəlikiniz yenilənmək üçün təyin edilməmişdir, buna görə indi bir dəfə alışa keçə bilərsiz. Xahiş edirik qeyd edin: bu, sizin abonəlikinizi ləğv etməyəcək və ya geri qaytarmayacaq ayrı bir ödəniş olacaqdır, buna görə hər ikisi üçün eyni Google hesabını istifadə edin.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Əvvəlcə Google Play-də sizin yenilənən abonəlikinizi ləğv edin, sonra bir dəfə alışa keçə bilərsiz.</string>
+    <string name="upgrade_screen_restore_body">Bu hesabda Pro-nu artıq almısınız? Google Play-dən alışlarınızı yenidən yoxlamağı xahiş edin.</string>
+    <string name="upgrade_screen_restore_checked_message">Google Play-dən bu hesabın alışlarını yenidən yoxlamağı xahiş etdik və heç bir şey tapmadıq.</string>
+    <string name="upgrade_screen_restore_contact_hint">Hələ də problemin var? Satın aldığınız eyni Google hesabından bizimlə əlaqə saxlayın, Google Play sifariş nömrənizi daxil edin və biz onu həll edəcəyik.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play ilə yoxlamağı vaxtında tamamlaya bilmədi, bəs sizin satın alma vəziyyətinizi bilmirik — bir andan sonra yenidən cəhd edin.</string>
+    <string name="upgrades_gplay_billing_error_label">Satın alma problemi</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play bir problemi bildirdi: %1$s. Daha sonra yenidən cəhd edin və ya cihazınızı yenidən başladın.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Təklif əlçatan deyil</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play bu elementi indi təklif etmədi. Sizin hesabınız ya da bölgəniz üçün hələ də əlçatan olmaya bilər — sonra yenidən cəhd edin.</string>
 </resources>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Перайсці на BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro прапануе лепшыя вынікі, больш функцый і настроек для прасунутых карыстальнікаў.</string>
     <string name="upgrade_prompt_upgrade_action">Абнавіць</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Абнавіце на %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не мае рэкламы і не прадае дадзеныя карыстальнікаў. Мая праца фінансуецца вамі ❤️.</string>
     <string name="upgrade_screen_why_title">Перавагі</string>
     <string name="upgrade_screen_subscription_trial_action">Пачаць бясплатны пробны 14-дзённы перыяд</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Не ўдалося падключыцца да Google Play. Праверце інтэрнэт-злучэнне і паспрабуйце зноў.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play недаступны</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не можа падключыцца да Google Play. Ці устанаўлены і абнаўлены Google Play? Ці ўвойдзены ваш акаўнт Google? Спрабуйце ачысціць кэш Google Play і перазагрузіць прыладу.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не удалося адкрыць Google Play. Гэта можа адсутнічаць, быць адключаным ці абмежаваным на гэтым прыладзе.</string>
     <string name="upgrades_no_purchases_found_check_account">Пакупак не знойдзена. Вы выкарыстоўваеце правільны ўліковы запіс?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Параметры абнаўлення</string>
+    <string name="upgrade_screen_offers_body">Абедзве опцыі разблокіруюць адзінакавыя функцыі Pro — выберыце адну, якая вам больш удоба.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Цэны недаступны</string>
+    <string name="upgrade_screen_offers_unavailable_message">Цэны не змагліся загрузіцца зараз. Праверце Google Play і паспрабуйце яшчэ раз крыху пазней.</string>
+    <string name="upgrade_screen_benefits_body">• Неабмежаваныя прылады\n• Налады злучэння\n• Персоналізацыя тэмы\n• Прасунутыя элементы кантролю гучнасці\n• Падтрымка будучага развіцця ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Гадавая падпіска</string>
+    <string name="upgrade_screen_subscription_offer_body">Пачынаецца з бясплатнага пробнага перыяду, а потым аднаўляецца кожны год. Адмяніце ў любы час ў Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Аднаўляецца кожны год. Адмяніце ў любы час ў Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Развязаны на жыццё</string>
+    <string name="upgrade_screen_iap_offer_body">Заплаціце адзін раз і валодайце Pro вечна.</string>
+    <string name="upgrade_screen_owned_hero_title">Вы Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Вы валодаеце %1$s вечна.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Ваша падпіска на %1$s актыўна.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Ваша падпіска не наладжана на аднаўленне, таму вы можаце зараз перайсці на адноразавую пакупку. Увага: гэта адзельны платёж, адмена якога не адменіт вашу падпіцу, таму выкарыстоўвайце адзін ліч Google для абодвух.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Спачатку адмяніце вашу аднаўляльную падпіцу ў Google Play, потым вы можаце перайсці на адноразавую пакупку.</string>
+    <string name="upgrade_screen_restore_body">Ужо купілі Pro на гэтым ліку? Попрасіце Google Play пераправерыць вашы пакупкі.</string>
+    <string name="upgrade_screen_restore_checked_message">Мы попрасілі Google Play пераправерыць пакупкі гэтага ліку і нічога не знайшлі.</string>
+    <string name="upgrade_screen_restore_contact_hint">Яшчэ застрялі? Звяжыцеся з тым самым лікам Google, з якога вы куплялі, дадайце свой нумар заказа Google Play, і мы гэта вырашым.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Мы не змаглі закончыць праверку Google Play у час, таму мы яшчэ не ведаем ваш статус пакупкі — пачакайце крыху і паспрабуйце яшчэ раз.</string>
+    <string name="upgrades_gplay_billing_error_label">Праблема з пакупкай</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play паведаміў пра праблему: %1$s. Паспрабуйце яшчэ раз пазней або перазагрузіце вашу прыладу.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Прапанова недаступна</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play не прапанаваў гэты тавар зараз. Ен можа быць яшчэ недаступны для вашага ліку ці рэгіёна — калі ласка, паспрабуйце пазней.</string>
 </resources>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Надграждане до BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro предлага по-добри резултати, повече функции и опции за напреднали потребители.</string>
     <string name="upgrade_prompt_upgrade_action">Ъпгрейд</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Надграждане до %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager няма реклами и не продава потребителски данни. Работата ми се финансира от вас ❤️.</string>
     <string name="upgrade_screen_why_title">Предимства</string>
     <string name="upgrade_screen_subscription_trial_action">Започнете безплатен 14-дневен пробен период</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Не може да се установи връзка с Google Play. Моля, проверете интернет връзката си и опитайте отново.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play не е достъпен</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може да се свърже с Google Play. Инсталиран ли е Google Play и актуален ли е? Влязъл ли е вашият Google акаунт? Опитайте да изчистите кеша на приложението Google Play и да рестартирате устройството си.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не се отвори Google Play. Възможно е приложението да липсва, е деактивирано или ограничено на това устройство.</string>
     <string name="upgrades_no_purchases_found_check_account">Не са намерени покупки. Използвате ли правилния акаунт?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Опции за надграждане</string>
+    <string name="upgrade_screen_offers_body">И двете опции отключват същите Pro функции — изберете която ви устройва по-добре.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Цените не са налични</string>
+    <string name="upgrade_screen_offers_unavailable_message">Цените не могат да бъдат заредени сега. Проверете Google Play и опитайте отново след малко.</string>
+    <string name="upgrade_screen_benefits_body">• Неограничени устройства\n• Персонализирани действия при свързване\n• Персонализиране на темата\n• Разширени контроли на звука\n• Подкрепа на развитието ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Годишен абонамент</string>
+    <string name="upgrade_screen_subscription_offer_body">Започва с безплатен пробен период, след това се подновява ежегодно. Отмяна по всяко време в Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Подновява се ежегодно. Отмяна по всяко време в Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Пожизнено отключване</string>
+    <string name="upgrade_screen_iap_offer_body">Платете веднъж и имайте Pro завинаги.</string>
+    <string name="upgrade_screen_owned_hero_title">Вие сте Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Вие имате %1$s завинаги.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Вашият %1$s абонамент е активен.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Вашият абонамент не е настроен за подновяване, така че можете да преминете към еднократната покупка сега. Внимание: това е отделна такса, която няма да отмени или възстанови вашия абонамент, така че използвайте един и същ Google акаунт за двата.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Отменете вашия подновяващ се абонамент в Google Play първо, след което можете да преминете към еднократната покупка.</string>
+    <string name="upgrade_screen_restore_body">Вече сте купили Pro на този акаунт? Помолете Google Play да провери отново вашите покупки.</string>
+    <string name="upgrade_screen_restore_checked_message">Поискахме от Google Play да провери отново покупките на този акаунт и не открихме никоя.</string>
+    <string name="upgrade_screen_restore_contact_hint">Все още имате проблем? Свържете се с нас от същия Google акаунт, с който сте купили, посочете номера на поръчката си в Google Play и ще го решим.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Не успяхме да завършим проверката с Google Play навреме, така че все още не знаем статуса на вашата покупка — изчакайте малко и опитайте отново.</string>
+    <string name="upgrades_gplay_billing_error_label">Проблем при покупката</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play съобщи за проблем: %1$s. Опитайте отново по-късно или рестартирайте устройството си.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Предложението не е налично</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play не предложи този елемент сега. Може да не е наличен за вашия акаунт или регион още — опитайте отново по-късно.</string>
 </resources>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -47,7 +47,7 @@
     <string name="upgrades_gplay_already_owned_error_title">ইতিমধ্যে কেনা হয়েছে</string>
     <string name="upgrades_gplay_already_owned_error_description">আপনার ক্রয় পুনরুদ্ধার করতে \"ক্রয় পুনরুদ্ধার করুন\" অপশনটি ব্যবহার করুন। সমস্যা থেকেই গেলে, Google Play ক্যাশে সাফ করে আপনার ডিভাইস পুনরায় চালু করার চেষ্টা করুন।</string>
     <string name="upgrades_gplay_internal_error_title">Google Play ত্রুটি</string>
-    <string name="upgrades_gplay_internal_error_description">একটি অভ্যন্তরীণ Google Play ত্রুটি ঘটেছে। অনুগ্রহ করে নিম্নলিখিতগুলো চেষ্টা করুন:\n\n• আপনার ডিভাইস পুনরায় চালু করুন\n• Google Play Store ক্যাশে সাফ করুন\n• পরে আবার চেষ্টা করুন</string>
+    <string name="upgrades_gplay_internal_error_description">একটি অভ্যন্তরীণ Google Play ত্রুটি ঘটেছে। অনুগ্রহ করে নিম্নলিখিতগুলো চেষ্টা করুন:\n\n• আপনার ডিভাইস পুনরায় চালু করুন\n• Google Play Store ক্যাশে সাফ করুন\n• পরে আবার চেষ্টা করুন</string>
     <string name="upgrades_gplay_network_error_title">সংযোগ ত্রুটি</string>
     <string name="upgrades_gplay_network_error_description">Google Play-এর সাথে সংযোগ করা যাচ্ছে না। অনুগ্রহ করে আপনার ইন্টারনেট সংযোগ যাচাই করে আবার চেষ্টা করুন।</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play অনুপলব্ধ৷</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro-তে আপগ্রেড করুন</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro পারভার ব্যবহারকারীদের জন্য ভালো ফলাফল, আরও ফিচার এবং বিকল্প দেয়।</string>
     <string name="upgrade_prompt_upgrade_action">আপগ্রেড করুন</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s-এ আপগ্রেড করুন</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-এ কোনো বিজ্ঞাপন নেই এবং ব্যবহারকারীর তথ্য বিক্রি করে না। আমার কাজ আপনার দ্বারা পরিচালিত ❤️।</string>
     <string name="upgrade_screen_why_title">সুবিধাসমূহ</string>
     <string name="upgrade_screen_subscription_trial_action">বিনামূল্যে ১৪-দিনের ট্রায়াল শুরু করুন</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play-এর সাথে সংযোগ করা যাচ্ছে না। অনুগ্রহ করে আপনার ইন্টারনেট সংযোগ যাচাই করে আবার চেষ্টা করুন।</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play অনুপলব্ধ৷</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play-এ সংযোগ করতে পারছে না। কি Google Play ইনস্টল এবং আপডেট আছে? আপনার Google অ্যাকাউন্ট লগইন করা আছে? Google Play অ্যাপের ক্যাশ পরিষ্কার করে ডিভাইস রিবুট করুন।</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play খোলা যাচ্ছে না। এটি এই ডিভাইসে অনুপস্থিত, নিষ্ক্রিয় বা সীমাবদ্ধ থাকতে পারে।</string>
     <string name="upgrades_no_purchases_found_check_account">আপনার পার্সেস পাওয়া যায় নাই। আপনি সঠিক অ্যাকাউন্ট ব্যবহার করছেন?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">আপগ্রেড বিকল্পগুলি</string>
+    <string name="upgrade_screen_offers_body">উভয় বিকল্পই একই Pro বৈশিষ্ট্য আনলক করে — যেটি আপনার জন্য উপযুক্ত তা বেছে নিন।</string>
+    <string name="upgrade_screen_offers_unavailable_title">মূল্য উপলব্ধ নয়</string>
+    <string name="upgrade_screen_offers_unavailable_message">মূল্যগুলি এখন লোড করা যায়নি। Google Play পরীক্ষা করুন এবং একটি মুহূর্তে আবার চেষ্টা করুন।</string>
+    <string name="upgrade_screen_benefits_body">• সীমাহীন ডিভাইস\n• কাস্টম সংযোগ ক্রিয়া\n• থিম কাস্টমাইজেশন\n• উন্নত ভলিউম নিয়ন্ত্রণ\n• ভবিষ্যৎ উন্নয়ন সমর্থন ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">বার্ষিক সাবস্ক্রিপশন</string>
+    <string name="upgrade_screen_subscription_offer_body">বিনামূল্যে পরীক্ষার সাথে শুরু করুন, তারপর বার্ষিক নবায়ন করুন। Google Play-এ যেকোনো সময় বাতিল করুন।</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">বার্ষিক নবায়ন করুন। Google Play-এ যেকোনো সময় বাতিল করুন।</string>
+    <string name="upgrade_screen_iap_offer_title">আজীবন আনলক</string>
+    <string name="upgrade_screen_iap_offer_body">একবার পেমেন্ট করুন এবং চিরকাল Pro মালিক হন।</string>
+    <string name="upgrade_screen_owned_hero_title">আপনি Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">আপনি %1$s চিরকাল মালিক।</string>
+    <string name="upgrade_screen_owned_hero_sub_body">আপনার %1$s সাবস্ক্রিপশন সক্রিয়।</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">আপনার সাবস্ক্রিপশন নবায়নের জন্য সেট করা নেই, তাই আপনি এখন এককালীন ক্রয়ে স্যুইচ করতে পারেন। মনোযোগ দিন: এটি একটি আলাদা চার্জ যা আপনার সাবস্ক্রিপশন বাতিল বা রিফান্ড করবে না, তাই উভয়ের জন্য একই Google অ্যাকাউন্ট ব্যবহার করুন।</string>
+    <string name="upgrade_screen_owned_iap_locked_note">প্রথমে Google Play-এ আপনার নবায়নশীল সাবস্ক্রিপশন বাতিল করুন, তারপর আপনি এককালীন ক্রয়ে স্যুইচ করতে পারেন।</string>
+    <string name="upgrade_screen_restore_body">ইতিমধ্যে এই অ্যাকাউন্টে Pro কিনেছেন? Google Play-কে আপনার ক্রয় পুনরায় পরীক্ষা করতে বলুন।</string>
+    <string name="upgrade_screen_restore_checked_message">আমরা Google Play-কে এই অ্যাকাউন্টের ক্রয় পুনরায় পরীক্ষা করতে বলেছিলাম এবং কোনটি পাইনি।</string>
+    <string name="upgrade_screen_restore_contact_hint">এখনও সমস্যা? যে Google অ্যাকাউন্ট দিয়ে কিনেছিলেন তা থেকে যোগাযোগ করুন, আপনার Google Play অর্ডার নম্বর অন্তর্ভুক্ত করুন এবং আমরা এটি সমাধান করব।</string>
+    <string name="upgrade_screen_restore_inconclusive_message">আমরা সময়মতো Google Play-এর সাথে পরীক্ষা সম্পন্ন করতে পারিনি, তাই আমরা এখনও আপনার ক্রয় অবস্থা জানি না — একটি মুহূর্ত অপেক্ষা করুন এবং আবার চেষ্টা করুন।</string>
+    <string name="upgrades_gplay_billing_error_label">ক্রয় সমস্যা</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play একটি সমস্যা রিপোর্ট করেছে: %1$s। পরে আবার চেষ্টা করুন বা আপনার ডিভাইস পুনরায় চালু করুন।</string>
+    <string name="upgrades_gplay_offer_unavailable_title">অফার উপলব্ধ নয়</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play এখন এই আইটেম অফার করেনি। এটি এখনও আপনার অ্যাকাউন্ট বা অঞ্চলের জন্য উপলব্ধ নাও হতে পারে — দয়া করে পরে আবার চেষ্টা করুন।</string>
 </resources>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Millora a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofereix millors resultats, més funcions i opcions per a usuaris avançats.</string>
     <string name="upgrade_prompt_upgrade_action">Actualitza</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Millora a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no té anuncis i no ven les dades d’usuari. El meu treball està finiançat per vosaltres ❤️.</string>
     <string name="upgrade_screen_why_title">Avantatges</string>
     <string name="upgrade_screen_subscription_trial_action">Comença la prova gratuïta de 14 dies</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">No es pot connectar al Google Play. Comproveu la connexió a Internet i torneu-ho a provar.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no es pot connectar a Google Play. Google Play està instal·lat i actualitzat? El vostre compte de Google ha iniciat sessió? Proveu d’esborrar la memòria cau de Google Play i reinicieu el dispositiu.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">No s\'ha pogut obrir Google Play. Pot que manque, estigui desactivat o restringit en aquest dispositiu.</string>
     <string name="upgrades_no_purchases_found_check_account">No s\'han trobat compres. Esteu fent servir el compte correcte?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opcions d\'actualització</string>
+    <string name="upgrade_screen_offers_body">Ambdues opcions desbloquejen exactament les mateixes funcions Pro — tria la que més s\'ajusti a tu.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Preus no disponibles</string>
+    <string name="upgrade_screen_offers_unavailable_message">No es van poder carregar els preus ara mateix. Comprova Google Play i torna-ho a intentar en un moment.</string>
+    <string name="upgrade_screen_benefits_body">• Dispositius il·limitats\n• Accions de connexió personalitzades\n• Personalització del tema\n• Controls de volum avançats\n• Suport del desenvolupament futur ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Subscripció anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Comença amb una prova gratuïta, es renova anualment. Cancel·la en qualsevol moment a Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Es renova anualment. Cancel·leu en qualsevol moment al Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Desbloqueig de per vida</string>
+    <string name="upgrade_screen_iap_offer_body">Paga una vegada i posseeix Pro per sempre.</string>
+    <string name="upgrade_screen_owned_hero_title">Ets Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Posseixes %1$s per sempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">La teva subscripció %1$s està activa.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">La teva subscripció no està configurada per renovar-se, així que ara pots canviar a la compra única. Avís: és un càrrec separat que no cancel·larà ni reemborsar la teva subscripció, així que utilitza el mateix compte de Google per a tots dos.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Cancel·la primer la teva subscripció renovable a Google Play, després pots canviar a la compra única.</string>
+    <string name="upgrade_screen_restore_body">Ja has comprat Pro en aquest compte? Demana a Google Play que recompti les teves compres.</string>
+    <string name="upgrade_screen_restore_checked_message">Vam demanar a Google Play que recomptés les compres d\'aquest compte i no en vam trobar cap.</string>
+    <string name="upgrade_screen_restore_contact_hint">Estàs encara amb problemes? Contacta\'ns des del mateix compte de Google amb el qual vas comprar, inclou el teu número de comanda de Google Play, i ho arreglarem.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">No vam poder acabar de verificar amb Google Play a temps, així que encara no sabem l\'estat de la teva compra — espera un moment i torna-ho a intentar.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema de compra</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ha reportat un problema: %1$s. Torna-ho a intentar més tard o reinicia el dispositiu.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta no disponible</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play no va oferir aquest element ara mateix. Pot ser que no estigui disponible per al teu compte o regió encara — si us plau, torna-ho a intentar més tard.</string>
 </resources>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Upgradovat na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro nabízí lepší výsledky, více funkcí a možností pro zkušené uživatele.</string>
     <string name="upgrade_prompt_upgrade_action">Upgradovat</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Upgradovat na %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neobsahuje žádné reklamy a neprodává data uživatelů. Moje práce je financována vámi ❤️.</string>
     <string name="upgrade_screen_why_title">Výhody</string>
     <string name="upgrade_screen_subscription_trial_action">Zahájit bezplatnou 14denní zkušební dobu</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Nelze se připojit k Google Play. Zkontrolujte připojení k internetu a zkuste to znovu.</string>
     <string name="upgrades_gplay_unavailable_error_title">Služba Google Play není k dispozici</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager se nemůže připojit ke Google Play. Je Google Play nainstalován a aktuální? Jste přihlášeni ke svému účtu Google? Zkuste vymazat mezipaměť aplikace Google Play a restartovat zařízení.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nebylo možné otevřít Google Play. Aplikace na tomto zařízení může být chybějící, zakázaná nebo omezená.</string>
     <string name="upgrades_no_purchases_found_check_account">Nebyly nalezeny žádné nákupy. Používáte správný účet?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Možnosti upgradu</string>
+    <string name="upgrade_screen_offers_body">Obě možnosti odemykají stejné funkce Pro — vyberte si, která vám vyhovuje.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Ceny nejsou dostupné</string>
+    <string name="upgrade_screen_offers_unavailable_message">Ceny se momentálně nepodařilo načíst. Podívejte se na Google Play a zkuste to za chvíli znovu.</string>
+    <string name="upgrade_screen_benefits_body">• Neomezená zařízení\n• Vlastní akce připojení\n• Přizpůsobení motivu\n• Pokročilé ovládání hlasitosti\n• Podpora budoucího vývoje ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Roční předplatné</string>
+    <string name="upgrade_screen_subscription_offer_body">Začíná bezplatnou zkušební verzí, pak se obnovuje ročně. Zrušit lze kdykoli v Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Obnovuje se ročně. Zrušit lze kdykoli v Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Trvalé odemčení</string>
+    <string name="upgrade_screen_iap_offer_body">Zaplaťte jednou a vlastněte Pro navždy.</string>
+    <string name="upgrade_screen_owned_hero_title">Jste Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Vlastníte %1$s navždy.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Vaše předplatné %1$s je aktivní.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Vaše předplatné není nastaveno na obnovení, takže nyní můžete přejít na jednorázový nákup. Pozor: jedná se o oddělený poplatek, který neodstráni ani nevrátí vaše předplatné, takže pro obě možnosti použijte stejný účet Google.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Nejdříve zrušte své obnovující se předplatné v Google Play, pak můžete přejít na jednorázový nákup.</string>
+    <string name="upgrade_screen_restore_body">Již jste si koupili Pro na tomto účtu? Požádejte Google Play, aby znovu zkontroloval vaše nákupy.</string>
+    <string name="upgrade_screen_restore_checked_message">Požádali jsme Google Play, aby znovu zkontroloval nákupy tohoto účtu, a nenašli jsme žádný.</string>
+    <string name="upgrade_screen_restore_contact_hint">Stále to nejde? Kontaktujte nás ze stejného účtu Google, kterým jste si zakoupili, a uveďte číslo objednávky v Google Play – my to vyřešíme.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Nemohli jsme včas dokončit kontrolu s Google Play, takže stále neznáme váš stav nákupu — počkejte chvíli a zkuste to znovu.</string>
+    <string name="upgrades_gplay_billing_error_label">Problém s nákupem</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play nahlásil problém: %1$s. Zkuste to zase později nebo restartujte zařízení.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Nabídka není dostupná</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play nyní tuto položku nenabízí. Nemusí být dostupná pro váš účet nebo region – zkuste to prosím později.</string>
 </resources>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Opgrader til BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro giver bedre resultater, flere funktioner og muligheder for superbrugere.</string>
     <string name="upgrade_prompt_upgrade_action">Opgrader</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Opgrader til %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen reklamer og sælger ikke brugerdata. Mit arbejde er finansieret af dig ❤️.</string>
     <string name="upgrade_screen_why_title">Fordele</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis 14-dages prøveperiode</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Kunne ikke oprette forbindelse til Google Play. Tjek din internetforbindelse, og prøv igen.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play er utilgængelig</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan ikke oprette forbindelse til Google Play. Er Google Play installeret og opdateret? Er din Google-konto logget ind? Prov at rydde cachen i Google Play-appen og genstarte din enhed.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kunne ikke åbne Google Play. Det kan være manglende, deaktiveret eller begrænset på denne enhed.</string>
     <string name="upgrades_no_purchases_found_check_account">Ingen køb fundet. Bruger du den rigtige konto?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opgraderingsmuligheder</string>
+    <string name="upgrade_screen_offers_body">Begge muligheder låser op for de samme Pro-funktioner — vælg den, der passer dig bedst.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Priser utilgængelige</string>
+    <string name="upgrade_screen_offers_unavailable_message">Priser kunne ikke indlæses lige nu. Kontroller Google Play og prøv igen om et øjeblik.</string>
+    <string name="upgrade_screen_benefits_body">• Ubegrænsede enheder\n• Brugerdefinerede forbindelingshandlinger\n• Temakustomisering\n• Avancerede lydstyrkereguleringer\n• Støtte til fremtidig udvikling ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Årligt abonnement</string>
+    <string name="upgrade_screen_subscription_offer_body">Starter med en gratis prøveperiode, fornyes derefter årligt. Annuller når som helst i Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Fornyes årligt. Annuller når som helst i Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Livstidslås op</string>
+    <string name="upgrade_screen_iap_offer_body">Betal én gang og få Pro for evigt.</string>
+    <string name="upgrade_screen_owned_hero_title">Du er Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Du ejer %1$s for evigt.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Dit %1$s-abonnement er aktivt.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Dit abonnement er ikke indstillet til at blive fornyet, så du kan skifte til engangskøbet nu. Pas på: det er en separat afgift, som ikke annullerer eller refunderer dit abonnement, så brug den samme Google-konto til begge dele.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Annuller dit fornyende abonnement i Google Play først, så kan du skifte til engangskøbet.</string>
+    <string name="upgrade_screen_restore_body">Har du allerede købt Pro på denne konto? Bed Google Play om at genkontrollere dine køb.</string>
+    <string name="upgrade_screen_restore_checked_message">Vi bad Google Play om at genkontrollere denne kontos køb, men fandt ikke noget.</string>
+    <string name="upgrade_screen_restore_contact_hint">Stadig problemer? Kontakt os fra den samme Google-konto, som du købte med, medtag dit Google Play-ordrenummer, og vi løser det.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Vi kunne ikke færdiggøre kontrollen med Google Play i tide, så vi ved stadig ikke din købstatus — vent et øjeblik og prøv igen.</string>
+    <string name="upgrades_gplay_billing_error_label">Købsproblem</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play rapporterede et problem: %1$s. Prøv igen senere eller genstart din enhed.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Tilbud utilgængelig</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play tilbød ikke dette element lige nu. Det er muligvis ikke tilgængeligt for din konto eller region endnu — prøv venligst igen senere.</string>
 </resources>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Auf BVM Pro upgraden</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro bietet bessere Ergebnisse, mehr Funktionen und Optionen für Power-User.</string>
     <string name="upgrade_prompt_upgrade_action">Upgrade</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Upgrade auf %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager enthält keine Werbung und verkauft keine Nutzerdaten. Meine Arbeit wird von dir finanziert ❤️.</string>
     <string name="upgrade_screen_why_title">Vorteile</string>
     <string name="upgrade_screen_subscription_trial_action">Kostenlose 14-tägige Testversion starten</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Verbindung zu Google Play nicht möglich. Bitte überprüfe Deine Internetverbindung und versuche es erneut.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ist nicht verfügbar</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kann keine Verbindung zu Google Play herstellen. Ist Google Play installiert und aktuell? Ist dein Google-Konto angemeldet? Versuche, den Cache der Google Play-App zu leeren und dein Gerät neu zu starten.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play konnte nicht geöffnet werden. Möglicherweise ist die App auf diesem Gerät nicht installiert, deaktiviert oder der Zugriff darauf wurde eingeschränkt.</string>
     <string name="upgrades_no_purchases_found_check_account">Keine Käufe gefunden. Verwendest Du das richtige Konto?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Upgrade-Möglichkeiten</string>
+    <string name="upgrade_screen_offers_body">Beide Optionen bieten die gleichen Pro-Funktionen – wählen die aus, die dir am besten passt.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Preise nicht verfügbar</string>
+    <string name="upgrade_screen_offers_unavailable_message">Die Preise konnten gerade nicht geladen werden. Überprüfe Google Play und versuche es gleich noch einmal.</string>
+    <string name="upgrade_screen_benefits_body">• Unbegrenzte Geräte\n• Benutzerdefinierte Verbindungsaktionen\n• Anpassung des Designs\n• Erweiterte Lautstärkeregelung\n• Weitere App Entwicklung unterstützen ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Jährliches Abonnement</string>
+    <string name="upgrade_screen_subscription_offer_body">Beginnt mit einer kostenlosen Testversion und verlängert sich dann jährlich. Du kannst es jederzeit in Google Play abbrechen.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Verlängert sich jährlich. Jederzeit über Google Play kündbar.</string>
+    <string name="upgrade_screen_iap_offer_title">Einmalkauf</string>
+    <string name="upgrade_screen_iap_offer_body">Einmal bezahlen und Pro dauerhaft nutzen.</string>
+    <string name="upgrade_screen_owned_hero_title">Du bist Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Du besitzt %1$s für immer.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Dein %1$s-Abonnement ist aktiv.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Dein Abonnement ist nicht auf Verlängerung eingestellt, daher kannst du jetzt zum Einmalkauf wechseln. Achtung: Es ist eine separate Gebühr, die dein Abonnement nicht storniert oder erstattet, daher nutze für beide dasselbe Google-Konto.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Kündige zunächst dein automatisch erneuerndes Abonnement in Google Play, dann kannst du zum Einmalkauf wechseln.</string>
+    <string name="upgrade_screen_restore_body">Pro bereits auf diesem Konto gekauft? Lass Google Play deine Käufe erneut überprüfen.</string>
+    <string name="upgrade_screen_restore_checked_message">Wir haben Google Play gebeten, deine Käufe erneut zu überprüfen, und keinen Pro-Kauf gefunden.</string>
+    <string name="upgrade_screen_restore_contact_hint">Immer noch nicht weiter? Kontaktiere uns über das Google-Konto, mit dem du gekauft hast, gib deine Google Play-Bestellnummer an, und wir kümmern uns darum.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Wir konnten die Überprüfung bei Google Play nicht rechtzeitig abschließen, daher kennen wir deinen Kaufstatus noch nicht – warte einen Moment und versuche es erneut.</string>
+    <string name="upgrades_gplay_billing_error_label">Kaufproblem</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play hat ein Problem gemeldet: %1$s. Versuche es später erneut oder starte dein Gerät neu.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Angebot nicht verfügbar</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play bietet diesen Artikel gerade nicht an. Er ist möglicherweise noch nicht für dein Konto oder deine Region verfügbar – bitte versuche es später erneut.</string>
 </resources>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Αναβαθμίστε στο BVM Pro</string>
     <string name="upgrade_prompt_body">Το Bluetooth Volume Manager Pro προσφέρει καλύτερα αποτελέσματα, περισσότερες δυνατότητες και επιλογές για προχωρημένους χρήστες.</string>
     <string name="upgrade_prompt_upgrade_action">Αναβάθμιση</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Αναβάθμιση σε %1$s</string>
     <string name="upgrade_screen_preamble">Το Bluetooth Volume Manager δεν έχει διαφημίσεις και δεν πωλεί δεδομένα χρηστών. Η δουλειά μου χρηματοδοτείται από εσάς ❤️.</string>
     <string name="upgrade_screen_why_title">Πλεονεκτήματα</string>
     <string name="upgrade_screen_subscription_trial_action">Έναρξη δωρεάν δοκιμής 14 ημερών</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Αδυναμία σύνδεσης με το Google Play. Ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.</string>
     <string name="upgrades_gplay_unavailable_error_title">Το Google Play δεν είναι διαθέσιμο</string>
     <string name="upgrades_gplay_unavailable_error_description">Το Bluetooth Volume Manager δεν μπορεί να συνδεθεί με το Google Play. Είναι το Google Play εγκατεστημένο και ενημερωμένο; Έχετε συνδεθεί με τον λογαριασμό Google σας; Δοκιμάστε να διαγράψετε την προσωρινή μνήμη της εφαρμογής Google Play και να επανεκκινήσετε τη συσκευή σας.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Δεν μπόρεσε να ανοίξει το Google Play. Ενδέχεται να λείπει, να είναι απενεργοποιημένο ή περιορισμένο σε αυτήν τη συσκευή.</string>
     <string name="upgrades_no_purchases_found_check_account">Δεν βρέθηκαν αγορές. Χρησιμοποιείτε τον σωστό λογαριασμό;</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Επιλογές αναβάθμισης</string>
+    <string name="upgrade_screen_offers_body">Και οι δύο επιλογές ξεκλειδώνουν ακριβώς τα ίδια Pro χαρακτηριστικά — επιλέξτε ό,τι σας ταιριάζει.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Τιμές μη διαθέσιμες</string>
+    <string name="upgrade_screen_offers_unavailable_message">Οι τιμές δεν μπόρεσαν να φορτωθούν αυτή τη στιγμή. Ελέγξτε το Google Play και δοκιμάστε ξανά σε λίγο.</string>
+    <string name="upgrade_screen_benefits_body">• Απεριόριστες συσκευές\n• Προσαρμοσμένες ενέργειες σύνδεσης\n• Προσαρμογή θέματος\n• Προχωρημένα χειριστήρια έντασης\n• Υποστήριξη μελλοντικής ανάπτυξης ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Ετήσια συνδρομή</string>
+    <string name="upgrade_screen_subscription_offer_body">Ξεκινά με δωρεάν δοκιμή, στη συνέχεια ανανεώνεται ετησίως. Ακύρωση ανά πάσα στιγμή στο Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Ανανεώνεται ετησίως. Ακύρωση ανά πάσα στιγμή στο Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Ξεκλείδωμα για πάντα</string>
+    <string name="upgrade_screen_iap_offer_body">Πληρώστε μια φορά και κατέχετε Pro για πάντα.</string>
+    <string name="upgrade_screen_owned_hero_title">Είστε Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Κατέχετε %1$s για πάντα.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Η συνδρομή σας %1$s είναι ενεργή.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Η συνδρομή σας δεν έχει ρυθμιστεί για ανανέωση, οπότε μπορείτε να κάνετε εναλλαγή στην αγορά μίας φοράς τώρα. Προσοχή: είναι ξεχωριστή χρέωση που δεν θα ακυρώσει ή επιστρέψει τη συνδρομή σας, επομένως χρησιμοποιήστε το ίδιο λογαριασμό Google και για τα δύο.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Ακυρώστε πρώτα τη συνδρομή σας που ανανεώνεται στο Google Play, στη συνέχεια μπορείτε να κάνετε εναλλαγή στην αγορά μίας φοράς τώρα.</string>
+    <string name="upgrade_screen_restore_body">Έχετε ήδη αγοράσει Pro σε αυτό το λογαριασμό; Ζητήστε από το Google Play να επανελέγξει τις αγορές σας.</string>
+    <string name="upgrade_screen_restore_checked_message">Ζητήσαμε από το Google Play να επανελέγξει τις αγορές αυτού του λογαριασμού και δεν βρήκαμε καμία.</string>
+    <string name="upgrade_screen_restore_contact_hint">Εξακολουθείτε να έχετε πρόβλημα; Επικοινωνήστε μαζί μας χρησιμοποιώντας τον ίδιο λογαριασμό Google που χρησιμοποιήσατε για αγορά, συμπεριλάβετε τον αριθμό παραγγελίας σας στο Google Play και θα το λύσουμε.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Δεν μπορέσαμε να ολοκληρώσουμε τον έλεγχο με το Google Play έγκαιρα, οπότε δεν γνωρίζουμε ακόμα την κατάστασή σας — περιμένετε λίγο και δοκιμάστε ξανά.</string>
+    <string name="upgrades_gplay_billing_error_label">Πρόβλημα αγοράς</string>
+    <string name="upgrades_gplay_billing_error_description">Το Google Play ανέφερε ένα πρόβλημα: %1$s. Δοκιμάστε ξανά αργότερα ή επανεκκινήστε τη συσκευή σας.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Μη διαθέσιμη προσφορά</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Το Google Play δεν προσφέρει αυτό το είδος αυτή τη στιγμή. Ενδέχεται να μην είναι ακόμα διαθέσιμο για το λογαριασμό σας ή την περιοχή σας — δοκιμάστε ξανά αργότερα.</string>
 </resources>

--- a/app/src/gplay/res/values-eo-rUY/strings.xml
+++ b/app/src/gplay/res/values-eo-rUY/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Plibonigi al BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofertas pli bonajn rezultojn, pli da funkcioj kaj opcioj por potencaj uzantoj.</string>
     <string name="upgrade_prompt_upgrade_action">Plibonigi</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Ĝisdatigi al %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ne havas reklamojn kaj ne vendas uzantoajn datumojn. Mia laboro estas financata de vi ❤️.</string>
     <string name="upgrade_screen_why_title">Avantaĝoj</string>
     <string name="upgrade_screen_subscription_trial_action">Komenci senpagan 14-tagan provon</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Ne eblas konektiĝi al Google Play. Bonvolu kontroli vian interretan konekton kaj provu denove.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ne estas disponebla</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ne povas konektiĝi al Google Play. Ču Google Play estas instalita kaj ĝisdatigita? Ču via Google-konto estas ensalutinta? Provu forigi la kaŝmemoron de la aplikaĵo Google Play kaj restartiĝi vian aparaton.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Ne povis malfermi Google Play. Ĝi eble ne ekzistas, estas malŝaltita aŭ limigita en ĉi tiu aparato.</string>
     <string name="upgrades_no_purchases_found_check_account">Neniaj aĉetoj trovis. Ču vi uzas la ĝustan konton?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Ĝisdatigo-variantoj</string>
+    <string name="upgrade_screen_offers_body">Ambaŭ variantoj malŝlosus la ekzakte samajn Pro-funkciojn — elektu iun, kiu konvenas al vi.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prezoj ne atingeblaj</string>
+    <string name="upgrade_screen_offers_unavailable_message">Prezoj ne povis ŝarĝiĝi nun. Kontrolu Google Play kaj reprovu post momento.</string>
+    <string name="upgrade_screen_benefits_body">• Senlimaj aparatoj\n• Agordaj konekt-agoj\n• Tema agordo\n• Progresa laudo-kontrolo\n• Subteno al estonta disvolviĝo ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Jara abono</string>
+    <string name="upgrade_screen_subscription_offer_body">Komencas per senpaga provo, poste renoviĝas ĉiujare. Nuligu en ajna momento en Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Renoviĝas ĉiujare. Nuligu en ajna momento en Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Eterna malŝloseco</string>
+    <string name="upgrade_screen_iap_offer_body">Pagu unu fojon kaj posedi Pro por ĉiam.</string>
+    <string name="upgrade_screen_owned_hero_title">Vi estas Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Vi posedas %1$s por ĉiam.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Via %1$s abono estas aktiva.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Via abono ne estas agordita renoviĝi, do vi povas ŝanĝi al la unufoja aĉeto nun. Averto: ĝi estas aparta ĉargo, kiu ne nuligus aŭ repagus vian abonon, do uzu la saman Google-konton por ambaŭ.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Unue nuligu vian renoviĝantan abonon en Google Play, poste vi povas ŝanĝi al la unufoja aĉeto.</string>
+    <string name="upgrade_screen_restore_body">Ĉu vi jam aĉetis Pro en ĉi tiu konto? Petu Google Play kontroli ĉi-novaĝe viajn aĉetojn.</string>
+    <string name="upgrade_screen_restore_checked_message">Ni petis Google Play kontroli ĉi-novaĝe la aĉetojn de ĉi tiu konto kaj ne trovis neniun.</string>
+    <string name="upgrade_screen_restore_contact_hint">Ĉu vi ankoraŭ ĉe problemo? Kontaktu nin el la sama Google-konto per kiu vi aĉetis, aldonu vian Google Play-ordronumeron, kaj ni ĝin solvos.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Ni ne povis fini la kontrolon kun Google Play en tempo, do ni ankoraŭ ne scias vian aĉeto-staton — atendu momenton kaj reprovu.</string>
+    <string name="upgrades_gplay_billing_error_label">Problemo pri aĉeto</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play raportis problemon: %1$s. Reprovu poste aŭ restartu vian aparaton.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Propono ne atingebla</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ne proponis ĉi tiun aĵon nun. Ĝi eble ne estas atingebla por via konto aŭ regiono ankoraŭ — bonvolu reprovi poste.</string>
 </resources>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
     <string name="upgrade_prompt_upgrade_action">Mejorar</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Actualizar a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende datos de usuario. Mi trabajo es financiado por vos ❤️.</string>
     <string name="upgrade_screen_why_title">Ventajas</string>
     <string name="upgrade_screen_subscription_trial_action">Empezá la prueba gratuita de 14 días</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">No se pudo conectar con Google Play. Revisá tu conexión a internet y probá de nuevo.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no está disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no puede conectarse a Google Play. ¿Está instalado y actualizado Google Play? ¿Tu cuenta de Google está iniciada? Intentá limpiar el caché de la app de Google Play y reiniciar tu dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">No se pudo abrir Google Play. Podría estar ausente, deshabilitado o restringido en este dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opciones de actualización</string>
+    <string name="upgrade_screen_offers_body">Ambas opciones desbloquean exactamente las mismas funciones Pro — elegí la que mejor te convenga.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Precios no disponibles</string>
+    <string name="upgrade_screen_offers_unavailable_message">Los precios no pudieron cargarse en este momento. Verificá Google Play e intentá de nuevo en un momento.</string>
+    <string name="upgrade_screen_benefits_body">• Dispositivos ilimitados\n• Acciones de conexión personalizadas\n• Personalización de temas\n• Controles de volumen avanzados\n• Apoya el desarrollo futuro ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Suscripción anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Comienza con una prueba gratuita, luego se renueva anualmente. Cancelá en cualquier momento en Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Se renueva anualmente. Cancelá en cualquier momento en Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Desbloqueo de por vida</string>
+    <string name="upgrade_screen_iap_offer_body">Pagá una sola vez y tenés Pro para siempre.</string>
+    <string name="upgrade_screen_owned_hero_title">¡Sos Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Tenés %1$s para siempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Tu suscripción a %1$s está activa.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Tu suscripción no está configurada para renovarse, así que podés cambiar a la compra única ahora. Aviso: es un cargo separado que no cancelará ni reembolsará tu suscripción, así que usá la misma cuenta de Google para ambas.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Primero cancelá tu suscripción que se renueva en Google Play, luego podés cambiar a la compra única.</string>
+    <string name="upgrade_screen_restore_body">¿Ya compraste Pro en esta cuenta? Pedile a Google Play que verifique nuevamente tus compras.</string>
+    <string name="upgrade_screen_restore_checked_message">Le pedimos a Google Play que verificara nuevamente las compras de esta cuenta y no encontramos una.</string>
+    <string name="upgrade_screen_restore_contact_hint">¿Todavía atascado? Contactate desde la misma cuenta de Google con la que compraste, incluí tu número de pedido de Google Play, y lo resolveremos.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">No pudimos terminar de verificar con Google Play a tiempo, así que todavía no sabemos tu estado de compra — esperá un momento e intentá de nuevo.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema con la compra</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play reportó un problema: %1$s. Intentá de nuevo más tarde o reiniciá tu dispositivo.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta no disponible</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play no ofreció este artículo en este momento. Puede que no esté disponible para tu cuenta o región aún — por favor intentá de nuevo más tarde.</string>
 </resources>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
     <string name="upgrade_prompt_upgrade_action">Actualizar</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Actualizar a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene publicidad y no vende datos de usuarios. Mi trabajo es financiado por ti ❤️.</string>
     <string name="upgrade_screen_why_title">Ventajas</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar prueba gratuita de 14 días</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">No se pudo conectar con Google Play. Revisa tu conexión a internet e intenta de nuevo.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no está disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no puede conectarse a Google Play. ¿Está Google Play instalado y actualizado? ¿Está tu cuenta de Google conectada? Intenta limpiar la caché de la app Google Play y reiniciar tu dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">No se pudo abrir Google Play. Podría estar faltando, deshabilitado o restringido en este dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opciones de actualización</string>
+    <string name="upgrade_screen_offers_body">Ambas opciones desbloquean exactamente las mismas características Pro — elige la que más te convenga.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Precios no disponibles</string>
+    <string name="upgrade_screen_offers_unavailable_message">Los precios no pudieron cargarse en este momento. Verifica Google Play e intenta de nuevo en un momento.</string>
+    <string name="upgrade_screen_benefits_body">• Dispositivos ilimitados\n• Acciones de conexión personalizadas\n• Personalización de tema\n• Controles de volumen avanzados\n• Apoya el desarrollo futuro ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Suscripción anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Comienza con una prueba gratuita y después se renueva anualmente. Cancela en cualquier momento desde Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Se renueva anualmente. Cancela en cualquier momento desde Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Desbloqueo de por vida</string>
+    <string name="upgrade_screen_iap_offer_body">Paga una sola vez y ten Pro de por vida.</string>
+    <string name="upgrade_screen_owned_hero_title">¡Eres Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Tienes %1$s de por vida.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Tu suscripción a %1$s está activa.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Tu suscripción no está configurada para renovarse, así que ahora puedes cambiar a la compra única. Aviso: es un cargo separado que no cancelará ni reembolsará tu suscripción, así que usa la misma cuenta de Google para ambas.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Primero cancela tu suscripción renovable en Google Play, después podrás cambiar a la compra única.</string>
+    <string name="upgrade_screen_restore_body">¿Ya compraste Pro en esta cuenta? Solicita a Google Play que verifique nuevamente tus compras.</string>
+    <string name="upgrade_screen_restore_checked_message">Le solicitamos a Google Play que verificara nuevamente las compras de esta cuenta y no encontramos ninguna.</string>
+    <string name="upgrade_screen_restore_contact_hint">¿Aún tienes problemas? Ponte en contacto desde la misma cuenta de Google con la que compraste, incluye tu número de orden de Google Play, y lo resolveremos.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">No pudimos terminar la verificación con Google Play a tiempo, así que aún desconocemos tu estado de compra — espera un momento e intenta de nuevo.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema de compra</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play reportó un problema: %1$s. Intenta de nuevo más tarde o reinicia tu dispositivo.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta no disponible</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play no ofreció este artículo en este momento. Puede que aún no esté disponible para tu cuenta o región — por favor intenta de nuevo más tarde.</string>
 </resources>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mejores resultados, más características y opciones para los usuarios avanzados.</string>
     <string name="upgrade_prompt_upgrade_action">Actualizar</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Actualizar a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende los datos de los usuarios. Mi trabajo está financiado por ti ❤️.</string>
     <string name="upgrade_screen_why_title">Ventajas</string>
     <string name="upgrade_screen_subscription_trial_action">Empieza la prueba gratuita de 14 días</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">No se pudo conectar con Google Play. Comprueba tu conexión a internet e inténtalo de nuevo.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no está disponible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no puede conectarse a Google Play. ¿Está Google Play instalado y actualizado? ¿Has iniciado sesión con tu cuenta de Google? Prueba a borrar la caché de la aplicación Google Play y reinicia tu dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">No se pudo abrir Google Play. Puede estar ausente, deshabilitado o restringido en este dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opciones de actualización</string>
+    <string name="upgrade_screen_offers_body">Ambas opciones desbloquean exactamente las mismas funciones Pro — elige la que te convenga mejor.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Precios no disponibles</string>
+    <string name="upgrade_screen_offers_unavailable_message">Los precios no se pudieron cargar en este momento. Verifica Google Play e intenta de nuevo en un momento.</string>
+    <string name="upgrade_screen_benefits_body">• Dispositivos ilimitados\n• Acciones de conexión personalizadas\n• Personalización de temas\n• Controles de volumen avanzados\n• Apoya el desarrollo futuro ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Suscripción anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Comienza con una prueba gratuita y luego se renueva anualmente. Cancela en cualquier momento en Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Se renueva anualmente. Cancela en cualquier momento en Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Desbloqueo de por vida</string>
+    <string name="upgrade_screen_iap_offer_body">Paga una sola vez y disfruta de Pro para siempre.</string>
+    <string name="upgrade_screen_owned_hero_title">¡Eres Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Tienes %1$s para siempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Tu suscripción %1$s está activa.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Tu suscripción no está configurada para renovarse, así que puedes cambiar a la compra de una sola vez ahora. Atención: es un cargo separado que no cancelará ni reembolsará tu suscripción, así que usa la misma cuenta de Google para ambas.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Cancela primero tu suscripción renovable en Google Play, luego puedes cambiar a la compra de una sola vez.</string>
+    <string name="upgrade_screen_restore_body">¿Ya compraste Pro en esta cuenta? Pídele a Google Play que verifique nuevamente tus compras.</string>
+    <string name="upgrade_screen_restore_checked_message">Le pedimos a Google Play que verificara nuevamente las compras de esta cuenta y no encontramos ninguna.</string>
+    <string name="upgrade_screen_restore_contact_hint">¿Aún sin resolver? Ponte en contacto desde la misma cuenta de Google con la que compraste, incluye tu número de pedido de Google Play, y lo resolveremos.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">No pudimos terminar de verificar con Google Play a tiempo, así que aún no sabemos tu estado de compra — espera un momento e intenta de nuevo.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema de compra</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play informó de un problema: %1$s. Intenta de nuevo más tarde o reinicia tu dispositivo.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta no disponible</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play no está ofreciendo este elemento en este momento. Puede que no esté disponible para tu cuenta o región aún — intenta de nuevo más tarde.</string>
 </resources>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Uuenda BVM Pro-ks</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro pakub paremaid tulemusi, rohkem funktsioone ja valikuid edasijõudnutele.</string>
     <string name="upgrade_prompt_upgrade_action">Täienda</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Täienda %1$s-le</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manageris pole reklaame ja see ei müü kasutajaandmeid. Minu tööd toetate teie ❤️.</string>
     <string name="upgrade_screen_why_title">Eelised</string>
     <string name="upgrade_screen_subscription_trial_action">Alustage tasuta 14 päevast prooviperioodi</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Ühendumine Google Playga nurjus. Kontrollige internetiühendust ja proovige uuesti.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play pole saadaval</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ei suuda ühenduda Google Playga. Kas Google Play on paigaldatud ja ajakohane? Kas olete Google\'i kontole sisse logitud? Proovige tühjendada Google Play rakenduse vahemälu ja taaskäivitada seade.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play avamine nurjus. See võib olla selles seadmes puudu, keelatud või piiratud.</string>
     <string name="upgrades_no_purchases_found_check_account">Oste ei leitud. Kas kasutate õiget kontot?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Täiendamise valikud</string>
+    <string name="upgrade_screen_offers_body">Mõlemad valikud avavad täpselt samad Pro funktsioonid — vali, milline sulle sobib.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Hinnad pole saadaval</string>
+    <string name="upgrade_screen_offers_unavailable_message">Hindu ei saanud praegu laadida. Kontrolli Google Playd ja proovi mõne hetke pärast uuesti.</string>
+    <string name="upgrade_screen_benefits_body">• Piiramatu seadmete arv\n• Kohandatud ühendustegevused\n• Kujunduse kohandamine\n• Täpsemad helitugevuse juhtelemendid\n• Toeta tulevast arengut ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Aastane tellimus</string>
+    <string name="upgrade_screen_subscription_offer_body">Algab tasuta prooviga, seejärel uueneb igal aastal. Tühista igal ajal Google Play-s.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Uueneb igal aastal. Saate igal ajal Google Plays loobuda.</string>
+    <string name="upgrade_screen_iap_offer_title">Igavene avamine</string>
+    <string name="upgrade_screen_iap_offer_body">Maksa üks kord ja omanda Pro igaveseks.</string>
+    <string name="upgrade_screen_owned_hero_title">Oled Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Omad %1$s igaveseks.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Sinu %1$s tellimus on aktiivne.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Sinu tellimus pole seatud uuendamisele, seega saad nüüd ühekordsele ostule üle minna. Tähelepanu: see on eraldi kulumine, mis ei tühista ega refundee sinu tellimust, seega kasuta mõlema jaoks sama Google\'i kontot.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Tühista esmalt Google Play-s uuenev tellimus, seejärel saad ühekordsele ostule üle minna.</string>
+    <string name="upgrade_screen_restore_body">Ostsid juba Pro-d sellel kontol? Palu Google Play-l oma oste uuesti kontrollida.</string>
+    <string name="upgrade_screen_restore_checked_message">Palusime Google Play-l selle konto oste uuesti kontrollida ja midagi ei leitud.</string>
+    <string name="upgrade_screen_restore_contact_hint">Oled endiselt hädas? Võta ühendust sama Google\'i kontoga, millega ostsid, lisa oma Google Play tellimuse number ja me lahendame selle.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Me ei saanud Google Play-ga õigeaegselt kontrollida, seega me ei tea ikkagi sinu ostu staatust — anna hetk aega ja proovi uuesti.</string>
+    <string name="upgrades_gplay_billing_error_label">Ostu probleem</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play teatas probleemist: %1$s. Proovi hiljem uuesti või taaskäivita oma seade.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Pakkumine pole saadaval</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ei pakkunud seda praegu. See ei pruugi sinu kontole või piirkonnale veel saadaval olla — palun proovi hiljem uuesti.</string>
 </resources>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Berritu BVM Pro-ra</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro-k emaitza hobeak, ezaugarri gehiago eta aukera gehiago eskaintzen ditu erabiltzaile aurreratuei.</string>
     <string name="upgrade_prompt_upgrade_action">Eguneratu</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Igo %1$s-ra</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ek ez du iragarkirik eta ez du erabiltzailearen daturik saltzen. Nire lana zuk finantzatzen duzu ❤️.</string>
     <string name="upgrade_screen_why_title">Abantailak</string>
     <string name="upgrade_screen_subscription_trial_action">14 eguneko proba doan hasi</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Ezin izan da Google Play-rekin konektatu. Egiaztatu zure interneteko konexioa eta saiatu berriro.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ez dago erabilgarri</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager-ek ezin du Google Play-ra konektatu. Google Play instalatuta eta eguneratuta al dago? Zure Google kontua saioa hasi al du? Saiatu Google Play aplikazioaren cachea garbitzen eta gailua berrabiarazten.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play ireki ez da ahal izan. Agian falta dago, desgaituta dago edo mugatuta dago gailu honetan.</string>
     <string name="upgrades_no_purchases_found_check_account">Ez dira erosketarik aurkitu. Kontu zuzena erabiltzen ari zara?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Hobekuntza aukerak</string>
+    <string name="upgrade_screen_offers_body">Bi aukerek Pro ezaugarri berdinak desblokeatu dituzte — egin zure gogoan duena.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prezioak ez daude erabilgarri</string>
+    <string name="upgrade_screen_offers_unavailable_message">Prezioak ez dira kargatu ahal izan orain. Begiratu Google Play eta berriro saia zaitez unean batean.</string>
+    <string name="upgrade_screen_benefits_body">• Mugarik gabeko gailuak\n• Konexio ekintza pertsonalizatuak\n• Tema pertsonalizazioa\n• Bolumen kontrol aurreratuak\n• Etorkizunaren garapena laguntza ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Urtean behin harpidetza</string>
+    <string name="upgrade_screen_subscription_offer_body">Librezko saiakera batekin hasi, ondoren urtean behin berritsi. Atzera dezakezu Google Play-n nahi duzun unean.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Urtean behin berritsi. Atzera dezakezu Google Play-n nahi duzun unean.</string>
+    <string name="upgrade_screen_iap_offer_title">Betirako desblokeo</string>
+    <string name="upgrade_screen_iap_offer_body">Behin ordaindu eta Pro betirako.</string>
+    <string name="upgrade_screen_owned_hero_title">Pro zara! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">%1$s betirako dituzu.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Zure %1$s harpidetzak aktibo daude.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Zure harpidetza ez dago berritsi ezarrita, beraz orain aldatu dezakezu ordain bakarrean. Kontuan: ordain bakarra berezia da eta ez du zure harpidetzari uko egingo, beraz kontua berean ordaindu beharko duzu.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Lehenik zure berritsi diren harpidetzak atzera dezakezu Google Play-n, ondoren ordain bakarrean aldatu dezakezu.</string>
+    <string name="upgrade_screen_restore_body">Pro dagoeneko erosi duzu kontu honetan? Google Play-ri zure erosketak berriro begiratzeko eskatu.</string>
+    <string name="upgrade_screen_restore_checked_message">Google Play-ri kontu horren erosketak berriro begiratzeko eskatu genion eta ez genion bat aurkitu.</string>
+    <string name="upgrade_screen_restore_contact_hint">Oraindik arazo? Google Play kontutik harremanetan jarri, zure erosketaren zenbakia sartu, eta konpondu egingo dugu.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play-rekin denboraz begiratzea ezin izan genuen bukatu, beraz zure erosketaren egoera oraindik ez dakigu — itxaron eta berriro saia zaitez.</string>
+    <string name="upgrades_gplay_billing_error_label">Erosketa arazoa</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play-k arazoa jakinarazi zuen: %1$s. Gero saia zaitez edo gailua berrabiarazi.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Eskaintza ez dago erabilgarri</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play-k ez du item hau orain eskaintzen. Baliteke zure kontua edo espareltzea ez dagoela oraindik — saia zaitez gero.</string>
 </resources>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">ارتقاء به BVM Pro</string>
     <string name="upgrade_prompt_body">مدیر صدای بلوتوث Pro نتایج بهتر، ویژگی‌ها و گزینه‌های بیشتری برای کاربران حرفه‌ای ارائه می‌دهد.</string>
     <string name="upgrade_prompt_upgrade_action">ارتقاء</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">ارتقا به %1$s</string>
     <string name="upgrade_screen_preamble">مدیر صدای بلوتوث تبلیغات ندارد و داده‌های کاربر را نمی‌فروشد. کار من توسط شما تأمین می‌شود ❤️.</string>
     <string name="upgrade_screen_why_title">مزایا</string>
     <string name="upgrade_screen_subscription_trial_action">شروع دوره آزمایشی ۱۴ روزه رایگان</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">اتصال به Google Play ممکن نیست. لطفاً اتصال اینترنت خود را بررسی کرده و دوباره تلاش کنید.</string>
     <string name="upgrades_gplay_unavailable_error_title">گوگل پلی در دسترس نیست</string>
     <string name="upgrades_gplay_unavailable_error_description">مدیر صدای بلوتوث نمی‌تواند به Google Play وصل شود. آیا Google Play نصب و به‌روز است؟ آیا حساب گوگلتان وارد شده؟ حافظه‌پنهان برنامه Google Play را پاک کنید و دستگاه را راه‌اندازی مجدد کنید.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">نمی‌توان Google Play را باز کرد. ممکن است در این دستگاه نصب نشده، غیرفعال یا محدود باشد.</string>
     <string name="upgrades_no_purchases_found_check_account">هیچ خریدی یافت نشد. آیا از حساب صحیح استفاده می‌کنید؟</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">گزینه‌های ارتقا</string>
+    <string name="upgrade_screen_offers_body">هر دو گزینه دقیقا همان ویژگی‌های Pro را باز می‌کنند — هرکدام که برای شما مناسب است انتخاب کنید.</string>
+    <string name="upgrade_screen_offers_unavailable_title">قیمت‌ها در دسترس نیست</string>
+    <string name="upgrade_screen_offers_unavailable_message">قیمت‌ها در حال حاضر قابل بارگذاری نیستند. Google Play را بررسی کنید و لحظه‌ای دوباره سعی کنید.</string>
+    <string name="upgrade_screen_benefits_body">• دستگاه‌های نامحدود\n• اقدامات اتصال سفارشی\n• سفارشی‌سازی تم\n• کنترل‌های صدای پیشرفته\n• حمایت از توسعه آینده ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">اشتراک سالانه</string>
+    <string name="upgrade_screen_subscription_offer_body">با یک دوره آزمایشی رایگان شروع می‌شود، سپس هر سال تجدید می‌شود. در هر زمان در Google Play لغو کنید.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">هر سال تجدید می‌شود. در هر زمان در Google Play لغو کنید.</string>
+    <string name="upgrade_screen_iap_offer_title">باز کردن دائمی</string>
+    <string name="upgrade_screen_iap_offer_body">یک بار پرداخت کنید و Pro را برای همیشه داشته باشید.</string>
+    <string name="upgrade_screen_owned_hero_title">شما Pro هستید! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">شما برای همیشه %1$s را مالک هستید.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">اشتراک %1$s شما فعال است.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">اشتراک شما برای تجدید تنظیم نشده است، بنابراین اکنون می‌توانید به خریدهای یک‌باره تغییر دهید. توجه داشته باشید: این یک هزینه جداگانه است که اشتراک شما را لغو یا بازپرداخت نخواهد کرد، بنابراین برای هر دو از همان حساب Google استفاده کنید.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">ابتدا اشتراک تجدیدی خود را در Google Play لغو کنید، سپس می‌توانید به خریدهای یک‌باره تغییر دهید.</string>
+    <string name="upgrade_screen_restore_body">آیا قبلاً Pro را در این حساب خریداری کرده‌اید؟ از Google Play بخواهید خریدهای شما را دوباره بررسی کند.</string>
+    <string name="upgrade_screen_restore_checked_message">ما از Google Play خواستیم خریدهای این حساب را دوباره بررسی کند و هیچ کدام یافت نشد.</string>
+    <string name="upgrade_screen_restore_contact_hint">هنوز مشکل دارید؟ از همان حساب Google که خریدید تماس بگیرید، شماره سفارش Google Play خود را درج کنید و ما مشکل را حل خواهیم کرد.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">ما نتوانستیم به موقع بررسی را با Google Play تمام کنیم، بنابراین ما هنوز وضعیت خریدتان را نمی‌دانیم — لحظه‌ای صبر کنید و دوباره سعی کنید.</string>
+    <string name="upgrades_gplay_billing_error_label">مشکل خرید</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play مشکلی را گزارش کرد: %1$s. بعداً دوباره سعی کنید یا دستگاه خود را دوباره راه‌اندازی کنید.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">پیشنهاد در دسترس نیست</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play در حال حاضر این مورد را ارائه نداد. ممکن است هنوز برای حساب یا منطقه شما در دسترس نباشد — لطفاً بعداً دوباره سعی کنید.</string>
 </resources>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Päivitä BVM Pro:hon</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro tarjoaa parempia tuloksia, enemmän ominaisuuksia ja vaihtoehtoja tehokäyttäjille.</string>
     <string name="upgrade_prompt_upgrade_action">Päivitä</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Päivitä versioon %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerissa ei ole mainoksia eikä se myy käyttäjätietoja. Työni rahoitetaan sinun toimestasi ❤️.</string>
     <string name="upgrade_screen_why_title">Edut</string>
     <string name="upgrade_screen_subscription_trial_action">Aloita ilmainen 14 päivän kokeilu</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Playhin ei saatu yhteyttä. Tarkista internetyhteytesi ja yritä uudelleen.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ei ole käytettävissä</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ei voi yhdistää Google Playhin. Onko Google Play asennettu ja ajan tasalla? Onko Google-tilisi kirjautunut sisään? Kokeile tyhjenntää Google Play -sovelluksen välimuisti ja käynnistä laite uudelleen.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Playta ei voitu avata. Se saattaa olla puuttuva, käytöstä poistettu tai rajoitettu tällä laitteella.</string>
     <string name="upgrades_no_purchases_found_check_account">Ostoja ei löytynyt. Käytätkö oikeaa tiliä?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Päivitysvaihtoehdot</string>
+    <string name="upgrade_screen_offers_body">Molemmat vaihtoehdot vapauttavat täsmälleen samat Pro-ominaisuudet – valitse se, joka sopii sinulle parhaiten.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Hinnat eivät ole saatavilla</string>
+    <string name="upgrade_screen_offers_unavailable_message">Hintoja ei voitu ladata juuri nyt. Tarkista Google Play ja yritä uudelleen hetken kuluttua.</string>
+    <string name="upgrade_screen_benefits_body">• Rajattomat laitteet\n• Mukautetut yhteyden toiminnot\n• Teeman mukauttaminen\n• Kehittyneet äänenvoimakkuuden säädöt\n• Tulevaisuuden kehityksen tukeminen ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Vuosittainen tilaus</string>
+    <string name="upgrade_screen_subscription_offer_body">Alkaa ilmaisella kokeiluversiolla, sitten uusitaan vuosittain. Peruuta milloin tahansa Google Playssa.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Uusitaan vuosittain. Peruuta milloin tahansa Google Playssa.</string>
+    <string name="upgrade_screen_iap_offer_title">Elinikäinen avaus</string>
+    <string name="upgrade_screen_iap_offer_body">Maksa kerran ja omista Pro ikuisesti.</string>
+    <string name="upgrade_screen_owned_hero_title">Olet Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Omistat %1$s ikuisesti.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Tilauksesi %1$s on aktiivinen.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Tilauksesi ei ole asetettu uusiutumaan, joten voit nyt vaihtaa kertamaksuun. Huomio: se on erillinen maksu, joka ei peruuta tai palauta tilaustasi, joten käytä molemmissa samaa Google-tiliä.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Peruuta ensin uusiutuva tilauksesi Google Playssa, sitten voit vaihtaa kertamaksuun.</string>
+    <string name="upgrade_screen_restore_body">Ostanut Pro:n jo tällä tilillä? Pyydä Google Playta tarkistamaan ostoksesi uudelleen.</string>
+    <string name="upgrade_screen_restore_checked_message">Pyysimme Google Playta tarkistamaan tämän tilin ostokset uudelleen, mutta emme löytäneet yhtään.</string>
+    <string name="upgrade_screen_restore_contact_hint">Vielä jumissa? Ota yhteyttä samasta Google-tilistä, jolla ostit, sisällytä Google Play -tilausnumerosi, ja ratkaisemme sen.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Emme voineet suorittaa Google Play -tarkistusta ajoissa, joten emme vieläkään tiedä ostostasi – odota hetki ja yritä uudelleen.</string>
+    <string name="upgrades_gplay_billing_error_label">Ostosongelma</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ilmoitti ongelmasta: %1$s. Yritä uudelleen myöhemmin tai käynnistä laitteesi uudelleen.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Tarjous ei ole saatavilla</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ei tarjonnut tätä kohdetta juuri nyt. Se ei ehkä ole vielä saatavilla tilillesi tai alueellesi – yritä uudelleen myöhemmin.</string>
 </resources>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">I-upgrade sa BVM Pro</string>
     <string name="upgrade_prompt_body">Ang Bluetooth Volume Manager Pro ay nag-aalok ng mas mahusay na mga resulta, mas maraming mga feature at mga opsyon para sa mga power user.</string>
     <string name="upgrade_prompt_upgrade_action">I-upgrade</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">I-upgrade sa %1$s</string>
     <string name="upgrade_screen_preamble">Ang Bluetooth Volume Manager ay walang mga ad at hindi nagbebenta ng data ng user. Ang aking trabaho ay pinopondohan mo ❤️.</string>
     <string name="upgrade_screen_why_title">Mga Benepisyo</string>
     <string name="upgrade_screen_subscription_trial_action">Simulan ang libreng 14-day trial</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Hindi makakonekta sa Google Play. Pakisuri ang iyong internet connection at subukan ulit.</string>
     <string name="upgrades_gplay_unavailable_error_title">Ang Google Play ay kasalukoyang hindi magagamit</string>
     <string name="upgrades_gplay_unavailable_error_description">Hindi makakonekta ang Bluetooth Volume Manager sa Google Play. Naka-install ba at updated ang Google Play? Naka-log in ba ang iyong Google Account? Subukang i-clear ang cache ng Google Play app at i-reboot ang iyong device.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Hindi mabuksan ang Google Play. Maaari itong wala, na-disable, o na-restrict sa device na ito.</string>
     <string name="upgrades_no_purchases_found_check_account">Walang nahanap na mga binili. Ginagamit mo ba ang iyong tamang account?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Mga opsyon sa upgrade</string>
+    <string name="upgrade_screen_offers_body">Ang parehong opsyon ay nag-unlock ng parehong Pro features — pumili ng swak sa iyo.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Hindi available ang mga presyo</string>
+    <string name="upgrade_screen_offers_unavailable_message">Ang mga presyo ay hindi maaaring ma-load sa kasalukuyan. Suriin ang Google Play at subukan muli sa ilang sandali.</string>
+    <string name="upgrade_screen_benefits_body">• Walang hanggang devices\n• Custom na aksyon sa koneksyon\n• Customization ng tema\n• Advanced na kontrol sa volume\n• Suportahan ang hinaharap na development ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Taunang subscription</string>
+    <string name="upgrade_screen_subscription_offer_body">Nagsisimula sa libreng trial, pagkatapos ay nag-renew taun-taon. Maaaring kanselahin anumang oras sa Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Nag-renew taun-taon. Maaaring kanselahin anumang oras sa Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Pangmatagalang unlock</string>
+    <string name="upgrade_screen_iap_offer_body">Magbayad nang minsan at magmamay-ari ng Pro magpakailanman.</string>
+    <string name="upgrade_screen_owned_hero_title">Pro ka na! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Magmamay-ari ka ng %1$s magpakailanman.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Ang iyong %1$s subscription ay aktibo.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Ang iyong subscription ay hindi itinakda na mag-renew, kaya maaari ka nang lumipat sa one-time purchase ngayon. Abiso: ito ay isang hiwalay na bayad na hindi magkakansel o magbabigay ng refund sa iyong subscription, kaya gamitin ang parehong Google account para sa pareho.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Kanselahin muna sa Google Play ang iyong nag-renew na subscription, pagkatapos ay maaari kang lumipat sa one-time purchase.</string>
+    <string name="upgrade_screen_restore_body">Nabili na ang Pro sa account na ito? Tanungin ang Google Play na muling suriin ang iyong mga pagbili.</string>
+    <string name="upgrade_screen_restore_checked_message">Humingi kami sa Google Play na muling suriin ang mga pagbili ng account na ito ngunit walang nahanap.</string>
+    <string name="upgrade_screen_restore_contact_hint">May problema pa rin? Makipag-ugnayan gamit ang parehong Google account na ginamit mo sa pagbili, isama ang iyong Google Play order number, at kami ay magresolba nito.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Hindi namin nakumpleto ang pagsusuri sa Google Play sa oras, kaya hindi pa rin namin alam ang iyong status sa pagbili — magbigay ng ilang sandali at subukan muli.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema sa pagbili</string>
+    <string name="upgrades_gplay_billing_error_description">Nag-report ang Google Play ng isang problema: %1$s. Subukan muli sa ibang pagkakataon o i-restart ang iyong device.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Hindi available ang alok</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Ang Google Play ay hindi nag-aalok ng item na ito sa kasalukuyan. Maaaring hindi ito available pa para sa iyong account o rehiyon — mangyaring subukan muli sa ibang pagkakataon.</string>
 </resources>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Passer à BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro offre de meilleurs résultats, plus de fonctions et d’options pour les utilisateurs expérimentés.</string>
     <string name="upgrade_prompt_upgrade_action">Surclasser</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Passer à %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n’affiche pas de publicités et ne vend pas les données des utilisateurs. Mon travail est financé par vous ❤️.</string>
     <string name="upgrade_screen_why_title">Avantages</string>
     <string name="upgrade_screen_subscription_trial_action">Commencer l’essai gratuit de 14 jours</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Impossible de se connecter à Google Play. Vérifiez votre connexion à Internet et réessayez.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play est inaccessible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ne peut pas se connecter à Google Play. Google Play est-il installé et à jour ? Votre compte Google est-il connecté ? Essayez de vider le cache de l’appli Google Play et de redémarrer votre appareil.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Impossible d\'ouvrir Google Play. Il peut être manquant, désactivé ou restreint sur cet appareil.</string>
     <string name="upgrades_no_purchases_found_check_account">Aucun achat n’a été trouvé. Utilisez-vous le bon compte ?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Options de mise à niveau</string>
+    <string name="upgrade_screen_offers_body">Les deux options déverrouillent exactement les mêmes fonctionnalités Pro — choisissez celle qui vous convient.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prix non disponibles</string>
+    <string name="upgrade_screen_offers_unavailable_message">Les prix n\'ont pas pu être chargés en ce moment. Vérifiez Google Play et réessayez dans un instant.</string>
+    <string name="upgrade_screen_benefits_body">• Appareils illimités\n• Actions de connexion personnalisées\n• Personnalisation du thème\n• Contrôles de volume avancés\n• Soutenir le développement futur ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Abonnement annuel</string>
+    <string name="upgrade_screen_subscription_offer_body">Commence par un essai gratuit, puis se renouvelle chaque année. Annulez à tout moment dans Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Se renouvelle chaque année. Annulez à tout moment dans Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Déverrouillage à vie</string>
+    <string name="upgrade_screen_iap_offer_body">Payez une fois et possédez Pro à jamais.</string>
+    <string name="upgrade_screen_owned_hero_title">Vous êtes Pro ! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Vous possédez %1$s à jamais.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Votre abonnement %1$s est actif.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Votre abonnement n\'est pas défini pour se renouveler, vous pouvez donc passer à l\'achat unique maintenant. Attention : c\'est un frais séparé qui n\'annulera ni ne remboursera votre abonnement, alors utilisez le même compte Google pour les deux.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Annulez d\'abord votre abonnement renouvelable dans Google Play, puis vous pourrez passer à l\'achat unique.</string>
+    <string name="upgrade_screen_restore_body">Vous avez déjà acheté Pro sur ce compte ? Demandez à Google Play de vérifier à nouveau vos achats.</string>
+    <string name="upgrade_screen_restore_checked_message">Nous avons demandé à Google Play de vérifier à nouveau les achats de ce compte et nous n\'en avons pas trouvé.</string>
+    <string name="upgrade_screen_restore_contact_hint">Toujours bloqué ? Contactez-nous à partir du même compte Google avec lequel vous avez acheté, incluez votre numéro de commande Google Play, et nous résoudrons le problème.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Nous n\'avons pas pu terminer la vérification auprès de Google Play à temps, nous ne connaissons donc toujours pas votre statut d\'achat — attendez un moment et réessayez.</string>
+    <string name="upgrades_gplay_billing_error_label">Problème d\'achat</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play a signalé un problème : %1$s. Réessayez plus tard ou redémarrez votre appareil.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Offre non disponible</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play n\'a pas proposé cet élément en ce moment. Il se peut qu\'il ne soit pas encore disponible pour votre compte ou votre région — veuillez réessayer plus tard.</string>
 </resources>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mellores resultados, máis funcionalidades e opcións para usuarios avanzados.</string>
     <string name="upgrade_prompt_upgrade_action">Actualizar</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Actualizar a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non ten anuncios e non vende datos de usuario. O meu traballo está financiado por ti ❤️.</string>
     <string name="upgrade_screen_why_title">Vantaxes</string>
     <string name="upgrade_screen_subscription_trial_action">Comezar proba gratuíta de 14 días</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Non foi posible conectar con Google Play. Comproba a túa conexión a internet e téntao de novo.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play non está dispoñible</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager non pode conectarse a Google Play. ¿Está Google Play instalado e actualizado? ¿Iniciaches sesión na túa conta de Google? Proba a borrar a caché da app Google Play e reinicia o dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Non se puido abrir Google Play. Pode que non estea dispoñible, deshabilitada ou restrinxida neste dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Non se atoparon compras. Estás usando a conta correcta?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opcións de actualización</string>
+    <string name="upgrade_screen_offers_body">Ambas as opcións desbloquean exactamente as mesmas características Pro — escolle a que máis te convena.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prezos non dispoñibles</string>
+    <string name="upgrade_screen_offers_unavailable_message">Os prezos non puideron cargarse neste momento. Comproba Google Play e téntao de novo nun momento.</string>
+    <string name="upgrade_screen_benefits_body">• Dispositivos ilimitados\n• Accións de conexión personalizadas\n• Personalización de tema\n• Controles de volume avanzados\n• Apoiar o desenvolvemento futuro ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Subscrición anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Comeza cunha proba gratuíta, despois renova anualmente. Cancela en calquera momento en Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Renova anualmente. Cancela en calquera momento en Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Desbloqueo de por vida</string>
+    <string name="upgrade_screen_iap_offer_body">Paga unha vez e terás Pro para sempre.</string>
+    <string name="upgrade_screen_owned_hero_title">¡Eres Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Posees %1$s para sempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">A túa subscrición de %1$s está activa.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">A túa subscrición non está configurada para renovarse, polo que podes cambiar á compra única agora. Aviso: é un cargo separado que non cancelará nin reembolsará a túa subscrición, polo que usa a mesma conta de Google para as dúas.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Primeiro cancela a túa subscrición renovable en Google Play, despois podes cambiar á compra única.</string>
+    <string name="upgrade_screen_restore_body">¿Xa compraches Pro nesta conta? Pídelle a Google Play que volva verificar as túas compras.</string>
+    <string name="upgrade_screen_restore_checked_message">Pedimoslle a Google Play que volvera verificar as compras desta conta e non atopamos ningunha.</string>
+    <string name="upgrade_screen_restore_contact_hint">¿Aínda con problemas? Ponte en contacto desde a mesma conta de Google coa que compraches, inclúe o teu número de pedido de Google Play e o resolveremos.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Non puidemos rematar de verificar con Google Play a tempo, así que aínda non sabemos o teu estado de compra — agarda un momento e téntao de novo.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema de compra</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play informou dun problema: %1$s. Téntao de novo máis tarde ou reinicia o teu dispositivo.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta non dispoñible</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play non ofreceu este elemento neste momento. É posible que aínda non estea dispoñible para a túa conta ou rexión — por favor, téntao máis tarde.</string>
 </resources>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro में अपग्रेड करें</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro पावर उपयोगकर्ताओं के लिए बेहतर परिणाम, अधिक सुविधाएं और विकल्प प्रदान करता है।</string>
     <string name="upgrade_prompt_upgrade_action">अपग्रेड</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s में अपग्रेड करें</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager में कोई विज्ञापन नहीं है और वह उपयोगकर्ता डेटा नहीं बेचता। मेरा काम आपके द्वारा वित्तपोषित है ❤️।</string>
     <string name="upgrade_screen_why_title">लाभ</string>
     <string name="upgrade_screen_subscription_trial_action">14 दिन का निःशुल्क परीक्षण प्रारंभ करें</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play से कनेक्ट नहीं हो सका। कृपया अपना इंटरनेट कनेक्शन जांचें और फिर से प्रयास करें।</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play अनुपलब्ध है</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play से कनेक्ट नहीं हो सकता। क्या Google Play इंस्टॉल और अप-टू-डेट है? क्या आपका Google खाता लॉग इन है? Google Play ऐप का कैश साफ़ करने और अपने डिवाइस को रीबूट करने का प्रयास करें।</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play को नहीं खोला जा सका। यह इस डिवाइस पर गायब, अक्षम या प्रतिबंधित हो सकता है।</string>
     <string name="upgrades_no_purchases_found_check_account">कोई खरीदारी जानकारी नहीं मिली। क्या आप सही खाते का उपयोग कर रहे हैं?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">अपग्रेड विकल्प</string>
+    <string name="upgrade_screen_offers_body">दोनों विकल्प बिल्कुल समान Pro सुविधाओं को अनलॉक करते हैं — जो आपको सूट करे उसे चुनें।</string>
+    <string name="upgrade_screen_offers_unavailable_title">कीमतें अनुपलब्ध हैं</string>
+    <string name="upgrade_screen_offers_unavailable_message">कीमतें अभी लोड नहीं की जा सकीं। Google Play जांचें और एक पल में फिर से कोशिश करें।</string>
+    <string name="upgrade_screen_benefits_body">• असीमित डिवाइस\n• कस्टम कनेक्शन क्रियाएँ\n• थीम अनुकूलन\n• उन्नत वॉल्यूम नियंत्रण\n• भविष्य के विकास का समर्थन ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">वार्षिक सदस्यता</string>
+    <string name="upgrade_screen_subscription_offer_body">मुफ्त परीक्षण के साथ शुरू होता है, फिर वार्षिक नवीनीकरण होता है। Google Play में कभी भी रद्द करें।</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">वार्षिक नवीनीकरण होता है। Google Play में कभी भी रद्द करें।</string>
+    <string name="upgrade_screen_iap_offer_title">आजीवन अनलॉक</string>
+    <string name="upgrade_screen_iap_offer_body">एक बार भुगतान करें और Pro को हमेशा के लिए रखें।</string>
+    <string name="upgrade_screen_owned_hero_title">आप Pro हैं! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">आप %1$s को हमेशा के लिए रखते हैं।</string>
+    <string name="upgrade_screen_owned_hero_sub_body">आपकी %1$s सदस्यता सक्रिय है।</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">आपकी सदस्यता नवीनीकरण के लिए सेट नहीं है, इसलिए आप अब एकबारी खरीद पर स्विच कर सकते हैं। ध्यान दें: यह एक अलग शुल्क है जो आपकी सदस्यता को रद्द या वापस नहीं करेगा, इसलिए दोनों के लिए एक ही Google खाते का उपयोग करें।</string>
+    <string name="upgrade_screen_owned_iap_locked_note">पहले Google Play में अपनी नवीनीकरण वाली सदस्यता को रद्द करें, फिर आप एकबारी खरीद पर स्विच कर सकते हैं।</string>
+    <string name="upgrade_screen_restore_body">क्या आपने इस खाते पर पहले ही Pro खरीद लिया है? Google Play को अपनी खरीद को फिर से जांचने के लिए कहें।</string>
+    <string name="upgrade_screen_restore_checked_message">हमने Google Play को इस खाते की खरीद को फिर से जांचने के लिए कहा, लेकिन कोई नहीं मिला।</string>
+    <string name="upgrade_screen_restore_contact_hint">अभी भी अटके हुए हैं? अपने खरीद के साथ जो Google खाता उपयोग किया है उससे संपर्क करें, अपना Google Play ऑर्डर नंबर शामिल करें, और हम इसे सुलझा देंगे।</string>
+    <string name="upgrade_screen_restore_inconclusive_message">हम समय पर Google Play के साथ जांच पूरी नहीं कर सके, इसलिए हम अभी भी आपकी खरीद की स्थिति नहीं जानते — एक पल रुकें और फिर से कोशिश करें।</string>
+    <string name="upgrades_gplay_billing_error_label">खरीद की समस्या</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ने एक समस्या की रिपोर्ट की: %1$s। बाद में फिर से कोशिश करें या अपना डिवाइस पुनः शुरू करें।</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ऑफर अनुपलब्ध है</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ने अभी इस आइटम को ऑफर नहीं किया। यह आपके खाते या क्षेत्र के लिए अभी उपलब्ध नहीं हो सकता — कृपया बाद में फिर से कोशिश करें।</string>
 </resources>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Nadogradite na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro nudi bolje rezultate, više značajki i opcije za napredne korisnike.</string>
     <string name="upgrade_prompt_upgrade_action">Nadogradi</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Nadogradnja na %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nema oglasa i ne prodaje korisničke podatke. Moj rad financirate vi ❤️.</string>
     <string name="upgrade_screen_why_title">Prednosti</string>
     <string name="upgrade_screen_subscription_trial_action">Započnite besplatno probno razdoblje od 14 dana</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Nije moguće povezati se s Google Playom. Provjerite internetsku vezu i pokušajte ponovno.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nije dostupan</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager se ne može spojiti na Google Play. Je li Google Play instaliran i ažuriran? Je li vaš Google račun prijavljen? Pokušajte obrisati predmemoriju aplikacije Google Play i restartajte uređaj.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nije moguće otvoriti Google Play. Možda nedostaje, onemogućena je ili ograničena na ovom uređaju.</string>
     <string name="upgrades_no_purchases_found_check_account">Nema pronađenih kupnji. Koristite li pravi račun?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opcije nadogradnje</string>
+    <string name="upgrade_screen_offers_body">Obje opcije otključavaju iste Pro značajke — odaberite onu koja vam više odgovara.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Cijene nisu dostupne</string>
+    <string name="upgrade_screen_offers_unavailable_message">Cijene se trenutno ne mogu učitati. Provjerite Google Play i pokušajte ponovno za trenutak.</string>
+    <string name="upgrade_screen_benefits_body">• Neograničeni uređaji\n• Prilagođene akcije povezivanja\n• Prilagodba teme\n• Napredne kontrole glasnoće\n• Podrška budućem razvoju ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Godišnja pretplata</string>
+    <string name="upgrade_screen_subscription_offer_body">Počinje s besplatnim probnim periodom, zatim se obnavlja godišnje. Otkazite bilo kada u Google Play-u.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Obnavlja se godišnje. Otkazite bilo kada u Google Play-u.</string>
+    <string name="upgrade_screen_iap_offer_title">Doživotno otključavanje</string>
+    <string name="upgrade_screen_iap_offer_body">Platite jednom i imajte Pro zauvijek.</string>
+    <string name="upgrade_screen_owned_hero_title">Imate Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Posjedujete %1$s zauvijek.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Vaša %1$s pretplata je aktivna.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Vaša pretplata nije postavljena na obnovu, pa možete sada preći na jednokratnu kupovinu. Napomena: to je odvojena naknada koja neće otkazati ili vratiti novac vaše pretplate, pa koristite isti Google račun za oba.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Prvo otkazite vašu pretplatu u Google Play-u, zatim možete preći na jednokratnu kupovinu.</string>
+    <string name="upgrade_screen_restore_body">Već ste kupili Pro na ovom računu? Zamolite Google Play da ponovno provjeri vaše kupovine.</string>
+    <string name="upgrade_screen_restore_checked_message">Zamolili smo Google Play da ponovno provjeri kupovine na ovom računu i nisu pronašli ništa.</string>
+    <string name="upgrade_screen_restore_contact_hint">Još ste u poteškoći? Javite nam se sa istog Google računa s kojim ste kupili, uključite broj narudžbe Google Play-a, i mi ćemo to riješiti.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Nismo mogli završiti provjeru s Google Play-om na vrijeme, pa još uvijek ne znamo vaš status kupovine — čekajte malo i pokušajte ponovno.</string>
+    <string name="upgrades_gplay_billing_error_label">Problem s kupovinom</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play je javio problem: %1$s. Pokušajte ponovno kasnije ili ponovno pokrenite uređaj.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ponuda nedostupna</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play nije ponudio ovu stavku baš sada. Možda nije dostupna za vaš račun ili regiju — pokušajte ponovno kasnije.</string>
 </resources>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Frissítés BVM Pro-ra</string>
     <string name="upgrade_prompt_body">A Bluetooth Volume Manager Pro jobb eredményeket, több funkciót és lehetőséget kínál a haladó felhasználóknak.</string>
     <string name="upgrade_prompt_upgrade_action">Frissítés</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Frissítés a %1$s-re</string>
     <string name="upgrade_screen_preamble">A Bluetooth Volume Manager nem tartalmaz hirdetéseket, és nem értékesít felhasználói adatokat. A munkámat te finanszírozód ❤️.</string>
     <string name="upgrade_screen_why_title">Előnyök</string>
     <string name="upgrade_screen_subscription_trial_action">Ingyenes 14 napos próbaidőszak indítása</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Nem sikerült kapcsolódni a Google Playhez. Ellenőrizd az internetkapcsolatod, és próbáld újra.</string>
     <string name="upgrades_gplay_unavailable_error_title">A Google Play nem elérhető</string>
     <string name="upgrades_gplay_unavailable_error_description">A Bluetooth Volume Manager nem tud csatlakozni a Google Playhez. Telepítve és naprакész a Google Play? Be vagy jelentkezve a Google-fiókodba? Próbáld meg törölni a Google Play alkalmazás gyorsítótárát és indítsd újra az eszközt.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nem sikerült megnyitni a Google Play-t. Lehetséges, hogy az eszközön hiányzik, letiltott vagy korlátozott.</string>
     <string name="upgrades_no_purchases_found_check_account">Nem található vásárlás. A megfelelő fiókot használja?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Frissítési lehetőségek</string>
+    <string name="upgrade_screen_offers_body">Mindkét lehetőség ugyanazokat a Pro funkciókat oldja fel – válaszd azt, amelyik jobban passzol hozzád.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Az árak nem érhetőek el</string>
+    <string name="upgrade_screen_offers_unavailable_message">Az árakat nem lehetett most betölteni. Ellenőrizd a Google Play-t és próbálkozz később.</string>
+    <string name="upgrade_screen_benefits_body">• Korlátlan eszközök\n• Egyéni csatlakozási műveletek\n• Téma testreszabása\n• Speciális hangerő-vezérlés\n• Támogass a folyamatos fejlesztést ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Éves előfizetés</string>
+    <string name="upgrade_screen_subscription_offer_body">Ingyenes próbaverzióval kezdődik, majd évente megújul. Bármikor törölheted a Google Play-ben.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Évente megújul. Bármikor törölheted a Google Play-ben.</string>
+    <string name="upgrade_screen_iap_offer_title">Élettartam feloldás</string>
+    <string name="upgrade_screen_iap_offer_body">Fizess egyszer, és a Pro funkciókat örökre megtartod.</string>
+    <string name="upgrade_screen_owned_hero_title">Pro vagy! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Az %1$s örökre a tiéd.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Az %1$s előfizetésed aktív.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Az előfizetésed nem fog megújulni, így mostantól az egyszeri vásárlásra válthatsz. Figyelem: ez egy külön díj, amely nem szünteti meg és nem adja vissza az előfizetésed, ezért mindkettőhöz ugyanazt a Google-fiókot használd.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Előbb szüntessed meg a Google Play-ben a megújuló előfizetésed, utána az egyszeri vásárlásra válthatsz.</string>
+    <string name="upgrade_screen_restore_body">Már vásárolt Pro-t erre a fiókra? Kérd meg a Google Play-t, hogy ellenőrizze újra a vásárlásaidat.</string>
+    <string name="upgrade_screen_restore_checked_message">Megkértük a Google Play-t, hogy ellenőrizze újra a vásárlásaidat, de nem találtunk semmi.</string>
+    <string name="upgrade_screen_restore_contact_hint">Még mindig elakadt? Lépj velünk kapcsolatba ugyanarról a Google-fiókról, és add meg a Google Play rendelési számodat – mi rendezzük el.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Nem tudtuk időben befejezni a Google Play-vel való ellenőrzést, ezért még nem ismerjük a vásárlási állapotodat – várj egy kicsit és próbálkozz újra.</string>
+    <string name="upgrades_gplay_billing_error_label">Vásárlási probléma</string>
+    <string name="upgrades_gplay_billing_error_description">A Google Play problémát jelzett: %1$s. Próbálkozz később vagy indítsd újra az eszközt.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ajánlat nem elérhető</string>
+    <string name="upgrades_gplay_offer_unavailable_description">A Google Play jelenleg nem kínálja ezt az elemet. Előfordulhat, hogy még nem elérhető a fiókodra vagy a régiódra – próbálkozz később.</string>
 </resources>

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Անցնել BVM Pro-ին</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ավելի լավ արդյունքներ՝ գորունակություններ և հնարավորություններ հզոր ուժղատություն ունեցողների համար։</string>
     <string name="upgrade_prompt_upgrade_action">Թարմացնել</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Արդիացեք %1$s-ին</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ում գովազդներ չկան և ուժղատության տվյալներ չի վարարկում։ Մեր աշխատանքե ժղարգարվում ե դզեր կողմից։</string>
     <string name="upgrade_screen_why_title">Առավելություններ</string>
     <string name="upgrade_screen_subscription_trial_action">Սկսել անվճար 14 օրվա փորձարկումը</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Հնարավոր չէ միանալ Google Play-ին։ Ստուգեք ձեր ինտերնետ կապը և կրկին փորձեք։</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play հասանելի չէ</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager-ե հնարավորություն չունի կապուտվել Google Play-ին։ Google Play տեղադրված և արդիականացված ե՞ Կիրարնեք Google հաշվիե մուտքագրված ե՞ Պորդեք մաքրել Google Play տվյալե և վերագնել սարքե։</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Չհաջողվեց Google Play բացել: Հնարավոր է, որ այն բացակա, անջատված կամ սահմանափակված է այս սարքում:</string>
     <string name="upgrades_no_purchases_found_check_account">Գնումներ չեն գտնվել: Օգտագործում եք ճիշտ հաշիվը:</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Արդիացման տարբերակներ</string>
+    <string name="upgrade_screen_offers_body">Երկու տարբերակներն էլ մեկնում են Pro-ի նույն հատկանիշները — ընտրեք որը հարմար է ձեզ համար։</string>
+    <string name="upgrade_screen_offers_unavailable_title">Գներ հասանելի չեն</string>
+    <string name="upgrade_screen_offers_unavailable_message">Գներ չկարողացան բեռնել հիմա։ Ստուգեք Google Play-ը և փորձեք կրկին մի պահ հետո։</string>
+    <string name="upgrade_screen_benefits_body">• Անսահմանափակ սարքեր\n• Հատուկ միացման գործողություններ\n• Թեմայի հարմարեցում\n• Ընդլայնված ծավալի կառավարում\n• Ապագա զարգացման աջակցություն ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Տարեկան բաժանորդագրություն</string>
+    <string name="upgrade_screen_subscription_offer_body">Սկսվում է անվճար փորձարկմամբ, ապա վերամեկնարկվում տարեկան։ Ցանկացած ժամանակ չեղարկել Google Play-ում։</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Վերամեկնարկվում տարեկան։ Ցանկացած ժամանակ չեղարկել Google Play-ում։</string>
+    <string name="upgrade_screen_iap_offer_title">Ցմահ արձակում</string>
+    <string name="upgrade_screen_iap_offer_body">Միանգամ վճարեք և տիրապետեք Pro-ին ընդմեր։</string>
+    <string name="upgrade_screen_owned_hero_title">Դուք Pro եք! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Դուք տիրապետում եք %1$s-ին ընդմեր։</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Ձեր %1$s բաժանորդագրությունը ակտիվ է։</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Ձեր բաժանորդագրությունը սահմանված չէ վերամեկնարկվելու համար, այնպես որ դուք կարող եք հիմա անցել միանգամյա ձեռքբերմանը։ Ուշադրություն. դա առանձին վճար է, որը չի չեղարկի կամ հետ չի կտա ձեր բաժանորդագրությունը, այնպես որ օգտագործեք նույն Google հաշիվը երկուսի համար։</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Նախ չեղարկել ձեր վերամեկնարկվող բաժանորդագրությունը Google Play-ում, ապա կարող եք անցել միանգամյա ձեռքբերմանը։</string>
+    <string name="upgrade_screen_restore_body">Արդեն այս հաշվում Pro ձեռք բերե՞լ եք։ Խնդրեք Google Play-ից ստուգել ձեր ձեռքբերումները վերից։</string>
+    <string name="upgrade_screen_restore_checked_message">Մենք խնդրեցինք Google Play-ից ստուգել այս հաշվի ձեռքբերումները վերից և չգտանք դրանք։</string>
+    <string name="upgrade_screen_restore_contact_hint">Դեռ խրված եք։ Կապ հաստատեք նույն Google հաշիվից, որից ձեռք բերել եք, ներառեք ձեր Google Play պատվերի համարը, և մենք կհաշտեցնենք այն։</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Մենք չկարողացանք ժամանակին ավարտել Google Play-ի հետ ստուգումը, ուստի մենք դեռ չգիտենք ձեր ձեռքբերման կարգավիճակը — մի պահ ընդ փորձեք։</string>
+    <string name="upgrades_gplay_billing_error_label">Ձեռքբերման խնդիր</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play հաղորդեց խնդիր. %1$s։ Փորձեք ավելի ուշ կամ վերամեկնեք ձեր սարքը։</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Առաջարկը հասանելի չէ</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play այս պահին այս ապրանքը չառաջարկեց։ Այն կարող է դեռ հասանելի չլինել ձեր հաշվի կամ տարածաշրջանի համար — խնդրում ենք փորձել ավելի ուշ։</string>
 </resources>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Upgrade ke BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro menawarkan hasil lebih baik, lebih banyak fitur dan opsi untuk pengguna mahir.</string>
     <string name="upgrade_prompt_upgrade_action">Tingkatkan</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Tingkatkan ke %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tidak menampilkan iklan dan tidak menjual data pengguna. Pekerjaan saya dibiayai oleh Anda ❤️.</string>
     <string name="upgrade_screen_why_title">Kelebihan</string>
     <string name="upgrade_screen_subscription_trial_action">Mulai coba gratis 14 hari</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Tidak dapat terhubung ke Google Play. Silakan periksa koneksi internet Anda dan coba lagi.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play tidak tersedia</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager tidak dapat terhubung ke Google Play. Apakah Google Play sudah terpasang dan diperbarui? Apakah Akun Google Anda sudah masuk? Coba hapus cache aplikasi Google Play dan mulai ulang perangkat Anda.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Tidak bisa membuka Google Play. Aplikasinya mungkin tidak tersedia, dinonaktifkan, atau dibatasi di perangkat ini.</string>
     <string name="upgrades_no_purchases_found_check_account">Pembelian tidak ditemukan. Apakah Anda menggunakan akun yang benar?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opsi upgrade</string>
+    <string name="upgrade_screen_offers_body">Kedua opsi membuka fitur Pro yang sama persis — pilih yang paling sesuai untuk Anda.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Harga tidak tersedia</string>
+    <string name="upgrade_screen_offers_unavailable_message">Harga tidak dapat dimuat sekarang. Periksa Google Play dan coba lagi sebentar.</string>
+    <string name="upgrade_screen_benefits_body">• Perangkat tak terbatas\n• Tindakan koneksi kustom\n• Kustomisasi tema\n• Kontrol volume lanjutan\n• Dukung pengembangan di masa depan ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Langganan tahunan</string>
+    <string name="upgrade_screen_subscription_offer_body">Dimulai dengan uji coba gratis, lalu diperbarui setiap tahun. Batalkan kapan saja di Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Diperbarui setiap tahun. Batalkan kapan saja di Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Akses seumur hidup</string>
+    <string name="upgrade_screen_iap_offer_body">Bayar sekali dan miliki Pro selamanya.</string>
+    <string name="upgrade_screen_owned_hero_title">Anda Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Anda memiliki %1$s selamanya.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Langganan %1$s Anda aktif.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Langganan Anda tidak diatur untuk diperbarui, jadi Anda dapat beralih ke pembelian sekali bayar sekarang. Perhatian: ini adalah tagihan terpisah yang tidak akan membatalkan atau memberikan pengembalian dana untuk langganan Anda, jadi gunakan akun Google yang sama untuk keduanya.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Batalkan langganan yang diperbarui di Google Play terlebih dahulu, kemudian Anda dapat beralih ke pembelian sekali bayar.</string>
+    <string name="upgrade_screen_restore_body">Sudah membeli Pro di akun ini? Minta Google Play untuk memeriksa kembali pembelian Anda.</string>
+    <string name="upgrade_screen_restore_checked_message">Kami meminta Google Play untuk memeriksa kembali pembelian akun ini dan tidak menemukan satupun.</string>
+    <string name="upgrade_screen_restore_contact_hint">Masih terjebak? Hubungi kami dari akun Google yang sama yang Anda gunakan untuk membeli, sertakan nomor pesanan Google Play Anda, dan kami akan menyelesaikannya.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kami tidak dapat menyelesaikan pemeriksaan dengan Google Play tepat waktu, jadi kami masih tidak mengetahui status pembelian Anda — tunggu sebentar dan coba lagi.</string>
+    <string name="upgrades_gplay_billing_error_label">Masalah pembelian</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play melaporkan masalah: %1$s. Coba lagi nanti atau mulai ulang perangkat Anda.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Penawaran tidak tersedia</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play tidak menawarkan item ini sekarang. Mungkin belum tersedia untuk akun atau wilayah Anda — silakan coba lagi nanti.</string>
 </resources>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Uppfæra í BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro býður upp á betri niðurstöður, fleiri eiginleika og valkosti fyrir öfluga notendur.</string>
     <string name="upgrade_prompt_upgrade_action">Uppfæra</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Uppfæra í %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager birtir engar auglýsingar og selur ekki notendagögn. Verk mitt er fjármagnaö af þér ❤️.</string>
     <string name="upgrade_screen_why_title">Kostir</string>
     <string name="upgrade_screen_subscription_trial_action">Byrja ókeypis 14 daga prufu</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Ekki tókst að tengjast Google Play. Athugaðu nettenginguna og reyndu aftur.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play er ekki tiltækt</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager getur ekki tengst Google Play. Er Google Play uppsett og uppfært? Ertu skráður inn á Google reikninginn? Prófaðu að hreinsa skyndiminnni Google Play forritsins og endurræsa tækið þit.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Gat ekki opnað Google Play. Það gæti verið að vantast, óvirkjað eða takmarkað á þessu tæki.</string>
     <string name="upgrades_no_purchases_found_check_account">Engin kaup fundust. Ertu að nota réttan reikning?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Uppfærslumöguleikar</string>
+    <string name="upgrade_screen_offers_body">Báðir valkostir opna sömu Pro eiginleika — veldu þann sem hentar þér best.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Verð ekki tiltekt</string>
+    <string name="upgrade_screen_offers_unavailable_message">Ekki tókst að hlaða verðum núna. Athugaðu Google Play og reyndu aftur eftir stund.</string>
+    <string name="upgrade_screen_benefits_body">• Ótakmörk tæki\n• Sérsniðnar tengingaðgerðir\n• Sérsniðning útlits\n• Ítarleg hljóðstyrk stjórnun\n• Stuðningur við framtíðarþróun ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Árleg áskrift</string>
+    <string name="upgrade_screen_subscription_offer_body">Byrjar með óendurgjaldri prufu, endurnýist síðan ár hvert. Segðu upp hvenær sem er í Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Endurnýist ár hvert. Segðu upp hvenær sem er í Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Ævarleigu aðgangur</string>
+    <string name="upgrade_screen_iap_offer_body">Borga einu sinni og eiga Pro endalaust.</string>
+    <string name="upgrade_screen_owned_hero_title">Þú ert Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Þú átt %1$s endalaust.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Þín %1$s áskrift er virk.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Þín áskrift er ekki stillt til endurnýjunar, svo þú getur skipt yfir í einfalda kaup nú. Viðvörun: þetta er sérstakt gjald sem mun ekki hætta við eða endurgreiða áskriftina þína, svo notaðu sama Google reikning fyrir bæði.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Segðu upp endurnýjandi áskrift þinni í Google Play fyrst, síðan geturðu skipt yfir í einfalda kaup.</string>
+    <string name="upgrade_screen_restore_body">Keyptir þú nú þegar Pro á þessum reikningi? Bið Google Play um að endurathuga kaup þín.</string>
+    <string name="upgrade_screen_restore_checked_message">Við báðum Google Play um að endurathuga kaup þessa reiknings og fundum ekkert.</string>
+    <string name="upgrade_screen_restore_contact_hint">Enn fastur? Hafðu samband frá sama Google reikningi og þú keyptir frá, taktu með Google Play pöntunarnúmerið, og við munum leysa það.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Við gátum ekki lokið athugun með Google Play á réttum tíma, svo við vitum enn ekki stöðu kaupa þinna — gefðu því stund og reyndu aftur.</string>
+    <string name="upgrades_gplay_billing_error_label">Vandamál við kaup</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play tilkynnti vandamál: %1$s. Reyndu aftur seinna eða endurræstu tækið þitt.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Tilboð ekki tiltækt</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play bauð ekki þennan hlut núna. Það gæti ekki verið tiltækt fyrir þinn reikning eða svæði ennþá — reyndu aftur seinna.</string>
 </resources>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Aggiorna a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro offre risultati migliori, più funzioni e opzioni per gli utenti avanzati.</string>
     <string name="upgrade_prompt_upgrade_action">Acquista</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Esegui l\'upgrade a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non contiene pubblicità e non vende i dati degli utenti. Il mio lavoro è finanziato da te ❤️.</string>
     <string name="upgrade_screen_why_title">Vantaggi</string>
     <string name="upgrade_screen_subscription_trial_action">Inizia la prova gratuita di 14 giorni</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Impossibile connettersi a Google Play. Controlla la tua connessione internet e riprova.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play non è disponibile</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager non riesce a connettersi a Google Play. Google Play è installato e aggiornato? Il tuo account Google è connesso? Prova a cancellare la cache dell’app Google Play e a riavviare il dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Impossibile aprire Google Play. Potrebbe essere mancante, disabilitato o limitato su questo dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nessun acquisto trovato. Stai usando l\'account corretto?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opzioni di upgrade</string>
+    <string name="upgrade_screen_offers_body">Entrambe le opzioni sbloccano le stesse identiche funzioni Pro — scegli quella che preferisci.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prezzi non disponibili</string>
+    <string name="upgrade_screen_offers_unavailable_message">I prezzi non possono essere caricati in questo momento. Controlla Google Play e riprova tra poco.</string>
+    <string name="upgrade_screen_benefits_body">• Dispositivi illimitati\n• Azioni di connessione personalizzate\n• Personalizzazione del tema\n• Controlli del volume avanzati\n• Supporto dello sviluppo futuro ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Abbonamento annuale</string>
+    <string name="upgrade_screen_subscription_offer_body">Inizia con una prova gratuita, quindi si rinnova annualmente. Puoi disdire in qualsiasi momento in Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Si rinnova annualmente. Puoi disdire in qualsiasi momento in Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Sblocco permanente</string>
+    <string name="upgrade_screen_iap_offer_body">Paga una volta e possiedi Pro per sempre.</string>
+    <string name="upgrade_screen_owned_hero_title">Sei Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Possiedi %1$s per sempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Il tuo abbonamento %1$s è attivo.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Il tuo abbonamento non è impostato per il rinnovo, quindi puoi passare all\'acquisto una tantum adesso. Attenzione: è un addebito separato che non annullerà o rimborserà l\'abbonamento, quindi usa lo stesso account Google per entrambi.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Innanzitutto annulla l\'abbonamento che si rinnova in Google Play, quindi potrai passare all\'acquisto una tantum.</string>
+    <string name="upgrade_screen_restore_body">Hai già acquistato Pro su questo account? Chiedi a Google Play di verificare nuovamente i tuoi acquisti.</string>
+    <string name="upgrade_screen_restore_checked_message">Abbiamo chiesto a Google Play di verificare nuovamente gli acquisti di questo account e non ne abbiamo trovato uno.</string>
+    <string name="upgrade_screen_restore_contact_hint">Ancora bloccato? Contattaci dallo stesso account Google con cui hai acquistato, includi il tuo numero di ordine di Google Play e risolveremo il problema.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Non abbiamo potuto terminare il controllo con Google Play in tempo, quindi non conosciamo ancora il tuo stato di acquisto — aspetta un momento e riprova.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema di acquisto</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ha segnalato un problema: %1$s. Riprova più tardi o riavvia il dispositivo.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Offerta non disponibile</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play non ha offerto questo articolo in questo momento. Potrebbe non essere ancora disponibile per il tuo account o la tua regione — riprova più tardi.</string>
 </resources>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">שדרג ל-BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro מציע תוצאות טובות יותר, יותר תכונות ואפשרויות למשתמשים מתקדמים.</string>
     <string name="upgrade_prompt_upgrade_action">שדרוג</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">שדרג ל-%1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ללא מודעות ואינה מוכרת נתוני משתמשים. העבודה שלי ממומנת על ידך ❤️.</string>
     <string name="upgrade_screen_why_title">יתרונות</string>
     <string name="upgrade_screen_subscription_trial_action">התחילו 14 ימי ניסיון</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">לא ניתן להתחבר ל-Google Play. בדקו את חיבור האינטרנט שלכם ונסו שוב.</string>
     <string name="upgrades_gplay_unavailable_error_title">החנות של גוגל לא זמינה כרגע</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager לא מצליחה להתחבר ל-Google Play. האם Google Play מותקן ומעודכן? האם חשבון Google שלך מחובר? נסה לנקות את המטמון של אפליקציית Google Play ולהפעיל מחדש את המכשיר.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">לא ניתן לפתוח את Google Play. ייתכן שהוא לא מותקן, מנוטרל או מוגבל במכשיר זה.</string>
     <string name="upgrades_no_purchases_found_check_account">לא נמצאו רכישות. האם אתה משתמש בחשבון הנכון?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">אפשרויות שדרוג</string>
+    <string name="upgrade_screen_offers_body">שתי האפשרויות משחררות את אותן תכונות Pro בדיוק - בחר באיזו שמתאימה לך.</string>
+    <string name="upgrade_screen_offers_unavailable_title">מחירים לא זמינים</string>
+    <string name="upgrade_screen_offers_unavailable_message">לא ניתן היה לטעון מחירים כרגע. בדוק את Google Play ונסה שוב בעוד רגע.</string>
+    <string name="upgrade_screen_benefits_body">• מכשירים בלתי מוגבלים\n• פעולות חיבור מותאמות\n• התאמה של ערכת נושא\n• בקרות עוצמת קול מתקדמות\n• תמיכה בפיתוח עתידי ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">מנוי שנתי</string>
+    <string name="upgrade_screen_subscription_offer_body">מתחיל בניסיון חינם, ואחר כך מתחדש מדי שנה. בטל בכל עת ב-Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">מתחדש מדי שנה. בטל בכל עת ב-Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">פתיחה לכל החיים</string>
+    <string name="upgrade_screen_iap_offer_body">שלם פעם אחת והחזק Pro לתמיד.</string>
+    <string name="upgrade_screen_owned_hero_title">אתה Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">אתה מחזיק את %1$s לתמיד.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">המנוי שלך %1$s פעיל.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">המנוי שלך אינו מוגדר להתחדש, כך שתוכל לעבור לרכישה חד-פעמית עכשיו. זהירות: זו חיוב נפרד שלא יבטל או יחזיר את המנוי שלך, כך השתמש באותו חשבון Google לשניהם.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">בטל תחילה את המנוי המתחדש שלך ב-Google Play, ואחר כך תוכל לעבור לרכישה חד-פעמית.</string>
+    <string name="upgrade_screen_restore_body">כבר קנית Pro בחשבון זה? בקש מ-Google Play לבדוק שוב את הקניות שלך.</string>
+    <string name="upgrade_screen_restore_checked_message">ביקשנו מ-Google Play לבדוק שוב את הקניות של חשבון זה ולא מצאנו אחת.</string>
+    <string name="upgrade_screen_restore_contact_hint">עדיין תקוע? צור קשר מאותו חשבון Google שבו קנית, כלול את מספר ההזמנה של Google Play שלך, ואנחנו נסדר זאת.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">לא הצלחנו לסיים את הבדיקה עם Google Play בזמן, כך אנחנו עדיין לא יודעים את מצב הקניה שלך - תן לזה רגע ונסה שוב.</string>
+    <string name="upgrades_gplay_billing_error_label">בעיית רכישה</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play דיווח על בעיה: %1$s. נסה שוב מאוחר יותר או הפעל מחדש את המכשיר שלך.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">הצעה לא זמינה</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play לא הציע את הפריט הזה כרגע. ייתכן שהוא עדיין לא זמין לחשבון או לאזור שלך - אנא נסה שוב מאוחר יותר.</string>
 </resources>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro にアップグレード</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Proは、パワーユーザーにより良い結果、より多くの機能とオプションを提供します。</string>
     <string name="upgrade_prompt_upgrade_action">アップグレード</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s にアップグレード</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerは広告がなく、ユーザーデータを販売しません。私の作業はあなたによって支えられています ❤️。</string>
     <string name="upgrade_screen_why_title">メリット</string>
     <string name="upgrade_screen_subscription_trial_action">14日間の無料トライアルを開始</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Playに接続できません。インターネット接続を確認してもう一度お試しください。</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Playは利用できません</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager は Google Play に接続できません。Google Play はインストールされており、最新の状態ですか？Google アカウントにログインしていますか？Google Play アプリのキャッシュをクリアしてデバイスを再起動してみてください。</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play を開けませんでした。このデバイスで見つからない、無効になっている、または制限されている可能性があります。</string>
     <string name="upgrades_no_purchases_found_check_account">購入が確認できませんでした。正しいアカウントを使用していますでしょうか？</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">アップグレードオプション</string>
+    <string name="upgrade_screen_offers_body">どちらのオプションでも全く同じ Pro 機能が利用できます。あなたに合った方をお選びください。</string>
+    <string name="upgrade_screen_offers_unavailable_title">価格が利用できません</string>
+    <string name="upgrade_screen_offers_unavailable_message">現在、価格を読み込めません。Google Play を確認して、後ほどもう一度お試しください。</string>
+    <string name="upgrade_screen_benefits_body">• 無制限のデバイス\n• カスタム接続アクション\n• テーマのカスタマイズ\n• 高度なボリュームコントロール\n• 今後の開発をサポート ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">年間サブスクリプション</string>
+    <string name="upgrade_screen_subscription_offer_body">無料トライアルから開始して、毎年更新されます。Google Play からいつでもキャンセルできます。</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">毎年更新されます。Google Play からいつでもキャンセルできます。</string>
+    <string name="upgrade_screen_iap_offer_title">生涯ロック解除</string>
+    <string name="upgrade_screen_iap_offer_body">1 回の支払いで Pro を永遠に所有できます。</string>
+    <string name="upgrade_screen_owned_hero_title">Pro になりました！❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">%1$s を永遠に所有しています。</string>
+    <string name="upgrade_screen_owned_hero_sub_body">あなたの %1$s サブスクリプションは有効です。</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">サブスクリプションが更新されるように設定されていないため、今は 1 回限りの購入に切り替えられます。注意：これは別の課金であり、サブスクリプションのキャンセルや払い戻しは行われません。両方に同じ Google アカウントを使用してください。</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Google Play でサブスクリプションをキャンセルしてから、1 回限りの購入に切り替えられます。</string>
+    <string name="upgrade_screen_restore_body">このアカウントで Pro を購入済みですか？Google Play に購入内容の再確認を依頼してください。</string>
+    <string name="upgrade_screen_restore_checked_message">Google Play にこのアカウントの購入内容を再確認するよう依頼しましたが、見つかりませんでした。</string>
+    <string name="upgrade_screen_restore_contact_hint">まだお困りですか？購入に使用した同じ Google アカウントからお問い合わせください。Google Play の注文番号を含めていただければ、対応いたします。</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play との確認をタイムリーに完了できなかったため、購入ステータスがわかりません。しばらく待ってからもう一度お試しください。</string>
+    <string name="upgrades_gplay_billing_error_label">購入の問題</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play が問題を報告しました：%1$s。後ほどもう一度お試しいただくか、デバイスを再起動してください。</string>
+    <string name="upgrades_gplay_offer_unavailable_title">オファーが利用できません</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play はこのアイテムを現在提供していません。アカウントまたは地域でまだ利用できない可能性があります。後ほどもう一度お試しください。</string>
 </resources>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">გადაიდგეს BVM Pro-ზე</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro გთავაზობს უკეთეს შედეგადებს, მეტ თვისებასა და პარამეტრებს გამოცდილი მომხმარებისთვის.</string>
     <string name="upgrade_prompt_upgrade_action">გარემონტება</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">დაუგრეჩეთ %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager რეკლამაგარეშია და მომხმარეთა მონაცემებს არ ყიდის. ჩემს სამუშაოს დაფინანსება თქვენია გვიერ გენიათ ❤️.</string>
     <string name="upgrade_screen_why_title">უპირატესობები</string>
     <string name="upgrade_screen_subscription_trial_action">დაიწყეთ უფასო 14-დღიანი საცდელი</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">ვერ ხერხდება Google Play-სთან დაკავშირება. გთხოვთ, შეამოწმოთ თქვენი ინტერნეტ კავშირი და ხელახლა სცადოთ.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play მიუწვდომელია</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager-ს არ შეუძლია Google Play-ზე დაკავშირება. დაყენებულია Google Play დაყენებულია და განახლებულია? ეში თქვენი Google ანგარიში შესულია? სცადეთ Google Play აპის ქეშის გასუფთავება და მოწყობილობის გადატვირთვა.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">ვერ გამოვხსნეთ Google Play. ის შეიძლება აკლია, გამორთული ან შეზღუდული იყოს ამ მოწყობილობაზე.</string>
     <string name="upgrades_no_purchases_found_check_account">შესყიდვები ვერ მოიძებნა. სწორ ანგარიშს იყენებთ?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">განახლების ვარიანტები</string>
+    <string name="upgrade_screen_offers_body">ორივე ვარიანტი გთავაზობთ იმავე Pro ფუნქციებს — აირჩიეთ ის, რომელიც თქვენთვის უფრო კარგია.</string>
+    <string name="upgrade_screen_offers_unavailable_title">ფასები მიუწვდომელია</string>
+    <string name="upgrade_screen_offers_unavailable_message">ფასები ამჯამად ვერ ჩამოირთვა. შეამოწმეთ Google Play და ცოტა ხნის შემდეგ კვლავ სცადეთ.</string>
+    <string name="upgrade_screen_benefits_body">• შეუზღუდავი მოწყობილობები\n• მორგებული კავშირის მოქმედებები\n• თემის მორგება\n• დაწვრილებული ხმის კონტროლი\n• მომავალი განვითარების ხელშეწყობა ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">წლიური გამოწერა</string>
+    <string name="upgrade_screen_subscription_offer_body">იწყება უფასო ტრიალი, შემდეგ აახლოვდება ყოველი წელი. შეგიძლიათ გაუქმება ნებისმიერ დროს Google Play-ში.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">აახლოვდება ყოველი წელი. გაუქმება შესაძლებელია ნებისმიერ დროს Google Play-ში.</string>
+    <string name="upgrade_screen_iap_offer_title">სამუდამო გახსნა</string>
+    <string name="upgrade_screen_iap_offer_body">გადაიხადეთ ერთხელ და Pro სამუდამოდ თქვენი იქნება.</string>
+    <string name="upgrade_screen_owned_hero_title">თქვენ ხართ Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">თქვენ ფლობთ %1$s სამუდამოდ.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">თქვენი %1$s გამოწერა აქტიურია.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">თქვენი გამოწერა არ არის დაყენებული აახლოვებისთვის, ამიტომ ახლა შეგიძლიათ გადაერთოთ ერთჯერადი ყიდვაზე. ყურადღება: ეს არის ცალკე გადახდა, რომელიც არ გააუქმებს ან არ დააბრუნებს თქვენი გამოწერას, ამიტომ გამოიყენეთ ერთი და იგივე Google ანგარიში ორივესთვის.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">პირველ რიგში გაუქმეთ თქვენი აახლოვებული გამოწერა Google Play-ში, შემდეგ შეგიძლიათ გადაერთოთ ერთჯერადი ყიდვაზე.</string>
+    <string name="upgrade_screen_restore_body">უკვე ყიდილი გაქვთ Pro ამ ანგარიშზე? მოითხოვეთ Google Play-ს თქვენი ყიდვების ხელახლა შემოწმება.</string>
+    <string name="upgrade_screen_restore_checked_message">ჩვენ მოვთხოვეთ Google Play-ს ამ ანგარიშის ყიდვების ხელახლა შემოწმება, მაგრამ ვერაფერი ვიპოვეთ.</string>
+    <string name="upgrade_screen_restore_contact_hint">ჯერ კიდევ პრობლემა აქვთ? დაკავშირდით ჩვენთან იმავე Google ანგარიშიდან, რომლითაც ყიდვა გაქვთ, დამატეთ თქვენი Google Play შეკვეთის ნომერი, და ჩვენ მივაგვარებთ.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">ჩვენ ვერ მოვასრულეთ Google Play-ს შემოწმება დროში, ამიტომ ჩვენ ჯერ კიდევ არ ვიცით თქვენი ყიდვის სტატუსი — მოითმინეთ ცოტა ხნა და კვლავ სცადეთ.</string>
+    <string name="upgrades_gplay_billing_error_label">ყიდვის პრობლემა</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play აცნობებს პრობლემის შესახებ: %1$s. ცადეთ კვლავ მოგვიანებით ან გადააქ მოწყობილობა.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">წინადადება მიუწვდომელია</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ამ ელემენტს ამჯამად არ აძლევს. ის შეიძლება ჯერ არ იყოს ხელმისაწვდომი თქვენი ანგარიშის ან რეგიონის თვალსაზრისით — გთხოვთ მოგვიანებით ხელახლა სცადეთ.</string>
 </resources>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">អ័ពគថ83 ត្រឹមត្រូវ BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ផ្តល់នួវផលលើសជាង្រើសមុខងារនិងជម្រើសប័កព្រមសម្រាប់សម្រាប់សធ្វី។</string>
     <string name="upgrade_prompt_upgrade_action">វិសិដ្ឋកម្ម</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">លើកកម្ពស់ទៅ %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager មិនមានព្សនា ។។។ ហើយមិនលក់លាយត្រម្វន្តិយរបស់ប្រើបស័រី។ ការការរបស់សម្រាប់របស់ត្រងប្រើទីអ្នក ❤️។</string>
     <string name="upgrade_screen_why_title">អត្ថប្រយោជន៍</string>
     <string name="upgrade_screen_subscription_trial_action">ចាប់ផ្តើមការសាកល្បង 14 ថ្ងៃដោយឥតគិតថ្លៃ</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">មិនអាចភ្ជាប់ទៅ Google Play បានទេ។ សូមពិនិត្យការតភ្ជាប់អ៊ីនធឺណិតរបស់អ្នក ហើយព្យាយាមម្តងទៀត។</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play មិនអាចប្រើបាន</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager មិនអាចភ្ជាប់ទៅ Google Play បានទេ។ តើ Google Play ត្រូវបានដំឡើងហើយទាន់សម័យទេ? តើគណនី Google របស់អ្នកបានចូលហើយទេ? សូមព្យាយាមមើលការសម្អាតឃ្លាំងសម្ងាត់នៃកម្មវិធី Google Play ហើយចាប់ផ្ដើមដំណើរការឧបករណ៍ឡើងវិញ។</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">មិនបានបើក Google Play ទេ។ វាប្រហែលជាបាត់ ឈប់ដំណើរការ ឬត្រូវបានដាក់ឆ្នោតលើឧបករណ៍នេះ។</string>
     <string name="upgrades_no_purchases_found_check_account">រកមិនឃើញការទិញ។ តើអ្នកកំពុងប្រើគណនីត្រឹមត្រូវទេ?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">ជម្រើសលើកកម្ពស់</string>
+    <string name="upgrade_screen_offers_body">ជម្រើសទាំងពីរដោះលែកលក្ខណៈពិសេស Pro ដូចគ្នាបេះបិទ — ជ្រើសរើសមួយដែលសមស្របលោកអ្នក។</string>
+    <string name="upgrade_screen_offers_unavailable_title">តម្លៃលែងមាន</string>
+    <string name="upgrade_screen_offers_unavailable_message">តម្លៃមិនអាចផ្ទុកបានឥឡូវនេះ។ ពិនិត្យ Google Play ហើយព្យាយាមម្តងទៀតក្នុងរយៈពេលដ៏ខ្លី។</string>
+    <string name="upgrade_screen_benefits_body">• ឧបករណ៍មិនមានដែនកំណត់\n• សកម្មភាពភ្ជាប់ដែលផ្ទាល់ខ្លួន\n• ការលៃតម្រូវរូបរាង\n• ការគ្រប់គ្រងសម្លេងលម្អិត\n• គាំទ្របង្ក្រឹងការអភិវឌ្ឍន៍នាពេលអនាគត ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">ការលេខិកលក្ខណ៍ប្រចាំឆ្នាំ</string>
+    <string name="upgrade_screen_subscription_offer_body">ចាប់ផ្តើមជាមួយការសាកល្បងឥតគិតថ្លៃ បន្ទាប់មកបង្កើតឡើងវិញរៀងរាល់ឆ្នាំ។ បោះបង់នៅពេលណាក៏បាននៅក្នុង Google Play។</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">បង្កើតឡើងវិញរៀងរាល់ឆ្នាំ។ បោះបង់នៅពេលណាក៏បាននៅក្នុង Google Play។</string>
+    <string name="upgrade_screen_iap_offer_title">ការដោះលែកមានអាយុកាលជីវិត</string>
+    <string name="upgrade_screen_iap_offer_body">ទូទាត់ម្តងហើយ ហើយមាន Pro រៀងរាល់ដង។</string>
+    <string name="upgrade_screen_owned_hero_title">អ្នក​គឺ Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">អ្នកគឺម្ចាស់ %1$s រៀងរាល់ដង។</string>
+    <string name="upgrade_screen_owned_hero_sub_body">ការលេខិកលក្ខណ៍ %1$s របស់អ្នកកំពុងសកម្ម។</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">ការលេខិកលក្ខណ៍របស់អ្នកមិនត្រូវបានកំណត់ដើម្បីបង្កើតឡើងវិញ ដូច្នេះអ្នកអាចប្តូរទៅការទិញម្តងដងឥឡូវនេះ។ ក្រលម៖ វាគឺជាការគិតថ្លៃដាច់ដោយឡែក ដែលលុបរំលាយ ឬសង្វិញការលេខិកលក្ខណ៍របស់អ្នកនឹងមិនកើតឡើងទេ ដូច្នេះប្រើគណនី Google ដដែលសម្រាប់ទាំងពីរ។</string>
+    <string name="upgrade_screen_owned_iap_locked_note">សូមលុបរំលាយការលេខិកលក្ខណ៍ដែលកំពុងបង្កើតឡើងវិញនៅក្នុង Google Play ដំបូង បន្ទាប់មកអ្នកអាចប្តូរទៅការទិញម្តងមួយដង។</string>
+    <string name="upgrade_screen_restore_body">បានទិញលក្ខណៈពិសេស Pro នៅលើគណនីនេះរួចហើយឬ? សូមស្នើឱ្យ Google Play ពិនិត្យមើលការទិញរបស់អ្នកម្តងទៀត។</string>
+    <string name="upgrade_screen_restore_checked_message">យើងបានស្នើឱ្យ Google Play ពិនិត្យមើលការទិញរបស់គណនីនេះម្តងទៀត ហើយមិនបានរកឃើញ។</string>
+    <string name="upgrade_screen_restore_contact_hint">នៅតែស្ទាក់ស្ទើរឬ? ទាក់ទងពីគណនី Google ដដែលដែលអ្នកបានទិញវា រួមបញ្ចូលលេខលំដាប់ Google Play របស់អ្នក ហើយយើងនឹងដោះស្រាយ។</string>
+    <string name="upgrade_screen_restore_inconclusive_message">យើងមិនអាចបញ្ចប់ការពិនិត្យជាមួយ Google Play ក្នុងរយៈពេលលម្អិតបានទេ ដូច្នេះយើងនៅតែមិនដឹងពីស្ថានភាពនៃការទិញរបស់អ្នក — សូមរង់ចាំបន្តិច ហើយព្យាយាមម្តងទៀត។</string>
+    <string name="upgrades_gplay_billing_error_label">បញ្ហាការទិញ</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play បានរាយការណ៍ពីបញ្ហា: %1$s។ ព្យាយាមម្តងទៀតក្រោយមក ឬចាប់ផ្តើមឧបករណ៍របស់អ្នកម្តងទៀត។</string>
+    <string name="upgrades_gplay_offer_unavailable_title">សម្ពោធលែងមាន</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play មិនបានផ្តល់ជូនធាតុនេះឥឡូវនេះទេ។ វាប្រហែលជាមិនមាននៅលើគណនី ឬតំបន់របស់អ្នកឡើយ — សូមព្យាយាមម្តងទៀតក្រោយមក។</string>
 </resources>

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Biçe BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ji bo bikarhênerên pêşkeftî encamên baştir, taybetmendî û vebijarkên zêdetir pêşkêş dike.</string>
     <string name="upgrade_prompt_upgrade_action">Nûjen bike</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Bihevkirin a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklamê nake û daneya bikarhêner nafroşe. Xebata min ji aliyê we ve tê fînanskirinê ❤️.</string>
     <string name="upgrade_screen_why_title">Avantaj</string>
     <string name="upgrade_screen_subscription_trial_action">Ceribandîna 14-rojî ya belaş dest pê bike</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Nabigihije Google Play-ê. Linkê internet xwe kontrol bikin û dîsa hewl bidin.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nayê dîtin</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nikare bi Google Play re girêbide. Ma Google Play saz û nûkirî ye? Cache ya Google Play pak bike û cîhazê xwe ji nû ve bixebite.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play nehat vekirin. Dibe ku winda bûbe, nehatiye çalak kirin an tê sînordar kirin di vê cihazê de.</string>
     <string name="upgrades_no_purchases_found_check_account">Kirîn nehatin dîtin. Hûn hesabê rast bikar tînin?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Vebijarkên bihevkirinê</string>
+    <string name="upgrade_screen_offers_body">Her du vebijark taybetmendiyên Pro-yê yên xwe de vekirî dikin — ya ku tu dixwazî, hilbijêre.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Nîqaş nebe</string>
+    <string name="upgrade_screen_offers_unavailable_message">Nîqaş niha ne dikarin were barkî. Google Play-ê kontrol bike û dûmahî dîsa hewl bide.</string>
+    <string name="upgrade_screen_benefits_body">• Amûrên bê sînor\n• Aksiyonên peywendîyê yên taybet\n• Guzerandinê reng\n• Kontrolên helûskên pêşketî\n• Piştgiriya pêşveçûna borî ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Abonementeya salane</string>
+    <string name="upgrade_screen_subscription_offer_body">Bi ceribandineke azad dest pê dike, hingê her sal nûborn dike. Her dem de di Google Play de betal bike.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Her sal nûborn dike. Her dem de di Google Play de betal bike.</string>
+    <string name="upgrade_screen_iap_offer_title">Azadî ya belavê</string>
+    <string name="upgrade_screen_iap_offer_body">Carekî bide û Pro-yî eternê xwedî bike.</string>
+    <string name="upgrade_screen_owned_hero_title">Tu Pro yî! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Tu %1$s eternê xwedî dikî.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Abonementeya %1$s ya te çalak e.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Abonementeya te nabe ku nûborn bibe, ji ber vê tu niha dikarî derbasî kirrîna yekcarî yî. Baldar: ew jor a cuda ye ku nabe ku abonementeya te betal bibe an jî gerîyê bide, ji ber vê hesaba Google ya heman ji bo her du bikarbîne.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Pêşî abonementeya nûborn a te di Google Play de betal bike, hingê tu dikarî derbasî kirrîna yekcarî yî.</string>
+    <string name="upgrade_screen_restore_body">Tu li ser vê hesabê Pro kirin? Google Play-î bibêje ku kirrîn a te dîsa kontrol bike.</string>
+    <string name="upgrade_screen_restore_checked_message">Me Google Play-î xwest ku kirrîn a vê hesabê dîsa kontrol bike û ne yek ne dît.</string>
+    <string name="upgrade_screen_restore_contact_hint">Hîn jî giredayî? Bi hesaba Google ya heman ku te bi wê kirrî kirin pê re têkilî tê de, hejmara fermanî ya Google Play-ê jî de, em ew çareser dikin.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Me ne karibe kontrolkirina Google Play-ê di demê de rewşenbend bike, ji ber vê me hîn nizanin ku bazirganî ya te çi ye — sekinînek cihê bike û dîsa hewl bide.</string>
+    <string name="upgrades_gplay_billing_error_label">Pirsgirêka bazirganîyê</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play pirsgirêyek ragihand: %1$s. Dûmahî dîsa hewl bide an jî amûra xwe dîsa dest pê bike.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Pêşkêşî nebe</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ev tişt niha ne pêşkêş kir. Ew dikare ji bo hesaba te an herêma te hîn peyda nebe — tûjî dûmahî dîsa hewl bide.</string>
 </resources>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -67,8 +67,9 @@
     <string name="upgrade_screen_iap_offer_title">ಜೀವನಕಾಲದ ಅನ್‌ಲಾಕ್</string>
     <string name="upgrade_screen_iap_offer_body">ಒಮ್ಮೆ ಪಾವತಿ ಮಾಡಿ, ಶಾಶ್ವತವಾಗಿ ಪ್ರೋ ಪಡೆ.</string>
     <string name="upgrade_screen_owned_hero_title">ನೀವು ಪ್ರೋ! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">ನೀವು %1$s ಅನ್ನು ಶಾಶ್ವತವಾಗಿ ಹೊಂದಿದ್ದೀರಿ.</string>
     <string name="upgrade_screen_owned_hero_sub_body">ನಿಮ್ಮ %1$s ಸಂಚಯ ಸಕ್ರಿಯವಾಗಿದೆ.</string>
-    <string name="upgrade_screen_owned_iap_purchase_note">ನಿಮ್ಮ ಸಂಚಯ ನವೀಕರಣದೊಂದಿಗೆ ನಿರ್ಧಾರಿತವಾಗಿಲ್ಲ, ಆದ್ದರಿಂದ ನೀವು ಈಗ ಏಕ-ಬಾರಿ ಖರೀದಿಗೆ ಬದಲಾಯಿಸಬಹುದು. ಗಮನಿಸಿ: ಇದು ನಿಮ್ಮ ಸಂಚಯವನ್ನು ರದ್ದುಮಾಡುವುದಿಲ್ಲ ಅಥವಾ ಹಿಂದುಕೊಳ್ಳುವುದಿಲ್ಲ ಎಂಬ ಪ್ರತ್ಯೇಕ ಶುಲ್ಕ, ಆದ್ದರಿಂದ ಎರಡೂಗಳಿಗಾಗಿ ಅದೇ Google ಖಾತೆಯನ್ನು ಬಳಸಿ.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">ನಿಮ್ಮ ಸದಸ್ಯತೆ ನವೀಕರಣಕ್ಕಾಗಿ ಹೊಂದಿಸಲಾಗಿಲ್ಲ, ಆದ್ದರಿಂದ ನೀವು ಈಗ ಏಕ-ಬಾರಿ ಖರೀದಿಗೆ ಬದಲಾಯಿಸಬಹುದು. ಗಮನಿಸಿ: ಇದು ಪ್ರತ್ಯೇಕ ಶುಲ್ಕವಾಗಿದ್ದು, ಇದು ನಿಮ್ಮ ಸದಸ್ಯತೆಯನ್ನು ರದ್ದುಗೊಳಿಸುವುದಿಲ್ಲ ಅಥವಾ ಮರುಪಾವತಿಸುವುದಿಲ್ಲ, ಆದ್ದರಿಂದ ಎರಡಕ್ಕೂ ಅದೇ Google ಖಾತೆಯನ್ನು ಬಳಸಿ.</string>
     <string name="upgrade_screen_owned_iap_locked_note">Google Play ನಲ್ಲಿ ನಿಮ್ಮ ನವೀಕರಣ ಸಂಚಯವನ್ನು ಮೊದಲು ರದ್ದುಮಾಡಿ, ನಂತರ ಏಕ-ಬಾರಿ ಖರೀದಿಗೆ ಬದಲಾಯಿಸಬಹುದು.</string>
     <string name="upgrade_screen_restore_body">ಈ ಖಾತೆಯಲ್ಲಿ ಪ್ರೋ ಈಗಾಗಲೇ ಖರೀದಿಸಿದ್ದೀರಾ? ನಿಮ್ಮ ಖರೀದಿಗಳನ್ನು ಮರುಪರೀಕ್ಷೆ ಮಾಡಲು Google Play ಅನ್ನು ಕೇಳಿ.</string>
     <string name="upgrade_screen_restore_checked_message">ನಾವು Google Play ಅನ್ನು ಈ ಖಾತೆಯ ಖರೀದಿಗಳನ್ನು ಮರುಪರೀಕ್ಷೆ ಮಾಡಲು ಕೇಳಿದ್ದೇವೆ ಮತ್ತು ಯಾವುದನ್ನೂ ಕಂಡುಹಿಡಿಯಲಿಲ್ಲ.</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -68,6 +68,7 @@
     <string name="upgrade_screen_iap_offer_body">ಒಮ್ಮೆ ಪಾವತಿ ಮಾಡಿ, ಶಾಶ್ವತವಾಗಿ ಪ್ರೋ ಪಡೆ.</string>
     <string name="upgrade_screen_owned_hero_title">ನೀವು ಪ್ರೋ! ❤️</string>
     <string name="upgrade_screen_owned_hero_sub_body">ನಿಮ್ಮ %1$s ಸಂಚಯ ಸಕ್ರಿಯವಾಗಿದೆ.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">ನಿಮ್ಮ ಸಂಚಯ ನವೀಕರಣದೊಂದಿಗೆ ನಿರ್ಧಾರಿತವಾಗಿಲ್ಲ, ಆದ್ದರಿಂದ ನೀವು ಈಗ ಏಕ-ಬಾರಿ ಖರೀದಿಗೆ ಬದಲಾಯಿಸಬಹುದು. ಗಮನಿಸಿ: ಇದು ನಿಮ್ಮ ಸಂಚಯವನ್ನು ರದ್ದುಮಾಡುವುದಿಲ್ಲ ಅಥವಾ ಹಿಂದುಕೊಳ್ಳುವುದಿಲ್ಲ ಎಂಬ ಪ್ರತ್ಯೇಕ ಶುಲ್ಕ, ಆದ್ದರಿಂದ ಎರಡೂಗಳಿಗಾಗಿ ಅದೇ Google ಖಾತೆಯನ್ನು ಬಳಸಿ.</string>
     <string name="upgrade_screen_owned_iap_locked_note">Google Play ನಲ್ಲಿ ನಿಮ್ಮ ನವೀಕರಣ ಸಂಚಯವನ್ನು ಮೊದಲು ರದ್ದುಮಾಡಿ, ನಂತರ ಏಕ-ಬಾರಿ ಖರೀದಿಗೆ ಬದಲಾಯಿಸಬಹುದು.</string>
     <string name="upgrade_screen_restore_body">ಈ ಖಾತೆಯಲ್ಲಿ ಪ್ರೋ ಈಗಾಗಲೇ ಖರೀದಿಸಿದ್ದೀರಾ? ನಿಮ್ಮ ಖರೀದಿಗಳನ್ನು ಮರುಪರೀಕ್ಷೆ ಮಾಡಲು Google Play ಅನ್ನು ಕೇಳಿ.</string>
     <string name="upgrade_screen_restore_checked_message">ನಾವು Google Play ಅನ್ನು ಈ ಖಾತೆಯ ಖರೀದಿಗಳನ್ನು ಮರುಪರೀಕ್ಷೆ ಮಾಡಲು ಕೇಳಿದ್ದೇವೆ ಮತ್ತು ಯಾವುದನ್ನೂ ಕಂಡುಹಿಡಿಯಲಿಲ್ಲ.</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro ಗೆ ದರ್ಜೆಯೇರಿ</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ಉತ್ತಮ ಫಲಿತಾಂಶಗಳನ್ನು, ಹೆಚ್ಚಿನ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಮತ್ತು ಪವರ್ ಬಳಕೆದಾರರಿಗೆ ಆಯ್ಕೆಗಳನ್ನು ನೀಡುತ್ತದೆ.</string>
     <string name="upgrade_prompt_upgrade_action">ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s ಗೆ ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ಜಾಹೀರಾತುಗಳಿಲ್ಲ ಮತ್ತು ಬಳಕೆದಾರರ ಡೇಟಾ ಮಾರಾಟುವುದಿಲ್ಲ. ನನ್ನ ಕೆಲಸ ನಿಮ್ಮಿಂದ ಹಗಲಾಗುತ್ತದೆ ❤️.</string>
     <string name="upgrade_screen_why_title">ಪ್ರಯೋಜನಗಳು</string>
     <string name="upgrade_screen_subscription_trial_action">ಉಚಿತ 14-ದಿನಗಳ ಪರೀಕ್ಷೆ ಪ್ರಾರಂಭಿಸಿ</string>
@@ -50,5 +52,29 @@
     <string name="upgrades_gplay_network_error_description">ಗೂಗಲ್ ಪ್ಲೇಗೆ ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ನಿಮ್ಮ ಇಂಟರ್ನೆಟ್ ಸಂಪರ್ಕವನ್ನು ಪರಿಶೀಲಿಸಿ ಮತ್ತು ಪುನಃ ಪ್ರಯತ್ನಿಸಿ.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ಲಭ್ಯವಿಲ್ಲ</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play ಗೆ ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ. Google Play ಇನ್ಸ್ಟಾಲ್ ಆಗಿ ನವೀಕರಿಸಲಾಗಿದೆಯೇ? ನಿಮ್ಮ Google ಖಾತೆ ಲಾಗಿನ್ ಆಗಿದೆಯೇ? Google Play ಅಪ್ ಕ್ಯಾಚೆ ತೆರವುಮಾಡಿ ಮರುಬುಟ್ ಮಾಡಿ.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play ಅನ್ನು ತೆರೆಯಲಾಗಲಿಲ್ಲ. ಇದು ಸ್ಥಾಪಿತವಾಗಿರದೆ, ನಿಷ್ಕ್ರಿಯವಾಗಿರುವ ಅಥವಾ ಈ ಸಾಧನದಲ್ಲಿ ನಿರ್ಬಂಧಿತವಾಗಿರುವ ಸಾಧ್ಯತೆ ಇದೆ.</string>
     <string name="upgrades_no_purchases_found_check_account">ಯಾವುದೇ ಖರೀದಿಗಳು ಕಂಡುಬಂದಿಲ್ಲ. ನೀವು ಸರಿಯಾದ ಖಾತೆಯನ್ನು ಬಳಸುತ್ತಿದ್ದೀರಾ?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">ಅಪ್‌ಗ್ರೇಡ್ ಆಯ್ಕೆಗಳು</string>
+    <string name="upgrade_screen_offers_body">ಎರಡೂ ಆಯ್ಕೆಗಳು ನಿಖಿಲವಾಗಿ ಅದೇ ಪ್ರೋ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಅನ್‌ಲಾಕ್ ಮಾಡುತ್ತವೆ — ನಿಮಗೆ ಸರಿಯಾದುದನ್ನು ಆರಿಸಿಕೊಳ್ಳಿ.</string>
+    <string name="upgrade_screen_offers_unavailable_title">ಬೆಲೆಗಳು ಲಭ್ಯವಲ್ಲ</string>
+    <string name="upgrade_screen_offers_unavailable_message">ಬೆಲೆಗಳನ್ನು ಈಗ ಲೋಡ್ ಮಾಡಲಾಗಲಿಲ್ಲ. Google Play ಪರಿಶೀಲಿಸಿ ಮತ್ತು ಸ್ವಲ್ಪ ಸಮಯದ ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
+    <string name="upgrade_screen_benefits_body">• ಅಸೀಮಿತ ಸಾಧನಗಳು\n• ಕಸ್ಟಮ್ ಸಂಪರ್ಕ ಕ್ರಿಯೆಗಳು\n• ಥೀಮ್ ಅನುಕೂಲನ\n• ಮುಂದುವರಿದ ವಾಲ್ಯೂಮ್ ನಿಯಂತ್ರಣಗಳು\n• ಭವಿಷ್ಯತ್ತಿನ ಅಭಿವೃದ್ಧಿಯನ್ನು ಬೆಂಬಲಿಸಿ ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">ವಾರ್ಷಿಕ ಯೋಜನೆ</string>
+    <string name="upgrade_screen_subscription_offer_body">ಉಚಿತ ಪ್ರಯೋಗವೊಂದಿಗೆ ಪ್ರಾರಂಭವಾಗುತ್ತದೆ, ನಂತರ ವಾರ್ಷಿಕವಾಗಿ ನವೀಕರಣವಾಗುತ್ತದೆ. Google Play ನಲ್ಲಿ ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ರದ್ದುಮಾಡಿ.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">ವಾರ್ಷಿಕವಾಗಿ ನವೀಕರಣವಾಗುತ್ತದೆ. Google Play ನಲ್ಲಿ ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ರದ್ದುಮಾಡಿ.</string>
+    <string name="upgrade_screen_iap_offer_title">ಜೀವನಕಾಲದ ಅನ್‌ಲಾಕ್</string>
+    <string name="upgrade_screen_iap_offer_body">ಒಮ್ಮೆ ಪಾವತಿ ಮಾಡಿ, ಶಾಶ್ವತವಾಗಿ ಪ್ರೋ ಪಡೆ.</string>
+    <string name="upgrade_screen_owned_hero_title">ನೀವು ಪ್ರೋ! ❤️</string>
+    <string name="upgrade_screen_owned_hero_sub_body">ನಿಮ್ಮ %1$s ಸಂಚಯ ಸಕ್ರಿಯವಾಗಿದೆ.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Google Play ನಲ್ಲಿ ನಿಮ್ಮ ನವೀಕರಣ ಸಂಚಯವನ್ನು ಮೊದಲು ರದ್ದುಮಾಡಿ, ನಂತರ ಏಕ-ಬಾರಿ ಖರೀದಿಗೆ ಬದಲಾಯಿಸಬಹುದು.</string>
+    <string name="upgrade_screen_restore_body">ಈ ಖಾತೆಯಲ್ಲಿ ಪ್ರೋ ಈಗಾಗಲೇ ಖರೀದಿಸಿದ್ದೀರಾ? ನಿಮ್ಮ ಖರೀದಿಗಳನ್ನು ಮರುಪರೀಕ್ಷೆ ಮಾಡಲು Google Play ಅನ್ನು ಕೇಳಿ.</string>
+    <string name="upgrade_screen_restore_checked_message">ನಾವು Google Play ಅನ್ನು ಈ ಖಾತೆಯ ಖರೀದಿಗಳನ್ನು ಮರುಪರೀಕ್ಷೆ ಮಾಡಲು ಕೇಳಿದ್ದೇವೆ ಮತ್ತು ಯಾವುದನ್ನೂ ಕಂಡುಹಿಡಿಯಲಿಲ್ಲ.</string>
+    <string name="upgrade_screen_restore_contact_hint">ಇನ್ನೂ ಅಡ್ಡಿಯಾಗಿದೆ? ನೀವು ಖರೀದಿಸಿದ ಅದೇ Google ಖಾತೆಯಿಂದ ಸಂಪರ್ಕಿಸಿ, ನಿಮ್ಮ Google Play ಆದೇಶ ಸಂಖ್ಯೆಯನ್ನು ಸೇರಿಸಿ, ಮತ್ತು ನಾವು ಅದನ್ನು ಪರಿಹರಿಸುತ್ತೇವೆ.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">ನಾವು Google Play ನೊಂದಿಗೆ ಸಮಯದಲ್ಲಿ ಪರೀಕ್ಷೆ ಮಾಡಿ ಮುಗಿಸಲಿಲ್ಲ, ಆದ್ದರಿಂದ ನಾವು ಇನ್ನೂ ನಿಮ್ಮ ಖರೀದಿ ಸ್ಥಿತಿ ತಿಳಿದಿಲ್ಲ — ಒಂದು ಕ್ಷಣ ಕಾಯಿ ಮತ್ತು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
+    <string name="upgrades_gplay_billing_error_label">ಖರೀದಿ ಸಮಸ್ಯೆ</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ಸಮಸ್ಯೆ ವರದಿ ಮಾಡಿದೆ: %1$s. ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ ಅಥವಾ ನಿಮ್ಮ ಸಾಧನವನ್ನು ಪುನರಾರಂಭಿಸಿ.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ಪ್ರಸ್ತಾವ ಲಭ್ಯವಲ್ಲ</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ಈಗ ಈ ಐಟಮ್ ಪ್ರಸ್ತಾವ ಮಾಡಲಿಲ್ಲ. ಇದು ನಿಮ್ಮ ಖಾತೆ ಅಥವಾ ಪ್ರದೇಶಕ್ಕೆ ಇನ್ನೂ ಲಭ್ಯವಿರಬಹುದು — ದಯವಿಟ್ಟು ನಂತರ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
 </resources>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro로 업그레이드</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro는 파워유저들을 위해 더 나은 결과와 더 많은 기능 및 옵션을 제공합니다.</string>
     <string name="upgrade_prompt_upgrade_action">업그레이드</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s로 업그레이드</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager는 광고가 없고 유저 데이터를 팔지 않습니다. 제 작업은 여러분의 지원으로 이루어집니다 ❤️.</string>
     <string name="upgrade_screen_why_title">장점</string>
     <string name="upgrade_screen_subscription_trial_action">14일 무료 평가판 시작</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play에 연결할 수 없습니다. 인터넷 연결을 확인하고 다시 시도해 주세요.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play에 연결할 수 없음</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager가 Google Play에 연결할 수 없습니다. Google Play가 설치되어 있고 최신 버전인가요? Google 계정이 로그인되어 있나요? Google Play 앱의 캐시를 지우고 기기를 재부팅해 보세요.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play를 열 수 없습니다. 이 기기에서 Google Play가 없거나 비활성화되었거나 제한되어 있을 수 있습니다.</string>
     <string name="upgrades_no_purchases_found_check_account">구매 항목을 찾을 수 없습니다. 올바른 계정을 사용 중인가요?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">업그레이드 옵션</string>
+    <string name="upgrade_screen_offers_body">두 옵션 모두 동일한 Pro 기능을 제공합니다 — 원하는 것을 선택하세요.</string>
+    <string name="upgrade_screen_offers_unavailable_title">가격을 볼 수 없음</string>
+    <string name="upgrade_screen_offers_unavailable_message">지금 가격을 불러올 수 없습니다. Google Play에서 확인하고 잠시 후 다시 시도하세요.</string>
+    <string name="upgrade_screen_benefits_body">• 무제한 기기\n• 맞춤 연결 작업\n• 테마 맞춤설정\n• 고급 볼륨 제어\n• 미래 개발 지원 ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">연간 구독</string>
+    <string name="upgrade_screen_subscription_offer_body">무료 체험으로 시작하고 매년 갱신됩니다. Google Play에서 언제든지 취소할 수 있습니다.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">매년 갱신됩니다. Google Play에서 언제든지 취소할 수 있습니다.</string>
+    <string name="upgrade_screen_iap_offer_title">평생 잠금 해제</string>
+    <string name="upgrade_screen_iap_offer_body">한 번 결제하고 Pro를 영구적으로 소유하세요.</string>
+    <string name="upgrade_screen_owned_hero_title">Pro 버전입니다! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">%1$s를 영구적으로 소유하고 있습니다.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">%1$s 구독이 활성화되어 있습니다.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">구독이 자동 갱신으로 설정되지 않았으므로 이제 일회성 구매로 전환할 수 있습니다. 주의: 이것은 구독을 취소하거나 환불하지 않으며 별도로 청구되는 요금이므로 두 결제 모두에 동일한 Google 계정을 사용하세요.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Google Play에서 먼저 자동 갱신 중인 구독을 취소한 후 일회성 구매로 전환할 수 있습니다.</string>
+    <string name="upgrade_screen_restore_body">이 계정에서 이미 Pro를 구매했나요? Google Play에 구매 내역을 다시 확인하도록 요청하세요.</string>
+    <string name="upgrade_screen_restore_checked_message">Google Play에 이 계정의 구매 내역을 다시 확인하도록 요청했지만 찾을 수 없습니다.</string>
+    <string name="upgrade_screen_restore_contact_hint">여전히 문제가 있나요? 구매할 때 사용한 동일한 Google 계정에서 연락하고 Google Play 주문 번호를 포함하면 해결해 드리겠습니다.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play에서 시간 내에 확인을 완료할 수 없어서 구매 상태를 알 수 없습니다 — 잠시 기다렸다가 다시 시도하세요.</string>
+    <string name="upgrades_gplay_billing_error_label">구매 문제</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play에서 문제가 보고되었습니다: %1$s. 나중에 다시 시도하거나 기기를 다시 시작하세요.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">제공 불가</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play에서 지금 이 항목을 제공하지 않습니다. 계정이나 지역에서 아직 사용 불가능할 수 있습니다 — 나중에 다시 시도하세요.</string>
 </resources>

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro га өтүү</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro күчтүү пайдалануучулар үчүн жакшыраак натыйжаларды, көбүрөк функцияларды жана мүмкүнчүлүктөрдү сунат.</string>
     <string name="upgrade_prompt_upgrade_action">Жаңыртуу</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s сунуштуу жогорулоо</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager жарнамаларсыз жана пайдалануучулардын мәлиматын сатпайт. Менин жумушум сиздин қаржыланат ❤️.</string>
     <string name="upgrade_screen_why_title">Артыкчылыктары</string>
     <string name="upgrade_screen_subscription_trial_action">14 күндүк бепло сынаманы баштоо</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play\'ге туташуу мүмкүн болбоду. Интернет байланышыңызды текшериңиз жана кайра аракет кылыңыз.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play жетиштүүсүз</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play га байлана албайт. Google Play орнотулган жана жаңыртылганбы? Google аккаунтыңызга киргенбе? Google Play кэшин тазалап, түзмөгүңүздү кайра чүмүрлөө көрүңүз.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play ачуу мүмкүн болбоду. Бул түзмөктө жок, өчүк же чектелген болушу мүмкүн.</string>
     <string name="upgrades_no_purchases_found_check_account">Эч кандай сатып алуулар табылган жок. Туура каттоо эсебин колдонуп жатасызбы?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Жогорулоо опциялары</string>
+    <string name="upgrade_screen_offers_body">Эки опция тең бирдей Pro функцияларын ачат — сизге ылайык болгонду тандаңыз.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Баалар жеткилик эмес</string>
+    <string name="upgrade_screen_offers_unavailable_message">Баалар ушу жолу жүктөлүп албаса болот. Google Play текшеңиз жана бир аз күтүп кайта аракет кылыңыз.</string>
+    <string name="upgrade_screen_benefits_body">• Чексиз түзмөктөр\n• Жөндөмдүү туташуу аракеттери\n• Тема ишкечтелери\n• Прогрессивдүү үндү башкаруу\n• Келечектеги өнүктүүлүккө колдоо ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Жылдык жазылуу</string>
+    <string name="upgrade_screen_subscription_offer_body">Бесплатка аракет менен башталат, анан жыл сайын жаңыланат. Google Play-де каалаган убакта жокко чыгарыңыз.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Жыл сайын жаңыланат. Google Play-де каалаган убакта жокко чыгарыңыз.</string>
+    <string name="upgrade_screen_iap_offer_title">Өмүр бою ачуу</string>
+    <string name="upgrade_screen_iap_offer_body">Бирок төлөп, Pro менен өмүр бою ээсинде болуңуз.</string>
+    <string name="upgrade_screen_owned_hero_title">Сиз Pro болосуз! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Сиз %1$s өмүр бою ээси болосуз.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Сиздин %1$s жазылуу активдүү.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Сиздин жазылууңуз жаңыланса да коюлган жок, ошондуктан сиз азыр бир жолу төлөөгө өтүп алаарсыңыз. Көңүл салыңыз: бул жазылууңузду жокко чыгарбайт же сатындыраат эмес жараяа болсо, эки үчүн тең бирдей Google аккаунтун колдонуңуз.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Адегиле Google Play-де жаңылана берүүчү жазылууңузду жокко чыгарыңыз, анан бир жолу төлөөгө өтүп алаарсыңыз.</string>
+    <string name="upgrade_screen_restore_body">Ушул аккаунтта Pro сатып алдыңыз? Google Play-де сатып алыштарыңыздын кайтадан текшеринишин сурануңуз.</string>
+    <string name="upgrade_screen_restore_checked_message">Биз Google Play-де бул аккаунтун сатып алыштарын кайта текшеринишин сурандык жана эч нерсе табылган жок.</string>
+    <string name="upgrade_screen_restore_contact_hint">Дээрлик кыйын? Сатып алган Google аккаунтуңуздан байланышып, Google Play буйрутмасынын номерин камтыңыз, жана биз аны чечип беребиз.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Биз Google Play менен убактысында текшеренче албадык, ошондуктан биз дагы эле сатып алыш статусуңузду билбейбиз — бир аз күтүп, кайта аракет кылыңыз.</string>
+    <string name="upgrades_gplay_billing_error_label">Сатып алуу маселеси</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play маселе билдирди: %1$s. Кейинче кайта аракет кылыңыз же түзмөгүңүздү эс тартыңыз.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Сунуш жеткилик эмес</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ушу жолу бул нерсени сунуш кылган жок. Ал сиздин аккаунтуңуз же аймак үчүн дагы жеткилик болушу мүмкүн эмес — кейинче кайта аракет кылып көрүңүз.</string>
 </resources>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">ອັບເກຣດເປັນ BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ໃຫ້ຜ໏ລໍບທີ່ດີກວ່າ, ມີຄຸນສົມແລະຕັວເລືອກເພິ່ມເຕີມສຳຫຣັບຜູ້ໃຊ້ທີ່ເພີບ.</string>
     <string name="upgrade_prompt_upgrade_action">ອັບເກຣດ</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">ອັບເກຣດເປັນ %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ບ່ມີໂຆສນາເກ໭ນແລະບ່ຂາຍຂ້ອມູນຜູ້ໃຊ້. ງານຂອງຂ້ອນສະຫນັບສນຸນໂດຍທ່ານ ❤️.</string>
     <string name="upgrade_screen_why_title">ຂໍ້ດີ</string>
     <string name="upgrade_screen_subscription_trial_action">ເລີ່ມທົດລອງຟຣີ 14 ວັນ</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">ບໍ່ສາມາດເຊື່ອມຕໍ່ກັບ Google Play ໄດ້. ກະລຸນາກວດເບິ່ງການເຊື່ອມຕໍ່ອິນຕີເນັດຂອງທ່ານແລ້ວລອງໃໝ່.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ບໍ່ພ້ອມໃຊ້ງານ</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ໂຊ່ມຕ່ອກັບ Google Play ໄດ້. ໂດຍຕິດຕັ້ງ Google Play ແລະອັດເດທໄດ້ບ່? ເຂົ້າລັອກ Google ໄດ້ບ່? ລອງລ້າງແຄຊແລະຊົກເລີ່ມອຸປກອນຂອງທ່ານໃຫມ່.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">ບໍ່ສາມາດເປີດ Google Play ໄດ້. ມັນອາດຈະຫາຍໄປ, ປິດໃຊ້ງານ, ຫຼື ຖືກຈໍາກັດໃນອຸປະກອນນີ້.</string>
     <string name="upgrades_no_purchases_found_check_account">ບໍ່ພົບການຊື້. ທ່ານກຳລັງໃຊ້ບັນຊີທີ່ຖືກຕ້ອງບໍ?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">ຕົວເລືອກການອັບເກຣດ</string>
+    <string name="upgrade_screen_offers_body">ທັງສອງຕົວເລືອກຈະປົ່ອຍໃຫ້ຟີເຈີ Pro ແບບດຽວກັນ — ເລືອກອັນໃດກໍ່ໄດ້ທີ່ເໝາະສົມກັບທ່ານ.</string>
+    <string name="upgrade_screen_offers_unavailable_title">ລາຄາບໍ່ມີ</string>
+    <string name="upgrade_screen_offers_unavailable_message">ລາຄາບໍ່ສາມາດໂຫຼດໄດ້ໃນປັດຈຸບັນ. ກວດສອບ Google Play ແລະລອງໃໝ່ໃນໄວ່ໄດ້ນີ້.</string>
+    <string name="upgrade_screen_benefits_body">• ອຸປະກອນທີ່ບໍ່ມີຂອບເຂດ\n• ການດໍາເນີນການເຊື່ອມຕໍ່ທີ່ກຳນົດເອງ\n• ການປັບແຕ່ງຫົວຂໍ້\n• ການຄວບຄຸມສຽງທີ່ກ້າວໜ້າ\n• ສະໜັບສະໜູນການພັດທະນາໃນອະນາຄົດ ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">ໂຄສະລາປະຈໍາປີ</string>
+    <string name="upgrade_screen_subscription_offer_body">ເລີ່ມຕົ້ນດ້ວຍການທົດລອງຟຣີ, ຫຼັງຈາກນັ້ນປັບປຸງໃໝ່ປະຈໍາປີ. ສາມາດຍົກເລີກໄດ້ທຸກເວລາໃນ Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">ປັບປຸງໃໝ່ປະຈໍາປີ. ສາມາດຍົກເລີກໄດ້ທຸກເວລາໃນ Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">ປົ່ອຍໃຫ້ຕະຫຼອດໄປ</string>
+    <string name="upgrade_screen_iap_offer_body">ຈ່າຍຄັ້ງດຽວ ແລະເປັນເຈົ້າຂອງ Pro ຕະຫຼອດໄປ.</string>
+    <string name="upgrade_screen_owned_hero_title">ທ່ານເປັນ Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">ທ່ານເປັນເຈົ້າຂອງ %1$s ຕະຫຼອດໄປ.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">ການໂຄສະລາ %1$s ຂອງທ່ານໃຊ້ງານຍູ່.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">ໂຄສະລາຂອງທ່ານບໍ່ໄດ້ຕັ້ງໄວ້ເພື່ອປັບປຸງໃໝ່, ດັ່ງນັ້ນທ່ານສາມາດປ່ຝນໄປຊື້ຄັ້ງດຽວໄດ້ດຽວນີ້. ລະວັງ: ມັນເປັນຄ່າໃຊ້ຈ່າຍແຍກຕ່າງໝາກທີ່ຈະບໍ່ຍົກເລີກ ໜືອ ຄືນເງິນໂຄສະລາຂອງທ່ານ, ດັ່ງນັ້ນໃຊ້ Google ບັນຊີ ດຽວກັນສຳລັບທັ້ງສອງ.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">ຍົກເລີກການໂຄສະລາທີ່ປັບປຸງໃນ Google Play ກ່ອນ, ຫຼັງຈາກນັ້ນທ່ານສາມາດປ່ຝນໄປຊື້ຄັ້ງດຽວໄດ້.</string>
+    <string name="upgrade_screen_restore_body">ຊື້ Pro ໃນບັນຊີນີ້ແລ້ວບໍ? ຂອໃໝ້ Google Play ກວດກາການຊື້ຂາຍຂອງທ່ານ.</string>
+    <string name="upgrade_screen_restore_checked_message">ພວກເຮາຂອໃໝ້ Google Play ກວດກາການຊື້ຂາຍໃນບັນຊີນີ້ ແລະບໍ່ພົບວ່າມີ.</string>
+    <string name="upgrade_screen_restore_contact_hint">ຍັງຕິດບໍ? ຕິດຕໍ່ຈາກ Google ບັນຊີ ດຽວກັນທີ່ທ່ານຊື້ດ້ວຍ, ລວມເອາເບີໂອເດີ Google Play ຂອງທ່ານ, ແລະພວກເຮາຈະແກ້ໄຂໃຫ້ທ່ານ.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">ພວກເຮາບໍ່ສາມາດກວດກາກັບ Google Play ໄດ້ທັນເວລາ, ດັ່ງນັ້ນພວກເຮາຍັງບໍ່ຮູ້ສະຖານະການຊື້ຂາຍຂອງທ່ານ — ລໍ້ໜົກສັກພັກ ແລະລອງໃໝ່.</string>
+    <string name="upgrades_gplay_billing_error_label">ບັນໜາການຊື້ຂາຍ</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ລາຍງານບັນໜາ: %1$s. ລອງໃໝ່ໃນໄວ່ໄດ້ນີ້ ໜືອ ເລີ່ມຕົ້ນອຸປະກອນຂອງທ່ານ.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ບໍ່ມີຂໍ້ສະເໝີ</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ບໍ່ໄດ້ສະເໝີລາຍການນີ້ໃນປັດຈຸບັນ. ມັນອາດຈະບໍ່ສາມາດໃຊ້ໄດ້ສຳລັບບັນຊີ ໜືອພາກພື້ນຂອງທ່ານໃນຕອນນີ້ — ກະລຸນາລອງໃໝ່ໃນໄວ່ໄດ້ນີ້.</string>
 </resources>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Atnaujinti į BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro siūlo geresnius rezultatus, daugiau funkcijų ir galimybių pažengusiems naudotojams.</string>
     <string name="upgrade_prompt_upgrade_action">Atnaujinti</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Atnaujinti į %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neturi reklamų ir neparduoda naudotojų duomenų. Mano darbas finansuojamas jūsų ❤️.</string>
     <string name="upgrade_screen_why_title">Privalumai</string>
     <string name="upgrade_screen_subscription_trial_action">Pradėti nemokamą 14 dienų bandomąjį laikotarpį</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Nepavyko prisijungti prie „Google Play“. Patikrinkite interneto ryšį ir bandykite dar kartą.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nepasiekiamas</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager negali prisijungti prie Google Play. Ar įdiegta ir atnaujinta Google Play? Ar esate prisijungę prie Google paskyros? Pabandykite išvalyti Google Play programėlės talpyklą ir paleisti iš naujo įrenginį.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nepavyko atidaryti „Google Play“. Jis gali būti nesuinstaliuotas, išjungtas arba apribotas šiame įrenginyje.</string>
     <string name="upgrades_no_purchases_found_check_account">Pirkimų nerasta. Ar naudojate tinkamą paskyrą?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Atnaujinimo parinktys</string>
+    <string name="upgrade_screen_offers_body">Abi parinktys atrakina tuos pačius Pro pranašumus — pasirinkite, kurie jums tinka.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Kainos neprieinamos</string>
+    <string name="upgrade_screen_offers_unavailable_message">Kainos negalėjo būti įkeltos šiuo metu. Patikrinkite „Google Play“ ir bandykite dar kartą po kurio laiko.</string>
+    <string name="upgrade_screen_benefits_body">• Neribota įrenginių skaičius\n• Pasirinktiniai ryšio veiksmai\n• Temos pritaikymas\n• Pažangūs garso valdymo nustatymai\n• Parama tolesnei plėtrai ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Metinė prenumerata</string>
+    <string name="upgrade_screen_subscription_offer_body">Prasideda nemokamu bandomuoju periodu, tada atsinaujina kasmet. Galite atšaukti bet kada per „Google Play“.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Atsinaujina kasmet. Galite atšaukti bet kada per „Google Play“.</string>
+    <string name="upgrade_screen_iap_offer_title">Amžinas atrakinimas</string>
+    <string name="upgrade_screen_iap_offer_body">Mokėkite vieną kartą ir turėkite Pro amžinai.</string>
+    <string name="upgrade_screen_owned_hero_title">Jūs esate Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Jūs turite %1$s amžinai.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Jūsų %1$s prenumerata yra aktyvi.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Jūsų prenumerata nėra nustatyta atsinaujinti, todėl dabar galite pereiti prie vienkartinio pirkinio. Atkreipkite dėmesį: tai atskiras mokestis, kuris nenutrauks ir negrąžins jūsų prenumeratos, todėl naudokite tą pačią „Google“ paskyrą abiem.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Pirmiausia atšaukite atsinaujinančią prenumeratą per „Google Play“, tada galite pereiti prie vienkartinio pirkinio.</string>
+    <string name="upgrade_screen_restore_body">Jau nusipirkote Pro šioje paskyroje? Paprašykite „Google Play“ dar kartą patikrinti jūsų pirkinius.</string>
+    <string name="upgrade_screen_restore_checked_message">Paprašėme „Google Play“ dar kartą patikrinti šios paskyros pirkinius ir jočių neradome.</string>
+    <string name="upgrade_screen_restore_contact_hint">Vis dar užstrigę? Susisiekite iš tos pačios „Google“ paskyros, su kuria pirkote, nurodykite savo „Google Play“ užsakymo numerį, ir mes tai išspręsime.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Nespėjome baigti tikrinimo su „Google Play“, todėl vis dar nežinome jūsų pirkinio būsenos — palaukite akimirką ir bandykite dar kartą.</string>
+    <string name="upgrades_gplay_billing_error_label">Pirkinio problema</string>
+    <string name="upgrades_gplay_billing_error_description">„Google Play“ pranešė apie problemą: %1$s. Bandykite dar kartą arba iš naujo paleiskite savo įrenginį.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Pasiūlymas neprieinamas</string>
+    <string name="upgrades_gplay_offer_unavailable_description">„Google Play“ šiuo metu nesiūlo šio elemento. Jis gali dar nebūti prieinamas jūsų paskyroje ar regione — bandykite dar kartą vėliau.</string>
 </resources>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name_upgraded">BSP Pro</string>
     <string name="app_name_upgrade_postfix">Pro</string>
     <string name="upgrade_badge_label">PRO</string>
     <string name="upgrade_feature_requires_pro">Nepieciešams BSP Pro</string>
     <string name="upgrade_prompt_title">Jaunināt uz BSP Pro</string>
     <string name="upgrade_prompt_body">Bluetooth skaļuma pārvaldnieks Pro piedāvā labākus rezultātus, vairāk funkciju un opciju sapļrotājiem lietotājiem.</string>
     <string name="upgrade_prompt_upgrade_action">Jaunināt</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Jaunināt uz %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth skaļuma pārvaldniekam nav reklāmu un tas nepardod lietotāju datus. Manu darbu finansiē jūs.</string>
     <string name="upgrade_screen_why_title">Priekšrocības</string>
     <string name="upgrade_screen_subscription_trial_action">Sāciet bezmaksas 14 dienu izmēģinājumu</string>
@@ -49,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Neizdevās izveidot savienojumu ar Google Play. Lūdzu, pārbaudi interneta savienojumu un mēģini vēlreiz.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nav pieejams</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth skaļuma pārvaldnieks nevar izveidot savienojumu ar Google Play. Vai Google Play ir instalēts un atjaunināts? Vai Google konts ir piezēmošanās? Mēģiniet notīrīt Google Play lietotnes kešatmiņu un pārstārtout ierīci.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nevarēja atvērt Google Play. Tas var nebūt instalēts, atspējots vai ierobežots šajā ierīcē.</string>
     <string name="upgrades_no_purchases_found_check_account">Pirkumi nav atrasti. Vai izmantojat pareizo kontu?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Jaunināšanas opcijas</string>
+    <string name="upgrade_screen_offers_body">Abas opcijas atbloķē tieši tās pašas Pro funkcijas — izvēlieties to, kas jums der.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Cenas nav pieejamas</string>
+    <string name="upgrade_screen_offers_unavailable_message">Cenas šobrīd nevarēja ielādēt. Pārbaudiet Google Play un mēģiniet vēlreiz pēc brīža.</string>
+    <string name="upgrade_screen_benefits_body">• Neierobežoti ierīces\n• Pielāgoti savienojuma darbības\n• Tēmas pielāgošana\n• Papildu skaļuma vadības iespējas\n• Atbalstīt turpmāko attīstību ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Gadīga abonēšana</string>
+    <string name="upgrade_screen_subscription_offer_body">Sākas ar bezmaksas izmēģinājumu, tad atjaunojas katru gadu. Jebkurā brīdī to varat atteikt no Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Atjaunojas katru gadu. Jebkurā brīdī to varat atteikt no Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Mūžīga atbloķēšana</string>
+    <string name="upgrade_screen_iap_offer_body">Maksājiet vienreiz un Pro būs jūsu uz mūžu.</string>
+    <string name="upgrade_screen_owned_hero_title">Jūs esat Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Jums pieder %1$s uz mūžu.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Jūsu %1$s abonēšana ir aktīva.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Jūsu abonēšana nav iestatīta atjaunošanai, tāpēc varat pārslēgties uz vienreizēju pirkumu tagad. Pievērsiet uzmanību: tā ir atsevišķa maksāšana, kas neatceļ vai neatgriezīs jūsu abonēšanu, tāpēc izmantojiet vienu un to pašu Google kontu abiem.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Vispirms atceliet savu atjaunojamo abonēšanu Google Play, pēc tam varat pārslēgties uz vienreizēju pirkumu.</string>
+    <string name="upgrade_screen_restore_body">Jau pirkāt Pro šajā kontā? Lūdziet Google Play pārbaudīt jūsu pirkumus.</string>
+    <string name="upgrade_screen_restore_checked_message">Mēs lūdzām Google Play pārbaudīt šī konta pirkumus un neatradām nevienu.</string>
+    <string name="upgrade_screen_restore_contact_hint">Joprojām iestrēgusi? Sazinieties no tā paša Google konta, ar kuro esat veikuši pirkumu, iekļaujiet Google Play pasūtījuma numuru, un mēs to sakārtosim.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Mēs nevarējām laicīgi pabeigt pārbaudi ar Google Play, tāpēc mēs vēl nezinām jūsu pirkuma statusu — gaidiet brīdi un mēģiniet vēlreiz.</string>
+    <string name="upgrades_gplay_billing_error_label">Pirkuma problēma</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ziņoja par problēmu: %1$s. Mēģiniet vēlreiz vēlāk vai restartējiet ierīci.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Piedāvājums nav pieejams</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play šobrīd nepiedāvāja šo vienumu. Tas var būt nepieejams jūsu kontam vai reģionam — lūdzu, mēģiniet vēlreiz vēlāk.</string>
 </resources>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Надгради на BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro нуди подобри резултати, повеќе функции и опции за напредни корисници.</string>
     <string name="upgrade_prompt_upgrade_action">Надградба</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Надградете на %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклами и не продава кориснички податоци. Мојата работа е финансирана од вас ❤️.</string>
     <string name="upgrade_screen_why_title">Предности</string>
     <string name="upgrade_screen_subscription_trial_action">Започнете бесплатен пробен период од 14 дена</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Не успеавме да се поврземе со Google Play. Проверете ја вашата интернет врска и обидете се повторно.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play не е достапен</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може да се поврзе со Google Play. Дали Google Play е инсталиран и ажуриран? Дали вашата Google сметка е најавена? Обидете се да ја исчистите кеш меморијата на апликацијата Google Play и рестартирајте го вашиот уред.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не можеше да се отвори Google Play. Може да е отсутно, деактивирано или ограничено на овој уред.</string>
     <string name="upgrades_no_purchases_found_check_account">Не се пронајдени купувања. Дали користите вистинска сметка?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Опции за надградба</string>
+    <string name="upgrade_screen_offers_body">Обете опции ви даваат исти Pro функции — одберите онаа која вам одговара.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Цени недостапни</string>
+    <string name="upgrade_screen_offers_unavailable_message">Цени не можеа да се вчитаат сега. Проверете Google Play и пробајте повторно за момент.</string>
+    <string name="upgrade_screen_benefits_body">• Неограничени уреди\n• Прилагодени акции за поврзување\n• Прилагодување на изглед\n• Напредни контроли за звук\n• Поддршка на развој ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Годишна претплата</string>
+    <string name="upgrade_screen_subscription_offer_body">Почнува со бесплатен пробен период, потоа се обновува годишно. Откажете во секој момент преку Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Се обновува годишно. Откажете во секој момент преку Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Доживотно одблокување</string>
+    <string name="upgrade_screen_iap_offer_body">Платете еднаш и владејте Pro заувек.</string>
+    <string name="upgrade_screen_owned_hero_title">Вие сте Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Владеете %1$s заувек.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Вашата %1$s претплата е активна.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Вашата претплата не е поставена да се обновува, така да можете да преминете на еднократна куповина сега. Забелешка: тоа е одделна наплата која нема да ја откаже или врати вашата претплата, затоа користете ја истата Google сметка за обе.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Прво откажете ја вашата претплата која се обновува преку Google Play, потоа можете да преминете на еднократна куповина.</string>
+    <string name="upgrade_screen_restore_body">Веќе купивте Pro на оваа сметка? Побарајте од Google Play да ги проверат вашите куповини повторно.</string>
+    <string name="upgrade_screen_restore_checked_message">Од Google Play побаравме да ги проверат куповините на оваа сметка повторно, но не најдовме ништо.</string>
+    <string name="upgrade_screen_restore_contact_hint">Се уште блокирани? Контактирајте нас од истата Google сметка со која купивте, вклучувајќи го вашиот број на нарачка од Google Play, и ќе го решиме.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Не можевме да ја завршиме проверката со Google Play на време, па сè уште не го знаеме статусот на вашата куповина — дајте еден момент и пробајте повторно.</string>
+    <string name="upgrades_gplay_billing_error_label">Проблем со куповина</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play пријави проблем: %1$s. Пробајте повторно подоцна или рестартирајте го вашиот уред.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Понуда недостапна</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play не ја нудеше оваа ставка сега. Можеби не е достапна за вашата сметка или регион сè уште — обидете се повторно подоцна.</string>
 </resources>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro മികക്കല് മിക്ക ഫലം, പവർ ഉപയോക്താക്കൾക്ക് കൂടുതൽ ഫീച്ചർം ഓപ്ഷനുകളും നൽകുന്നു.</string>
     <string name="upgrade_prompt_upgrade_action">അപ്ഗ്രേഡുചെയ്യുക</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s-ലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager പ്രജ്ഞാപനങ്ങൾ ഇല്ല, ഉപയോക്തൃ ഡേറ്റ വിൽക്കുന്നില്ല. എന്റെ ജോലി നിങ്ങൾ വഴി ധനസഹായം കിട്ടുന്നു ❤️.</string>
     <string name="upgrade_screen_why_title">പ്രയോജനങ്ങൾ</string>
     <string name="upgrade_screen_subscription_trial_action">സൗജന്യ 14-ദിവസ ട്രയൽ ആരംഭിക്കുക</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play ൽ ബന്ധപ്പെടാൻ കഴിഞ്ഞില്ല. ദയവായി നിങ്ങളുടെ ഇന്റർനെറ്റ് കണക്ഷൻ പരിശോധിക്കുകയും വീണ്ടും ശ്രമിക്കുകയും ചെയ്യുക.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ലഭ്യമല്ല</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ക്ക് Google Play യുമായ് ബന്ധപ്പെടാൻ കഴിയുന്നില്ല. Google Play ഇൻസ്റ്റൽ ചെയ്ത് അപ്ഡേറ്റ് ചെയ്തിട്ടുണ്ടോ? നിങ്ങളുടെ Google അക്കൗൺട് ലോഗിൻ ചെയ്തിട്ടുണ്ടോ? Google Play ആപ്പിന്റെ ക്യാഷ് മാർജിക്കുകയും ഉപകരണം രീബൂട്ട് ചെയ്യുകയും ശ്രമിക്കുക.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play തുറക്കാൻ കഴിഞ്ഞില്ല. ഈ ഉപകരണത്തിൽ ഇത് നഷ്ടപ്പെട്ടതോ നിഷ്ക്രിയമാക്കപ്പെട്ടതോ നിയന്ത്രിതമാക്കപ്പെട്ടതോ ആയിരിക്കാം.</string>
     <string name="upgrades_no_purchases_found_check_account">വാങ്ങലുകളൊന്നും കണ്ടെത്തിയില്ല. നിങ്ങൾ ശരിയായ അക്കൗണ്ട് തന്നെയാണോ ഉപയോഗിക്കുന്നത്?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">അപ്ഗ്രേഡ് ഐച്ഛികതകൾ</string>
+    <string name="upgrade_screen_offers_body">രണ്ട് ഐച്ഛികതകളും ഒരേപോലെ Pro സവിശേഷതകൾ അൺലോക്ക് ചെയ്യുന്നു — നിങ്ങൾക്ക് ഇഷ്ടപ്പെട്ടത് തിരഞ്ഞെടുക്കുക.</string>
+    <string name="upgrade_screen_offers_unavailable_title">വിലകൾ ലഭ്യമല്ല</string>
+    <string name="upgrade_screen_offers_unavailable_message">വിലകൾ ഇപ്പോൾ ലോഡ് ചെയ്യാൻ കഴിഞ്ഞില്ല. Google Play പരിശോധിക്കുക നിന്നും ഒരു നിമിഷത്തിൽ വീണ്ടും ശ്രമിക്കുക.</string>
+    <string name="upgrade_screen_benefits_body">• പരിധിയില്ലാത്ത ഡിവൈസുകൾ\n• കസ്റ്റം കണക്ഷൻ പ്രവർത്തനങ്ങൾ\n• തീം അനുകൂലീകരണം\n• വിപുലമായ വോളിയം നിയന്ത്രണങ്ങൾ\n• ഭാവിഷ്യത്തിന്റെ വികസനം പിന്തുണയ്ക്കുക ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">വാർഷിക സബ്സ്ക്രിപ്ഷൻ</string>
+    <string name="upgrade_screen_subscription_offer_body">സ്വതന്ത്ര പരീക്ഷണം ഉപയോഗിച്ച് ആരംഭിക്കുന്നു, പിന്നീട് വർഷത്തിലൊരിക്കൽ പുതുക്കുന്നു. Google Play-ൽ എപ്പോൾ വേണ്ടലും റദ്ദ് ചെയ്യുക.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">വർഷത്തിലൊരിക്കൽ പുതുക്കുന്നു. Google Play-ൽ എപ്പോൾ വേണ്ടലും റദ്ദ് ചെയ്യുക.</string>
+    <string name="upgrade_screen_iap_offer_title">ജീവിതകാല അൺലോക്ക്</string>
+    <string name="upgrade_screen_iap_offer_body">ഒരിക്കൽ നൽകുക നിന്നും Pro നിരന്തരം സ്വാധീനിക്കുക.</string>
+    <string name="upgrade_screen_owned_hero_title">നിങ്ങൾ Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">നിങ്ങൾ %1$s നിരന്തരം ഉടമകളാണ്.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">നിങ്ങളുടെ %1$s സബ്സ്ക്രിപ്ഷൻ സജീവമാണ്.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ പുതുക്കുന്നതിനായി സജ്ജീകരിച്ചിട്ടില്ല, അതിനാൽ നിങ്ങൾ ഇപ്പോൾ ഒരിക്കൽ വാങ്ങലിലേക്ക് മാറാൻ കഴിയും. ശ്രദ്ധിക്കുക: ഇത് ഒരു വ്യത്യസ്ത ചാർജ് ആണ് അത് നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ റദ്ദ് അല്ലെങ്കിൽ വിനിയോഗം ചെയ്യില്ല, അതിനാൽ രണ്ടിനും ഒരേ Google അക്കൗണ്ട് ഉപയോഗിക്കുക.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">ആദ്യം Google Play-ൽ നിങ്ങളുടെ പുതുക്കുന്ന സബ്സ്ക്രിപ്ഷൻ റദ്ദ് ചെയ്യുക, പിന്നീട് നിങ്ങൾ ഒരിക്കൽ വാങ്ങലിലേക്ക് മാറാൻ കഴിയും.</string>
+    <string name="upgrade_screen_restore_body">ഈ അക്കൗണ്ടിൽ ഇതിനകം Pro വാങ്ങിയിട്ടുണ്ടോ? Google Play-നോട് നിങ്ങളുടെ വാങ്ങലുകൾ വീണ്ടും പരിശോധിക്കാൻ ആവശ്യപ്പെടുക.</string>
+    <string name="upgrade_screen_restore_checked_message">ഈ അക്കൗണ്ടിന്റെ വാങ്ങലുകൾ വീണ്ടും പരിശോധിക്കാൻ ഞങ്ങൾ Google Play-നോട് ആവശ്യപ്പെട്ടെങ്കിലും ഒന്നും കണ്ടെത്തിയില്ല.</string>
+    <string name="upgrade_screen_restore_contact_hint">ഇപ്പോഴും കുടുങ്ങിയിരിക്കുന്നോ? നിങ്ങൾ വാങ്ങിയ ഒരേ Google അക്കൗണ്ടിൽ നിന്ന് ഞങ്ങളെ ബന്ധപ്പെടുക, നിങ്ങളുടെ Google Play ഓർഡർ നമ്പർ ഉൾപ്പെടുത്തുക, ഞങ്ങൾ അത് പരിഹരിക്കും.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">ഞങ്ങൾ സമയത്തിൽ Google Play ഉപയോഗിച്ച് പരിശോധന പൂർത്തിയാക്കാൻ കഴിഞ്ഞില്ല, അതിനാൽ ഞങ്ങൾ ഇപ്പോഴും നിങ്ങളുടെ വാങ്ങൽ സ്ഥിതി അറിയിക്കുന്നില്ല — ഒരു നിമിഷം കാത്തിരിക്കുക നിന്നും വീണ്ടും ശ്രമിക്കുക.</string>
+    <string name="upgrades_gplay_billing_error_label">വാങ്ങൽ പ്രശ്നം</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ഒരു പ്രശ്നം റിപ്പോർട്ട് ചെയ്തു: %1$s. പിന്നീട് വീണ്ടും ശ്രമിക്കുക അല്ലെങ്കിൽ നിങ്ങളുടെ ഡിവൈസ് പുനരാരംഭിക്കുക.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ഓഫർ ലഭ്യമല്ല</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ഇപ്പോൾ ഈ ഇനം വാഗ്ദാനം ചെയ്തില്ല. ഇത് നിങ്ങളുടെ അക്കൗണ്ടിനോ മേഖലയ്ക്കോ ഇതിനകം ലഭ്യമായിരിക്കണമെന്നില്ല — ദയവായി പിന്നീട് വീണ്ടും ശ്രമിക്കുക.</string>
 </resources>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro рүү шилжээх</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro илүү үр дүн, илүү онцлог ба шинжлэх хэрэглэгчиддүгээр илүү сонголтыг саналддаг.</string>
     <string name="upgrade_prompt_upgrade_action">Сайжруулах</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s рүү шаруулах</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager сурталчилгаагүй бөгөөд хэрэглэгчийн өгөгдлийг зардаггүй. Миний ажиллыг та нараар санхүүжнэ ❤️.</string>
     <string name="upgrade_screen_why_title">Давуу талууд</string>
     <string name="upgrade_screen_subscription_trial_action">14 хоногийн үнэ төлбөргүй туршилт эхлүүлэх</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play-д холбогдох боломжгүй. Интернет холболтоо шалгаж, дахин оролдоно уу.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play боломжгүй байна</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play-тай холбогдож чадахгүй байна. Google Play суулгагдсан бөгөөд шинэчлэлтсэн уу? Google хаднаа нэвтрээсэн байна уу? Google Play аппын кэшийг арилгаад төхөөрөмжийгеэ дахин ньюцлаарай.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play-г нээх боломжгүй байна. Энэ төхөөрөмжид байхгүй, идэвхгүй эсвэл хязгаарлагдсан байж болно.</string>
     <string name="upgrades_no_purchases_found_check_account">Худалдан авалт олдсонгүй. Та зөв бүртгэл ашиглаж байна уу?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Шаруулах сонголтууд</string>
+    <string name="upgrade_screen_offers_body">Хоёр сонголт нь яг адилхан Pro функцүүдийг нээдэг — танд тохирохыг сонгоно уу.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Үнэ боломжгүй</string>
+    <string name="upgrade_screen_offers_unavailable_message">Үнэ одоо ачаалж чадсонгүй. Google Play дээр шалгаж, дараа нь дахин оролдоно уу.</string>
+    <string name="upgrade_screen_benefits_body">• Хязгааргүй төхөөрөмж\n• Өөрчлөлттэй холболтын үйлдэл\n• Сэдвийн өөрчлөлт\n• Дэвшилтэт эзлэхүүнийг удирдах\n• Ирээдүйн хөгжүүлэлтийг дэмжих ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Жилийн захиалга</string>
+    <string name="upgrade_screen_subscription_offer_body">Үнэгүй туршилтаас эхлээд жил бүр сэргээгдэнэ. Google Play-ээс ямар ч үед цуцлаж болно.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Жил бүр сэргээгдэнэ. Google Play-ээс ямар ч үед цуцлаж болно.</string>
+    <string name="upgrade_screen_iap_offer_title">Бүх нас болгоны түлхүүц задлах</string>
+    <string name="upgrade_screen_iap_offer_body">Нэг удаа төлөөд Pro-г бүх нас болгоны эзэмших.</string>
+    <string name="upgrade_screen_owned_hero_title">Та Pro байна! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Та %1$s-г бүх нас болгоны эзэмшинэ.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Таны %1$s захиалга идэвхтэй байна.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Таны захиалга сэргээгдэхийн тулд тогтоогдоогүй байгаа тул одоо нэг удаа худалдаж авахад шилжүүлж болно. Анхааруулга: энэ нь таны захиалгыг цуцлахгүй эсвэл буцаан олгохгүй тусдаа төлбөр байгаа тул хоёуланд нь ижил Google данс ашигла.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Эхлээд Google Play-ээс таны сэргээгдэх захиалгыг цуцлаж, дараа нь нэг удаа худалдаж авахад шилжүүлж болно.</string>
+    <string name="upgrade_screen_restore_body">Энэ дансанд аль хэдийн Pro авсан уу? Google Play-ээс та худалдан авалтаа дахин шалгахыг хүс.</string>
+    <string name="upgrade_screen_restore_checked_message">Бид Google Play-ээс энэ дансанд худалдан авалт байгаа эсэхийг дахин шалгахыг хүсэж, олсонгүй.</string>
+    <string name="upgrade_screen_restore_contact_hint">Хэрэн цаашид асуудалтай уу? Та худалдан авалт хийсэн ижил Google данс дээр биднэтэй холбоо барь, Google Play захиалгын дугаараа оруулж, бид үүнийг шийдүүлнэ.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Бид Google Play-тэй цаг хугацааны дотор шалгалтыг дуусгаж чадаагүй, тул таны худалдан авалтын статус үл мэдэгдэх байна — түр хүлээтэл дахин оролдоно уу.</string>
+    <string name="upgrades_gplay_billing_error_label">Худалдан авалтын асуудал</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play асуудлыг мэдээлэв: %1$s. Дараа нь дахин оролдоно уу эсвэл таны төхөөрөмжийг дахин идэвхжүүлнэ үү.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Санал боломжгүй</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play энэ товчийг одоо санал болгосонгүй. Энэ нь та болон та оршин сууцаж буй бүсэд бэлэн биш байж болно — дараа нь дахин оролдоно уу.</string>
 </resources>

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro वर अपग्रेड करा</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro शक्तिशाली वापरकर्त्यांसाठी चांगले परिणाम, अधिक वैशिष्ट्ये आणि पर्याय देते.</string>
     <string name="upgrade_prompt_upgrade_action">अपग्रेड करा</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s वर अपग्रेड करा</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ला कोणतीही अॅड नाही आणि वापरकर्त्यांचा डेटा विकत नाही. माझे काम तुम्ही उचलवून अर्थपुरवठा केलेली आहे ❤️.</string>
     <string name="upgrade_screen_why_title">फायदे</string>
     <string name="upgrade_screen_subscription_trial_action">मोफत 14-दिवसांची चाचणी सुरू करा</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play शी जोडणे अशक्य. कृपया आपले इंटरनेट कनेक्शन तपासा आणि पुन्हा प्रयत्न करा.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play उपलब्ध नाही</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play शी कनेक्ट करू शकत नाही. Google Play इन्स्टॉल आणि अपडेट आहे का? तुमचे Google खाते लॉग इन आहे का? Google Play अॅपचा कॅश साफ करण्याचा आणि डिव्हाइस रीबूट करण्याचा प्रयत्न करा.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">गूगल प्ले खोलू शकलो नाही. हे या डिव्हाइसवर गहाळ, अक्षम किंवा प्रतिबंधित असू शकते.</string>
     <string name="upgrades_no_purchases_found_check_account">कोणतीही खरेदी आढळली नाही. तुम्ही योग्य खाते वापरत आहात का?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">अपग्रेड पर्याय</string>
+    <string name="upgrade_screen_offers_body">दोन्ही पर्याय समान Pro वैशिष्ट्ये अनलॉक करतात — जो तुम्हाला योग्य वाटतो तो निवडा.</string>
+    <string name="upgrade_screen_offers_unavailable_title">किंमत उपलब्ध नाही</string>
+    <string name="upgrade_screen_offers_unavailable_message">किंमत आत्ता लोड केली जाऊ शकली नाही. Google Play तपासा आणि थोड्या वेळात पुन्हा प्रयत्न करा.</string>
+    <string name="upgrade_screen_benefits_body">• असीम डिव्हाइस\n• कस्टम कनेक्शन क्रिया\n• थीम कस्टमाइजेशन\n• उन्नत व्हॉल्यूम नियंत्रण\n• भविष्य विकासाचे समर्थन ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">वार्षिक सदस्यता</string>
+    <string name="upgrade_screen_subscription_offer_body">मुक्त चाचणीसह सुरू होते, नंतर वार्षिक नवीनीकरण होते. Google Play मध्ये कधीही रद्द करा.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">वार्षिक नवीनीकरण होते. Google Play मध्ये कधीही रद्द करा.</string>
+    <string name="upgrade_screen_iap_offer_title">आजीवन अनलॉक</string>
+    <string name="upgrade_screen_iap_offer_body">एकदा देय द्या, Pro चिरकाळ आपला होईल.</string>
+    <string name="upgrade_screen_owned_hero_title">तुम्ही Pro आहात! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">तुम्ही %1$s चिरकाळ मालकीचे आहात.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">तुमची %1$s सदस्यता सक्रिय आहे.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">तुमची सदस्यता नवीनीकरणासाठी सेट केलेली नाही, म्हणून तुम्ही आता एकस्व खरेदीवर स्विच करू शकता. सूचना: हे एक वेगळे शुल्क आहे जे तुमची सदस्यता रद्द किंवा परत करणार नाही, त्यामुळे दोन्हीसाठी समान Google खाते वापरा.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">प्रथम Google Play मध्ये तुमची नवीनीकरण सदस्यता रद्द करा, नंतर तुम्ही एकस्व खरेदीवर स्विच करू शकता.</string>
+    <string name="upgrade_screen_restore_body">या खात्यावर आधीच Pro खरेदी केला? Google Play ला तुमची खरेदी पुन्हा तपासण्यास सांगा.</string>
+    <string name="upgrade_screen_restore_checked_message">आम्ही Google Play ला या खात्याची खरेदी पुन्हा तपासण्यास सांगितले पण एक आढळले नाही.</string>
+    <string name="upgrade_screen_restore_contact_hint">अजूनही अडकले? तुम्ही ज्या Google खात्यातून खरेदी केली त्यातून संपर्क करा, तुमचा Google Play ऑर्डर क्रमांक समाविष्ट करा, आणि आम्ही याचे निराकरण करू.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">आम्ही वेळेत Google Play सह तपासणी पूर्ण करू शकलो नाही, म्हणून आम्हाला अजूनही तुमची खरेदी स्थिती माहित नाही — एक क्षण द्या आणि पुन्हा प्रयत्न करा.</string>
+    <string name="upgrades_gplay_billing_error_label">खरेदी समस्या</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ने समस्या नोंद केली: %1$s. नंतर पुन्हा प्रयत्न करा किंवा तुमची डिव्हाइस पुन्हा सुरू करा.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ऑफर उपलब्ध नाही</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ने हे आयटम आत्ता ऑफर केले नाही. हे तुमच्या खात्यासाठी किंवा प्रदेशासाठी अजून उपलब्ध नसू शकते — कृपया नंतर पुन्हा प्रयत्न करा.</string>
 </resources>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Naik taraf ke BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro menawarkan hasil yang lebih baik, lebih banyak ciri dan pilihan untuk pengguna berkuasa.</string>
     <string name="upgrade_prompt_upgrade_action">Naik taraf</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Tingkatkan kepada %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tiada iklan dan tidak menjual data pengguna. Kerja saya dibiayai oleh anda ❤️.</string>
     <string name="upgrade_screen_why_title">Kelebihan</string>
     <string name="upgrade_screen_subscription_trial_action">Mulakan percubaan 14 hari percuma</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Tidak dapat menyambung ke Google Play. Sila periksa sambungan internet anda dan cuba semula.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play tidak tersedia</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager tidak dapat menyambung ke Google Play. Adakah Google Play dipasang dan dikemaskini? Adakah Akaun Google anda log masuk? Cuba kosongkan cache aplikasi Google Play dan but semula peranti anda.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Tidak dapat membuka Google Play. Ia mungkin tiada, dimatikan, atau dibatasi di peranti ini.</string>
     <string name="upgrades_no_purchases_found_check_account">Tiada pembelian ditemui. Adakah anda menggunakan akaun yang betul?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Pilihan peningkatan</string>
+    <string name="upgrade_screen_offers_body">Kedua-dua pilihan membuka fitur Pro yang sama — pilih yang paling sesuai untuk anda.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Harga tidak tersedia</string>
+    <string name="upgrade_screen_offers_unavailable_message">Harga tidak dapat dimuat sekarang. Semak Google Play dan cuba lagi sebentar lagi.</string>
+    <string name="upgrade_screen_benefits_body">• Peranti tanpa had\n• Tindakan sambungan khusus\n• Penyesuaian tema\n• Kawalan volum maju\n• Sokongan pembangunan masa depan ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Langganan tahunan</string>
+    <string name="upgrade_screen_subscription_offer_body">Bermula dengan percubaan percuma, kemudian diperbaharui setiap tahun. Batalkan pada bila-bila masa di Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Diperbaharui setiap tahun. Batalkan pada bila-bila masa di Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Pembukaan seumur hidup</string>
+    <string name="upgrade_screen_iap_offer_body">Bayar sekali dan miliki Pro selamanya.</string>
+    <string name="upgrade_screen_owned_hero_title">Anda Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Anda memiliki %1$s selamanya.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Langganan %1$s anda aktif.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Langganan anda tidak ditetapkan untuk memperbaharui, jadi anda boleh beralih ke pembelian sekali sahaja sekarang. Perhatian: ia adalah caj berasingan yang tidak akan membatalkan atau mengembalikan wang langganan anda, gunakan akaun Google yang sama untuk kedua-duanya.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Batalkan langganan yang memperbaharui di Google Play terlebih dahulu, kemudian anda boleh beralih ke pembelian sekali sahaja.</string>
+    <string name="upgrade_screen_restore_body">Sudah membeli Pro di akaun ini? Minta Google Play untuk menyemak semula pembelian anda.</string>
+    <string name="upgrade_screen_restore_checked_message">Kami meminta Google Play untuk menyemak semula pembelian akaun ini dan tidak menemukan satu pun.</string>
+    <string name="upgrade_screen_restore_contact_hint">Masih terjebak? Hubungi kami menggunakan akaun Google yang sama yang anda gunakan untuk membeli, sertakan nombor pesanan Google Play anda, dan kami akan menyelesaikannya.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Kami tidak dapat menyelesaikan pemeriksaan dengan Google Play tepat pada masanya, jadi kami masih tidak tahu status pembelian anda — tunggu sebentar dan cuba lagi.</string>
+    <string name="upgrades_gplay_billing_error_label">Masalah pembelian</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play melaporkan masalah: %1$s. Cuba lagi nanti atau mulai semula peranti anda.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Tawaran tidak tersedia</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play tidak menawarkan item ini sekarang. Ia mungkin belum tersedia untuk akaun atau wilayah anda — sila cuba lagi nanti.</string>
 </resources>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro သို့ အဆင့်မြှင့်ပါ</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro သည် ပိုမိုကောင်းမွန်သော ရလဒ်များ၊ ပိုမိုများပြားသော လုပ်ဆောင်ချက်များနှင့် ကျွမ်းကျင်အသုံးပြုသူများအတွက် ရွေးချယ်စရာများကို ပေးပါသည်။</string>
     <string name="upgrade_prompt_upgrade_action">အဆင့်မြှင့်ပါ</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s သို့ အဆင့်မြှင့်တင်ပါ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager တွင် ကြော်ငြာများမရှိပါ၊ အသုံးပြုသူဒေတာများကိုလည်း မရောင်းချပါ။ ကျွန်ုပ်၏အလုပ်ကို သင်မှ ငွေကြေးထောက်ပံ့ထားပါသည် ❤️။</string>
     <string name="upgrade_screen_why_title">အကျိုးကျေးဇူးများ</string>
     <string name="upgrade_screen_subscription_trial_action">၁၄ ရက် အခမဲ့အစမ်းသုံးခြင်း စတင်မည်</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play သို့ချိတ်ဆက်၏မရနိုင်ပါ။ သင်၏အင််ဂာရပ်ချိတ်ဆက်မှုကိုစုံစမ်းပြီးထပ်မံစမ်းသပ်ကြည့်ပါ။</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play မရရှိနိုင်ပါ</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager မှ Google Play သို့ ချိတ်ဆက်၍မရပါ။ Google Play ထည့်သွင်းပြီး နောက်ဆုံးဗားရှင်းဖြစ်ပါသလား? သင်၏ Google အကောင့် ဝင်ရောက်ထားပါသလား? Google Play အက်ပ်၏ cache ကိုရှင်းလင်းပြီး ကိရိယာကိုပြန်လည်စတင်ကြည့်ပါ။</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play ကို မဖွင့်နိုင်ခဲ့ပါ။ ယင်းသည် ဤကိရိယာ ပေါ်တွင် မရှိခြင်း၊ ပိတ်ထားခြင်း သို့မဟုတ် ကန့်သတ်ထားခြင်း ရှိနိုင်ပါသည်။</string>
     <string name="upgrades_no_purchases_found_check_account">ဝယ်ယူမှုများ ရှာမတွေ့ပါ။ မှန်ကန်သော အကောင့်ကို အသုံးပြုနေပါသလား။</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">အဆင့်မြှင့်တင်ခြင်းရွေးချယ်မှုများ</string>
+    <string name="upgrade_screen_offers_body">ရွေးချယ်မှုနှစ်ခုစလုံးသည် အတူတူ Pro သွင်သတ္တာများကို သုံးစွဲနိုင်စေသည် — သင့်လျှောက်တွင်ရှိသည့်အရာ ရွေးချယ်ပါ။</string>
+    <string name="upgrade_screen_offers_unavailable_title">စျေးနှုန်းများမရှိပါ</string>
+    <string name="upgrade_screen_offers_unavailable_message">စျေးနှုန်းများကို ယခုအခါ အားပြုပါခွင့်မရခဲ့သည်။ Google Play ကို စစ်ဆေးပြီး အခြိန်အနည်းငယ်အတွင်း ထပ်မံစမ်းသုံးပါ။</string>
+    <string name="upgrade_screen_benefits_body">• အကန့်အသတ်မရှိသော စက်ပစ္စည်းများ\n• စိတ်ကြိုက်ချိတ်ဆက်မှု လုပ်ဆောင်ချက်များ\n• ပုံစံအင်္ဂါ စိတ်ကြိုက်ပြင်ဆင်ခြင်း\n• အဆင့်မြင့်အသံအတိုးအကျယ်ထိန်းချုပ်မှုများ\n• အနာဂတ် ထုတ်ပြန်မှု ထောက်ခံခြင်း ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">နှစ်စဉ်စာရင်းသွင်း</string>
+    <string name="upgrade_screen_subscription_offer_body">အခမဲ့စမ်းသုံးခွင်မှ စတင်လည်ပတ်ပြီး နှစ်စဉ်သုံးဆောင်းခွင်။ Google Play တွင် အချိန်မည်သည့်အခါမျိုးတွင် ပယ်ဖျက်နိုင်ပါသည်။</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">နှစ်စဉ်သုံးဆောင်းခွင်။ Google Play တွင် အချိန်မည်သည့်အခါမျိုးတွင် ပယ်ဖျက်နိုင်ပါသည်။</string>
+    <string name="upgrade_screen_iap_offer_title">အစဉ်အမြဲဖွင့်လှစ်ခြင်း</string>
+    <string name="upgrade_screen_iap_offer_body">တစ်ကြိမ်ငွေချေ ပြီး Pro ကို အစဉ်အမြဲ ပိုင်ဆိုင်ပါ။</string>
+    <string name="upgrade_screen_owned_hero_title">သင်သည် Pro ဖြစ်ပါသည်။ ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">သင်သည် %1$s ကို အစဉ်အမြဲ ပိုင်ဆိုင်ပါသည်။</string>
+    <string name="upgrade_screen_owned_hero_sub_body">သင်၏ %1$s စာရင်းသွင်းမှု ရှင်သန်လျက်ရှိပါသည်။</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">သင်၏စာရင်းသွင်းမှု သုံးဆောင်းရန် သတ်မှတ်မထားသောကြောင့် သုံးဆောင်းခွင်တစ်ကြိမ်သို့ သင်ပြောင်းလဲနိုင်ပါသည်။ သတိပေးချက်- ၎င်းသည် သင်၏စာရင်းသွင်းမှုကို ပယ်ဖျက်ခြင်း သို့မဟုတ် ငွေပြန်အခ်င်းမပေးသည့် သီးခြားငွေချေခြင်းဖြစ်သောကြောင့် နှစ်ခုစလုံးအတွက် တူညီသော Google အကောင့်ကို အသုံးပြုပါ။</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Google Play တွင် သုံးဆောင်းမည်ဖြစ်သည့် သင်၏စာရင်းသွင်းမှုကို ကြိုးစီးပင်ပယ်ဖျက်ပါ၊ ထို့နောက် သုံးဆောင်းခွင်တစ်ကြိမ်သို့ သင်ပြောင်းလဲနိုင်ပါသည်။</string>
+    <string name="upgrade_screen_restore_body">ဤအကောင့်တွင် Pro ကို အသုံးပြုထားပြီးပါလား။ သင်၏ဝယ်ယူမှုများကို ထပ်မံစစ်ဆေးရန် Google Play ကို တောင်းဆိုပါ။</string>
+    <string name="upgrade_screen_restore_checked_message">ကျွန်ုပ်တို့သည် Google Play ကို ဤအကောင့်၏ဝယ်ယူမှုများကို ထပ်မံစစ်ဆေးရန် တောင်းဆိုခဲ့သည်သော်လည်း မတွေ့ရှိခဲ့ပါ။</string>
+    <string name="upgrade_screen_restore_contact_hint">အဆင်မပြေရဲပါလား။ သင်ဝယ်ယူသည့်တူညီသော Google အကောင့်မှ ကျွန်ုပ်တို့ထံ ဆက်သွယ်ပြီး သင်၏ Google Play အမှာစာနံပါတ်ကို ထည့်သွင်းပါ၊ ထို့ကြောင့် ကျွန်ုပ်တို့သည် ၎င်းကို ဖြေရှင်းပေးပါ့မည်။</string>
+    <string name="upgrade_screen_restore_inconclusive_message">ကျွန်ုပ်တို့သည် Google Play ဖြင့် အချိန်မှီ စစ်ဆေးခြင်းကို ပြီးမြောက်နိုင်ခြင်းမရှိသောကြောင့်၊ ကျွန်ုပ်တို့သည် သင်၏ဝယ်ယူမှုအခြေအနေကို အခြိုးမသိသေးပါ — ခဏစောင့်ထားပြီး ထပ်မံစမ်းသုံးပါ။</string>
+    <string name="upgrades_gplay_billing_error_label">ဝယ်ယူမှုပြဿနာ</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play သည် ပြဿနာတစ်ခုကို အစီရင်ခံခဲ့သည်- %1$s။ နောက်ပိုင်းတွင် ထပ်မံစမ်းသုံးပြီး သို့မဟုတ် သင်၏စက်ပစ္စည်းကို စတင်လည်ပတ်ပါ။</string>
+    <string name="upgrades_gplay_offer_unavailable_title">အခွင်လျှောက်ကြောင်းမရှိ</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play သည် ယခုအခါ ဤပစ္စည်းကို အခွင်လျှောက်ကြောင်းမပေးသည်။ ၎င်းသည် သင်၏အကောင့် သို့မဟုတ် ဒေသအတွက် အဆင်မပြေသေးရှိနိုင်ပါ — နောက်ပိုင်းတွင် စမ်းသုံးပါ။</string>
 </resources>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro मा अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ले शक्तिशाली प्रयोगकर्ताहरूका लागि राम्रो परिणाम, थप फिचरहरू र विकल्पहरू प्रदान गर्दछ।</string>
     <string name="upgrade_prompt_upgrade_action">अपग्रेड गर्नुहोस्</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s मा अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager मा कुनै विज्ञापन छैन र यसले प्रयोगकर्ताको डेटा बাंड्दैन। मेरो काम तपाईंले गर्नुभएको आर्थिक सहयोगबाट चलिरहेको छ ❤️।</string>
     <string name="upgrade_screen_why_title">फाइदाहरू</string>
     <string name="upgrade_screen_subscription_trial_action">14-दिनको निःशुल्क परीक्षण सुरु गर्नुहोस्</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play मा जडान गर्न सक्नु भएन। कृपया आफ्नो इन्टरनेट जडान जाँच गर्नुहोस् र फेरि प्रयास गर्नुहोस्।</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play उपलब्ध छैन</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play मा जोडिन सक्दैन। क्षमा गर्नुहोस्, Google Play स्थापित र अद्यतन छ? तपाईंको Google खाता लग इन गरिएको छ? Google Play अ्यापको क्यास साफ गर्नुहोस् र आफ्नो यन्त्र पुनःसुरू गर्नुहोस्।</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">गूगल प्ले खोल्न सकिएन। यो यस डिभाइसमा हराएको, अक्षम गरिएको वा प्रतिबन्धित हो सक्छ।</string>
     <string name="upgrades_no_purchases_found_check_account">कुनै खरिदहरू फेला परेनन्। के तपाईं सही खाता प्रयोग गर्दै हुनुहुन्छ?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">अपग्रेड विकल्पहरू</string>
+    <string name="upgrade_screen_offers_body">दोनै विकल्पले एक जस्तै Pro सुविधाहरू अनलक गर्छन् — आफूलाई सहि जो कुनै छनोट गर्नुहोस्।</string>
+    <string name="upgrade_screen_offers_unavailable_title">मूल्यहरू उपलब्ध छैन</string>
+    <string name="upgrade_screen_offers_unavailable_message">मूल्यहरू अहिले लोड गर्न सकेनन्। Google Play जाँच गर्नुहोस् र एक पल मा फेरि प्रयास गर्नुहोस्।</string>
+    <string name="upgrade_screen_benefits_body">• असीमित उपकरणहरू\n• अनुकूल जडान कार्यहरू\n• विषयवस्तु अनुकूलन\n• उन्नत भलिउम नियन्त्रण\n• भविष्य विकास समर्थन ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">वार्षिक सदस्यता</string>
+    <string name="upgrade_screen_subscription_offer_body">नि: शुल्क परीक्षणबाट सुरु हुन्छ, त्यसपछि वार्षिक नवीनीकरण हुन्छ। Google Play मा कुनै पनि समयमा रद्द गर्नुहोस्।</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">वार्षिक नवीनीकरण हुन्छ। Google Play मा कुनै पनि समयमा रद्द गर्नुहोस्।</string>
+    <string name="upgrade_screen_iap_offer_title">आजीवन अनलक</string>
+    <string name="upgrade_screen_iap_offer_body">एक पटक भुक्तानी गर्नुहोस् र Pro सदैव आफ्नो बनाउनुहोस्।</string>
+    <string name="upgrade_screen_owned_hero_title">तपाई Pro हुनुहुन्छु! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">तपाई %1$s सदैव आफ्नो बनाउनुहुन्छु।</string>
+    <string name="upgrade_screen_owned_hero_sub_body">आपको %1$s सदस्यता सक्रिय छ।</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">आपको सदस्यता नवीनीकरणको लागि सेट गरिएको छैन, त्सैले तपाई अब एक पटकको खरीदमा स्विच गर्न सक्नुहुन्छु। ध्यान दिनुहोस्: यो अलग शुल्क हो जसले आपको सदस्यता रद्द वा फिर्ता नदिइ, दुबैको लागि एक जस्तै Google खाता प्रयोग गर्नुहोस्।</string>
+    <string name="upgrade_screen_owned_iap_locked_note">पहिले Google Play मा आपको नवीनीकरण हुने सदस्यता रद्द गर्नुहोस्, त्यसपछि तपाई एक पटकको खरीदमा स्विच गर्न सक्नुहुन्छु।</string>
+    <string name="upgrade_screen_restore_body">यो खातामा पहिले Pro किनिएको छ? Google Play लाई आपको खरीदहरू पुनः जाँच गर्न सोध्नुहोस्।</string>
+    <string name="upgrade_screen_restore_checked_message">हामीले Google Play लाई यो खातार खरीदहरू पुनः जाँच गर्न सोधेका छौं र कुनै नभेट्टाएका छौं।</string>
+    <string name="upgrade_screen_restore_contact_hint">अझै अलमल छ? जो Google खातासबाट खरीद गर्नुभएको थियो त्यहीबाट सम्पर्क गर्नुहोस्, आपको Google Play अर्डर नम्बर समावेश गर्नुहोस्, र हामी सबै व्यवस्थापन गर्नेछौं।</string>
+    <string name="upgrade_screen_restore_inconclusive_message">हामी समयमा Google Play संग जाँच पूरा गर्न सकेनौं, त्सैले हामी अझै तपाईको खरीद स्थिति थाहा पाएनौं — एक पल दिनुहोस् र फेरि प्रयास गर्नुहोस्।</string>
+    <string name="upgrades_gplay_billing_error_label">खरीद समस्या</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ले समस्या रिपोर्ट गरेको छ: %1$s। पछि अर्को पटक प्रयास गर्नुहोस् वा आपको उपकरण पुनः सुरु गर्नुहोस्।</string>
+    <string name="upgrades_gplay_offer_unavailable_title">अफर उपलब्ध छैन</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ले यो वस्तु अहिले अफर गरेको छैन। यो आपको खाता वा क्षेत्रको लागि अभी उपलब्ध नहुन सक्छ — कृपया पछि फेरि प्रयास गर्नुहोस्।</string>
 </resources>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Upgrade naar BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro biedt betere resultaten, meer functies en opties voor hoofdgebruikers.</string>
     <string name="upgrade_prompt_upgrade_action">Upgraden</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Upgrade naar %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager bevat geen advertenties en verkoopt geen gebruikersgegevens. Mijn werk wordt door jou gefinancierd ❤️.</string>
     <string name="upgrade_screen_why_title">Voordelen</string>
     <string name="upgrade_screen_subscription_trial_action">Start gratis proefperiode van 14 dagen</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Kan geen verbinding maken met Google Play. Controleer je internetverbinding en probeer het opnieuw.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play is niet beschikbaar</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan geen verbinding maken met Google Play. Is Google Play geïnstalleerd en up-to-date? Is je Google-account ingelogd? Probeer de cache van de Google Play-app te wissen en je apparaat opnieuw op te starten.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kon Google Play niet openen. Het kan zijn dat het ontbreekt, is uitgeschakeld of beperkt is op dit apparaat.</string>
     <string name="upgrades_no_purchases_found_check_account">Geen aankopen gevonden. Gebruik je de juiste rekening?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Upgrade-opties</string>
+    <string name="upgrade_screen_offers_body">Beide opties ontgrendelen exact dezelfde Pro-functies — kies wat het beste voor je past.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prijzen niet beschikbaar</string>
+    <string name="upgrade_screen_offers_unavailable_message">Prijzen konden nu niet worden geladen. Controleer Google Play en probeer het over een moment opnieuw.</string>
+    <string name="upgrade_screen_benefits_body">• Onbeperkte apparaten\n• Aangepaste verbindingsacties\n• Thema-aanpassingen\n• Geavanceerde volumeregelingen\n• Ondersteun toekomstige ontwikkeling ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Jaarlijks abonnement</string>
+    <string name="upgrade_screen_subscription_offer_body">Begint met een gratis proefperiode en vernieuwt dan jaarlijks. Annuleren kan op elk moment in Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Wordt jaarlijks verlengd. Annuleer op elk moment via Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Levenslange ontgrendeling</string>
+    <string name="upgrade_screen_iap_offer_body">Betaal eenmaal en heb Pro voor altijd.</string>
+    <string name="upgrade_screen_owned_hero_title">Je bent Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Je bezit %1$s voor altijd.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Je %1$s-abonnement is actief.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Je abonnement staat niet ingesteld om te vernieuwen, dus je kunt nu naar de eenmalige aankoop overstappen. Let op: dit is een aparte aankoop die je abonnement niet annuleert of terugbetaalt, dus gebruik hetzelfde Google-account voor beide.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Annuleer eerst je verlengde abonnement in Google Play, dan kun je overstappen naar de eenmalige aankoop.</string>
+    <string name="upgrade_screen_restore_body">Al Pro gekocht op dit account? Vraag Google Play om je aankopen opnieuw te controleren.</string>
+    <string name="upgrade_screen_restore_checked_message">We hebben Google Play gevraagd om de aankopen op dit account opnieuw te controleren, maar hebben er geen gevonden.</string>
+    <string name="upgrade_screen_restore_contact_hint">Nog steeds vast? Neem contact op vanuit hetzelfde Google-account waarmee je hebt gekocht, voeg je Google Play-ordernummer in en we zullen het oplossen.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">We konden de controle met Google Play niet op tijd afmaken, dus we weten nog steeds niet of je iets hebt aangeschaft — wacht even en probeer opnieuw.</string>
+    <string name="upgrades_gplay_billing_error_label">Aankoopprobleem</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play heeft een probleem gemeld: %1$s. Probeer het later opnieuw of herstart je apparaat.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Aanbieding niet beschikbaar</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play biedt dit artikel nu niet aan. Het is mogelijk nog niet beschikbaar voor je account of regio — probeer het later opnieuw.</string>
 </resources>

--- a/app/src/gplay/res/values-no/strings.xml
+++ b/app/src/gplay/res/values-no/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Oppgrader til BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro tilbyr bedre resultater, flere funksjoner og alternativer for avanserte brukere.</string>
     <string name="upgrade_prompt_upgrade_action">Oppgrader</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Oppgrader til %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen annonser og selger ikke brukerdata. Arbeidet mitt er finansiert av deg ❤️.</string>
     <string name="upgrade_screen_why_title">Fordeler</string>
     <string name="upgrade_screen_subscription_trial_action">Start 14-dagers gratis prøveperiode</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Kunne ikke koble til Google Play. Kontroller internettforbindelsen din og prøv igjen.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play er utilgjengelig</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan ikke koble til Google Play. Er Google Play installert og oppdatert? Er Google-kontoen din logget inn? Prøv å tømme hurtigbufferen til Google Play-appen og starte enheten på nytt.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kunne ikke åpne Google Play. Det kan være manglende, deaktivert eller begrenset på denne enheten.</string>
     <string name="upgrades_no_purchases_found_check_account">Ingen kjøp funnet. Bruker du riktig konto?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Oppgraderingsalternativer</string>
+    <string name="upgrade_screen_offers_body">Begge alternativene låser opp nøyaktig samme Pro-funksjoner — velg det som passer best for deg.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Priser utilgjengelige</string>
+    <string name="upgrade_screen_offers_unavailable_message">Prisene kunne ikke lastes inn nå. Sjekk Google Play og prøv igjen om et øyeblikk.</string>
+    <string name="upgrade_screen_benefits_body">• Ubegrensede enheter\n• Egendefinerte tilkoblingshandlinger\n• Tematilpasning\n• Avanserte volumkontroller\n• Støtt fremtidig utvikling ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Årlig abonnement</string>
+    <string name="upgrade_screen_subscription_offer_body">Starter med en gratis prøveperiode, fornyes deretter årlig. Avbryt når som helst i Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Fornyes årlig. Avbryt når som helst i Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Livsvarig opplåsning</string>
+    <string name="upgrade_screen_iap_offer_body">Betal en gang og eie Pro for alltid.</string>
+    <string name="upgrade_screen_owned_hero_title">Du er Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Du eier %1$s for alltid.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Abonnementet ditt %1$s er aktivt.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Abonnementet ditt er ikke satt til å fornyes, så du kan bytte til engangskjøpet nå. Viktig: det er en separat kostnad som ikke vil avbryte eller refundere abonnementet ditt, så bruk samme Google-konto for begge deler.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Avbryt først det fornyende abonnementet ditt i Google Play, deretter kan du bytte til engangskjøpet.</string>
+    <string name="upgrade_screen_restore_body">Allerede kjøpt Pro på denne kontoen? Be Google Play om å sjekke kjøpene dine på nytt.</string>
+    <string name="upgrade_screen_restore_checked_message">Vi ba Google Play om å sjekke kjøpene på denne kontoen på nytt og fant ingen.</string>
+    <string name="upgrade_screen_restore_contact_hint">Fremdeles problemer? Ta kontakt fra samme Google-konto du kjøpte med, inkluder Google Play-ordrenummeret ditt, og vi løser det.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Vi kunne ikke fullføre kontrollen med Google Play i tide, så vi vet fremdeles ikke kjøpsstatusen din — gi det et øyeblikk og prøv igjen.</string>
+    <string name="upgrades_gplay_billing_error_label">Kjøpsproblem</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play rapporterte et problem: %1$s. Prøv igjen senere eller start enheten på nytt.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Tilbud utilgjengelig</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play tilbød ikke dette elementet akkurat nå. Det er kanskje ikke tilgjengelig for kontoen eller regionen din ennå — prøv igjen senere.</string>
 </resources>

--- a/app/src/gplay/res/values-pcm-rNG/strings.xml
+++ b/app/src/gplay/res/values-pcm-rNG/strings.xml
@@ -65,7 +65,9 @@
     <string name="upgrade_screen_subscription_offer_body">E start with free trial first, den e renew every year. Cancel am anytime for Google Play.</string>
     <string name="upgrade_screen_subscription_offer_body_no_trial">E renew every year. Cancel am anytime for Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Forever unlock</string>
+    <string name="upgrade_screen_iap_offer_body">Pay just once and Pro go be yours forever.</string>
     <string name="upgrade_screen_owned_hero_title">You be Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">You don own %1$s forever.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Your %1$s subscription active.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Your subscription no set to renew, so you fit switch to one-time purchase now. Hear me: e go charge you separate and e no go cancel or refund your subscription, so use di same Google account for both.</string>
     <string name="upgrade_screen_owned_iap_locked_note">Cancel your subscription wey dey renew for Google Play first, den you fit switch to one-time purchase.</string>

--- a/app/src/gplay/res/values-pcm-rNG/strings.xml
+++ b/app/src/gplay/res/values-pcm-rNG/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Upgrade to BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro dey give better results, more features and options for power users.</string>
     <string name="upgrade_prompt_upgrade_action">Upgrade</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Upgrade to %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no get ads and no dey sell user data. My work dey financed by you.</string>
     <string name="upgrade_screen_why_title">Advantages</string>
     <string name="upgrade_screen_subscription_trial_action">Start free 14-day trial</string>
@@ -50,5 +52,29 @@
     <string name="upgrades_gplay_network_error_description">You no fit connect to Google Play. Abeg check your internet connection and try again.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no dey available</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no fit connect to Google Play. Google Play don install and up to date? Your Google Account don log in? Try clear di cache of Google Play app and reboot your device.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">No fit open Google Play. E fit be say am don miss, disabled or e restricted on this device.</string>
     <string name="upgrades_no_purchases_found_check_account">No purchases found. You dey use di right account?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Ways to upgrade</string>
+    <string name="upgrade_screen_offers_body">Both options go unlock same Pro features — pick di one wey fit you best.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prices no show</string>
+    <string name="upgrade_screen_offers_unavailable_message">Prices no fit load now. Check Google Play and try again later.</string>
+    <string name="upgrade_screen_benefits_body">• Unlimited devices\n• Make your own connection actions\n• Change your theme\n• Top volume controls\n• Support future development ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Yearly subscription</string>
+    <string name="upgrade_screen_subscription_offer_body">E start with free trial first, den e renew every year. Cancel am anytime for Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">E renew every year. Cancel am anytime for Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Forever unlock</string>
+    <string name="upgrade_screen_owned_hero_title">You be Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Your %1$s subscription active.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Your subscription no set to renew, so you fit switch to one-time purchase now. Hear me: e go charge you separate and e no go cancel or refund your subscription, so use di same Google account for both.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Cancel your subscription wey dey renew for Google Play first, den you fit switch to one-time purchase.</string>
+    <string name="upgrade_screen_restore_body">You buy Pro before for this account? Ask Google Play make e check your purchases again.</string>
+    <string name="upgrade_screen_restore_checked_message">We ask Google Play check this account purchases again but e no find anything.</string>
+    <string name="upgrade_screen_restore_contact_hint">Still stuck? Get in touch from di same Google account wey you buy with, add your Google Play order number, and we go fix am.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">We no fit finish di check with Google Play in time, so we no know your purchase status yet — wait small and try again.</string>
+    <string name="upgrades_gplay_billing_error_label">Buy problem</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play report problem: %1$s. Try am again later or restart your device.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Offer no show</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play no offer this item now. E no dey available for your account or region yet — try again later.</string>
 </resources>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Uaktualnij do BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferuje lepsze wyniki, więcej funkcji i opcji dla zaawansowanych użytkowników.</string>
     <string name="upgrade_prompt_upgrade_action">Ulepszenie</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Uaktualnij do %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nie zawiera reklam i nie sprzedaje danych użytkowników. Moja praca jest finansowana przez ciebie ❤️.</string>
     <string name="upgrade_screen_why_title">Zalety</string>
     <string name="upgrade_screen_subscription_trial_action">Rozpocznij bezpłatny 14-dniowy okres próbny</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Nie udało się połączyć się z Google Play. Sprawdź swoje połączenie internetowe i spróbuj ponownie.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play jest niedostępne</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nie może połączyć się z Google Play. Czy Google Play jest zainstalowany i aktualny? Czy jesteś zalogowany na swoim koncie Google? Spróbuj wyczyścić pamięć podręczną aplikacji Google Play i zrestartować urządzenie.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nie udało się otworzyć Google Play. Może być brakujące, wyłączone lub ograniczone na tym urządzeniu.</string>
     <string name="upgrades_no_purchases_found_check_account">Nie znaleziono zakupów. Czy używasz właściwego konta?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opcje aktualizacji</string>
+    <string name="upgrade_screen_offers_body">Obie opcje odblokowują dokładnie te same funkcje Pro — wybierz tę, która ci się bardziej podoba.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Ceny niedostępne</string>
+    <string name="upgrade_screen_offers_unavailable_message">Ceny nie mogły zostać załadowane. Sprawdź Sklep Google Play i spróbuj ponownie za chwilę.</string>
+    <string name="upgrade_screen_benefits_body">• Nieograniczona liczba urządzeń\n• Niestandardowe akcje połączenia\n• Dostosowywanie motywu\n• Zaawansowane kontroli głośności\n• Wspieranie dalszego rozwoju ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Roczna subskrypcja</string>
+    <string name="upgrade_screen_subscription_offer_body">Zaczyna się od bezpłatnego okresu próbnego, a następnie odnawia się co roku. Możesz anulować w dowolnym momencie w Sklepie Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Odnawiane co roku. Anuluj w dowolnym momencie w Sklepie Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Dożywotne odblokowywanie</string>
+    <string name="upgrade_screen_iap_offer_body">Zapłać raz i posiadaj Pro na zawsze.</string>
+    <string name="upgrade_screen_owned_hero_title">Jesteś Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Posiadasz %1$s na zawsze.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Twoja subskrypcja %1$s jest aktywna.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Twoja subskrypcja nie jest ustawiona na odnowienie, więc możesz teraz przełączyć się na jednorazowy zakup. Ostrzeżenie: to oddzielna opłata, która nie anuluje ani nie zwróci pieniędzy z twojej subskrypcji, więc użyj tego samego konta Google dla obu.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Najpierw anuluj swoją odnawialną subskrypcję w Sklepie Google Play, a następnie możesz przełączyć się na jednorazowy zakup.</string>
+    <string name="upgrade_screen_restore_body">Kupiłeś już wersję Pro na tym koncie? Poproś Sklep Google Play o ponowne sprawdzenie zakupów w tej aplikacji.</string>
+    <string name="upgrade_screen_restore_checked_message">Poprosiliśmy Sklep Google Play o ponowne sprawdzenie zakupów na tym koncie i nic nie znaleźliśmy.</string>
+    <string name="upgrade_screen_restore_contact_hint">Ciągle masz problem? Skontaktuj się z tego samego konta Google, z którego dokonałeś zakupu, dołącz numer zamówienia ze Sklepu Google Play i my to rozwiążemy.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Nie mogliśmy ukończyć sprawdzania ze Sklepem Google Play na czas, więc nadal nie znamy twojego statusu zakupu — czekaj chwilę i spróbuj ponownie.</string>
+    <string name="upgrades_gplay_billing_error_label">Problem z zakupem</string>
+    <string name="upgrades_gplay_billing_error_description">Sklep Google Play zgłosił problem: %1$s. Spróbuj ponownie później lub zrestartuj urządzenie.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta niedostępna</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Sklep Google Play nie oferuje tego przedmiotu teraz. Może nie być jeszcze dostępne dla twojego konta lub regionu — spróbuj ponownie później.</string>
 </resources>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Atualizar para BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferece melhores resultados, mais recursos e opções para usuários avançados.</string>
     <string name="upgrade_prompt_upgrade_action">Atualizar</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Atualizar para %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados do usuário. Meu trabalho é financiado por você ❤️.</string>
     <string name="upgrade_screen_why_title">Vantagens</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito de 14 dias</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Não foi possível conectar ao Google Play. Verifique sua conexão com a internet e tente novamente.</string>
     <string name="upgrades_gplay_unavailable_error_title">O Google Play está indisponível</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager não consegue se conectar ao Google Play. O Google Play está instalado e atualizado? Sua Conta do Google está conectada? Tente limpar o cache do app Google Play e reiniciar o dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Não foi possível abrir o Google Play. Pode estar ausente, desabilitado ou restrito neste dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Você está usando a conta certa?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opções de upgrade</string>
+    <string name="upgrade_screen_offers_body">Ambas as opções desbloqueiam os mesmos recursos Pro — escolha a que melhor se adequa a você.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Preços indisponíveis</string>
+    <string name="upgrade_screen_offers_unavailable_message">Os preços não puderam ser carregados no momento. Verifique o Google Play e tente novamente em breve.</string>
+    <string name="upgrade_screen_benefits_body">• Dispositivos ilimitados\n• Ações de conexão personalizadas\n• Personalização de tema\n• Controles de volume avançados\n• Apoie o desenvolvimento futuro ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Assinatura anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Começa com um período de avaliação gratuito, depois renova anualmente. Cancele a qualquer momento no Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Renova anualmente. Cancele a qualquer momento no Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Desbloqueio vitalício</string>
+    <string name="upgrade_screen_iap_offer_body">Pague uma vez e tenha Pro para sempre.</string>
+    <string name="upgrade_screen_owned_hero_title">Você é Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Você possui %1$s para sempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Sua assinatura %1$s está ativa.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Sua assinatura não está configurada para renovar, então você pode mudar para a compra única agora. Atenção: é uma cobrança separada que não cancelará ou reembolsará sua assinatura, então use a mesma conta do Google para ambas.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Primeiro cancele sua assinatura renovável no Google Play, então você poderá mudar para a compra única.</string>
+    <string name="upgrade_screen_restore_body">Já comprou Pro nesta conta? Peça ao Google Play para verificar novamente suas compras.</string>
+    <string name="upgrade_screen_restore_checked_message">Pedimos ao Google Play para verificar novamente as compras desta conta e nenhuma foi encontrada.</string>
+    <string name="upgrade_screen_restore_contact_hint">Ainda com dificuldades? Entre em contato pela mesma conta do Google com a qual você comprou, inclua seu número de pedido do Google Play e resolveremos.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Não conseguimos terminar a verificação com o Google Play a tempo, então ainda não sabemos seu status de compra — aguarde um pouco e tente novamente.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema de compra</string>
+    <string name="upgrades_gplay_billing_error_description">O Google Play reportou um problema: %1$s. Tente novamente mais tarde ou reinicie seu dispositivo.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta indisponível</string>
+    <string name="upgrades_gplay_offer_unavailable_description">O Google Play não ofereceu este item no momento. Pode não estar disponível para sua conta ou região ainda — tente novamente mais tarde.</string>
 </resources>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Atualizar para BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferece melhores resultados, mais funcionalidades e opções para utilizadores avançados.</string>
     <string name="upgrade_prompt_upgrade_action">Atualizar</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Atualizar para %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados dos utilizadores. O meu trabalho é financiado por si ❤️.</string>
     <string name="upgrade_screen_why_title">Vantagens</string>
     <string name="upgrade_screen_subscription_trial_action">Iniciar teste gratuito de 14 dias</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Não foi possível estabelecer ligação ao Google Play. Verifique a ligação à Internet e tente novamente.</string>
     <string name="upgrades_gplay_unavailable_error_title">O Google Play está indisponível</string>
     <string name="upgrades_gplay_unavailable_error_description">O Bluetooth Volume Manager não se consegue conectar ao Google Play. O Google Play está instalado e atualizado? A sua conta Google está conectada? Tente limpar a cache da aplicação Google Play e reinicie o seu dispositivo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Não foi possível abrir o Google Play. Pode estar em falta, desativado ou restringido neste dispositivo.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Está a usar a conta certa?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opções de atualização</string>
+    <string name="upgrade_screen_offers_body">Ambas as opções desbloqueiam as mesmas funcionalidades Pro — escolha a que melhor se adequa.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Preços indisponíveis</string>
+    <string name="upgrade_screen_offers_unavailable_message">Os preços não puderam ser carregados neste momento. Verifique o Google Play e tente novamente em alguns instantes.</string>
+    <string name="upgrade_screen_benefits_body">• Dispositivos ilimitados\n• Ações de ligação personalizadas\n• Personalização de tema\n• Controlos de volume avançados\n• Apoiar o desenvolvimento futuro ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Subscrição anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Começa com um teste gratuito, depois renova anualmente. Cancele a qualquer momento no Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Renova anualmente. Cancele a qualquer momento no Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Desbloqueio vitalício</string>
+    <string name="upgrade_screen_iap_offer_body">Pague uma vez e possua Pro para sempre.</string>
+    <string name="upgrade_screen_owned_hero_title">Tem a versão Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Tem %1$s para sempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">A sua subscrição %1$s está ativa.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">A sua subscrição não está configurada para renovar, portanto pode mudar para a compra única agora. Tenha em conta: é uma cobrança separada que não cancelará nem reembolsará a sua subscrição, portanto use a mesma conta Google para ambas.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Cancele primeiro a sua subscrição que está a renovar no Google Play, depois pode mudar para a compra única.</string>
+    <string name="upgrade_screen_restore_body">Já comprou Pro nesta conta? Peça ao Google Play para verificar novamente as suas compras.</string>
+    <string name="upgrade_screen_restore_checked_message">Pedimos ao Google Play para verificar novamente as compras desta conta e não encontramos nenhuma.</string>
+    <string name="upgrade_screen_restore_contact_hint">Ainda com problemas? Entre em contacto usando a mesma conta Google com a qual fez a compra, inclua o seu número de encomenda do Google Play e nós resolveremos.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Não conseguimos terminar a verificação com o Google Play a tempo, portanto ainda não sabemos o seu estado de compra — dê um momento e tente novamente.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema de compra</string>
+    <string name="upgrades_gplay_billing_error_description">O Google Play reportou um problema: %1$s. Tente novamente mais tarde ou reinicie o seu dispositivo.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta indisponível</string>
+    <string name="upgrades_gplay_offer_unavailable_description">O Google Play não ofereceu este item neste momento. Pode não estar disponível para a sua conta ou região ainda — por favor tente novamente mais tarde.</string>
 </resources>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Upgradar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro offra megliers resultats, pli blers featura ed opziuns per utilisaders avanzads.</string>
     <string name="upgrade_prompt_upgrade_action">Actualisar</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Promomn tar %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n\'ha nagins annunzis e na venda betg las datas dals utilisaders. Mia lavur vegn finanziada da tai ❤️.</string>
     <string name="upgrade_screen_why_title">Avantatgs</string>
     <string name="upgrade_screen_subscription_trial_action">Cumenzar prova gratuita da 14 dis</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Impussibel da connectar a Google Play. Controllescha tia connexiun d\'internet e prova anc ina volta.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play n\'è betg disponibel</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager na po betg sa connectar cun Google Play. Es Google Play installar ed actualisà? Es tiu conto Google s\'annunzià? Emprova da stgular il cache da l\'applicaziun Google Play e da ristar tiu apparat.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">N\'ha pudì avrir Google Play. Igl pudess èsser che manca, deactivà u restringscha sin quest apparat.</string>
     <string name="upgrades_no_purchases_found_check_account">Nagins acquists chattads. Utiliseschas ti il conto gist?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opziuns da promomn</string>
+    <string name="upgrade_screen_offers_body">Entrambi las opziuns deblieran las identicas funcziuns Pro — tscherna quella che ti stat meglier.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prejas n\'èn betg disponiblas</string>
+    <string name="upgrade_screen_offers_unavailable_message">Las prejas n\'han betg pudü vegn chargadas giunz. Controllescha Google Play e tschenta novamain en üna moment.</string>
+    <string name="upgrade_screen_benefits_body">• Apparails sensa limit\n• Acziuns da cunnexiun persunalisadas\n• Persunalisaziun dal tema\n• Controllas da volumen avanzads\n• Sustegn dal svilup futir ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Abonament annual</string>
+    <string name="upgrade_screen_subscription_offer_body">Cumenzia cun ina prüva gratuita, dapöi sa renovescha cull\'ann. Cancella en tgel moment en Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Sa renovescha cull\'ann. Cancella en tgel moment en Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Deblierada per sempre</string>
+    <string name="upgrade_screen_iap_offer_body">Paiescha üna giada e possedascha Pro per sempre.</string>
+    <string name="upgrade_screen_owned_hero_title">Ti ies Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Ti possedascha %1$s per sempre.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Tia abonament %1$s è activ.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Tia abonament n\'è betg confiturada per renovescha, perquai che ti pudais tschanger ala cumpra ina giada. Attenziun: tia è ina ladschada separada che n\'canchellescha betg tia abonament e n\'refundida betg, perquai che ti duratscha la medesma cunt da Google per entrambi.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Cancella damaun tia abonament che sa renovescha en Google Play, dapöi ti pudais tschanger ala cumpra ina giada.</string>
+    <string name="upgrade_screen_restore_body">Has ti gia cumprat Pro en questa cunt? Dumonda a Google Play da controllar novamain tias cumpras.</string>
+    <string name="upgrade_screen_restore_checked_message">Nus dumandain a Google Play da controllar novamain las cumpras da questa cunt e n\'habain betg trovà naja.</string>
+    <string name="upgrade_screen_restore_contact_hint">Anc\'uschas da prümeins? Contactascha nus da la medesma cunt da Google cun cha ti has cumprat, includi tia numer d\'ordinaziun da Google Play, e nus vareschain da saglir la situaziun.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Nus n\'habain betg pudü terminar la controlla cun Google Play en temps, perquai che nus anc\'uschas n\'savain betg tia status da cumpra — dur üna moment e tschenta novamain.</string>
+    <string name="upgrades_gplay_billing_error_label">Problem da cumpra</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ha rapportà ün problem: %1$s. Tschenta ün\'altra giada pli tard o restarta tia aparail.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Offerta n\'è betg disponibla</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play n\'ha betg offert quest\'elem giunz. Ella n\'è meina betg disponibla per tia cunt o regiun anc\'uschas — tschenta ti novamain pli tard, ti pli grad.</string>
 </resources>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Actualizează la BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferă rezultate mai bune, mai multe funcții şi opțiuni pentru utilizatorii avanсați.</string>
     <string name="upgrade_prompt_upgrade_action">Actualizează</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Upgrade la %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nu are reclame şi nu vinde datele utilizatorilor. Munca mea este finanțată de tine ❤️.</string>
     <string name="upgrade_screen_why_title">Avantaje</string>
     <string name="upgrade_screen_subscription_trial_action">Începeți trial-ul gratuit 14 zile</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Nu se poate conecta la Google Play. Verifică conexiunea ta la internet și încearcă din nou.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nu este disponibil</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nu se poate conecta la Google Play. Este Google Play instalat şi actualizat? Eşti conectat cu contul Google? Încearcă să ștergă cache-ul aplicației Google Play şi reporneşte dispozitivul.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nu s-a putut deschide Google Play. Este posibil să lipsească, să fie dezactivat sau restricționat pe acest dispozitiv.</string>
     <string name="upgrades_no_purchases_found_check_account">Nu s-a găsit nicio achiziție. Ești sigur că folosești contul corect?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opțiuni de upgrade</string>
+    <string name="upgrade_screen_offers_body">Ambele opțiuni deblochează exact aceleași funcții Pro — alege pe care ți se potrivește.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prețuri indisponibile</string>
+    <string name="upgrade_screen_offers_unavailable_message">Prețurile nu au putut fi încărcate acum. Verifică Google Play și încearcă din nou într-un moment.</string>
+    <string name="upgrade_screen_benefits_body">• Dispozitive nelimitate\n• Acțiuni de conexiune personalizate\n• Personalizare temă\n• Comenzi volum avansate\n• Suportă dezvoltarea viitoare ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Abonament anual</string>
+    <string name="upgrade_screen_subscription_offer_body">Începe cu o versiune de probă gratuită, apoi se reînnuiește anual. Anulează oricând în Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Se reînnuiește anual. Anulează oricând în Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Deblocare pe viață</string>
+    <string name="upgrade_screen_iap_offer_body">Plătește o dată și deține Pro pentru totdeauna.</string>
+    <string name="upgrade_screen_owned_hero_title">Ești Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Deții %1$s pentru totdeauna.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Abonamentul tău %1$s este activ.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Abonamentul tău nu este setat să se reînnuiască, deci poți trece la achiziția unică acum. Atenție: este o taxă separată care nu va anula sau returna abonamentul tău, deci folosește același cont Google pentru ambele.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Anulează mai întâi abonamentul tău care se reînnuiește în Google Play, apoi poți trece la achiziția unică.</string>
+    <string name="upgrade_screen_restore_body">Ai cumpărat deja Pro pe acest cont? Cere Google Play să-ți reverifice achizițiile.</string>
+    <string name="upgrade_screen_restore_checked_message">Am cerut Google Play să reverifice achizițiile acestui cont și nu am găsit una.</string>
+    <string name="upgrade_screen_restore_contact_hint">Încă blocat? Contactează-ne din același cont Google cu care ai cumpărat, include numărul comenzii Google Play și o vom rezolva.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Nu am putut termina verificarea cu Google Play la timp, deci încă nu știm starea achiziției tale — dă-i un moment și încearcă din nou.</string>
+    <string name="upgrades_gplay_billing_error_label">Problemă de achiziție</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play a raportat o problemă: %1$s. Încearcă din nou mai târziu sau repornește dispozitivul.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ofertă indisponibilă</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play nu a oferit acest articol acum. Este posibil să nu fie disponibil pentru contul tău sau regiunea ta încă — te rugăm încearcă din nou mai târziu.</string>
 </resources>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Обновить до BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro предлагает лучшие результаты, больше функций и опций для опытных пользователей.</string>
     <string name="upgrade_prompt_upgrade_action">Обновление</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Перейти на %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не содержит рекламы и не продаёт данные пользователей. Моя работа финансируется вами ❤️.</string>
     <string name="upgrade_screen_why_title">Преимущества</string>
     <string name="upgrade_screen_subscription_trial_action">Начать 14-дневный бесплатный период</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Не удалось подключиться к Google Play. Пожалуйста, проверьте подключение к интернету и повторите попытку.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play недоступен</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не может подключиться к Google Play. Проверьте, установлен ли Google Play и обновлён ли до последней версии? Выполнен ли вход с Вашей учётной записью Google? Попробуйте очистить кэш Google Play и перезагрузить устройство.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не удалось открыть Google Play. Возможно, он отсутствует, отключен или недоступен на этом устройстве.</string>
     <string name="upgrades_no_purchases_found_check_account">Покупки не найдены. Используете ли Вы правильный аккаунт?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Варианты обновления</string>
+    <string name="upgrade_screen_offers_body">Оба варианта разблокируют одинаковые функции Pro — выберите тот, который вам подходит.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Цены недоступны</string>
+    <string name="upgrade_screen_offers_unavailable_message">Не удалось загрузить цены. Проверьте Google Play и повторите попытку через некоторое время.</string>
+    <string name="upgrade_screen_benefits_body">• Неограниченное количество устройств\n• Пользовательские действия при подключении\n• Настройка темы\n• Расширенные элементы управления громкостью\n• Поддержка дальнейшей разработки ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Годовая подписка</string>
+    <string name="upgrade_screen_subscription_offer_body">Начинается с бесплатного пробного периода, затем продлевается ежегодно. Отмену можно выполнить в любой момент в Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Возобновляется ежегодно. Отменить можно в любой момент в Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Пожизненная активация</string>
+    <string name="upgrade_screen_iap_offer_body">Оплатите один раз и владейте Pro навсегда.</string>
+    <string name="upgrade_screen_owned_hero_title">Вы Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Вы владеете %1$s навсегда.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Ваша подписка %1$s активна.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Ваша подписка не настроена на продление, поэтому вы можете переключиться на единовременную покупку. Внимание: это отдельный платеж, который не отменит и не вернет вашу подписку, поэтому используйте один и тот же аккаунт Google для обоих вариантов.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Сначала отмените продление подписки в Google Play, затем вы сможете переключиться на единовременную покупку.</string>
+    <string name="upgrade_screen_restore_body">Уже купили Pro на этом аккаунте? Попросите Google Play перепроверить ваши покупки.</string>
+    <string name="upgrade_screen_restore_checked_message">Мы попросили Google Play перепроверить покупки этого аккаунта, но ничего не нашли.</string>
+    <string name="upgrade_screen_restore_contact_hint">Все еще есть проблема? Свяжитесь с нами с того же аккаунта Google, с которого вы покупали, укажите номер заказа Google Play, и мы разберемся.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Мы не смогли завершить проверку в Google Play вовремя, поэтому мы еще не знаем статус вашей покупки — подождите немного и попробуйте снова.</string>
+    <string name="upgrades_gplay_billing_error_label">Проблема с покупкой</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play сообщила о проблеме: %1$s. Попробуйте еще раз позже или перезагрузите устройство.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Предложение недоступно</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play не предлагает этот товар в данный момент. Возможно, он еще недоступен для вашего аккаунта или региона — попробуйте позже.</string>
 </resources>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Addobba a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferit risultados mègius, prus caraterìsticas e optziones pro utentes avantzados.</string>
     <string name="upgrade_prompt_upgrade_action">Agiornare</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Umpadu a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non tenet publitzidade e non bendet datos de sos utentes. Su traballu meu est finantziadu dae bois ❤️.</string>
     <string name="upgrade_screen_why_title">Vantàgios</string>
     <string name="upgrade_screen_subscription_trial_action">Cumintza sa proa de badas de 14 dies</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">No podo connetimi a Google Play. Controlla sa connessione de internet e tenta de novu.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play no est disponìbile</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager non podet si connètere a Google Play. Google Play est installadu e agiornadu? Su contu Google tuo est intradu? Proa a limpiare sa cache de s\'aplicatzione Google Play e a torrare a allùghere su dispositivu tuo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">No at po abri Google Play. At po esser mancu, disabilidu o restrintu in custu dispositivu.</string>
     <string name="upgrades_no_purchases_found_check_account">Perunu cùmperu agatadu. Ses impreande su contu giustu?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Optziones de umpadu</string>
+    <string name="upgrade_screen_offers_body">Ambas as optziones isbalumant sa mesma funtzionalidades Pro — iscolzi chini ti cumenti.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Prezos no disponìbiles</string>
+    <string name="upgrade_screen_offers_unavailable_message">Sos prezos no podan esse carrigaus in custu momentu. Controlla Google Play e proba de nouv in un momentu.</string>
+    <string name="upgrade_screen_benefits_body">• Dispositivos illimitaus\n• Atziones de connessione personalizadas\n• Personalizatzione de tema\n• Controlos de volume avanzados\n• Suportu at su isvilluppu futuru ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Sottoscritzione annuali</string>
+    <string name="upgrade_screen_subscription_offer_body">Comintzat cun una prueba libera, pue se renovaz anualmente. Annulla in calet in Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Se renovaz anualmente. Annulla in calet in Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Disblocu de vida</string>
+    <string name="upgrade_screen_iap_offer_body">Paga una borta e possess Pro pro semper.</string>
+    <string name="upgrade_screen_owned_hero_title">Ses Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Tu possidis %1$s pro semper.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Tua sottoscritzione %1$s est attiva.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Tua sottoscritzione no est cunfigurada pro renovatzione, assa t\'as pòdis cambiare a una cumpra una borta. Atentzione: est un cariggu separadu chi no at annulla o resfuindit tua sottoscritzione, assa etzas a mesma cunta Google pro ambas.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Annulla prima tua sottoscritzione chi se renovaz in Google Play, pue t\'as pòdis cambiare a una cumpra una borta.</string>
+    <string name="upgrade_screen_restore_body">Gia cumpradas Pro in custu contu? Chidi a Google Play a verificare de nouv tuas cumpras.</string>
+    <string name="upgrade_screen_restore_checked_message">Abbiamus chistu a Google Play a verificare de nouv tuas cumpras de custu contu e no abbiamus atonadu nent.</string>
+    <string name="upgrade_screen_restore_contact_hint">Sempre inblocadu? Chuntattane dae sa mesma cunta Google cun chi as cumpradas, includi su numeru de ordine de Google Play, e abbiamus a issonnet.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Non abbiamus potidu finire a verificare cun Google Play in tempus, assa non abbiamus ancora sa tua situatzione de cumpra — aspeta un momentu e proba de nouv.</string>
+    <string name="upgrades_gplay_billing_error_label">Problema de cumpra</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play at informadu de unu problema: %1$s. Proba de nouv più tardi o reini sa tua aplicatzione.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta no disponìbile</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play no at ofertu custu produttu in custu momentu. Deppu no essere disponìbile pro sa tua cunta o regione ancora — chi proba de nouv più tardi.</string>
 </resources>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -61,12 +61,16 @@
     <string name="upgrade_screen_offers_unavailable_title">මිල ලබාගත නොහැක</string>
     <string name="upgrade_screen_offers_unavailable_message">මිල දැනින් පූරණය කළ හැකි නොවිණි. Google Play පිරික්සා ගෙන තත්පරයකින් නැවත ප්‍රයාස කරන්න.</string>
     <string name="upgrade_screen_benefits_body">• සීමාවිරහිත උපාංගයන්\n• අභිරුචි සංයෝගනය ක්‍රියා\n• තේමා අභිරුචිකරණ\n• උසස් ශබ්ද පාලන\n• අනාගත සංවර්ධනය සහාය කරන්න ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">වාර්ෂික දිගටි ගිණුම</string>
     <string name="upgrade_screen_subscription_offer_body">නිරීක්ෂණ කාලය සමඟ ආරම්භ වන්න, පසුව වාර්ෂිකව නවීකරණය කරන්න. Google Play හි ඕනෑම අවස්ථාවක අවලංගු කරන්න.</string>
     <string name="upgrade_screen_subscription_offer_body_no_trial">වාර්ෂිකව නවීකරණය කරන්න. Google Play හි ඕනෑම අවස්ථාවක අවලංගු කරන්න.</string>
     <string name="upgrade_screen_iap_offer_title">ජීවිතකාල අගුළු හැරීම</string>
     <string name="upgrade_screen_iap_offer_body">එක්වර ගෙවන්න සහ ඉතිරි කාලය Pro හිමිකරන්න.</string>
     <string name="upgrade_screen_owned_hero_title">ඔබ Pro! ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">ඔබ %1$s ඉතිරි කාලය හිමිකරන්න.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">ඔබේ %1$s දිගටි ගිණුම සක්‍රිය.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">ඔබේ දිගටි ගිණුම නවීකරණය කිරීමට සකස්ස කර නැත, එබැවින් ඔබ දැන් එක්වර ගෙවීමට මාරු කළ හැක. අවධාන: එය ඔබේ දිගටි ගිණුම අවලංගු කරන්නේ හෝ ආපසු ගෙවන්නේ නැති වෙනම ගෙවීමක්, එබැවින් සමස්ත Google ගිණුම භාවිතා කරන්න.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Google Play හි ඔබේ නවීකරණ දිගටි ගිණුම අවලංගු කරන්න ප්‍රථමයෙන්, පසුව ඔබ එක්වර ගෙවීමට මාරු කළ හැක.</string>
     <string name="upgrade_screen_restore_body">මේ ගිණුමෙහි දැනටමත් Pro ගෙවා ඇත? Google Play ට ඔබේ ගෙවීම් නැවත පිරික්සීමට ඉල්ලා සිටින්න.</string>
     <string name="upgrade_screen_restore_checked_message">අපි Google Play ට මේ ගිණුමේ ගෙවීම් නැවත පිරික්සීමට ඉල්ලා සිටින කිසිවක් සොයාගෙන නැත.</string>
     <string name="upgrade_screen_restore_contact_hint">තවදුරටත් සිරස්ස? ඔබ ගෙවා ගත් එකම Google ගිණුමෙන් සම්බන්ධ වන්න, ඔබේ Google Play ඇණවුම් අංකය ඇතුළු කරන්න, සහ අපි එය විසඳා ගනිමු.</string>
@@ -74,4 +78,5 @@
     <string name="upgrades_gplay_billing_error_label">ගෙවීමේ ගැටලුව</string>
     <string name="upgrades_gplay_billing_error_description">Google Play ගැටලුවක් වාර්තා කළේය: %1$s. පසුව නැවත ප්‍රයාස කරන්න හෝ ඔබේ උපාංගය නැවත ආරම්භ කරන්න.</string>
     <string name="upgrades_gplay_offer_unavailable_title">ඉදිරිපත්කරණ ලබාගත නොහැක</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play දැනින් මේ අයිතමය ඉදිරිපත් නොකළේය. එය ඔබේ ගිණුම හෝ කලාපය සඳහා තවම ලබාගත නොහැක — කරුණාකර පසුව නැවත ප්‍රයාස කරන්න.</string>
 </resources>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro වෙත උත්‍යෝජනය කරන්න</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro වඩා හොඳ ප්‍රතිඵල, වැඩි විශේෂාංග සහ බලවත් පරිශීලකයින් සඳහා විකල්ප ලබා දෙයි.</string>
     <string name="upgrade_prompt_upgrade_action">වැඩිදියුණු කරන්න</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s වෙත උත්තර කරන්න</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager හි දැන්වීම් නොමැති අතර පරිශීලක දත්ත විකුණන්නේ නැත. මගේ වැඩ ඔබ විසින් මූල්‍යාධාර සපයයි ❤️.</string>
     <string name="upgrade_screen_why_title">වාසි</string>
     <string name="upgrade_screen_subscription_trial_action">දින 14ක නොමිලේ අත්හදා බැලීම ආරම්භ කරන්න</string>
@@ -50,5 +52,26 @@
     <string name="upgrades_gplay_network_error_description">Google Play සමඟ සම්බන්ධ වීමට නොහැකි විය. කරුණාකර ඔබගේ අන්තර්ජාල සම්බන්ධතාව පරීක්ෂා කර නැවත උත්සාහ කරන්න.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ලබා ගත නොහැක</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager හට Google Play වෙත සම්බන්ධ වීමට නොහැකිය. Google Play ස්ථාපිත කර යාවත්කාලීන ද? ඔබේ Google ගිණුම පිවිසී ද? Google Play යෙදුමේ හැඹිලිය ඉවත් කර ඔබේ උපාංගය නැවත ආරම්භ කිරීමට උත්සාහ කරන්න.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play විවෘත කිරීමට නොහැකි විය. එය මෙම උපාංගයේ අතුරුදහන්, අබල හෝ සීමා කර ඇත.</string>
     <string name="upgrades_no_purchases_found_check_account">කිසිදු මිලදී ගැනීමක් හමු නොවිණි. ඔබ නිවැරදි ගිණුම භාවිතා කරන්නේද?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">උත්තරණ විකල්පයන්</string>
+    <string name="upgrade_screen_offers_body">දෙවිධ විකල්පයන්ම එකම ප්‍රෝ ගුණාංගයන් අගුළු ඇරයි — ඔබට සුදුසු එකක් තෝරන්න.</string>
+    <string name="upgrade_screen_offers_unavailable_title">මිල ලබාගත නොහැක</string>
+    <string name="upgrade_screen_offers_unavailable_message">මිල දැනින් පූරණය කළ හැකි නොවිණි. Google Play පිරික්සා ගෙන තත්පරයකින් නැවත ප්‍රයාස කරන්න.</string>
+    <string name="upgrade_screen_benefits_body">• සීමාවිරහිත උපාංගයන්\n• අභිරුචි සංයෝගනය ක්‍රියා\n• තේමා අභිරුචිකරණ\n• උසස් ශබ්ද පාලන\n• අනාගත සංවර්ධනය සහාය කරන්න ❤️</string>
+    <string name="upgrade_screen_subscription_offer_body">නිරීක්ෂණ කාලය සමඟ ආරම්භ වන්න, පසුව වාර්ෂිකව නවීකරණය කරන්න. Google Play හි ඕනෑම අවස්ථාවක අවලංගු කරන්න.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">වාර්ෂිකව නවීකරණය කරන්න. Google Play හි ඕනෑම අවස්ථාවක අවලංගු කරන්න.</string>
+    <string name="upgrade_screen_iap_offer_title">ජීවිතකාල අගුළු හැරීම</string>
+    <string name="upgrade_screen_iap_offer_body">එක්වර ගෙවන්න සහ ඉතිරි කාලය Pro හිමිකරන්න.</string>
+    <string name="upgrade_screen_owned_hero_title">ඔබ Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">ඔබ %1$s ඉතිරි කාලය හිමිකරන්න.</string>
+    <string name="upgrade_screen_restore_body">මේ ගිණුමෙහි දැනටමත් Pro ගෙවා ඇත? Google Play ට ඔබේ ගෙවීම් නැවත පිරික්සීමට ඉල්ලා සිටින්න.</string>
+    <string name="upgrade_screen_restore_checked_message">අපි Google Play ට මේ ගිණුමේ ගෙවීම් නැවත පිරික්සීමට ඉල්ලා සිටින කිසිවක් සොයාගෙන නැත.</string>
+    <string name="upgrade_screen_restore_contact_hint">තවදුරටත් සිරස්ස? ඔබ ගෙවා ගත් එකම Google ගිණුමෙන් සම්බන්ධ වන්න, ඔබේ Google Play ඇණවුම් අංකය ඇතුළු කරන්න, සහ අපි එය විසඳා ගනිමු.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">අපි Google Play සමඟ කාලීනව පිරික්සීම අවසන් කිරීමට හැකි නොවිණි, එබැවින් අපි තවමත් ඔබේ ගෙවීමේ තත්ත්වය දන්නේ නැත — තත්පරයක් ගෙවී නැවත ප්‍රයාස කරන්න.</string>
+    <string name="upgrades_gplay_billing_error_label">ගෙවීමේ ගැටලුව</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ගැටලුවක් වාර්තා කළේය: %1$s. පසුව නැවත ප්‍රයාස කරන්න හෝ ඔබේ උපාංගය නැවත ආරම්භ කරන්න.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ඉදිරිපත්කරණ ලබාගත නොහැක</string>
 </resources>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Prejsť na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ponúka lepšie výsledky, viac funkcií a možností pre náročných používateľov.</string>
     <string name="upgrade_prompt_upgrade_action">Upgrade</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Upgradujte na %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nemá žiadne reklamy a nepredáva používateľské údaje. Moja práca je financovaná vami ❤️.</string>
     <string name="upgrade_screen_why_title">Výhody</string>
     <string name="upgrade_screen_subscription_trial_action">Spustite bezplatnú 14-dňovú skúšobnú verziu</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Nie je možné pripojiť sa k Obchodu Play. Skontrolujte internetové pripojenie a skúste znova.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play nie je k dispozícii</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager sa nemôže pripojiť k Google Play. Je Google Play nainštalovaný a aktuálny? Je vaše konto Google prihlásené? Skúste vymazalť vyrovnávaciu pamäť aplikácie Google Play a reštartovať zariadenie.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nepodarilo sa otvoriť Google Play. Môže chýbať, byť zakázaná alebo obmedzená na tomto zariadení.</string>
     <string name="upgrades_no_purchases_found_check_account">Nenašli sa žiadne nákupy. Používate správny účet?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Možnosti upgradu</string>
+    <string name="upgrade_screen_offers_body">Obe možnosti odomknú presne rovnaké funkcie Pro — vyberte si tú, ktorá vám vyhovuje.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Ceny nie sú dostupné</string>
+    <string name="upgrade_screen_offers_unavailable_message">Ceny sa nemohli v tomto momente načítať. Skontrolujte Google Play a skúste znova o chvíľu.</string>
+    <string name="upgrade_screen_benefits_body">• Neobmedzené zariadenia\n• Vlastné akcie pripojenia\n• Prispôsobenie témy\n• Pokročilé ovládanie hlasitosti\n• Podpora budúceho vývoja ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Ročné predplatné</string>
+    <string name="upgrade_screen_subscription_offer_body">Začína bezplatnou skúšobnou verziou, potom sa obnovuje každoročne. Zrušte kedykoľvek v Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Obnovuje sa každoročne. Zrušte kedykoľvek v Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Doživotné odomknutie</string>
+    <string name="upgrade_screen_iap_offer_body">Zaplaťte raz a vlastnite Pro navždy.</string>
+    <string name="upgrade_screen_owned_hero_title">Si Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Vlastníš %1$s navždy.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Vaše predplatné %1$s je aktívne.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Vaše predplatné nie je nastavené na obnovenie, takže teraz môžete prejsť na jednorazový nákup. Upozornenie: ide o samostatný poplatok, ktorý nezruší ani nevráti vaše predplatné, takže na obe položky použite rovnaký účet Google.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Najprv zrušte svoje obnovujúce sa predplatné v Google Play, potom môžete prejsť na jednorazový nákup.</string>
+    <string name="upgrade_screen_restore_body">Už ste si kúpili Pro na tomto účte? Požiadajte Google Play, aby znova skontroloval vaše nákupy.</string>
+    <string name="upgrade_screen_restore_checked_message">Požiadali sme Google Play, aby znova skontroloval nákupy na tomto účte, a nenašli sme žiadny.</string>
+    <string name="upgrade_screen_restore_contact_hint">Stále máte problém? Kontaktujte nás z rovnakého účtu Google, s ktorým ste si kúpili, zahrňte číslo objednávky Google Play a pomôžeme vám.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Nemohli sme dokončiť kontrolu s Google Play v čase, takže stále nevieme váš stav nákupu — počkajte chvíľu a skúste znova.</string>
+    <string name="upgrades_gplay_billing_error_label">Problém s nákupom</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play hlásil problém: %1$s. Skúste to neskôr alebo reštartujte zariadenie.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ponuka nie je dostupná</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play teraz túto položku neponúka. Možno nie je k dispozícii pre váš účet alebo región — skúste prosím neskôr.</string>
 </resources>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Nadgradite na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ponuja boljše rezultate, več funkcij in možnosti za napredne uporabnike.</string>
     <string name="upgrade_prompt_upgrade_action">Nadgradi</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Nadgradite na %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nima oglasov in ne prodaja uporabniških podatkov. Moje delo financirate vi ❤️.</string>
     <string name="upgrade_screen_why_title">Prednosti</string>
     <string name="upgrade_screen_subscription_trial_action">Začni 14-dnevni preizkus</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Ni mogoče se povezati s Google Play. Preverite svojo internetno povezavo in poskusite znova.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ni na voljo.</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager se ne more povezati z Google Play. Ali je Google Play nameščen in posodobljen? Ali ste prijavljeni v Google Račun? Poskusite počistiti predpomnilnik aplikacije Google Play in znova zagnati napravo.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Ni bilo mogoče odpreti Google Play. Morda je onemogočena, ni dostopna ali omejena na tej napravi.</string>
     <string name="upgrades_no_purchases_found_check_account">Nakup ni bil najden.  Ali uporabljate pravi račun?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Možnosti nadgradnje</string>
+    <string name="upgrade_screen_offers_body">Obe možnosti odkleneta enake Pro funkcije — izberite tisto, ki vam najbolj ustreza.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Cene niso na voljo</string>
+    <string name="upgrade_screen_offers_unavailable_message">Cen ni bilo mogoče naložiti zdaj. Preverite Google Play in poskusite znova v trenutku.</string>
+    <string name="upgrade_screen_benefits_body">• Neomejene naprave\n• Prilagojene možnosti priklopitve\n• Prilagajanje teme\n• Napredni nadzori glasnosti\n• Podpora prihodnjemu razvoju ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Letna naročnina</string>
+    <string name="upgrade_screen_subscription_offer_body">Začne s preizkušnim obdobjem, nato se obnavlja letno. Prekličite kadar koli v Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Obnavlja se letno. Prekličite kadar koli v Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Trajno odklenjevanje</string>
+    <string name="upgrade_screen_iap_offer_body">Plačajte enkrat in imate Pro za vedno.</string>
+    <string name="upgrade_screen_owned_hero_title">Ste Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Imate %1$s za vedno.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Vaša %1$s naročnina je aktivna.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Vaša naročnina ni nastavljena za obnavljanje, zato se lahko zdaj preklopite na enkratni nakup. Opozorilo: to je ločena pristojbina, ki ne bo preklicala ali povrnila vaše naročnine, zato za obe uporabite isti račun Google.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Najprej prekličite svojo obnavljajočo se naročnino v Google Play, nato pa se lahko preklopite na enkratni nakup.</string>
+    <string name="upgrade_screen_restore_body">Ste že kupili Pro na tem računu? Prosite Google Play, da ponovno preveri vaše nakupe.</string>
+    <string name="upgrade_screen_restore_checked_message">Prosili smo Google Play, da ponovno preveri nakupe tega računa, in nismo našli nobenega.</string>
+    <string name="upgrade_screen_restore_contact_hint">Še vedno imate težave? Stopite v stik s tistega Google računa, s katerim ste kupili, vključite svojo številko naročila Google Play, in uredili bomo.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Nismo mogli pravočasno zaključiti preverjanja s Google Play, zato še vedno ne vemo, kakšen je vaš status nakupa — počakajte trenutek in poskusite znova.</string>
+    <string name="upgrades_gplay_billing_error_label">Problem z nakupom</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play je poročal o problemu: %1$s. Poskusite znova pozneje ali znova zaženite napravo.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ponudba ni na voljo</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play to trenutno ne ponuja. Morda še ni na voljo za vaš račun ali regijo — poskusite znova kasneje.</string>
 </resources>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Përmirëso në BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofron rezultate më të mira, më shumë veçori dhe opsione për përdoruesit e fuqishëm.</string>
     <string name="upgrade_prompt_upgrade_action">Përmirëso</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Përmirëso në %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nuk ka reklama dhe nuk shet të dhënat e përdoruesit. Puna ime financohet nga ju ❤️.</string>
     <string name="upgrade_screen_why_title">Avantazhet</string>
     <string name="upgrade_screen_subscription_trial_action">Filloni provën falas 14-ditore</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Nuk mund të lidhet me Google Play. Ju lutemi kontrolloni lidhjen tuaj të internetit dhe provoni përsëri.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play dyqani është i padisponueshëm</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nuk mund të lidhet me Google Play. A është Google Play i instaluar dhe i përditësuar? A jeni kyçur me llogarinë tuaj Google? Provoni të pastroni memorien e Google Play dhe të rinisni pajisjen tuaj.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Nuk mund të hape Google Play. Mund të mungojë, të jetë çaktivizuar ose i kufizuar në këtë pajisje.</string>
     <string name="upgrades_no_purchases_found_check_account">Nuk u gjet asnjë blerje. A po përdorni llogarinë e duhur?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Opsionet e përmirësimit</string>
+    <string name="upgrade_screen_offers_body">Të dy opsionet zhbllokojnë saktësisht të njëjtat veçori Pro — zgjidhni atë që ju përshtatet.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Çmimet nuk janë të disponueshme</string>
+    <string name="upgrade_screen_offers_unavailable_message">Çmimet nuk mund të ngarkohen tani. Kontrolloni Google Play dhe provoni përsëri në një moment.</string>
+    <string name="upgrade_screen_benefits_body">• Pajisje të pakufizuara\n• Veprime të personalizuara të lidhjes\n• Përshtatje e temës\n• Kontrolle të avancuara të volumit\n• Mbështetni zhvillimin e ardhshëm ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Abonimi vjetor</string>
+    <string name="upgrade_screen_subscription_offer_body">Fillon me një periudhë prove falas, pastaj rinovon çdo vit. Anuloni në çdo kohë në Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Rinovon çdo vit. Anuloni në çdo kohë në Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Shbllokimi përjetësor</string>
+    <string name="upgrade_screen_iap_offer_body">Paguani një herë dhe zotëroni Pro përgjithmonë.</string>
+    <string name="upgrade_screen_owned_hero_title">Je Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Ju zotëroni %1$s përgjithmonë.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Abonamenti juaj %1$s është aktiv.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Abonamenti juaj nuk është caktuar për rinovim, kështu që mund të kaloni në blerje njëherësh tani. Kujdes: është një tarifë e veçantë që nuk do të anulojë ose rimbursojë abonimin tuaj, kështu që përdorni të njëjtin llogari Google për të dyja.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Anuloni abonimin tuaj në Google Play fillimisht, pastaj mund të kaloni në blerje njëherësh.</string>
+    <string name="upgrade_screen_restore_body">Keni blerë tashmë Pro në këtë llogari? Kërkojini Google Play-it të rikontrollojë blerjet tuaja.</string>
+    <string name="upgrade_screen_restore_checked_message">I kërkuam Google Play-it të rikontrollojë blerjet e kësaj llogarie dhe nuk gjetëm asnjë.</string>
+    <string name="upgrade_screen_restore_contact_hint">Akoma i bllokuar? Kontaktoni ne nga i njëjti llogari Google që keni përdorur për blerje, përfshijeni numrin e porosisë Google Play, dhe do t\'ju ndihmojmë.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Nuk mundëm të përfundojmë kontrollimin me Google Play në kohë, kështu që ne nuk e dimë akoma statusin e blerjes suaj — prisni një moment dhe provoni përsëri.</string>
+    <string name="upgrades_gplay_billing_error_label">Problem me blerjen</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play raportoi një problem: %1$s. Provoni përsëri më vonë ose rinisni pajisjen tuaj.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Oferta nuk disponohet</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play nuk ofroi këtë artikull tani. Mund të mos jetë i disponueshëm për llogarinë tuaj ose rajonin ende — ju lutemi provoni përsëri më vonë.</string>
 </resources>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Надогради на BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro нуди боље резултате, више функција и опција за искусне кориснике.</string>
     <string name="upgrade_prompt_upgrade_action">Надогради</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Надгради на %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклама и не продаје корисничке податке. Мој рад финансираш ти ❤️.</string>
     <string name="upgrade_screen_why_title">Предности</string>
     <string name="upgrade_screen_subscription_trial_action">Започни бесплатни 14-дневни пробни период</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Није могуће повезати се на Google Play. Молимо проверите вашу интернет везу и покушајте поново.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play није доступан</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може да се повеже на Google Play. Да ли је Google Play инсталиран и ажуриран? Да ли си пријављен на свој Google налог? Покушај очистити кеш Google Play апликације и поново покрени уређај.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Није могуће отворити Google Play. Може бити да недостаје, онемогућено је или ограничено на овом уређају.</string>
     <string name="upgrades_no_purchases_found_check_account">Нису пронађене куповине. Користите ли прави налог?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Опције надградње</string>
+    <string name="upgrade_screen_offers_body">Обе опције омогућавају исте Pro функције — изабери ону која ти одговара.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Цене нису доступне</string>
+    <string name="upgrade_screen_offers_unavailable_message">Цене се тренутно нису могле учитати. Провери Google Play и покушај поново за тренутак.</string>
+    <string name="upgrade_screen_benefits_body">• Неограничени уређаји\n• Прилагођене акције повезивања\n• Прилагођавање теме\n• Напредне контроле јачине звука\n• Подршка развоју апликације ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Годишња претплата</string>
+    <string name="upgrade_screen_subscription_offer_body">Почиње са бесплатном пробном верзијом, затим се обнавља годишње. Откажи у било којем тренутку на Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Обнавља се годишње. Откажи у било којем тренутку на Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Доживотна куповина</string>
+    <string name="upgrade_screen_iap_offer_body">Плати једном и поседуј Pro заувек.</string>
+    <string name="upgrade_screen_owned_hero_title">Ти си Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Поседујеш %1$s заувек.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Твоја %1$s претплата је активна.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Твоја претплата није подешена за обнављање, па можеш сада прећи на једнократну куповину. Пажња: то је одвојена наплата која неће отказати или вратити твоју претплату, па користи исти Google налог за обоје.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Прво откажи своју претплату која се обнавља на Google Play, затим можеш прећи на једнократну куповину.</string>
+    <string name="upgrade_screen_restore_body">Већ си куповао Pro на овом налогу? Затражи од Google Play да поново провери твоје куповине.</string>
+    <string name="upgrade_screen_restore_checked_message">Затражили смо од Google Play да поново провери куповине овог налога, али нисмо нашли ништа.</string>
+    <string name="upgrade_screen_restore_contact_hint">Још си заглављен? Напиши нам са истог Google налога са кога си куповао, укључи твој Google Play број налога, и решићемо то.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Нисмо могли завршити проверу са Google Play на време, па још увек не знамо твој статус куповине — дај му тренутак и покушај поново.</string>
+    <string name="upgrades_gplay_billing_error_label">Проблем са куповином</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play је пријавио проблем: %1$s. Покушај касније или поново покрени свој уређај.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Понуда није доступна</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play тренутно није нудио ову ставку. Можда још није доступна за твој налог или регион — покушај касније.</string>
 </resources>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Uppgradera till BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro erbjuder bättre resultat, fler funktioner och alternativ för avancerade användare.</string>
     <string name="upgrade_prompt_upgrade_action">Uppgradera</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Uppgradera till %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har inga annonser och säljer inte användardata. Mitt arbete finansieras av dig ❤️.</string>
     <string name="upgrade_screen_why_title">Fördelar</string>
     <string name="upgrade_screen_subscription_trial_action">Starta gratis 14-dagars test</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Det gick inte att ansluta till Google Play. Kontrollera din internetanslutning och försök igen.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play är inte tillgängligt</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan inte ansluta till Google Play. Är Google Play installerat och uppdaterat? Är ditt Google-konto inloggat? Försök rensa cachen för Google Play-appen och starta om enheten.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Kunde inte öppna Google Play. Det kan vara saknat, inaktiverat eller begränsat på den här enheten.</string>
     <string name="upgrades_no_purchases_found_check_account">Inga köp hittades. Använder du rätt konto?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Uppgraderingsalternativ</string>
+    <string name="upgrade_screen_offers_body">Båda alternativen låser upp exakt samma Pro-funktioner – välj det som passar dig bäst.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Priser otillgängliga</string>
+    <string name="upgrade_screen_offers_unavailable_message">Priserna kunde inte läsas in just nu. Kontrollera Google Play och försök igen om en stund.</string>
+    <string name="upgrade_screen_benefits_body">• Obegränsade enheter\n• Anpassade anslutningsåtgärder\n• Temakustomisering\n• Avancerad volymkontroll\n• Stöd för framtida utveckling ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Årlig prenumeration</string>
+    <string name="upgrade_screen_subscription_offer_body">Börjar med en gratis testperiod och förnyas sedan årligen. Avbryt när som helst i Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Förnyas årligen. Avbryt när som helst i Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Livstidsåtkomst</string>
+    <string name="upgrade_screen_iap_offer_body">Betala en gång och äg Pro för alltid.</string>
+    <string name="upgrade_screen_owned_hero_title">Du är Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Du äger %1$s för alltid.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Din %1$s-prenumeration är aktiv.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Din prenumeration är inte inställd på förnyelse, så du kan byta till engångsköp nu. OBS: Det är en separat avgift som inte avbryter eller återbetalar din prenumeration, så använd samma Google-konto för båda.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Avbryt först din prenumeration i Google Play, sedan kan du byta till engångsköp.</string>
+    <string name="upgrade_screen_restore_body">Redan köpt Pro på det här kontot? Be Google Play att kontrollera dina köp igen.</string>
+    <string name="upgrade_screen_restore_checked_message">Vi bad Google Play att kontrollera det här kontots köp igen och hittade inget.</string>
+    <string name="upgrade_screen_restore_contact_hint">Fortfarande problem? Kontakta oss från samma Google-konto som du köpte med, inkludera ditt Google Play-ordernummer, och vi löser det.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Vi kunde inte slutföra kontrollen med Google Play i tid, så vi vet fortfarande inte din köpstatus – försök igen om en stund.</string>
+    <string name="upgrades_gplay_billing_error_label">Köpproblem</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play rapporterade ett problem: %1$s. Försök igen senare eller starta om enheten.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Erbjudande otillgängligt</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play erbjöd inte den här artikeln just nu. Den kanske inte är tillgänglig för ditt konto eller region ännu – försök igen senare.</string>
 </resources>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -61,12 +61,16 @@
     <string name="upgrade_screen_offers_unavailable_title">Bei haipatikani</string>
     <string name="upgrade_screen_offers_unavailable_message">Bei hazikuweza kupakia sasa. Angalia Google Play na jaribu tena haraka.</string>
     <string name="upgrade_screen_benefits_body">• Vifaa bila kikomo\n• Hatua za kuunganisha zilizobadilishwa\n• Ubadilishaji wa mandhari\n• Vidhibiti vya sauti vya juu\n• Kuunga mkono maendeleo ya baadaye ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Usajili wa kila mwaka</string>
     <string name="upgrade_screen_subscription_offer_body">Inaanza na jaribio la bure, kisha inajipi upya kila mwaka. Ghairi wakati wowote katika Google Play.</string>
     <string name="upgrade_screen_subscription_offer_body_no_trial">Inajipi upya kila mwaka. Ghairi wakati wowote katika Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Kufungua milele</string>
     <string name="upgrade_screen_iap_offer_body">Lipa mara moja na kumiliki Pro milele.</string>
     <string name="upgrade_screen_owned_hero_title">Wewe ni Pro! ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Unamiliki %1$s milele.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Usajili wako wa %1$s unaendelea.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Usajili wako haujawekwa kujirudisha upya, kwa hivyo unaweza kubadili kwenda ununuzi wa mara moja sasa. Kumbuka: ni malipo tofauti ambayo hayataghairi au kurudisha pesa za usajili wako, kwa hivyo tumia akaunti moja ya Google kwa zote mbili.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Ghairi usajili wako unaojirudisha upya katika Google Play kwanza, kisha unaweza kubadili kwa ununuzi wa mara moja.</string>
     <string name="upgrade_screen_restore_body">Tayari kununua Pro kwa akaunti hii? Omba Google Play kuangalia upya ununuzi wako.</string>
     <string name="upgrade_screen_restore_checked_message">Tuliomba Google Play kuangalia upya ununuzi wa akaunti hii na hatukupata.</string>
     <string name="upgrade_screen_restore_contact_hint">Bado na tatizo? Wasiliana kutoka kwa akaunti sawa ya Google uliyotumia kununua, jumuisha nambari yako ya agizo la Google Play, na tutakamatia.</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Boresha hadi BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro inatoa matokeo bora zaidi, vipengele vingi zaidi na chaguzi kwa watumiaji wa hali ya juu.</string>
     <string name="upgrade_prompt_upgrade_action">Boresha</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Boreshwa kwa %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager haina matangazo na haiuzi data ya mtumiaji. Kazi yangu inafadhiliwa na wewe ❤️.</string>
     <string name="upgrade_screen_why_title">Faida</string>
     <string name="upgrade_screen_subscription_trial_action">Anza majaribio ya bure ya siku 14</string>
@@ -50,5 +52,27 @@
     <string name="upgrades_gplay_network_error_description">Haiwezi kuungana na Google Play. Tafadhali angalia muunganisho wako wa mtandao na jaribu tena.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play haipo</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager haiwezi kuunganika na Google Play. Je, Google Play imewekwa na iko ya kisasa? Je, akaunti yako ya Google imeingia? Jaribu kufuta kashe ya programu ya Google Play na kuanzisha upya kifaa chako.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Haiwezi kufungua Google Play. Inaweza kuwa imefutwa, iliyolemazwa au iliyozuiwa kwenye simu hii.</string>
     <string name="upgrades_no_purchases_found_check_account">Hakuna ununuzi uliopatikana. Je, unatumia akaunti sahihi?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Chaguo za kuboreshwa</string>
+    <string name="upgrade_screen_offers_body">Chaguo zote zimefungua uwezo sawa wa Pro — chagua yoyote inayokufaa.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Bei haipatikani</string>
+    <string name="upgrade_screen_offers_unavailable_message">Bei hazikuweza kupakia sasa. Angalia Google Play na jaribu tena haraka.</string>
+    <string name="upgrade_screen_benefits_body">• Vifaa bila kikomo\n• Hatua za kuunganisha zilizobadilishwa\n• Ubadilishaji wa mandhari\n• Vidhibiti vya sauti vya juu\n• Kuunga mkono maendeleo ya baadaye ❤️</string>
+    <string name="upgrade_screen_subscription_offer_body">Inaanza na jaribio la bure, kisha inajipi upya kila mwaka. Ghairi wakati wowote katika Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Inajipi upya kila mwaka. Ghairi wakati wowote katika Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Kufungua milele</string>
+    <string name="upgrade_screen_iap_offer_body">Lipa mara moja na kumiliki Pro milele.</string>
+    <string name="upgrade_screen_owned_hero_title">Wewe ni Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Unamiliki %1$s milele.</string>
+    <string name="upgrade_screen_restore_body">Tayari kununua Pro kwa akaunti hii? Omba Google Play kuangalia upya ununuzi wako.</string>
+    <string name="upgrade_screen_restore_checked_message">Tuliomba Google Play kuangalia upya ununuzi wa akaunti hii na hatukupata.</string>
+    <string name="upgrade_screen_restore_contact_hint">Bado na tatizo? Wasiliana kutoka kwa akaunti sawa ya Google uliyotumia kununua, jumuisha nambari yako ya agizo la Google Play, na tutakamatia.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Hatukuweza kumaliza kuangalia na Google Play kwa wakati, kwa hivyo bado hatujui hali ya ununuzi wako — subiri kidogo na jaribu tena.</string>
+    <string name="upgrades_gplay_billing_error_label">Tatizo la ununuzi</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ilizea tatizo: %1$s. Jaribu tena baadaye au anzisha upya kifaa chako.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ofa haipatikani</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play haikutoa kipengee hiki sasa. Inaweza kuwa haijapatikana kwa akaunti yako au eneo lako bado — tafadhali jaribu tena baadaye.</string>
 </resources>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Proக்கு மேம்படுத்து</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro சிறந்த தர்வ்ூதல்கள், மேலும் அனுபவம், மேலும் அமைப்்புகள் மற்றும் சக்தியான பயனர்களுக்கான விருப்பங்களை வாயில் வளர்கிறது.</string>
     <string name="upgrade_prompt_upgrade_action">மேம்படுத்து</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s க்கு மேம்படுத்தவும்</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager விளம்பரங்கள் இல்லாதது மற்றும் பயனர் தரவுகளை விற்கவிற்கை இல்லை. என் பணியின் நிதியம் உங்களால் வழங்கப்படுகிறது.</string>
     <string name="upgrade_screen_why_title">நன்மைகள்</string>
     <string name="upgrade_screen_subscription_trial_action">இலவச 14-நாள் சோதனையைத் தொடங்கு</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play கு இணைய முடியவில்லை. தயவு செய்து உங்கள் இணைய இணைப்பை சரிபார்த்து மீண்டும் முயற்சி செய்யவும்.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play கிடைக்கவில்லை</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Playஆல் இணையமுடியவில்லை. Google Play நிறுவப்பட்டு புதுப்பிக்கப்பட்டதா? உங்கள் Google கணக்கு உள்நுழைகிறீர்களா? Google Play பயன்பாட்டுகள் தீளிப்பை அழித்து சாதனத்தை மறுதொடக்கம் செய்து முயற்சிக்கவும்.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play ஐ திறக்க முடியவில்லை. இது சாதனத்தில் இல்லாமல் இருக்கலாம், முடக்கப்பட்டிருக்கலாம் அல்லது கட்டுப்படுத்தப்பட்டிருக்கலாம்.</string>
     <string name="upgrades_no_purchases_found_check_account">கொள்முதல்கள் எதுவும் இல்லை. நீங்கள் சரியான கணக்கைப் பயன்படுத்துகிறீர்களா?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">மேம்படுத்தல் விருப்பங்கள்</string>
+    <string name="upgrade_screen_offers_body">இரண்டு விருப்பங்களும் ஒரே Pro அம்சங்களை திறக்கின்றன — உங்களுக்குப் பொருத்தமான ஒன்றைத் தேர்ந்தெடுக்கவும்.</string>
+    <string name="upgrade_screen_offers_unavailable_title">விலைகள் கிடைக்கவில்லை</string>
+    <string name="upgrade_screen_offers_unavailable_message">விலைகள் இப்போது ஏற்ற முடியவில்லை. Google Play ஐ சரிபார்க்கவும் மற்றும் ஒரு தருணத்தில் மீண்டும் முயற்சி செய்யவும்.</string>
+    <string name="upgrade_screen_benefits_body">• வரம்பற்ற சாதனங்கள்\n• தனிப்பயன் இணைப்பு செயல்கள்\n• கருப்பொருள் தனிப்பயனாக்கம்\n• முன்னேற்ற ஒலி கட்டுப்பாடுகள்\n• வருங்கால வளர்ச்சிக்கு ஆதரவு ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">வருடாந்த சந்தா</string>
+    <string name="upgrade_screen_subscription_offer_body">இலவச சோதனையுடன் தொடங்குகிறது, பின்னர் ஆண்டுக்கு புதுப்பிக்கப்படுகிறது. Google Play இல் எந்த நேரத்திலும் ரத்து செய்யலாம்.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">ஆண்டுக்கு புதுப்பிக்கப்படுகிறது. Google Play இல் எந்த நேரத்திலும் ரத்து செய்யலாம்.</string>
+    <string name="upgrade_screen_iap_offer_title">வாழ்நாள் திறக்கல்</string>
+    <string name="upgrade_screen_iap_offer_body">ஒரு முறை பணம் செலுத்தவும் மற்றும் Pro ஐ என்றென்றும் சொந்தமாக வைத்துக்கொள்ளவும்.</string>
+    <string name="upgrade_screen_owned_hero_title">நீங்கள் Pro ஆகிவிட்டீர்கள்! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">நீங்கள் %1$s ஐ என்றென்றும் சொந்தமாக வைத்துக்கொள்ளுகிறீர்கள்.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">உங்கள் %1$s சந்தா செயல்பாட்டுக்குள் உள்ளது.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">உங்கள் சந்தா புதுப்பிக்க அமைக்கப்படவில்லை, எனவே நீங்கள் இப்போது ஒரு முறை வாங்குதலுக்கு மாற்றலாம். முன்னெச்சரிக்கை: இது உங்கள் சந்தாவை ரத்து செய்யாமல் அல்லது திருப்பி செலுத்தாமல் ஒரு தனிப்பட்ட கட்டணம், எனவே இரண்டிற்கும் ஒரே Google கணக்கைப் பயன்படுத்தவும்.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Google Play இல் உங்கள் புதுப்பிக்கப்படும் சந்தாவை முதலில் ரத்து செய்யவும், பின்னர் நீங்கள் ஒரு முறை வாங்குதலுக்கு மாற்றலாம்.</string>
+    <string name="upgrade_screen_restore_body">ஏற்கனவே இந்த கணக்கில் Pro ஐ வாங்கினீர்களா? Google Play ஐ உங்கள் வாங்குதல்களை மீண்டும் சரிபார்க்க கேளுங்கள்.</string>
+    <string name="upgrade_screen_restore_checked_message">நாங்கள் Google Play ஐ இந்த கணக்கின் வாங்குதல்களை மீண்டும் சரிபார்க்க கேட்டோம் மற்றும் ஒன்றைக் கண்டுபிடிக்கவில்லை.</string>
+    <string name="upgrade_screen_restore_contact_hint">இன்னும் சிக்கலில் உள்ளீர்களா? நீங்கள் வாங்கிய ஒரே Google கணக்கிலிருந்து தொடர்பு கொள்ளுங்கள், உங்கள் Google Play ஆணை எண்ணைச் சேர்த்து, நாங்கள் அதைத் தீர்ப்போம்.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">நாங்கள் Google Play உடன் சரிபார்ப்பை சரியான நேரத்தில் முடிக்க முடியவில்லை, எனவே உங்கள் வாங்குதல் நிலை இன்னும் தெரியவில்லை — ஒரு தருணத்தை கொடுங்கள் மற்றும் மீண்டும் முயற்சி செய்யவும்.</string>
+    <string name="upgrades_gplay_billing_error_label">வாங்குதல் சிக்கல்</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ஒரு சிக்கலை அறிவித்தது: %1$s. பிறகு இன்னொரு முறை முயற்சி செய்யுங்கள் அல்லது உங்கள் சாதனத்தை மறுதொடக்கம் செய்யுங்கள்.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">வாய்ப்பு கிடைக்கவில்லை</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play இப்போது இந்த உருப்படியை வழங்கவில்லை. இது உங்கள் கணக்கு அல்லது பிராந்திய இப்போது கிடைக்கவில்லை — பிறகு மீண்டும் முயற்சி செய்யவும்.</string>
 </resources>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro కి అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro మెరుగైన ఫలితాలు, మరిన్ని ఫీచర్లు మరియు పవర్ యూజర్ల కోసం ఆప్షన్లను అందిస్తుంది.</string>
     <string name="upgrade_prompt_upgrade_action">అప్‌గ్రేడ్ చేయండి</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s కు అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager కి ప్రకటనలు లేవు మరియు వినియోగదారు డేటాను విక్రయించదు. నా పని మీరు ఆర్థిక సహాయం చేస్తున్నారు ❤️.</string>
     <string name="upgrade_screen_why_title">ప్రయోజనాలు</string>
     <string name="upgrade_screen_subscription_trial_action">ఉచిత 14-రోజుల ట్రయల్ ప్రారంభించండి</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Playకు కనెక్ట్ చేయలేకపోయాను. దయచేసి మీ ఇంటర్నెట్ కనెక్షన్‌ను తనిఖీ చేసి మళ్ళీ ప్రయత్నించండి.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play అందుబాటులో లేదు</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play కి కనెక్ట్ కాలేకపోతోంది. Google Play ఇన్‌స్టాల్ చేయబడి అప్-టు-డేట్‌గా ఉందా? మీ Google అకౌంట్ లాగిన్ అయి ఉందా? Google Play యాప్ యొక్క కాష్‌ని క్లియర్ చేసి మీ పరికరాన్ని రీబూట్ చేయడానికి ప్రయత్నించండి.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Playని తెరవలేకపోయాము. ఇది ఈ పరికరంపై లేకపోవచ్చు, నిష్క్రియం చేయబడవచ్చు లేదా నిషేధించబడవచ్చు.</string>
     <string name="upgrades_no_purchases_found_check_account">కొనుగోళ్లు కనుగొనబడలేదు. మీరు సరైన ఖాతాను ఉపయోగిస్తున్నారా?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">అప్‌గ్రేడ్ ఎంపికలు</string>
+    <string name="upgrade_screen_offers_body">రెండు ఎంపికలు ఖచ్చితంగా ఒకే Pro ఫీచర్‌లను అన్‌లాక్ చేస్తాయి — మీకు సరిపోయే దానిని ఎంచుకోండి.</string>
+    <string name="upgrade_screen_offers_unavailable_title">ధరలు అందుబాటులో లేనివి</string>
+    <string name="upgrade_screen_offers_unavailable_message">ధరలను ఇప్పుడు లోడ్ చేయలేకపోయాము. Google Play ను తనిఖీ చేసి, కొంచెం సేపటి తరువాత మళ్లీ ప్రయత్నించండి.</string>
+    <string name="upgrade_screen_benefits_body">• సీమాహీన పరికరాలు\n• కస్టమ్ కనెక్షన్ చర్యలు\n• థీమ్ కస్టమైజేషన్\n• అధునాతన వాల్యూమ్ నియంత్రణలు\n• భవిష్యత్ అభివృద్ధికి సపోర్ట్ చేయండి ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">ఏటా సభ్యత్వం</string>
+    <string name="upgrade_screen_subscription_offer_body">ఉచిత ట్రయల్‌తో ప్రారంభమవుతుంది, ఆపై ఏటా పునరుద్ధరిస్తుంది. Google Play లో ఎప్పుడైనా రద్దు చేయవచ్చు.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">ఏటా పునరుద్ధరిస్తుంది. Google Play లో ఎప్పుడైనా రద్దు చేయవచ్చు.</string>
+    <string name="upgrade_screen_iap_offer_title">జీవితకాల అన్‌లాక్</string>
+    <string name="upgrade_screen_iap_offer_body">ఒకసారి చెల్లించండి మరియు Pro ను శాశ్వతంగా సొంతం చేసుకోండి.</string>
+    <string name="upgrade_screen_owned_hero_title">మీరు Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">మీరు %1$s ను శాశ్వతంగా సొంతం చేసుకున్నారు.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">మీ %1$s సభ్యత్వం క్రియాశీలంగా ఉంది.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">మీ సభ్యత్వం పునరుద్ధరించటానికి సెట్ చేయబడలేదు, కాబట్టి మీరు ఇప్పుడు ఒకసారి కొనుగోలుకు మారవచ్చు. గమనించండి: ఇది ప్రత్యేక ఛార్జ్, ఇది మీ సభ్యత్వాన్ని రద్దు చేయదు లేదా నిర్వసూల చేయదు, కాబట్టి రెండింటికీ ఒకే Google ఖాతాను ఉపయోగించండి.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">మొదట Google Play లో మీ పునరుద్ధరణ సభ్యత్వాన్ని రద్దు చేయండి, ఆపై మీరు ఒకసారి కొనుగోలుకు మారవచ్చు.</string>
+    <string name="upgrade_screen_restore_body">ఈ ఖాతాపై ఇప్పటికే Pro కొనుగోలు చేసారా? మీ కొనుగోలులను పునః తనిఖీ చేయమని Google Play ను అడగండి.</string>
+    <string name="upgrade_screen_restore_checked_message">మేము Google Play ను ఈ ఖాతా యొక్క కొనుగోలులను పునః తనిఖీ చేయమని అడిగాము మరియు ఒకటి కనుగొనలేదు.</string>
+    <string name="upgrade_screen_restore_contact_hint">ఇప్పటికీ సమస్య కొనసాగుతున్నారా? కొనుగోలు చేసిన ఒకే Google ఖాతా నుండి సంప్రదించండి, మీ Google Play ఆర్డర్ నంబర్‌ను చేర్చండి, మరియు మేము దీనిని పరిష్కరిస్తాము.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">మేము సమయానికి Google Play తో తనిఖీ చేయడం పూర్తి చేయలేకపోయాము, కాబట్టి మేము ఇప్పటికీ మీ కొనుగోలు స్థితిని తెలుసుకోలేదు — ఒక క్షణం ఇవ్వండి మరియు మళ్లీ ప్రయత్నించండి.</string>
+    <string name="upgrades_gplay_billing_error_label">కొనుగోలు సమస్య</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play ఒక సమస్యను నివేదించింది: %1$s. కొంచెం సేపటి తరువాత మళ్లీ ప్రయత్నించండి లేదా మీ పరికరాన్ని పునఃప్రారంభించండి.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ఆఫర్ అందుబాటులో లేనిది</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ఈ సమయంలో ఈ వస్తువును అందించలేదు. ఇది మీ ఖాతా లేదా ప్రాంతానికి ఇంకా అందుబాటులో ఉండకపోవచ్చు — దయచేసి కొంచెం సేపటి తరువాత మళ్లీ ప్రయత్నించండి.</string>
 </resources>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">อัปเกรดเป็น BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ให้ผลลัพธ์ที่ดีกว่า ฟีเจอร์เพิ่มเติม และตัวเลือกสำหรับผู้ใช้ขั้นสูง</string>
     <string name="upgrade_prompt_upgrade_action">อัปเกรด</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">อัปเกรดเป็น %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ไม่มีโฆษณาและไม่ขายข้อมูลผู้ใช้ งานของฉันได้รับการสนับสนุนทางการเงินจากคุณ ❤️</string>
     <string name="upgrade_screen_why_title">ข้อดี</string>
     <string name="upgrade_screen_subscription_trial_action">เริ่มทดลองใช้ฟรี 14 วัน</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">ไม่สามารถเชื่อมต่อกับ Google Play โปรดตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ไม่พร้อมใช้งาน</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ไม่สามารถเชื่อมต่อกับ Google Play ได้ Google Play ได้รับการติดตั้งและอัปเดตแล้วหรือไม่? บัญชี Google ของคุณเข้าสู่ระบบแล้วหรือไม่? ลองล้างแคชของแอป Google Play และรีบูตอุปกรณ์ของคุณ</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">ไม่สามารถเปิด Google Play ได้ แอปอาจหายไป ปิดใช้งาน หรือถูกจำกัดบนอุปกรณ์นี้</string>
     <string name="upgrades_no_purchases_found_check_account">ไม่พบการซื้อ คุณใช้บัญชีที่ถูกต้องหรือไม่?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">ตัวเลือกอัปเกรด</string>
+    <string name="upgrade_screen_offers_body">ตัวเลือกทั้งสองปลดล็อกฟีเจอร์ Pro เดียวกัน — เลือกตัวเลือกใดก็ได้ที่เหมาะกับคุณ</string>
+    <string name="upgrade_screen_offers_unavailable_title">ไม่พบราคา</string>
+    <string name="upgrade_screen_offers_unavailable_message">ราคาไม่สามารถโหลดได้ในขณะนี้ ตรวจสอบ Google Play และลองอีกครั้งในอีกสักครู่</string>
+    <string name="upgrade_screen_benefits_body">• อุปกรณ์ไม่จำกัด\n• การดำเนินการเชื่อมต่อที่กำหนดเอง\n• ปรับแต่งธีม\n• ตัวควบคุมระดับเสียงขั้นสูง\n• สนับสนุนการพัฒนาในอนาคต ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">การสมัครสมาชิกรายปี</string>
+    <string name="upgrade_screen_subscription_offer_body">เริ่มต้นด้วยการทดลองใช้ฟรี จากนั้นต่ออายุรายปี คุณสามารถยกเลิกได้ตลอดเวลาใน Google Play</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">ต่ออายุรายปี คุณสามารถยกเลิกได้ตลอดเวลาใน Google Play</string>
+    <string name="upgrade_screen_iap_offer_title">ปลดล็อกตลอดชีวิต</string>
+    <string name="upgrade_screen_iap_offer_body">จ่ายเพียงครั้งเดียวและเป็นเจ้าของ Pro ตลอดไป</string>
+    <string name="upgrade_screen_owned_hero_title">คุณเป็น Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">คุณเป็นเจ้าของ %1$s ตลอดไป</string>
+    <string name="upgrade_screen_owned_hero_sub_body">การสมัครสมาชิก %1$s ของคุณใช้งานได้</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">การสมัครสมาชิกของคุณไม่ได้ตั้งค่าให้ต่ออายุ ดังนั้นคุณสามารถเปลี่ยนไปเป็นการซื้อครั้งเดียวได้แล้ว โปรดทราบ: เป็นการเรียกเก็บเงินแยกต่างหากซึ่งจะไม่ยกเลิกหรือคืนเงินการสมัครสมาชิกของคุณ ดังนั้นให้ใช้บัญชี Google เดียวกันสำหรับทั้งสองแบบ</string>
+    <string name="upgrade_screen_owned_iap_locked_note">ยกเลิกการสมัครสมาชิกที่ต่ออายุของคุณใน Google Play ก่อน จากนั้นคุณสามารถเปลี่ยนไปเป็นการซื้อครั้งเดียว</string>
+    <string name="upgrade_screen_restore_body">ซื้อ Pro แล้วบนบัญชีนี้หรือ? ขอให้ Google Play ตรวจสอบการซื้อของคุณอีกครั้ง</string>
+    <string name="upgrade_screen_restore_checked_message">เราขอให้ Google Play ตรวจสอบการซื้อของบัญชีนี้อีกครั้งและไม่พบการซื้อใดๆ</string>
+    <string name="upgrade_screen_restore_contact_hint">ยังติดอยู่? ติดต่อจากบัญชี Google เดียวกันที่คุณซื้อด้วย แสดงหมายเลขการสั่งซื้อ Google Play ของคุณ และเราจะแก้ไขให้คุณ</string>
+    <string name="upgrade_screen_restore_inconclusive_message">เราไม่สามารถเสร็จสิ้นการตรวจสอบกับ Google Play ได้ทันเวลา ดังนั้นเรายังไม่ทราบสถานะการซื้อของคุณ — รอสักครู่แล้วลองอีกครั้ง</string>
+    <string name="upgrades_gplay_billing_error_label">ปัญหาการซื้อ</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play รายงานปัญหา: %1$s ลองอีกครั้งในภายหลังหรือเปิดอุปกรณ์ของคุณใหม่</string>
+    <string name="upgrades_gplay_offer_unavailable_title">ไม่พบข้อเสนอ</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play ไม่ได้นำเสนอรายการนี้ในขณะนี้ อาจยังไม่พร้อมสำหรับบัญชีหรือภูมิภาคของคุณ — โปรดลองอีกครั้งในภายหลัง</string>
 </resources>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro\'ya Yükselt</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro, uzman kullanıcılar için daha iyi sonuçlar, daha fazla özellik ve seçenek sunar.</string>
     <string name="upgrade_prompt_upgrade_action">Yükselt</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s\'a yükseltin</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklam içermez ve kullanıcı verilerini satmaz. Çalışmalarım sizler tarafından finanse edilmektedir ❤️.</string>
     <string name="upgrade_screen_why_title">Avantajlar</string>
     <string name="upgrade_screen_subscription_trial_action">14 günlük ücretsiz denemeyi başlatın</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play\'e bağlanılamıyor. Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play kullanılamıyor</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play\'e bağlanamıyor. Google Play yüklü ve güncel mi? Google Hesabınız ile oturum açtınız mı? Google Play uygulamasının önbelleğini temizlemeyi ve cihazınızı yeniden başlatmayı deneyin.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play açılamadı. Bu cihazda yüklü olmayabilir, devre dışı olabilir veya kısıtlanmış olabilir.</string>
     <string name="upgrades_no_purchases_found_check_account">Satın alma bulunamadı. Doğru hesabı mı kullanıyorsunuz?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Yükseltme seçenekleri</string>
+    <string name="upgrade_screen_offers_body">Her iki seçenek tam olarak aynı Pro özelliklerinin kilidini açar — sizin için uygun olanı seçin.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Fiyatlar kullanılamıyor</string>
+    <string name="upgrade_screen_offers_unavailable_message">Fiyatlar şu anda yüklenemedi. Google Play\'i kontrol edin ve bir an sonra tekrar deneyin.</string>
+    <string name="upgrade_screen_benefits_body">• Sınırsız cihaz\n• Özel bağlantı eylemleri\n• Tema özelleştirmesi\n• Gelişmiş ses kontrolü\n• Gelecekteki geliştirmeyi destekleyin ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Yıllık abonelik</string>
+    <string name="upgrade_screen_subscription_offer_body">Ücretsiz deneme ile başlar, sonra yıllık olarak yenilenir. Google Play\'den istediğiniz zaman iptal edin.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Yıllık olarak yenilenir. Google Play\'den istediğiniz zaman iptal edin.</string>
+    <string name="upgrade_screen_iap_offer_title">Yaşam boyu kilit açma</string>
+    <string name="upgrade_screen_iap_offer_body">Bir kez ödeyip Pro\'ya sonsuza kadar sahip olun.</string>
+    <string name="upgrade_screen_owned_hero_title">Siz Pro\'sunuz! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">%1$s\'a sonsuza kadar sahipsiniz.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Sizin %1$s aboneliğiniz aktif.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Aboneliğiniz yenilenecek şekilde ayarlanmamış, bu nedenle şimdi tek seferlik satın almaya geçebilirsiniz. Dikkat: bu, aboneliğinizi iptal etmeyecek veya geri ödeme yapmayacak ayrı bir ücrettir, bu nedenle her ikisi için aynı Google hesabını kullanın.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Önce Google Play\'de yenilenen aboneliğinizi iptal edin, sonra tek seferlik satın almaya geçebilirsiniz.</string>
+    <string name="upgrade_screen_restore_body">Bu hesapta zaten Pro satın aldınız mı? Google Play\'den satın almalarınızı yeniden kontrol etmesini isteyin.</string>
+    <string name="upgrade_screen_restore_checked_message">Google Play\'den bu hesabın satın almalarını yeniden kontrol etmesini istedik ve bir tane bulamadık.</string>
+    <string name="upgrade_screen_restore_contact_hint">Hala takılı mı? Satın aldığınız aynı Google hesabından iletişime geçin, Google Play sipariş numaranızı ekleyin ve bunu çözeriz.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play ile kontrol işlemini zamanında tamamlayamadık, bu nedenle hala satın alma durumunuzu bilmiyoruz — bir an bekleyin ve tekrar deneyin.</string>
+    <string name="upgrades_gplay_billing_error_label">Satın alma sorunu</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play bir sorun bildirdi: %1$s. Daha sonra tekrar deneyin veya cihazınızı yeniden başlatın.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Teklif kullanılamıyor</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play şu anda bu öğeyi sunmadı. Hesabınız veya bölgeniz için henüz kullanılamayabilir — lütfen daha sonra tekrar deneyin.</string>
 </resources>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Оновити до BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro пропонує кращі результати, більше функцій та опцій для досвідчених користувачів.</string>
     <string name="upgrade_prompt_upgrade_action">Підвищити статус</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Оновити на %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не має реклами та не продає дані користувачів. Моя робота фінансується вами ❤️.</string>
     <string name="upgrade_screen_why_title">Переваги</string>
     <string name="upgrade_screen_subscription_trial_action">Розпочати безкоштовний 14-денний пробний період</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Неможливо підключитися до Google Play. Перевірте підключення до Інтернету та спробуйте ще раз.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play недоступний</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може підключитися до Google Play. Google Play встановлений та оновлений? Ви увійшли до облікового запису Google? Спробуйте очистити кеш Google Play та перезавантажити пристрій.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Не вдалося відкрити Google Play. Можливо, він відсутній, вимкнений або обмежений на цьому пристрої.</string>
     <string name="upgrades_no_purchases_found_check_account">Покупки не знайдено. Ви використовуєте правильний обліковий запис?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Варіанти оновлення</string>
+    <string name="upgrade_screen_offers_body">Обидва варіанти розблоковують абсолютно однакові функції Pro — виберіть той, що вам більше подобається.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Ціни недоступні</string>
+    <string name="upgrade_screen_offers_unavailable_message">Ціни не вдалося завантажити прямо зараз. Перевірте Google Play і спробуйте ще раз через деякий час.</string>
+    <string name="upgrade_screen_benefits_body">• Необмежена кількість пристроїв\n• Користувацькі дії при підключенні\n• Налаштування теми\n• Розширене управління гучністю\n• Підтримка подальшого розвитку ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Річна підписка</string>
+    <string name="upgrade_screen_subscription_offer_body">Починається з безплатного пробного періоду, потім автоматично продовжується щороку. Скасуйте будь-коли в Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Автоматично продовжується щороку. Скасуйте будь-коли в Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Довічне розблокування</string>
+    <string name="upgrade_screen_iap_offer_body">Сплатьте один раз і користуйтесь Pro назавжди.</string>
+    <string name="upgrade_screen_owned_hero_title">У вас є Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Ви володієте %1$s назавжди.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Ваша %1$s підписка активна.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Ваша підписка не встановлена на автоматичне продовження, тому ви можете зараз перейти на одноразову покупку. Увага: це окремий платіж, який не скасує вашу поточну підписку та не поверне кошти за неї, тому використовуйте один і той самий обліковий запис Google для обох.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Спочатку скасуйте вашу підписку в Google Play, а потім ви можете перейти до одноразової покупки.</string>
+    <string name="upgrade_screen_restore_body">Вже купили Pro на цьому обліковому записі? Попросіть Google Play переперевірити ваші покупки.</string>
+    <string name="upgrade_screen_restore_checked_message">Ми попросили Google Play переперевірити покупки цього облікового запису, але нічого не знайшли.</string>
+    <string name="upgrade_screen_restore_contact_hint">Все ще маєте проблеми? Зв\'яжіться з нами з того самого облікового запису Google, яким ви користувалися для покупки, вказавши номер вашого замовлення в Google Play, і ми допоможемо вам.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Ми не змогли завершити перевірку в Google Play вчасно, тому ми все ще не знаємо статус вашої покупки — дайте деякий час і спробуйте ще раз.</string>
+    <string name="upgrades_gplay_billing_error_label">Проблема з покупкою</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play повідомив про проблему: %1$s. Спробуйте ще раз пізніше або перезавантажте пристрій.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Пропозиція недоступна</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play не пропонує цей товар прямо зараз. Він може бути недоступним для вашого облікового запису чи регіону — спробуйте ще раз пізніше.</string>
 </resources>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro میں اپ گریڈ کریں</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro بہتر نتائج، زیادہ خصوصیات اور پاور یوزرز کے لیے آپشنز پیش کرتا ہے۔</string>
     <string name="upgrade_prompt_upgrade_action">اپ گریڈ کریں</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s کو اپ گریڈ کریں</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager میں کوئی اشتہار نہیں ہے اور یہ صارف کا ڈیٹا فروخت نہیں کرتا۔ میرا کام آپ کی وجہ سے فنڈ ہوتا ہے ❤️۔</string>
     <string name="upgrade_screen_why_title">فوائد</string>
     <string name="upgrade_screen_subscription_trial_action">14 دن کی مفت آزمائش شروع کریں</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play سے جڑ نہیں سکے۔ براہ کرم اپنی انٹرنیٹ کنکشن چیک کریں اور دوبارہ کوشش کریں۔</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play دستیاب نہیں ہے</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager گوگل پلے سے منسلک نہیں ہو سکتا۔ کیا گوگل پلے نصب اور تازہ کاری ہے؟ کیا آپ کا گوگل اکاؤنٹ لاگ ان ہے؟ گوگل پلے ایپ کیں صاف کریں اور ڈیوائس ریبوٹ کریں۔</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play نہیں کھل سکا۔ ہو سکتا ہے یہ موجود نہ ہو، غیر فعال ہو یا اس ڈیوائس پر محدود ہو۔</string>
     <string name="upgrades_no_purchases_found_check_account">کوئی خریداری نہیں ملی۔ کیا آپ صحیح اکاؤنٹ استعمال کر رہے ہیں؟</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">اپ گریڈ کے اختیارات</string>
+    <string name="upgrade_screen_offers_body">دونوں اختیارات بالکل ایک جیسی Pro خصوصیات کو کھولتے ہیں — جو بھی آپ کے لیے موزوں ہو وہ منتخب کریں</string>
+    <string name="upgrade_screen_offers_unavailable_title">قیمتیں دستیاب نہیں</string>
+    <string name="upgrade_screen_offers_unavailable_message">قیمتوں کو ابھی لوڈ نہیں کیا جا سکا۔ Google Play چیک کریں اور ایک لمحے میں دوبارہ کوشش کریں۔</string>
+    <string name="upgrade_screen_benefits_body">• لامحدود آلات\n• کسٹم کنکشن ایکشنز\n• تھیم کی تبدیلی\n• اعلیٰ حجم کنٹرول\n• مستقبل کی ترقی میں معاونت ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">سالانہ رکنیت</string>
+    <string name="upgrade_screen_subscription_offer_body">مفت ٹرائل سے شروع ہوتا ہے، پھر سالانہ تجدید ہوتا ہے۔ Google Play میں کسی بھی وقت منسوخ کریں۔</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">سالانہ تجدید ہوتا ہے۔ Google Play میں کسی بھی وقت منسوخ کریں۔</string>
+    <string name="upgrade_screen_iap_offer_title">زندگی بھر کی رہائی</string>
+    <string name="upgrade_screen_iap_offer_body">ایک بار ادائیگی کریں اور Pro کو ہمیشہ کے لیے رکھیں۔</string>
+    <string name="upgrade_screen_owned_hero_title">آپ Pro ہیں! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">آپ %1$s کو ہمیشہ کے لیے رکھتے ہیں۔</string>
+    <string name="upgrade_screen_owned_hero_sub_body">آپ کی %1$s رکنیت فعال ہے۔</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">آپ کی رکنیت تجدید کے لیے سیٹ نہیں ہے، تو آپ اب ایک بار خریداری میں تبدیل کر سکتے ہیں۔ احتیاط: یہ الگ چارج ہے جو آپ کی رکنیت کو منسوخ یا واپس نہیں کرے گا، تو دونوں کے لیے ایک جیسا Google اکاؤنٹ استعمال کریں۔</string>
+    <string name="upgrade_screen_owned_iap_locked_note">پہلے Google Play میں اپنی تجدید شدہ رکنیت منسوخ کریں، پھر آپ ایک بار خریداری میں تبدیل ہو سکتے ہیں۔</string>
+    <string name="upgrade_screen_restore_body">پہلے سے اس اکاؤنٹ پر Pro خریدا ہے؟ Google Play سے اپنی خریداریوں کو دوبارہ چیک کرنے کے لیے کہہ دیں۔</string>
+    <string name="upgrade_screen_restore_checked_message">ہم نے Google Play سے اس اکاؤنٹ کی خریداریوں کو دوبارہ چیک کرنے کو کہا اور کوئی نہیں ملا۔</string>
+    <string name="upgrade_screen_restore_contact_hint">ابھی بھی پھنسے ہوئے ہیں؟ اسی Google اکاؤنٹ سے رابطہ کریں جس سے آپ نے خریدا، اپنا Google Play آرڈر نمبر شامل کریں، اور ہم اسے حل کر دیں گے۔</string>
+    <string name="upgrade_screen_restore_inconclusive_message">ہم وقت پر Google Play کے ساتھ چیک ختم نہ کر سکے، تو ہمیں ابھی آپ کی خریداری کی حالت معلوم نہیں — ایک لمحہ دیں اور دوبارہ کوشش کریں۔</string>
+    <string name="upgrades_gplay_billing_error_label">خریداری کا مسئلہ</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play نے ایک مسئلہ کی اطلاع دی: %1$s۔ بعد میں دوبارہ کوشش کریں یا اپنا ڈیوائس دوبارہ شروع کریں۔</string>
+    <string name="upgrades_gplay_offer_unavailable_title">آفر دستیاب نہیں</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play نے ابھی اس چیز کی پیشکش نہیں کی۔ یہ آپ کے اکاؤنٹ یا علاقے کے لیے ابھی دستیاب نہیں ہو سکتا — براہ کرم بعد میں دوبارہ کوشش کریں۔</string>
 </resources>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">BVM Pro ga o\'tish</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro quvvatli foydalanuvchilar uchun yaxshiroq natijalar, ko\'proq funksiyalar va opsiyalar taklif qiladi.</string>
     <string name="upgrade_prompt_upgrade_action">Yangilash</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">%1$s ga yangilash</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklamasiz va foydalanuvchi ma\'lumotlarini sotmaydi. Mening ishim siz tomonidan moliyalashtiriladi ❤️.</string>
     <string name="upgrade_screen_why_title">Afzalliklar</string>
     <string name="upgrade_screen_subscription_trial_action">Bepul 14 kunlik sinovni boshlang</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Google Play bilan bog\'lana olmadi. Iltimos, internet ulanishingizni tekshiring va qayta urinib ko\'ring.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play mavjud emas</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play ga ulana olmadi. Google Play o\'rnatilgan va yangilangan? Google hisobingizda kirgansizmi? Google Play ilovasi keshini tozalab, qurilmangizni qayta yoqishga urinib ko\'ring.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Google Play\'ni ochib bo\'lmadi. Bu qurilmada yo\'q, o\'chirib qo\'yilgan yoki cheklangan bo\'lishi mumkin.</string>
     <string name="upgrades_no_purchases_found_check_account">Hech qanday xarid topilmadi. To\'g\'ri hisobdan foydalanyapsizmi?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Yangilash variantlari</string>
+    <string name="upgrade_screen_offers_body">Ikkala variant ham bir xil Pro imkoniyatlarini ochadi — o\'zingizga mos kelgan birini tanlang.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Narxlar mavjud emas</string>
+    <string name="upgrade_screen_offers_unavailable_message">Narxlarni hozir yuklab bo\'lmadi. Google Play\'ni tekshiring va bir lahzadan so\'ng qayta urinib ko\'ring.</string>
+    <string name="upgrade_screen_benefits_body">• Cheksiz qurilmalar\n• Maxsus ulanish harakatlari\n• Tema sozlanmasi\n• Ilg\'or ovoz boshqarish\n• Kelajakdagi ishlanmani qo\'llash ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Yillik obuna</string>
+    <string name="upgrade_screen_subscription_offer_body">Bepul sinashdan boshlanadi, keyin yilga qayta yangilanadi. Google Play\'da istalgan vaqtda bekor qilish mumkin.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Yilga qayta yangilanadi. Google Play\'da istalgan vaqtda bekor qilish mumkin.</string>
+    <string name="upgrade_screen_iap_offer_title">Umrbod yoqish</string>
+    <string name="upgrade_screen_iap_offer_body">Bir marta to\'lang va abadiy Pro egasi bo\'ling.</string>
+    <string name="upgrade_screen_owned_hero_title">Siz Pro\'siz! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Siz %1$s ni abadiy egallaysiz.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">%1$s obunangiz faol.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Obunangiz qayta yangilanishga o\'rnatilmagan, shuning uchun endi bir martalik xaridga o\'tishingiz mumkin. Diqqat: bu alohida to\'lov bo\'lib, obunangizni bekor qilmaydi yoki pulini qaytarmaydi, shuning uchun ikkalasi uchun ham bir xil Google hisobidan foydalaning.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Avval Google Play\'da qayta yangilanib turadigan obunangizni bekor qiling, keyin bir martalik xaridga o\'tishingiz mumkin.</string>
+    <string name="upgrade_screen_restore_body">Ushbu hisobda Pro allaqachon sotib olinganmi? Google Play\'dan xaridlaringizni qayta tekshirishni so\'rang.</string>
+    <string name="upgrade_screen_restore_checked_message">Biz Google Play\'dan ushbu hisob xaridlarini qayta tekshirishni so\'radik va hech narsa topilmadi.</string>
+    <string name="upgrade_screen_restore_contact_hint">Hali ham muammo bormi? Sotib olgan Google hisobingizdan bog\'laning, Google Play buyurtma raqamingizni ko\'rsating, biz uni hal qilamiz.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Google Play bilan tekshirishni vaqtida tugata olmadik, shuning uchun xarid holatingizni hali bilmaymiz — biroz kutib, qayta urinib ko\'ring.</string>
+    <string name="upgrades_gplay_billing_error_label">Xarid muammosi</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play muammo haqida xabar berdi: %1$s. Keyinroq qayta urinib ko\'ring yoki qurilmangizni qayta ishga tushiring.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Taklif mavjud emas</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play hozircha bu mahsulotni taklif qilmadi. U sizning hisobingiz yoki mintaqangiz uchun hali mavjud bo\'lmasligi mumkin — keyinroq qayta urinib ko\'ring.</string>
 </resources>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Nâng cấp lên BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro mang lại kết quả tốt hơn, nhiều tính năng và tùy chọn hơn cho người dùng.</string>
     <string name="upgrade_prompt_upgrade_action">Nâng cấp</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Nâng cấp lên %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager không có quảng cáo và không bán dữ liệu người dùng. Công việc của tôi được tài trợ bởi bạn ❤️.</string>
     <string name="upgrade_screen_why_title">Lợi thế</string>
     <string name="upgrade_screen_subscription_trial_action">Bắt đầu dùng thử 14 ngày miễn phí</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Không thể kết nối với Google Play. Vui lòng kiểm tra kết nối internet của bạn và thử lại.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play không khả dụng</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager không thể kết nối với Google Play. Google Play đã được cài đặt và cập nhật chưa? Bạn đã đăng nhập tài khoản Google chưa? Hãy thử xóa bộ nhớ cache của ứng dụng Google Play và khởi động lại thiết bị.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Không mở được Google Play. Có thể ứng dụng bị thiếu, bị tắt hoặc bị hạn chế trên thiết bị này.</string>
     <string name="upgrades_no_purchases_found_check_account">Không tìm thấy giao dịch nào. Bạn có đang sử dụng đúng tài khoản không?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Các tùy chọn nâng cấp</string>
+    <string name="upgrade_screen_offers_body">Cả hai tùy chọn đều mở khóa các tính năng Pro giống hệt nhau — hãy chọn tùy chọn phù hợp với bạn.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Giá không có sẵn</string>
+    <string name="upgrade_screen_offers_unavailable_message">Không thể tải giá lúc này. Kiểm tra Google Play và thử lại trong giây lát.</string>
+    <string name="upgrade_screen_benefits_body">• Thiết bị không giới hạn\n• Tùy chỉnh hành động kết nối\n• Tùy chỉnh chủ đề\n• Điều khiển âm lượng nâng cao\n• Hỗ trợ phát triển trong tương lai ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Gói đăng ký hàng năm</string>
+    <string name="upgrade_screen_subscription_offer_body">Bắt đầu bằng bản dùng thử miễn phí, sau đó gia hạn hàng năm. Hủy bất kỳ lúc nào trong Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Gia hạn hàng năm. Hủy bất kỳ lúc nào trong Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Mở khóa vĩnh viễn</string>
+    <string name="upgrade_screen_iap_offer_body">Trả một lần và sở hữu Pro mãi mãi.</string>
+    <string name="upgrade_screen_owned_hero_title">Bạn là Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Bạn sở hữu %1$s mãi mãi.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Đăng ký %1$s của bạn đang hoạt động.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Đăng ký của bạn không được đặt để gia hạn, vì vậy bạn có thể chuyển sang mua một lần ngay bây giờ. Chú ý: đây là một khoản phí riêng biệt sẽ không hủy hoặc hoàn lại đăng ký của bạn, vì vậy hãy sử dụng cùng một tài khoản Google cho cả hai.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Hủy đăng ký gia hạn của bạn trong Google Play trước, sau đó bạn có thể chuyển sang mua một lần.</string>
+    <string name="upgrade_screen_restore_body">Đã mua Pro trên tài khoản này? Yêu cầu Google Play kiểm tra lại các lần mua của bạn.</string>
+    <string name="upgrade_screen_restore_checked_message">Chúng tôi đã yêu cầu Google Play kiểm tra lại các lần mua của tài khoản này và không tìm thấy.</string>
+    <string name="upgrade_screen_restore_contact_hint">Vẫn còn vấn đề? Liên hệ từ cùng một tài khoản Google mà bạn đã mua, bao gồm số đơn hàng Google Play của bạn, và chúng tôi sẽ giải quyết.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Chúng tôi không thể hoàn thành kiểm tra với Google Play kịp thời, vì vậy chúng tôi vẫn không biết trạng thái mua hàng của bạn — chờ một chút và thử lại.</string>
+    <string name="upgrades_gplay_billing_error_label">Vấn đề mua hàng</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play báo cáo một vấn đề: %1$s. Hãy thử lại sau hoặc khởi động lại thiết bị của bạn.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Ưu đãi không có sẵn</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play không cung cấp mục này ngay bây giờ. Nó có thể chưa có sẵn cho tài khoản hoặc khu vực của bạn — vui lòng thử lại sau.</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">升级至 BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro 为高级用户提供更好的效果、更多的功能和选项。</string>
     <string name="upgrade_prompt_upgrade_action">升级</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">升级到%1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 没有广告，也不出售用户数据。我的工作由您资助 ❤️。</string>
     <string name="upgrade_screen_why_title">优点</string>
     <string name="upgrade_screen_subscription_trial_action">开始 14 天免费试用</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">无法连接到 Google Play。请检查您的互联网连接并重试。</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play 不可用</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager 无法连接到 Google Play。Google Play 是否已安装并更新至最新版本？您的 Google 账户是否已登录？请尝试清除 Google Play 应用的缓存并重启设备。</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">无法打开 Google Play。该应用可能未安装、已禁用或受到限制。</string>
     <string name="upgrades_no_purchases_found_check_account">未找到任何购买记录。您确定账号正确吗？</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">升级选项</string>
+    <string name="upgrade_screen_offers_body">两种选项都解锁相同的Pro功能——选择适合你的即可。</string>
+    <string name="upgrade_screen_offers_unavailable_title">价格不可用</string>
+    <string name="upgrade_screen_offers_unavailable_message">价格现在无法加载。请检查Google Play，稍后重试。</string>
+    <string name="upgrade_screen_benefits_body">• 无限制设备\n• 自定义连接操作\n• 主题自定义\n• 高级音量控制\n• 支持未来开发 ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">年度订阅</string>
+    <string name="upgrade_screen_subscription_offer_body">开始免费试用，然后每年续订。可随时在Google Play中取消。</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">每年续订。可随时在Google Play中取消。</string>
+    <string name="upgrade_screen_iap_offer_title">终身解锁</string>
+    <string name="upgrade_screen_iap_offer_body">一次性付款，永久拥有Pro。</string>
+    <string name="upgrade_screen_owned_hero_title">你是Pro！❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">你永久拥有%1$s。</string>
+    <string name="upgrade_screen_owned_hero_sub_body">你的%1$s订阅已激活。</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">你的订阅未设置为续订，因此现在可以切换到一次性购买。提醒：这是单独的一笔费用，不会取消或退款你的订阅，因此请在两者上使用相同的Google账户。</string>
+    <string name="upgrade_screen_owned_iap_locked_note">首先在Google Play中取消你的续订订阅，然后可以切换到一次性购买。</string>
+    <string name="upgrade_screen_restore_body">已在此账户购买过Pro？请要求Google Play重新检查你的购买记录。</string>
+    <string name="upgrade_screen_restore_checked_message">我们要求Google Play重新检查此账户的购买记录，但未找到。</string>
+    <string name="upgrade_screen_restore_contact_hint">仍无法解决？请使用购买时使用的Google账户与我们联系，并包含你的Google Play订单号，我们会帮助解决。</string>
+    <string name="upgrade_screen_restore_inconclusive_message">我们无法及时完成与Google Play的检查，因此仍不知道你的购买状态——请稍等片刻，然后重试。</string>
+    <string name="upgrades_gplay_billing_error_label">购买问题</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play报告了一个问题：%1$s。请稍后重试或重启设备。</string>
+    <string name="upgrades_gplay_offer_unavailable_title">商品不可用</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play目前未提供此商品。可能尚不适用于你的账户或地区——请稍后重试。</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">升級到 BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro 為進階用戶提供更好的效果、更多功能和選項。</string>
     <string name="upgrade_prompt_upgrade_action">升級</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">升級至 %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不出售用戶數據。我的工作由你支持 ❤️。</string>
     <string name="upgrade_screen_why_title">優點</string>
     <string name="upgrade_screen_subscription_trial_action">開始 14 天免費試用</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">無法連接 Google Play。請檢查您的網際網路連接並重試。</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play 無法使用</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager 無法連接 Google Play。Google Play 已安裝且是最新版本？你的 Google 帳戶已登入？請嘗試清除 Google Play 應用的快取並重新啟動裝置。</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">無法開啟 Google Play。它可能在此裝置上遺失、停用或受限。</string>
     <string name="upgrades_no_purchases_found_check_account">找不到購買，您正在使用正確的帳戶嗎？</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">升級選項</string>
+    <string name="upgrade_screen_offers_body">兩個選項都能解鎖相同的 Pro 功能 — 選擇最適合你的。</string>
+    <string name="upgrade_screen_offers_unavailable_title">價格不可用</string>
+    <string name="upgrade_screen_offers_unavailable_message">無法立即載入價格。檢查 Google Play 並稍後再試。</string>
+    <string name="upgrade_screen_benefits_body">• 無限裝置\n• 自訂連線動作\n• 主題自訂\n• 進階音量控制\n• 支持未來開發 ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">年度訂閱</string>
+    <string name="upgrade_screen_subscription_offer_body">開始免費試用，然後按年續約。可隨時在 Google Play 中取消。</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">按年續約。可隨時在 Google Play 中取消。</string>
+    <string name="upgrade_screen_iap_offer_title">永久解鎖</string>
+    <string name="upgrade_screen_iap_offer_body">一次付款，永久擁有 Pro。</string>
+    <string name="upgrade_screen_owned_hero_title">你已是 Pro！❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">你永久擁有 %1$s。</string>
+    <string name="upgrade_screen_owned_hero_sub_body">你的 %1$s 訂閱已啟用。</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">你的訂閱未設定續約，所以你現在可以改用一次性購買。提醒：這是單獨收費的，不會取消或退款你的訂閱，所以請對兩者使用相同的 Google 帳戶。</string>
+    <string name="upgrade_screen_owned_iap_locked_note">先在 Google Play 中取消你的續約訂閱，然後就可以改用一次性購買。</string>
+    <string name="upgrade_screen_restore_body">已經在此帳戶購買 Pro？請求 Google Play 重新檢查你的購買。</string>
+    <string name="upgrade_screen_restore_checked_message">我們要求 Google Play 重新檢查此帳戶的購買紀錄，但未找到任何購買。</string>
+    <string name="upgrade_screen_restore_contact_hint">仍有困難？請從你購買時使用的同一 Google 帳戶與我們聯絡，包括你的 Google Play 訂單編號，我們會為你解決。</string>
+    <string name="upgrade_screen_restore_inconclusive_message">我們無法及時完成 Google Play 檢查，所以仍不知道你的購買狀態 — 請稍候再試一次。</string>
+    <string name="upgrades_gplay_billing_error_label">購買問題</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play 報告了一個問題：%1$s。稍後重試或重新啟動你的裝置。</string>
+    <string name="upgrades_gplay_offer_unavailable_title">優惠不可用</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play 目前未提供此商品。它可能尚未提供給你的帳戶或地區 — 請稍後再試。</string>
 </resources>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">升級至 BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro 提供更佳的結果、更多的功能和選項，適用於進階使用者。</string>
     <string name="upgrade_prompt_upgrade_action">升級</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">升級到 %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不會出售使用者資料。我的工作由你贊助 ❤️。</string>
     <string name="upgrade_screen_why_title">優點</string>
     <string name="upgrade_screen_subscription_trial_action">開始 14 天免費試用</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">無法連線到 Google Play。請檢查您的網際網路連線並重試。</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play 無法使用</string>
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager 無法連接到 Google Play。Google Play 是否已安裝且為最新版本？您的 Google 帳戶是否已登入？請嘗試清除 Google Play 應用程式的快取並重新啟動您的裝置。</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">無法開啟 Google Play。此應用程式可能遺失、已停用或在此裝置上受限制。</string>
     <string name="upgrades_no_purchases_found_check_account">找不到購買，您正在使用正確的帳戶嗎？</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">升級選項</string>
+    <string name="upgrade_screen_offers_body">兩個選項都能解鎖相同的 Pro 功能 — 選擇最適合的。</string>
+    <string name="upgrade_screen_offers_unavailable_title">價格不可用</string>
+    <string name="upgrade_screen_offers_unavailable_message">目前無法載入價格。檢查 Google Play 並稍後重試。</string>
+    <string name="upgrade_screen_benefits_body">• 無限制設備\n• 自訂連接操作\n• 主題自訂\n• 進階音量控制\n• 支持未來開發 ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">年度訂閱</string>
+    <string name="upgrade_screen_subscription_offer_body">開始免費試用，然後每年自動續約。可隨時在 Google Play 中取消。</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">每年自動續約。可隨時在 Google Play 中取消。</string>
+    <string name="upgrade_screen_iap_offer_title">終身解鎖</string>
+    <string name="upgrade_screen_iap_offer_body">一次付費，永久擁有 Pro。</string>
+    <string name="upgrade_screen_owned_hero_title">你已成為 Pro！❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">你永久擁有 %1$s。</string>
+    <string name="upgrade_screen_owned_hero_sub_body">你的 %1$s 訂閱正在使用中。</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">你的訂閱未設定為自動續約，所以你現在可以切換到一次性購買。提醒：這是單獨費用，不會取消或退款你的訂閱，所以請使用相同的 Google 帳號購買兩者。</string>
+    <string name="upgrade_screen_owned_iap_locked_note">先在 Google Play 中取消你的自動續約訂閱，然後你可以切換到一次性購買。</string>
+    <string name="upgrade_screen_restore_body">已在此帳號購買 Pro？要求 Google Play 重新檢查你的購買。</string>
+    <string name="upgrade_screen_restore_checked_message">我們要求 Google Play 重新檢查此帳號的購買，但未找到。</string>
+    <string name="upgrade_screen_restore_contact_hint">仍然卡住？使用購買時相同的 Google 帳號聯絡我們，包括你的 Google Play 訂單編號，我們會幫你解決。</string>
+    <string name="upgrade_screen_restore_inconclusive_message">我們無法及時完成與 Google Play 的檢查，所以我們仍不知道你的購買狀態 — 稍等片刻後重試。</string>
+    <string name="upgrades_gplay_billing_error_label">購買問題</string>
+    <string name="upgrades_gplay_billing_error_description">Google Play 報告了問題：%1$s。稍後重試或重新啟動設備。</string>
+    <string name="upgrades_gplay_offer_unavailable_title">優惠不可用</string>
+    <string name="upgrades_gplay_offer_unavailable_description">Google Play 目前未提供此項目。此項目可能尚未在你的帳號或地區提供 — 請稍後重試。</string>
 </resources>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -7,6 +7,8 @@
     <string name="upgrade_prompt_title">Buyekeza kuya ku-BVM Pro</string>
     <string name="upgrade_prompt_body">I-Bluetooth Volume Manager Pro inikezela imiphumela engcono, izici ezengeziwe nezinketho zabasebenzisi abaphakeme.</string>
     <string name="upgrade_prompt_upgrade_action">Thuthukisa</string>
+    <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
+    <string name="upgrade_screen_title_template">Khulisa ku-%1$s</string>
     <string name="upgrade_screen_preamble">I-Bluetooth Volume Manager ayinazo izikhangiso futhi ayithengisi idatha yabasebenzisi. Umsebenzi wami uxhaswa nguwe ❤️.</string>
     <string name="upgrade_screen_why_title">Izinzuzo</string>
     <string name="upgrade_screen_subscription_trial_action">Qala ukuhlola kwamahhala kwezinsuku eziyi-14</string>
@@ -50,5 +52,31 @@
     <string name="upgrades_gplay_network_error_description">Ayikwazi ukuxhumana ne-Google Play. Ngiyacela uhlole ikonekshini yakho ye-inthanethi futhi uphinde uzame.</string>
     <string name="upgrades_gplay_unavailable_error_title">Google Play ayitholakali</string>
     <string name="upgrades_gplay_unavailable_error_description">I-Bluetooth Volume Manager ayikwazi ukuxhuma ku-Google Play. Ingabe i-Google Play ifakiwe futhi ibuyekeziwe? Ingabe i-Google Account yakho ingene? Zama ukukhwebula i-cache ye-Google Play uqalise kabusha idivayisi yakho.</string>
+    <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
+    <string name="upgrades_gplay_not_installed_message">Ayikwazanga ukuvula i-Google Play. Ingabe ayikhona, itumiwe noma imiselelwa kulolu longezelelo.</string>
     <string name="upgrades_no_purchases_found_check_account">Akukho ukuthenga okutholiwe. Ingabe usebenzisa i-akhawunti efanele?</string>
+    <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
+    <string name="upgrade_screen_offers_title">Okukhethwa kokukhulisa</string>
+    <string name="upgrade_screen_offers_body">Izinzwalo zombili zivulela izici ze-Pro ezifanayo — khetha eyakho.</string>
+    <string name="upgrade_screen_offers_unavailable_title">Izilinganiso zentengiso ayitholakali</string>
+    <string name="upgrade_screen_offers_unavailable_message">Izilinganiso zentengiso azisize kulayisha manje. Hlola i-Google Play futhi zama kabusha ngesikhathi.</string>
+    <string name="upgrade_screen_benefits_body">• Imizila engenali\n• Izenzo zokuxhuma zezithubutuhu\n• Ukwenyusa imibono\n• Ukulawula umthwali ophumelele\n• Okusekela ukuthuthuka kwesikhathi esizayo ❤️</string>
+    <string name="upgrade_screen_subscription_offer_title">Isikwelekelo sonyaka</string>
+    <string name="upgrade_screen_subscription_offer_body">Iqala nokuhlola okungenalo intengo, bese kutheshwa kabusha ngonyaka. Khansela nganoma iyiphi isikhathi ku-Google Play.</string>
+    <string name="upgrade_screen_subscription_offer_body_no_trial">Kutheshwa kabusha ngonyaka. Khansela nganoma iyiphi isikhathi ku-Google Play.</string>
+    <string name="upgrade_screen_iap_offer_title">Ukuvula ngokusisele</string>
+    <string name="upgrade_screen_iap_offer_body">Khokha kanye futhi unabe ne-Pro ngokusisele.</string>
+    <string name="upgrade_screen_owned_hero_title">Ungu-Pro! ❤️</string>
+    <string name="upgrade_screen_owned_hero_iap_body">Unabe ne-%1$s ngokusisele.</string>
+    <string name="upgrade_screen_owned_hero_sub_body">Isikwelekelo se-%1$s sakho siyasebenza.</string>
+    <string name="upgrade_screen_owned_iap_purchase_note">Isikwelekelo sakho ayisetheka ukubuya, ngakho ungashintshela ekuthengeni kanye manje. Ziqapela: lingubhili elahlukile engezelwe engayikhanseli noma ingayibuyele ngemali isikwelekelo sakho, ngakho sebenzisa i-akhawunti ye-Google efanayo kuzo zombili.</string>
+    <string name="upgrade_screen_owned_iap_locked_note">Khansela isikwelekelo sakho etheshwayo kabusha ku-Google Play kuqala, bese ungashintshela ekuthengeni kanye.</string>
+    <string name="upgrade_screen_restore_body">Sekuthengile i-Pro ekhawuntini? Cela i-Google Play ukuthi ibuyehlole izithengelo zakho.</string>
+    <string name="upgrade_screen_restore_checked_message">Sicele i-Google Play ukuthi ibuyehlole izithengelo zekhawuntini futhi ayitholikali.</string>
+    <string name="upgrade_screen_restore_contact_hint">Kusisekile? Thintanana ngaphandle kwekhawunti ye-Google efanayo oshicile nayo, ungeze inombolo ye-oda ye-Google Play, futhi sizolungisa.</string>
+    <string name="upgrade_screen_restore_inconclusive_message">Asakwazanga ukuphothula uhlolo ku-Google Play ngesikhathi, ngakho asikakazi isimo sakho sokuthengela — nikeza umomindi futhi zama kabusha.</string>
+    <string name="upgrades_gplay_billing_error_label">Inkinga yokuthengela</string>
+    <string name="upgrades_gplay_billing_error_description">I-Google Play ibikele inkinga: %1$s. Nikeza elinye ukulingisa kamuva noma uqale kabusha isixwayiso sakho.</string>
+    <string name="upgrades_gplay_offer_unavailable_title">Inzwalo ayitholakali</string>
+    <string name="upgrades_gplay_offer_unavailable_description">I-Google Play ayinike indlela yaleli tshubatshuba manje. Ingenxa yokukhubeka ayitholakali ngekhawunti yakho noma indawo — sicela zama kabusha kamuva.</string>
 </resources>

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Geen onbestuurde toestelle gevind nie</string>
     <string name="discover_all_devices_managed_msg">Al jou gekoppelde toestelle word bestuur! Het jy \'n nuwe een nodig?</string>
     <string name="discover_pair_new_device_action">Koppel nuwe toestel</string>
+    <string name="discover_device_speaker_desc">Hierdie selfoon se eie spreker. Die volumes daarvan word toegepas wanneer oudio terugskakel na die selfoon, bv. nadat jou Bluetooth-toestel ontkoppel.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Toestel-konfigurasie</string>
     <string name="devices_device_config_section_general_label">Algemeen</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Voeg toestel by</string>
     <string name="label_just_a_moment_please">Net \'n oomblik, asseblief.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Begin…</string>
     <string name="action_set">Stel</string>
     <string name="action_cancel">Kanselleer</string>
     <string name="label_invalid_input">Ongeldige invoer</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Verwyder</string>
     <string name="general_cancel_action">Kanselleer</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Maak toe</string>
+    <string name="general_progress_loading">Laai…</string>
     <string name="general_configure_action">Stel op</string>
     <string name="battery_optimization_hint_title">Battery-optimisering</string>
     <string name="battery_optimization_hint_message">Battery-optimiserings is geaktiveer en kan behoorlike werking voorkom. Oorweeg om dit te deaktiveer.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Moenie Steur Nie-toegang</string>
     <string name="dnd_access_hint_message">Sonder Moenie Steur Nie-toegang kan luitoon-, kennisgewing- en MSN-moduusinstellings nie toegepas word wanneer jou toestelle koppel nie.</string>
     <string name="dnd_access_fix_action">Verleen toegang</string>
+    <string name="device_speaker_hint_title">Volumes na ontkoppeling</string>
+    <string name="device_speaker_hint_message">Wil jy jou volumes herstel wanneer \'n Bluetooth-toestel ontkoppel? Voeg \"Toestelspreker\" as \'n bestuurde toestel by — die volumes daarvan word toegepas wanneer oudio terugskakel na jou selfoon.</string>
+    <string name="device_speaker_hint_action">Voeg by</string>
+    <string name="review_app_body">Wil jy graag vir BVM \'n hersiening los? ❤️</string>
+    <string name="review_app_review_action">Hersien</string>
+    <string name="review_app_dismiss_action">Miskien later</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Aankoop gekanselleer</string>
     <string name="error_iap_unavailable_message">In-program-aankope is nie beskikbaar nie</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">በኤፕ ያልተቀቀሉ መሣሪያዎች አይገኙ፡ም</string>
     <string name="discover_all_devices_managed_msg">የተጀረዱ መሣሪያዎችዋበት ሁሉም ይተቀቀላሉ። አዲስጀሩ? </string>
     <string name="discover_pair_new_device_action">አዲስ መሣሪያ አወች</string>
+    <string name="discover_device_speaker_desc">ይህ ስልክ ራሱ ተናጋሪ. ጎን ድምጽ ተግባር ስልክ, e.g. ከ Bluetooth መሳሪያ ስልክ ሊብ ወድ ድምጽ ተግባር.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">የመሣሪያ ውቅረት</string>
     <string name="devices_device_config_section_general_label">አጠቃላይ</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">መሣሪያ አክብቢ</string>
     <string name="label_just_a_moment_please">ንዘት ይበዐዘብ።</string>
     <string name="label_notification_channel_status">ሁኔተት</string>
+    <string name="monitor_notification_starting">ገና ጀምሮ…</string>
     <string name="action_set">አድርግ</string>
     <string name="action_cancel">ሰርዝ</string>
     <string name="label_invalid_input">ልክ ያልሆነ ግባት</string>
@@ -391,6 +393,8 @@
     <string name="general_delete_action">ሰርዝ</string>
     <string name="general_cancel_action">ሰርዝ</string>
     <string name="general_ok_action">እሰተ</string>
+    <string name="general_dismiss_action">አስወግድ</string>
+    <string name="general_progress_loading">መጫን…</string>
     <string name="general_configure_action">አድርግ</string>
     <string name="battery_optimization_hint_title">የደም ያሌዅ አመ፥ት</string>
     <string name="battery_optimization_hint_message">የደም ያሌዅ አመ፥ቶች ተፈንንዎል፥ ጀነታ ስራት እንዲያደርኑ እይዻይ።</string>
@@ -402,6 +406,12 @@
     <string name="dnd_access_hint_title">አትረብሽ ፍቃድ</string>
     <string name="dnd_access_hint_message">የ\'አትረብሽ\' ፍቃድ ሳይኖር፣ የደወል፣ ማሳወቂያ እና DND ሁነታ ቅንብሮች መሳሪያዎችዎ ሲገናኙ ሊተገበሩ አይችሉም።</string>
     <string name="dnd_access_fix_action">መዳረሻ ስጥ</string>
+    <string name="device_speaker_hint_title">Bluetooth ከተያያዙ በኋላ ድምጽ</string>
+    <string name="device_speaker_hint_message">Bluetooth መሳሪያ ስልክ ድምጽ ወደ ሊብ ይህ ወደ ያለ ፈለገ? \"ስልክ ተናጋሪ\" በ አምሳያ መሳሪያ ተጨምር — ጎን ድምጽ ተግባር ተዋወቀ.</string>
+    <string name="device_speaker_hint_action">ታክል</string>
+    <string name="review_app_body">ለBVM ግምገማ ማስቀመጥ ይፈልጋሉ? ❤️</string>
+    <string name="review_app_review_action">ግምገማ</string>
+    <string name="review_app_dismiss_action">ምናልባት በኋላ</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">ቕሌያ ተሰርዩ።</string>
     <string name="error_iap_unavailable_message">የአፕሊኬስን ዃየቶች አይገኙም።</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">لم يتم العثور على أجهزة غير مُدارة</string>
     <string name="discover_all_devices_managed_msg">جميع أجهزتك المقترنة مُدارة! هل تحتاج لجهاز جديد؟</string>
     <string name="discover_pair_new_device_action">اقتران جهاز جديد</string>
+    <string name="discover_device_speaker_desc">مكبر الصوت الخاص بهذا الهاتف. يتم تطبيق مستويات الصوت الخاصة به عندما ينتقل الصوت مرة أخرى إلى الهاتف، على سبيل المثال بعد قطع اتصال جهاز Bluetooth الخاص بك.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">إعدادات الجهاز</string>
     <string name="devices_device_config_section_general_label">عام</string>
@@ -331,6 +332,7 @@
     <string name="label_add_device">إضافة جهاز</string>
     <string name="label_just_a_moment_please">لحظة فقط، من فضلك.</string>
     <string name="label_notification_channel_status">الحالة</string>
+    <string name="monitor_notification_starting">جاري البدء…</string>
     <string name="action_set">ضبط</string>
     <string name="action_cancel">إلغاء</string>
     <string name="label_invalid_input">الإدخال غير صالح</string>
@@ -410,6 +412,8 @@
     <string name="general_delete_action">حذف</string>
     <string name="general_cancel_action">إلغاء</string>
     <string name="general_ok_action">حسناً</string>
+    <string name="general_dismiss_action">تجاهل</string>
+    <string name="general_progress_loading">جاري التحميل…</string>
     <string name="general_configure_action">تكوين</string>
     <string name="battery_optimization_hint_title">تحسين البطارية</string>
     <string name="battery_optimization_hint_message">تحسينات البطارية مفعلة وقد تمنع الأداء الصحيح. فكر في تعطيلها.</string>
@@ -421,6 +425,12 @@
     <string name="dnd_access_hint_title">وصول وضع عدم الإزعاج</string>
     <string name="dnd_access_hint_message">بدون وصول وضع عدم الإزعاج، لا يمكن تطبيق إعدادات نغمة الرنين والإشعارات ووضع عدم الإزعاج عند اتصال أجهزتك.</string>
     <string name="dnd_access_fix_action">السماح بالوصول</string>
+    <string name="device_speaker_hint_title">مستويات الصوت بعد قطع الاتصال</string>
+    <string name="device_speaker_hint_message">هل تريد استعادة مستويات الصوت عند قطع اتصال جهاز Bluetooth؟ أضف \"مكبر صوت الجهاز\" كجهاز مُدار — يتم تطبيق مستويات الصوت الخاصة به عند عودة الصوت إلى هاتفك.</string>
+    <string name="device_speaker_hint_action">إضافة</string>
+    <string name="review_app_body">هل ترغب في ترك تعليق لـ BVM؟ ❤️</string>
+    <string name="review_app_review_action">مراجعة</string>
+    <string name="review_app_dismiss_action">ربما لاحقًا</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">تم إلغاء الشراء</string>
     <string name="error_iap_unavailable_message">المشتريات داخل التطبيق غير متاحة</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">İdarəsiz cihaz tapılmadı</string>
     <string name="discover_all_devices_managed_msg">Bütün cütləşdirilmiş cihazlarınız idarə olunur! Yenisini əlavə etmək istəyirsiniz?</string>
     <string name="discover_pair_new_device_action">Yeni cihaz cütləşdir</string>
+    <string name="discover_device_speaker_desc">Bu telefonun öz hoparlörü. Onun səs səviyyələri audio telefona qayıtdıqda tətbiq edilir, məsələn Bluetooth cihazınız ayırıldıqdan sonra.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Cihaz konfiqurasiyası</string>
     <string name="devices_device_config_section_general_label">Ümumi</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Cihaz əlavə et</string>
     <string name="label_just_a_moment_please">Bir dəqiqə, zəhmət olmasa.</string>
     <string name="label_notification_channel_status">Vəziyyət</string>
+    <string name="monitor_notification_starting">Başladılır…</string>
     <string name="action_set">Tənzimlə</string>
     <string name="action_cancel">İmtina</string>
     <string name="label_invalid_input">Etibarsız giriş</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Sil</string>
     <string name="general_cancel_action">Ləğv et</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Rədd et</string>
+    <string name="general_progress_loading">Yüklənir</string>
     <string name="general_configure_action">Konfiqurasiya et</string>
     <string name="battery_optimization_hint_title">Batareya optimallaşdırması</string>
     <string name="battery_optimization_hint_message">Batareya optimallaşdırması aktivdir və düzgün işləməyə mane ola bilər. Söndürməyi düşünün.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Narahat etməyin rejiminə giriş</string>
     <string name="dnd_access_hint_message">Narahat etmə rejiminə giriş olmadan, zəng çalğısı, bildiriş və Narahat etmə rejimi parametrləri cihazlarınız qoşulduqda tətbiq edilməyə bilər.</string>
     <string name="dnd_access_fix_action">Giriş icazəsi ver</string>
+    <string name="device_speaker_hint_title">Ayırıldıqdan sonra səs səviyyələri</string>
+    <string name="device_speaker_hint_message">Bluetooth cihazı ayırıldıqda səs səviyyələriniz bərpa olunmasını istəyirsiniz? \"Cihaz hoparlörü\"-nü yönetilən cihaz olaraq əlavə edin — onun səs səviyyələri audionuz telefonunuza qayıtdıqda tətbiq edilir.</string>
+    <string name="device_speaker_hint_action">Əlavə et</string>
+    <string name="review_app_body">BVM üçün rəy yazmaq istərdinmi? ❤️</string>
+    <string name="review_app_review_action">Baxış</string>
+    <string name="review_app_dismiss_action">Bəlkə sonra</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Satınalma ləğv edildi</string>
     <string name="error_iap_unavailable_message">Tətbiq daxili alışlar mövcud deyil</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Некіраваныя прылады не знойдзены</string>
     <string name="discover_all_devices_managed_msg">Усе вашы спалучаныя прылады кіруюцца! Патрэбна новая?</string>
     <string name="discover_pair_new_device_action">Спалучыць новую прыладу</string>
+    <string name="discover_device_speaker_desc">Дынамік тэлефона. Яго гучнасці прымяняюцца, калі аўдыё вяртаецца да тэлефона, напр. пасля адключэння вашай прылады Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Канфігурацыя прылады</string>
     <string name="devices_device_config_section_general_label">Агульныя</string>
@@ -323,6 +324,7 @@
     <string name="label_add_device">Дадаць прыладу</string>
     <string name="label_just_a_moment_please">Хвіліначку, калі ласка.</string>
     <string name="label_notification_channel_status">Стан</string>
+    <string name="monitor_notification_starting">Запускаюцца…</string>
     <string name="action_set">Усталяваць</string>
     <string name="action_cancel">Скасаваць</string>
     <string name="label_invalid_input">Няправільнае значэнне</string>
@@ -400,6 +402,8 @@
     <string name="general_delete_action">Выдаліць</string>
     <string name="general_cancel_action">Скасаваць</string>
     <string name="general_ok_action">АК</string>
+    <string name="general_dismiss_action">Адхіліць</string>
+    <string name="general_progress_loading">Загрузка…</string>
     <string name="general_configure_action">Наладзіць</string>
     <string name="battery_optimization_hint_title">Аптымізацыя батарэі</string>
     <string name="battery_optimization_hint_message">Аптымізацыя батарэі ўключана і можа перашкодзіць правільнай рабоце. Разгледзце магчымасць іх адключэння.</string>
@@ -411,6 +415,12 @@
     <string name="dnd_access_hint_title">Доступ да рэжыму «Не турбаваць»</string>
     <string name="dnd_access_hint_message">Без доступу да рэжыму «Не турбаваць» налады звонку, апавяшчэнняў і рэжым «Не турбаваць» нельга адасобіць пры падключэнні вашых прылад.</string>
     <string name="dnd_access_fix_action">Даць доступ</string>
+    <string name="device_speaker_hint_title">Гучнасць пасля адключэння</string>
+    <string name="device_speaker_hint_message">Хочаце аднавіць вашы гучнасці пры адключэнні прылады Bluetooth? Дадайце \"Device speaker\" як кіруемую прыладу — яе гучнасці прымяняюцца, калі аўдыё вяртаецца да вашага тэлефона.</string>
+    <string name="device_speaker_hint_action">Дадаць</string>
+    <string name="review_app_body">Ці ты хочаш пакінуць водгук на BVM? ❤️</string>
+    <string name="review_app_review_action">Водгук</string>
+    <string name="review_app_dismiss_action">Магчыма пазней</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Пакупка адменена</string>
     <string name="error_iap_unavailable_message">Пакупкі ў дадатку недаступны</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Не са намерени неуправлявани устройства</string>
     <string name="discover_all_devices_managed_msg">Всички сдвоени устройства се управляват! Нужно ли ти е ново?</string>
     <string name="discover_pair_new_device_action">Сдвои ново устройство</string>
+    <string name="discover_device_speaker_desc">Собственият говорител на телефона. Неговите нива на звука се прилагат, когато аудиото се върне към телефона, напр. след като вашето Bluetooth устройство се развърже.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Конфигурация на устройство</string>
     <string name="devices_device_config_section_general_label">Основни</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Добави устройство</string>
     <string name="label_just_a_moment_please">Момент, моля.</string>
     <string name="label_notification_channel_status">Статус</string>
+    <string name="monitor_notification_starting">Стартиране…</string>
     <string name="action_set">Настрой</string>
     <string name="action_cancel">Отказ</string>
     <string name="label_invalid_input">Невалидно въвеждане</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Изтрий</string>
     <string name="general_cancel_action">Отказ</string>
     <string name="general_ok_action">ОК</string>
+    <string name="general_dismiss_action">Отхвърляне</string>
+    <string name="general_progress_loading">Зареждане…</string>
     <string name="general_configure_action">Конфигурирай</string>
     <string name="battery_optimization_hint_title">Оптимизация на батерията</string>
     <string name="battery_optimization_hint_message">Оптимизациите на батерията са включени и могат да попречат на нормалната работа. Помисли да ги изключиш.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Достъп до режим Не пречи</string>
     <string name="dnd_access_hint_message">Без достъп до режим Не пречи, настройките за звънец, уведомления и режим БзП не могат да се прилагат, когато устройствата ти се свържат.</string>
     <string name="dnd_access_fix_action">Даване на достъп</string>
+    <string name="device_speaker_hint_title">Нива на звука след развръзване</string>
+    <string name="device_speaker_hint_message">Искате ли вашите нива на звука да се възстановяват, когато Bluetooth устройството се развърже? Добавете \"Говорител на устройството\" като управлявано устройство — неговите нива на звука се прилагат, когато аудиото се върне към телефона ви.</string>
+    <string name="device_speaker_hint_action">Добави</string>
+    <string name="review_app_body">Бихте ли искали да оставите на BVM оценка? ❤️</string>
+    <string name="review_app_review_action">Преглед</string>
+    <string name="review_app_dismiss_action">Може би по-късно</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Покупката е отменена</string>
     <string name="error_iap_unavailable_message">Покупките в приложението не са налични</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">কোনো অপরিচালিত ডিভাইস পাওয়া যায়নি</string>
     <string name="discover_all_devices_managed_msg">আপনার সব পেয়ার করা ডিভাইস পরিচালিত! নতুন একটি দরকার?</string>
     <string name="discover_pair_new_device_action">নতুন ডিভাইস পেয়ার করুন</string>
+    <string name="discover_device_speaker_desc">এই ফোনের নিজস্ব স্পিকার। যখন অডিও ফোনে ফিরে আসে তখন এর ভলিউম প্রয়োগ করা হয়, যেমন আপনার Bluetooth ডিভাইস সংযোগ বিচ্ছিন্ন হওয়ার পরে।</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ডিভাইস কনফিগারেশন</string>
     <string name="devices_device_config_section_general_label">সাধারণ</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">ডিভাইস যোগ করুন</string>
     <string name="label_just_a_moment_please">একটু অপেক্ষা করুন।</string>
     <string name="label_notification_channel_status">অবস্থা</string>
+    <string name="monitor_notification_starting">চালু হচ্ছে…</string>
     <string name="action_set">সেট</string>
     <string name="action_cancel">বাতিল করুন</string>
     <string name="label_invalid_input">অবৈধ ইনপুট</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">মুছে ফেলুন</string>
     <string name="general_cancel_action">বাতিল করুন</string>
     <string name="general_ok_action">ওকে</string>
+    <string name="general_dismiss_action">খারিজ করুন</string>
+    <string name="general_progress_loading">লোড হচ্ছে…</string>
     <string name="general_configure_action">কনফিগার</string>
     <string name="battery_optimization_hint_title">ব্যাটারি অপ্টিমাইজেশন</string>
     <string name="battery_optimization_hint_message">ব্যাটারি অপ্টিমাইজেশন সক্রিয় এবং সঠিক কার্যশীলতা বিঘ্নিত করতে পারে। নিষ্ক্রিয় করার কথা ভাবুন।</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">বিরক্ত করবেন না অ্যাক্সেস</string>
     <string name="dnd_access_hint_message">বিরক্ত করবেন না অ্যাক্সেস ছাড়া, আপনার ডিভাইস সংযুক্ত হলে রিংটোন, নোটিফিকেশন এবং DND মোড সেটিংস প্রয়োগ হবে না।</string>
     <string name="dnd_access_fix_action">অ্যাক্সেস অনুমোদন করুন</string>
+    <string name="device_speaker_hint_title">সংযোগ বিচ্ছিন্নের পরে ভলিউম</string>
+    <string name="device_speaker_hint_message">একটি Bluetooth ডিভাইস সংযোগ বিচ্ছিন্ন হলে আপনার ভলিউম পুনরুদ্ধার করতে চান? \"Device speaker\" একটি পরিচালিত ডিভাইস হিসাবে যোগ করুন — যখন অডিও আপনার ফোনে ফিরে আসে তখন এর ভলিউম প্রয়োগ করা হয়।</string>
+    <string name="device_speaker_hint_action">যোগ করুন</string>
+    <string name="review_app_body">আপনি কি BVM-কে একটি পর্যালোচনা দিতে চান? ❤️</string>
+    <string name="review_app_review_action">পর্যালোচনা করুন</string>
+    <string name="review_app_dismiss_action">হয়তো পরে</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">কেনাকাটা বাতিল</string>
     <string name="error_iap_unavailable_message">ইন-অ্যাপ কেনাকাটা পাওয়া যাচ্ছে না</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">No s\'han trobat dispositius no gestionats</string>
     <string name="discover_all_devices_managed_msg">Tots els dispositius emparellats estan gestionats! En necessites un de nou?</string>
     <string name="discover_pair_new_device_action">Emparella un dispositiu nou</string>
+    <string name="discover_device_speaker_desc">L\'altaveu propi del telèfon. Els seus volums s\'apliquen quan l\'àudio canvia de nou al telèfon, per exemple, després que es desconnecti el dispositiu Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuració del dispositiu</string>
     <string name="devices_device_config_section_general_label">General</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Afegeix un dispositiu</string>
     <string name="label_just_a_moment_please">Un moment.</string>
     <string name="label_notification_channel_status">Estat</string>
+    <string name="monitor_notification_starting">Iniciant…</string>
     <string name="action_set">Estableix</string>
     <string name="action_cancel">Cancel·la</string>
     <string name="label_invalid_input">Entrada no vàlida</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Suprimeix</string>
     <string name="general_cancel_action">Cancel·la</string>
     <string name="general_ok_action">D\'acord</string>
+    <string name="general_dismiss_action">Ignora</string>
+    <string name="general_progress_loading">S\'està carregant</string>
     <string name="general_configure_action">Configura</string>
     <string name="battery_optimization_hint_title">Optimització de la bateria</string>
     <string name="battery_optimization_hint_message">Les optimitzacions de la bateria estan activades i poden impedir el funcionament correcte. Considera desactivar-les.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Accés a No molestar</string>
     <string name="dnd_access_hint_message">Sense accés a No molestar, no es poden aplicar els paràmetres de to de trucada, notificació i mode No molestar quan es connecten els teus dispositius.</string>
     <string name="dnd_access_fix_action">Permet l\'accés</string>
+    <string name="device_speaker_hint_title">Volums després de desconnectar</string>
+    <string name="device_speaker_hint_message">Vols que els volums es restaurin quan es desconnecti un dispositiu Bluetooth? Afegeix \"Altaveu del dispositiu\" com a dispositiu gestionat — els seus volums s\'apliquen quan l\'àudio canvia de nou al telèfon.</string>
+    <string name="device_speaker_hint_action">Afegeix</string>
+    <string name="review_app_body">Voleu deixar una ressenya de BVM? ❤️</string>
+    <string name="review_app_review_action">Revisió</string>
+    <string name="review_app_dismiss_action">Potser més tard</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Compra cancel·lada</string>
     <string name="error_iap_unavailable_message">Les compres integrades no estan disponibles</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nebyla nalezena žádná nespravovaná zařízení</string>
     <string name="discover_all_devices_managed_msg">Všechna vaše spárovaná zařízení jsou pod kontrolou! Potřebujete nové?</string>
     <string name="discover_pair_new_device_action">Spárovat nové zařízení</string>
+    <string name="discover_device_speaker_desc">Vlastní reproduktor telefonu. Jeho hlasitost se aplikuje, když se zvuk vrátí do telefonu, například poté, co se vaše zařízení Bluetooth odpojí.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfigurace zařízení</string>
     <string name="devices_device_config_section_general_label">Obecné</string>
@@ -323,6 +324,7 @@
     <string name="label_add_device">Přidat zařízení</string>
     <string name="label_just_a_moment_please">Chviličku prosím.</string>
     <string name="label_notification_channel_status">Stav</string>
+    <string name="monitor_notification_starting">Spouštění…</string>
     <string name="action_set">Nastavit</string>
     <string name="action_cancel">Zrušit</string>
     <string name="label_invalid_input">Neplatný vstup</string>
@@ -400,6 +402,8 @@
     <string name="general_delete_action">Smazat</string>
     <string name="general_cancel_action">Zrušit</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Zavřít</string>
+    <string name="general_progress_loading">Načítání…</string>
     <string name="general_configure_action">Konfigurovat</string>
     <string name="battery_optimization_hint_title">Optimalizace baterie</string>
     <string name="battery_optimization_hint_message">Optimalizace baterie je zapnutá a může bránit správnému fungování. Zvažte její vypnutí.</string>
@@ -411,6 +415,12 @@
     <string name="dnd_access_hint_title">Přístup k režimu Nerušit</string>
     <string name="dnd_access_hint_message">Bez přístupu k režimu Nerušit nelze při připojení zařízení použít nastavení vyzvánění, upozornění ani režimu Nerušit.</string>
     <string name="dnd_access_fix_action">Udělit přístup</string>
+    <string name="device_speaker_hint_title">Hlasitost po odpojení</string>
+    <string name="device_speaker_hint_message">Chcete, aby se vám hlasitost obnovila, když se zařízení Bluetooth odpojí? Přidejte \"Reproduktor zařízení\" jako spravované zařízení — jeho hlasitost se aplikuje, když se zvuk vrátí do vašeho telefonu.</string>
+    <string name="device_speaker_hint_action">Přidat</string>
+    <string name="review_app_body">Chcete ohodnotit BVM? ❤️</string>
+    <string name="review_app_review_action">Posoudit</string>
+    <string name="review_app_dismiss_action">Možná později</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Nákup zrušen</string>
     <string name="error_iap_unavailable_message">Nákupy v aplikaci nejsou dostupné</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Ingen uhåndterede enheder fundet</string>
     <string name="discover_all_devices_managed_msg">Alle dine parrede enheder er allerede håndteret! Har du brug for en ny?</string>
     <string name="discover_pair_new_device_action">Par ny enhed</string>
+    <string name="discover_device_speaker_desc">Denne telefons egen højttaler. Dens lydstyrker bruges, når lyd skifter tilbage til telefonen, f.eks. efter at din Bluetooth-enhed afbryder forbindelsen.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Enhedskonfiguration</string>
     <string name="devices_device_config_section_general_label">Generelt</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Tilføj enhed</string>
     <string name="label_just_a_moment_please">Et øjeblik.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Starter op…</string>
     <string name="action_set">Vælg</string>
     <string name="action_cancel">Annuller</string>
     <string name="label_invalid_input">Ugyldigt input</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Slet</string>
     <string name="general_cancel_action">Annuller</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Afvis</string>
+    <string name="general_progress_loading">Indlæser…</string>
     <string name="general_configure_action">Konfigurer</string>
     <string name="battery_optimization_hint_title">Batteri-optimering</string>
     <string name="battery_optimization_hint_message">Batteri-optimering er aktiveret og kan forhindre korrekt drift. Overvej at deaktivere dem.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Forstyr ikke-adgang</string>
     <string name="dnd_access_hint_message">Uden Forstyr ikke-adgang kan indstillinger for ringetone, notifikation og Forstyr ikke-tilstand ikke anvendes, når dine enheder tilsluttes.</string>
     <string name="dnd_access_fix_action">Giv adgang</string>
+    <string name="device_speaker_hint_title">Lydstyrker efter afbrydelse</string>
+    <string name="device_speaker_hint_message">Vil du have dine lydstyrker gendannet, når en Bluetooth-enhed afbryder forbindelsen? Tilføj \"Enhedshøjttaler\" som en administreret enhed — dens lydstyrker bruges, når lyd skifter tilbage til din telefon.</string>
+    <string name="device_speaker_hint_action">Tilføj</string>
+    <string name="review_app_body">Har du lyst til at give BVM en anmeldelse? ❤️</string>
+    <string name="review_app_review_action">Bedøm</string>
+    <string name="review_app_dismiss_action">Måske senere</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Køb annulleret</string>
     <string name="error_iap_unavailable_message">In-app køb er ikke tilgængelige</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Keine nicht verwalteten Geräte gefunden</string>
     <string name="discover_all_devices_managed_msg">Alle deine gekoppelten Geräte werden verwaltet! Brauchst du ein neues?</string>
     <string name="discover_pair_new_device_action">Neues Gerät koppeln</string>
+    <string name="discover_device_speaker_desc">Der eigene Lautsprecher dieses Telefons. Seine Lautstärkeeinstellungen werden angewendet, wenn der Ton zum Telefon zurückschaltet, z. B. nachdem dein Bluetooth-Gerät getrennt wurde.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Gerätekonfiguration</string>
     <string name="devices_device_config_section_general_label">Allgemein</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Gerät hinzufügen</string>
     <string name="label_just_a_moment_please">Einen Moment bitte.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Wird gestartet…</string>
     <string name="action_set">Übernehmen</string>
     <string name="action_cancel">Abbrechen</string>
     <string name="label_invalid_input">Ungültige Eingabe</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Löschen</string>
     <string name="general_cancel_action">Abbrechen</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Ausblenden</string>
+    <string name="general_progress_loading">Wird geladen…</string>
     <string name="general_configure_action">Konfigurieren</string>
     <string name="battery_optimization_hint_title">Batterieoptimierung</string>
     <string name="battery_optimization_hint_message">Batterieoptimierungen sind aktiviert und können den ordnungsgemäßen Betrieb verhindern. Erwäge, sie zu deaktivieren.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Zugriff auf „Nicht stören“</string>
     <string name="dnd_access_hint_message">Ohne Zugriff auf „Nicht stören“ können Klingelton-, Benachrichtigungs- und DND-Einstellungen nicht angewendet werden, wenn deine Geräte verbunden werden.</string>
     <string name="dnd_access_fix_action">Zugriff gewähren</string>
+    <string name="device_speaker_hint_title">Lautstärke nach Trennung</string>
+    <string name="device_speaker_hint_message">Möchtest du deine Lautstärkeeinstellungen wiederherstellen, wenn ein Bluetooth-Gerät getrennt wird? Füge „Gerätelautsprecher“ als verwaltetes Gerät hinzu – seine Lautstärkeeinstellungen werden angewendet, wenn der Ton zu deinem Telefon zurückschaltet.</string>
+    <string name="device_speaker_hint_action">Hinzufügen</string>
+    <string name="review_app_body">Möchtest du BVM bewerten? ❤️</string>
+    <string name="review_app_review_action">Bewerten</string>
+    <string name="review_app_dismiss_action">Vielleicht später</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Kauf abgebrochen</string>
     <string name="error_iap_unavailable_message">In-App-Käufe sind nicht verfügbar</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Δεν βρέθηκαν μη διαχειρισμένες συσκευές</string>
     <string name="discover_all_devices_managed_msg">Όλες οι συζευγμένες συσκευές σας διαχειρίζονται ήδη! Χρειάζεστε κάποια καινούρια;</string>
     <string name="discover_pair_new_device_action">Σύζευξη νέας συσκευής</string>
+    <string name="discover_device_speaker_desc">Το ηχείο του τηλεφώνου. Οι εντάσεις του εφαρμόζονται όταν ο ήχος επιστρέφει στο τηλέφωνο, π.χ. μετά την αποσύνδεση της συσκευής Bluetooth σας.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Διαμόρφωση συσκευής</string>
     <string name="devices_device_config_section_general_label">Γενικά</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Προσθήκη συσκευής</string>
     <string name="label_just_a_moment_please">Μια στιγμή, παρακαλώ.</string>
     <string name="label_notification_channel_status">Κατάσταση</string>
+    <string name="monitor_notification_starting">Εκκίνηση…</string>
     <string name="action_set">Ορισμός</string>
     <string name="action_cancel">Ακύρωση</string>
     <string name="label_invalid_input">Μή έκγυρη εισαγωγή</string>
@@ -391,6 +393,8 @@
     <string name="general_delete_action">Διαγραφή</string>
     <string name="general_cancel_action">Ακύρωση</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Κλείσιμο</string>
+    <string name="general_progress_loading">Φόρτωση…</string>
     <string name="general_configure_action">Διαμόρφωση</string>
     <string name="battery_optimization_hint_title">Βελτιστοποίηση μπαταρίας</string>
     <string name="battery_optimization_hint_message">Οι βελτιστοποιήσεις μπαταρίας είναι ενεργοποιημένες και μπορεί να εμποδίσουν την κανονική λειτουργία. Σκεφτείτε να τις απενεργοποιήσετε.</string>
@@ -402,6 +406,12 @@
     <string name="dnd_access_hint_title">Πρόσβαση «Μην ενοχλείτε»</string>
     <string name="dnd_access_hint_message">Χωρίς πρόσβαση «Μην ενοχλείτε», οι ρυθμίσεις ήχου κλήσης, ειδοποιήσεων και λειτουργίας ΜΕ δεν μπορούν να εφαρμοστούν όταν συνδέονται οι συσκευές σας.</string>
     <string name="dnd_access_fix_action">Παραχώρηση πρόσβασης</string>
+    <string name="device_speaker_hint_title">Εντάσεις μετά την αποσύνδεση</string>
+    <string name="device_speaker_hint_message">Θέλετε οι εντάσεις σας να επαναφέρονται όταν αποσυνδέεται μια συσκευή Bluetooth; Προσθέστε το \"Device speaker\" ως διαχειριζόμενη συσκευή — οι εντάσεις του εφαρμόζονται όταν ο ήχος επιστρέφει στο τηλέφωνό σας.</string>
+    <string name="device_speaker_hint_action">Προσθήκη</string>
+    <string name="review_app_body">Θα ήθελες να αφήσεις μια αξιολόγηση για το BVM; ❤️</string>
+    <string name="review_app_review_action">Αξιολόγηση</string>
+    <string name="review_app_dismiss_action">Ίσως αργότερα</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Αγορά ακυρώθηκε</string>
     <string name="error_iap_unavailable_message">Οι αγορές μέσα στην εφαρμογή δεν είναι διαθέσιμες</string>

--- a/app/src/main/res/values-eo-rUY/strings.xml
+++ b/app/src/main/res/values-eo-rUY/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Neniuj neadministrataj aparatoj trovitaj</string>
     <string name="discover_all_devices_managed_msg">Ĉiuj viaj parigitaj aparatoj estas administrataj! Bezonas novan?</string>
     <string name="discover_pair_new_device_action">Pari novan aparaton</string>
+    <string name="discover_device_speaker_desc">La propra son-aparato de ĉi tiu telefono. Ĝia sonlaŭto estas aplikata kiam la sono revenas al la telefono, ekz. post kiam via Bluetooth-aparato malkonektiĝas.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Aparata agordo</string>
     <string name="devices_device_config_section_general_label">Ĝenerala</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Aldoni aparaton</string>
     <string name="label_just_a_moment_please">Nur momenton, bonvolu.</string>
     <string name="label_notification_channel_status">Stato</string>
+    <string name="monitor_notification_starting">Komencas…</string>
     <string name="action_set">Agordi</string>
     <string name="action_cancel">Nuligi</string>
     <string name="label_invalid_input">Nevalida enigo</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Forigi</string>
     <string name="general_cancel_action">Nuligi</string>
     <string name="general_ok_action">Bone</string>
+    <string name="general_dismiss_action">Fermi</string>
+    <string name="general_progress_loading">Ŝarĝas…</string>
     <string name="general_configure_action">Agordi</string>
     <string name="battery_optimization_hint_title">Bateria optimumigo</string>
     <string name="battery_optimization_hint_message">Bateriooptimumigoj estas ebligitaj kaj povas malhelpi ĝustan funkciadon. Konsideru malŝalti ilin.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Ne-Ĝeni aliro</string>
     <string name="dnd_access_hint_message">Sen Ne-Ĝeni aliro, sonorilo, sciigo, kaj DND-reĝim-agordoj ne povas esti aplikataj kiam viaj aparatoj konektas.</string>
     <string name="dnd_access_fix_action">Doni aliron</string>
+    <string name="device_speaker_hint_title">Sonlaŭto post malkonekto</string>
+    <string name="device_speaker_hint_message">Ĉu vi volas restarigi vian sonlaŭton kiam Bluetooth-aparato malkonektiĝas? Aldonu \"Son-aparaton de la aparato\" kiel administratan aparaton — ĝia sonlaŭto estas aplikata kiam la sono revenas al via telefono.</string>
+    <string name="device_speaker_hint_action">Aldoni</string>
+    <string name="review_app_body">Ĉu vi ŝatus lasi al BVM recenzon? ❤️</string>
+    <string name="review_app_review_action">Recenzo</string>
+    <string name="review_app_dismiss_action">Eble poste</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Aĉeto nuligita</string>
     <string name="error_iap_unavailable_message">Enaĉetoj ne disponeblaj</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">No se encontraron dispositivos sin gestionar</string>
     <string name="discover_all_devices_managed_msg">¡Todos tus dispositivos vinculados están gestionados! ¿Necesás uno nuevo?</string>
     <string name="discover_pair_new_device_action">Vincular nuevo dispositivo</string>
+    <string name="discover_device_speaker_desc">El altavoz del teléfono. Sus volúmenes se aplican cuando el audio vuelve al teléfono, p. ej. después de que se desconecte tu dispositivo Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuración del dispositivo</string>
     <string name="devices_device_config_section_general_label">General</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Agregar dispositivo</string>
     <string name="label_just_a_moment_please">Solo un momento, por favor.</string>
     <string name="label_notification_channel_status">Estado</string>
+    <string name="monitor_notification_starting">Iniciando…</string>
     <string name="action_set">Establecer</string>
     <string name="action_cancel">Cancelar</string>
     <string name="label_invalid_input">Entrada inválida</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Borrar</string>
     <string name="general_cancel_action">Cancelar</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Descartar</string>
+    <string name="general_progress_loading">Cargando…</string>
     <string name="general_configure_action">Configurar</string>
     <string name="battery_optimization_hint_title">Optimización de batería</string>
     <string name="battery_optimization_hint_message">Las optimizaciones de batería están activadas y pueden impedir el funcionamiento correcto. Considerá desactivarlas.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Acceso a No molestar</string>
     <string name="dnd_access_hint_message">Sin acceso a No molestar, no se pueden aplicar las configuraciones de tono de llamada, notificaciones y modo No molestar cuando se conectan tus dispositivos.</string>
     <string name="dnd_access_fix_action">Otorgar acceso</string>
+    <string name="device_speaker_hint_title">Volúmenes después de desconectar</string>
+    <string name="device_speaker_hint_message">¿Querés que se restauren tus volúmenes cuando un dispositivo Bluetooth se desconecte? Agregá «Altavoz del dispositivo» como dispositivo administrado — sus volúmenes se aplican cuando el audio vuelve a tu teléfono.</string>
+    <string name="device_speaker_hint_action">Agregar</string>
+    <string name="review_app_body">¿Te gustaría dejar una reseña de BVM? ❤️</string>
+    <string name="review_app_review_action">Reseña</string>
+    <string name="review_app_dismiss_action">Quizás más tarde</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Compra cancelada</string>
     <string name="error_iap_unavailable_message">Las compras dentro de la app no están disponibles</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">No se encontraron dispositivos no gestionados</string>
     <string name="discover_all_devices_managed_msg">¡Todos tus dispositivos emparejados están gestionados! ¿Necesitas uno nuevo?</string>
     <string name="discover_pair_new_device_action">Emparejar nuevo dispositivo</string>
+    <string name="discover_device_speaker_desc">El altavoz propio del teléfono. Sus volúmenes se aplican cuando el audio vuelve al teléfono, por ejemplo, después de que se desconecte tu dispositivo Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuración del dispositivo</string>
     <string name="devices_device_config_section_general_label">General</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Agregar dispositivo</string>
     <string name="label_just_a_moment_please">Un momento, por favor.</string>
     <string name="label_notification_channel_status">Estado</string>
+    <string name="monitor_notification_starting">Iniciando…</string>
     <string name="action_set">Establecer</string>
     <string name="action_cancel">Cancelar</string>
     <string name="label_invalid_input">Entrada inválida</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Borrar</string>
     <string name="general_cancel_action">Cancelar</string>
     <string name="general_ok_action">Aceptar</string>
+    <string name="general_dismiss_action">Descartar</string>
+    <string name="general_progress_loading">Cargando…</string>
     <string name="general_configure_action">Configurar</string>
     <string name="battery_optimization_hint_title">Optimización de batería</string>
     <string name="battery_optimization_hint_message">Las optimizaciones de batería están activas y pueden impedir el funcionamiento correcto. Considera desactivarlas.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Acceso a No molestar</string>
     <string name="dnd_access_hint_message">Sin acceso a No molestar, la configuración de tono, notificaciones y modo No molestar no se puede aplicar cuando tus dispositivos se conectan.</string>
     <string name="dnd_access_fix_action">Permitir el acceso</string>
+    <string name="device_speaker_hint_title">Volúmenes después de desconectar</string>
+    <string name="device_speaker_hint_message">¿Quieres que se restauren tus volúmenes cuando se desconecte un dispositivo Bluetooth? Añade «Device speaker» como dispositivo gestionado — sus volúmenes se aplican cuando el audio vuelve a tu teléfono.</string>
+    <string name="device_speaker_hint_action">Agregar</string>
+    <string name="review_app_body">¿Te gustaría dejar una reseña de BVM? ❤️</string>
+    <string name="review_app_review_action">Reseñar</string>
+    <string name="review_app_dismiss_action">Quizás más tarde</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Compra cancelada</string>
     <string name="error_iap_unavailable_message">Las compras dentro de la app no están disponibles</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">No se encontraron dispositivos no administrados</string>
     <string name="discover_all_devices_managed_msg">¡Todos tus dispositivos emparejados están administrados! ¿Necesitas uno nuevo?</string>
     <string name="discover_pair_new_device_action">Emparejar nuevo dispositivo</string>
+    <string name="discover_device_speaker_desc">El altavoz del teléfono. Sus volúmenes se aplican cuando el audio vuelve al teléfono, por ejemplo, después de que tu dispositivo Bluetooth se desconecte.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuración del dispositivo</string>
     <string name="devices_device_config_section_general_label">General</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Agregar un dispositivo</string>
     <string name="label_just_a_moment_please">Un momento, por favor.</string>
     <string name="label_notification_channel_status">Estado</string>
+    <string name="monitor_notification_starting">Iniciando…</string>
     <string name="action_set">Establecer</string>
     <string name="action_cancel">Cancelar</string>
     <string name="label_invalid_input">Entrada no válida</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Eliminar</string>
     <string name="general_cancel_action">Cancelar</string>
     <string name="general_ok_action">Aceptar</string>
+    <string name="general_dismiss_action">Descartar</string>
+    <string name="general_progress_loading">Cargando…</string>
     <string name="general_configure_action">Configurar</string>
     <string name="battery_optimization_hint_title">Optimización de batería</string>
     <string name="battery_optimization_hint_message">Las optimizaciones de batería están habilitadas y pueden evitar el funcionamiento adecuado. Considera deshabilitarlas.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Acceso a No molestar</string>
     <string name="dnd_access_hint_message">Sin acceso a No molestar, los ajustes de tono de llamada, notificaciones y modo No molestar no se pueden aplicar cuando tus dispositivos se conectan.</string>
     <string name="dnd_access_fix_action">Otorgar acceso</string>
+    <string name="device_speaker_hint_title">Volúmenes después de la desconexión</string>
+    <string name="device_speaker_hint_message">¿Quieres que tus volúmenes se restauren cuando se desconecte un dispositivo Bluetooth? Añade \"Device speaker\" como dispositivo administrado — sus volúmenes se aplican cuando el audio vuelve a tu teléfono.</string>
+    <string name="device_speaker_hint_action">Añadir</string>
+    <string name="review_app_body">¿Te gustaría dejar una reseña de BVM? ❤️</string>
+    <string name="review_app_review_action">Revisar</string>
+    <string name="review_app_dismiss_action">Quizás más tarde</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Compra cancelada</string>
     <string name="error_iap_unavailable_message">Las compras dentro de la aplicación no están disponibles</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Haldamata seadmeid ei leitud</string>
     <string name="discover_all_devices_managed_msg">Kõik sinu seotud seadmed on hallatud! Vajad uut?</string>
     <string name="discover_pair_new_device_action">Seo uus seade</string>
+    <string name="discover_device_speaker_desc">Telefoni enda kõlar. Selle helitugevused rakendatakse, kui heli lülitub tagasi telefoni, nt pärast Bluetooth-seadme lahtiühendamist.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Seadme seaded</string>
     <string name="devices_device_config_section_general_label">Üldine</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Lisa seade</string>
     <string name="label_just_a_moment_please">Palun oodake üks hetk.</string>
     <string name="label_notification_channel_status">Olek</string>
+    <string name="monitor_notification_starting">Käivitamine…</string>
     <string name="action_set">Määra</string>
     <string name="action_cancel">Tühista</string>
     <string name="label_invalid_input">Vigane sisend</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Kustuta</string>
     <string name="general_cancel_action">Tühista</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Sulge</string>
+    <string name="general_progress_loading">Laeb…</string>
     <string name="general_configure_action">Seadista</string>
     <string name="battery_optimization_hint_title">Aku optimeerimine</string>
     <string name="battery_optimization_hint_message">Aku optimeerimine on lubatud ja võib takistada õiget toimimist. Kaalu selle keelamist.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Mitte segada juurdepääs</string>
     <string name="dnd_access_hint_message">Ilma Mitte segada juurdepääsuta ei saa helina, teate ja DND-réžiimi seadeid rakendada, kui teie seadmed ühenduvad.</string>
     <string name="dnd_access_fix_action">Võimalda juurdepääs</string>
+    <string name="device_speaker_hint_title">Helitugevused pärast lahtiühendamist</string>
+    <string name="device_speaker_hint_message">Kas soovid oma helitugevusi taastada, kui Bluetooth-seade lahti ühendatakse? Lisa \"Seadme kõlar\" hallatavaks seadmeks — selle helitugevused rakendatakse, kui heli lülitub tagasi sinu telefoni.</string>
+    <string name="device_speaker_hint_action">Lisa</string>
+    <string name="review_app_body">Tahate kommenteerida BVM? ❤️</string>
+    <string name="review_app_review_action">Arvustus</string>
+    <string name="review_app_dismiss_action">Võib-olla hiljem</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Ost tühistatud</string>
     <string name="error_iap_unavailable_message">Rakendusesisesed ostud pole saadaval</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Ez da kudeatugabeko gailurik aurkitu</string>
     <string name="discover_all_devices_managed_msg">Zure emparejatutako gailu guztiak kudeatuta daude! Berri bat behar duzu?</string>
     <string name="discover_pair_new_device_action">Gailu berria emparejatu</string>
+    <string name="discover_device_speaker_desc">Telefonoaren besteriko altabotzaile. Bere bolumenak aplikatzen dira entzungarria telefonora itzultzen denean, adibidez Bluetooth gailua deskonektatzen denean.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Gailuaren konfigurazioa</string>
     <string name="devices_device_config_section_general_label">Orokorra</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Gehitu gailua</string>
     <string name="label_just_a_moment_please">Mesedez, itxoin une bat.</string>
     <string name="label_notification_channel_status">Egoera</string>
+    <string name="monitor_notification_starting">Hasieratzen…</string>
     <string name="action_set">Ezarri</string>
     <string name="action_cancel">Utzi</string>
     <string name="label_invalid_input">Sarrera baliogabea</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Ezabatu</string>
     <string name="general_cancel_action">Utzi</string>
     <string name="general_ok_action">Ados</string>
+    <string name="general_dismiss_action">Baztertu</string>
+    <string name="general_progress_loading">Kargatzen…</string>
     <string name="general_configure_action">Konfiguratu</string>
     <string name="battery_optimization_hint_title">Bateria optimizazioa</string>
     <string name="battery_optimization_hint_message">Bateria optimizazioak gaituta daude eta funtzionamendu egokia eragotzi dezakete. Kontuan hartu desgaitzea.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Ez molestatzeko sarbidea</string>
     <string name="dnd_access_hint_message">Ez molestatzeko sarbiderik gabe, ezin dira ezarri tonu-jotzailea, jakinarazpena eta Ez molestatu moduko ezarpenak zure gailuak konektatzen direnean.</string>
     <string name="dnd_access_fix_action">Sarbidea eman</string>
+    <string name="device_speaker_hint_title">Bolumenak deskonexio ondoren</string>
+    <string name="device_speaker_hint_message">Nahi duzu zure bolumenak berreskuratzea Bluetooth gailua deskonektatzen denean? Gehitu «Gailuaren altabotzaile» kudeatutako gailua bezala — bere bolumenak aplikatzen dira entzungarria zure telefonora itzultzen denean.</string>
+    <string name="device_speaker_hint_action">Gehitu</string>
+    <string name="review_app_body">BVMari berrikuspen bat utzi nahi zenuke? ❤️</string>
+    <string name="review_app_review_action">Berrikuspen</string>
+    <string name="review_app_dismiss_action">Agian geroago</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Erosketa bertan behera utzi da</string>
     <string name="error_iap_unavailable_message">Aplikazioko erosketak ez daude erabilgarri</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">دستگاه مدیریت‌نشده‌ای یافت نشد</string>
     <string name="discover_all_devices_managed_msg">همه دستگاه‌های جفت‌شده شما مدیریت می‌شوند! به یکی جدید نیاز دارید؟</string>
     <string name="discover_pair_new_device_action">جفت کردن دستگاه جدید</string>
+    <string name="discover_device_speaker_desc">بلندگوی خود این تلفن. صدای آن زمانی اعمال می‌شود که صدا به تلفن بازگردد، مثلاً بعد از قطع اتصال دستگاه بلوتوث شما.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">پیکربندی دستگاه</string>
     <string name="devices_device_config_section_general_label">عمومی</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">افزودن دستگاه</string>
     <string name="label_just_a_moment_please">یه لحظه صبر کن.</string>
     <string name="label_notification_channel_status">وضعیت</string>
+    <string name="monitor_notification_starting">در حال شروع…</string>
     <string name="action_set">تنظیم</string>
     <string name="action_cancel">لفو</string>
     <string name="label_invalid_input">ورودی نامعتبر</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">حذف</string>
     <string name="general_cancel_action">لفو</string>
     <string name="general_ok_action">باشه</string>
+    <string name="general_dismiss_action">نادیده گرفتن</string>
+    <string name="general_progress_loading">بارگذاری…</string>
     <string name="general_configure_action">پیکربندی</string>
     <string name="battery_optimization_hint_title">بهینه‌سازی باتری</string>
     <string name="battery_optimization_hint_message">بهینه‌سازی باتری فعال است و ممکن است عملکرد صحیح را مختل کند. غیرفعال کردن آن را بررسی کنید.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">دسترسی به مزاحم نشوید</string>
     <string name="dnd_access_hint_message">بدون دسترسی به «مزاحم نشوید»، تنظیمات زنگ، اعلان و حالت DND هنگام اتصال دستگاه‌هایتان اعمال نمی‌شوند.</string>
     <string name="dnd_access_fix_action">موافقت کردن با دسترسی</string>
+    <string name="device_speaker_hint_title">صدا بعد از قطع اتصال</string>
+    <string name="device_speaker_hint_message">می‌خواهید صداهای خود را هنگام قطع اتصال دستگاه بلوتوث بازیابی کنید؟ \"Device speaker\" را به عنوان یک دستگاه مدیریت‌شده اضافه کنید — صداهای آن زمانی اعمال می‌شود که صدا به تلفن شما بازگردد.</string>
+    <string name="device_speaker_hint_action">افزودن</string>
+    <string name="review_app_body">آیا می خواهید نظری برای BVM بگذارید؟ ❤️</string>
+    <string name="review_app_review_action">مرور</string>
+    <string name="review_app_dismiss_action">شاید بعداً</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">خرید لغو شد</string>
     <string name="error_iap_unavailable_message">خرید درون‌برنامهای در دسترس نیست</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Hallitsemattomia laitteita ei löydy</string>
     <string name="discover_all_devices_managed_msg">Kaikki paritetut laitteesi on hallittu! Tarvitsetko uuden?</string>
     <string name="discover_pair_new_device_action">Parита uusi laite</string>
+    <string name="discover_device_speaker_desc">Tämän puhelimen oma kaiutin. Sen äänenvoimakkuuksia käytetään, kun ääni vaihtuu takaisin puhelimeen, esim. Bluetooth-laitteen irrottamisen jälkeen.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Laitteen asetukset</string>
     <string name="devices_device_config_section_general_label">Yleiset</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Lisää laite</string>
     <string name="label_just_a_moment_please">Pieni hetki, odotathan.</string>
     <string name="label_notification_channel_status">Tila</string>
+    <string name="monitor_notification_starting">Käynnistetään…</string>
     <string name="action_set">Aseta</string>
     <string name="action_cancel">Peruuta</string>
     <string name="label_invalid_input">Virheellinen syöte</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Poista</string>
     <string name="general_cancel_action">Peruuta</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Hylkää</string>
+    <string name="general_progress_loading">Ladataan…</string>
     <string name="general_configure_action">Määritä</string>
     <string name="battery_optimization_hint_title">Akun optimointi</string>
     <string name="battery_optimization_hint_message">Akun optimointi on käytössä ja saattaa estää oikean toiminnan. Harkitse niiden poistamista käytöstä.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Älä häiritse -käyttöoikeus</string>
     <string name="dnd_access_hint_message">Ilman Älä häiritse -käyttöoikeutta soittoääni-, ilmoitus- ja Älä häiritse -tila-asetuksia ei voi soveltaa, kun laitteet yhdistävät.</string>
     <string name="dnd_access_fix_action">Myönnä käyttöoikeus</string>
+    <string name="device_speaker_hint_title">Äänenvoimakkuudet irrotuksen jälkeen</string>
+    <string name="device_speaker_hint_message">Haluatko äänenvoimakkuuksien palautuvan, kun Bluetooth-laite irrotetaan? Lisää \"Laitteen kaiutin\" hallituksi laitteeksi – sen äänenvoimakkuudet käytetään, kun ääni vaihtuu takaisin puhelimeesi.</string>
+    <string name="device_speaker_hint_action">Lisää</string>
+    <string name="review_app_body">Haluaisitko jättää BVMlle arvostelun? ❤️</string>
+    <string name="review_app_review_action">Arvostele</string>
+    <string name="review_app_dismiss_action">Ehkä myöhemmin</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Osto peruutettu</string>
     <string name="error_iap_unavailable_message">Sovelluksen sisäiset ostokset eivät ole saatavilla</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Walang nahanap na hindi pinamahalaaang device</string>
     <string name="discover_all_devices_managed_msg">Lahat ng iyong paired na device ay pinamamahalaan na! Kailangan ng bago?</string>
     <string name="discover_pair_new_device_action">Mag-pair ng bagong device</string>
+    <string name="discover_device_speaker_desc">Ang sariling speaker ng phone na ito. Ang mga volume nito ay inilalapat kapag bumalik ang audio sa phone, hal. pagkatapos ang iyong Bluetooth device ay nag-disconnect.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuration ng device</string>
     <string name="devices_device_config_section_general_label">Pangkalahatan</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Magdagdag ng device</string>
     <string name="label_just_a_moment_please">Sandali lang, pakiusap.</string>
     <string name="label_notification_channel_status">Katayuan</string>
+    <string name="monitor_notification_starting">Nagsisimula…</string>
     <string name="action_set">I-set</string>
     <string name="action_cancel">Kanselahin</string>
     <string name="label_invalid_input">Maling input</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Burahin</string>
     <string name="general_cancel_action">Kanselahin</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Huwag pansinin</string>
+    <string name="general_progress_loading">Naglo-load…</string>
     <string name="general_configure_action">I-configure</string>
     <string name="battery_optimization_hint_title">Pag-optimize ng baterya</string>
     <string name="battery_optimization_hint_message">Naka-enable ang battery optimizations at maaaring pumigil sa tamang pagpapatakbo. Pag-isipang i-disable ang mga ito.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Access sa Do Not Disturb</string>
     <string name="dnd_access_hint_message">Kung wala ang access sa Do Not Disturb, hindi mailalapat ang mga setting ng ringtone, notification, at DND mode kapag kumonekta ang iyong mga device.</string>
     <string name="dnd_access_fix_action">Magbigay-pahintulot</string>
+    <string name="device_speaker_hint_title">Volume pagkatapos ng disconnect</string>
+    <string name="device_speaker_hint_message">Gusto mo bang maibalik ang iyong mga volume kapag nag-disconnect ang Bluetooth device? Idagdag ang \"Device speaker\" bilang managed device — ang mga volume nito ay inilalapat kapag bumalik ang audio sa iyong phone.</string>
+    <string name="device_speaker_hint_action">Idagdag</string>
+    <string name="review_app_body">Gusto ba ninyong mag-iwan ng review para sa BVM? ❤️</string>
+    <string name="review_app_review_action">Pagsusuri</string>
+    <string name="review_app_dismiss_action">Siguro mamaya</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Kinansela ang pagbili</string>
     <string name="error_iap_unavailable_message">Hindi available ang mga in-app na pagbili</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Aucun périphérique non géré trouvé</string>
     <string name="discover_all_devices_managed_msg">Tous vos appareils appairés sont gérés ! Besoin d\'un nouveau ?</string>
     <string name="discover_pair_new_device_action">Appairer un nouvel appareil</string>
+    <string name="discover_device_speaker_desc">Le haut-parleur propre de ce téléphone. Ses volumes sont appliqués lorsque l\'audio revient au téléphone, par exemple après la déconnexion de votre appareil Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuration du périphérique</string>
     <string name="devices_device_config_section_general_label">Général</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Ajouter un périphérique</string>
     <string name="label_just_a_moment_please">Un instant, s\'il vous plaît.</string>
     <string name="label_notification_channel_status">État</string>
+    <string name="monitor_notification_starting">Démarrage…</string>
     <string name="action_set">Définir</string>
     <string name="action_cancel">Annuler</string>
     <string name="label_invalid_input">Entrée invalide</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Supprimer</string>
     <string name="general_cancel_action">Annuler</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Fermer</string>
+    <string name="general_progress_loading">Chargement…</string>
     <string name="general_configure_action">Configurer</string>
     <string name="battery_optimization_hint_title">Optimisation de la batterie</string>
     <string name="battery_optimization_hint_message">Les optimisations de batterie sont activées et peuvent empêcher le bon fonctionnement. Envisagez de les désactiver.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Accès Ne pas déranger</string>
     <string name="dnd_access_hint_message">Sans accès Ne pas déranger, les paramètres de sonnerie, de notification et de mode NPD ne peuvent pas être appliqués lors de la connexion de vos appareils.</string>
     <string name="dnd_access_fix_action">Accorder l’accès</string>
+    <string name="device_speaker_hint_title">Volumes après la déconnexion</string>
+    <string name="device_speaker_hint_message">Voulez-vous que vos volumes soient restaurés lors de la déconnexion d\'un appareil Bluetooth ? Ajoutez « Haut-parleur de l\'appareil » comme appareil géré — ses volumes sont appliqués lorsque l\'audio revient à votre téléphone.</string>
+    <string name="device_speaker_hint_action">Ajouter</string>
+    <string name="review_app_body">Voudrais-tu évaluer BVM ? ❤️</string>
+    <string name="review_app_review_action">Évaluation</string>
+    <string name="review_app_dismiss_action">Plus tard, peut-être</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Achat annulé</string>
     <string name="error_iap_unavailable_message">Les achats intégrés ne sont pas disponibles</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Non se atoparon dispositivos non xestionados</string>
     <string name="discover_all_devices_managed_msg">Todos os teus dispositivos emparellados están xestionados! Necesitas un novo?</string>
     <string name="discover_pair_new_device_action">Emparellar novo dispositivo</string>
+    <string name="discover_device_speaker_desc">O propio altofalante do teléfono. Os seus volumes aplícanse cando o audio volve ao teléfono, p.e., despois de que se desconecte o teu dispositivo Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuración do dispositivo</string>
     <string name="devices_device_config_section_general_label">Xeral</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Engadir dispositivo</string>
     <string name="label_just_a_moment_please">Agarda un intre, por favor.</string>
     <string name="label_notification_channel_status">Estado</string>
+    <string name="monitor_notification_starting">Iniciando…</string>
     <string name="action_set">Establecer</string>
     <string name="action_cancel">Cancelar</string>
     <string name="label_invalid_input">Entrada non válida</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Eliminar</string>
     <string name="general_cancel_action">Cancelar</string>
     <string name="general_ok_action">Aceptar</string>
+    <string name="general_dismiss_action">Descartar</string>
+    <string name="general_progress_loading">Cargando…</string>
     <string name="general_configure_action">Configurar</string>
     <string name="battery_optimization_hint_title">Optimización da batería</string>
     <string name="battery_optimization_hint_message">As optimizacións da batería están activadas e poden impedir o correcto funcionamento. Considera desactivalas.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Acceso a Non molestar</string>
     <string name="dnd_access_hint_message">Sen acceso a Non molestar, non se poden aplicar os axustes de ton de chamada, notificación e modo Non molestar cando os teus dispositivos se conectan.</string>
     <string name="dnd_access_fix_action">Conceder acceso</string>
+    <string name="device_speaker_hint_title">Volumes despois da desconexión</string>
+    <string name="device_speaker_hint_message">¿Queres que os teus volumes se restauren cando un dispositivo Bluetooth se desconecta? Engade \"Altofalante do dispositivo\" como un dispositivo xestionado — os seus volumes aplícanse cando o audio volve ao teu teléfono.</string>
+    <string name="device_speaker_hint_action">Engadir</string>
+    <string name="review_app_body">Gustaríalle deixar unha valoración para BVM? ❤️</string>
+    <string name="review_app_review_action">Valorar</string>
+    <string name="review_app_dismiss_action">Quizais máis tarde</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Compra cancelada</string>
     <string name="error_iap_unavailable_message">As compras dentro da aplicación non están dispoñibles</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">कोई अप्रबंधित डिवाइस नहीं मिला</string>
     <string name="discover_all_devices_managed_msg">आपके सभी पेयर्ड डिवाइस प्रबंधित हैं! एक नया चाहिए?</string>
     <string name="discover_pair_new_device_action">नया डिवाइस पेयर करें</string>
+    <string name="discover_device_speaker_desc">इस फोन का अपना स्पीकर। इसकी वॉल्यूम तब लागू होती है जब ऑडियो फोन पर वापस स्विच हो, जैसे आपके Bluetooth डिवाइस के डिस्कनेक्ट होने के बाद।</string>
     <!-- Devices -->
     <string name="devices_device_config_label">डिवाइस कॉन्फिगरेशन</string>
     <string name="devices_device_config_section_general_label">सामान्य</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">डिवाइस जोड़ें</string>
     <string name="label_just_a_moment_please">कृपया, एक पल रुके</string>
     <string name="label_notification_channel_status">स्थिति</string>
+    <string name="monitor_notification_starting">शुरुआत हो रही है…</string>
     <string name="action_set">सेट</string>
     <string name="action_cancel">रद्द</string>
     <string name="label_invalid_input">अमान्य इनपुट</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">डिलीट</string>
     <string name="general_cancel_action">रद्द</string>
     <string name="general_ok_action">ठीक है</string>
+    <string name="general_dismiss_action">खारिज करें</string>
+    <string name="general_progress_loading">लोड हो रहा है…</string>
     <string name="general_configure_action">कॉन्फिगर</string>
     <string name="battery_optimization_hint_title">बैटरी ओप्टिमाइजेशन</string>
     <string name="battery_optimization_hint_message">बैटरी ओप्टिमाइजेशन सक्षम हैं और सही ऑपरेशन को रोक सकते हैं। इन्हें अक्षम करने पर विचार करें।</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">डू नॉट डिस्टर्ब एक्सेस</string>
     <string name="dnd_access_hint_message">डू नॉट डिस्टर्ब एक्सेस के बिना, रिंगटोन, नोटिफ़िकेशन और DND मोड सेटिंग्स आपके डिवाइसेस कनेक्ट होने पर लागू नहीं हो सकतीं।</string>
     <string name="dnd_access_fix_action">पहुंच प्रदान करें</string>
+    <string name="device_speaker_hint_title">डिस्कनेक्ट के बाद वॉल्यूम</string>
+    <string name="device_speaker_hint_message">क्या आप चाहते हैं कि आपकी वॉल्यूम तब बहाल हो जब कोई Bluetooth डिवाइस डिस्कनेक्ट हो? \"डिवाइस स्पीकर\" को एक प्रबंधित डिवाइस के रूप में जोड़ें — इसकी वॉल्यूम तब लागू होती है जब ऑडियो आपके फोन पर वापस स्विच हो।</string>
+    <string name="device_speaker_hint_action">जोड़ें</string>
+    <string name="review_app_body">क्या आप BVM को एक समीक्षा देना चाहेंगे? ❤️</string>
+    <string name="review_app_review_action">समीक्षा करें</string>
+    <string name="review_app_dismiss_action">शायद बाद में</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">खरीदारी रद्द</string>
     <string name="error_iap_unavailable_message">इन-आप खरीदारी उपलब्ध नहीं</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nisu pronađeni neupravljani uređaji</string>
     <string name="discover_all_devices_managed_msg">Svi vaši upareni uređaji su upravljani! Trebate novi?</string>
     <string name="discover_pair_new_device_action">Upari novi uređaj</string>
+    <string name="discover_device_speaker_desc">Vlastiti zvučnik telefona. Njegove razine glasnoće primjenjuju se kada se zvuk prebaci natrag na telefon, npr. nakon što se vaš Bluetooth uređaj isključi.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfiguracija uređaja</string>
     <string name="devices_device_config_section_general_label">Općenito</string>
@@ -319,6 +320,7 @@
     <string name="label_add_device">Dodaj uređaj</string>
     <string name="label_just_a_moment_please">Samo trenutak.</string>
     <string name="label_notification_channel_status">Stanje</string>
+    <string name="monitor_notification_starting">Pokretanje…</string>
     <string name="action_set">Postavi</string>
     <string name="action_cancel">Odustani</string>
     <string name="label_invalid_input">Pogrešan unos</string>
@@ -395,6 +397,8 @@
     <string name="general_delete_action">Izbriši</string>
     <string name="general_cancel_action">Odustani</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Odbaci</string>
+    <string name="general_progress_loading">Učitavanje…</string>
     <string name="general_configure_action">Konfiguriraj</string>
     <string name="battery_optimization_hint_title">Optimizacija baterije</string>
     <string name="battery_optimization_hint_message">Optimizacije baterije su uključene i mogu spriječiti pravilno funkcioniranje. Razmislite o njihovom onemogućavanju.</string>
@@ -406,6 +410,12 @@
     <string name="dnd_access_hint_title">Pristup načinu Ne uznemiravaj</string>
     <string name="dnd_access_hint_message">Bez pristupa opciji Ne uznemiravaj, postavke zvona, obavijesti i načina Ne uznemiravaj ne mogu se primijeniti kada se vaši uređaji povežu.</string>
     <string name="dnd_access_fix_action">Dozvoli pristup</string>
+    <string name="device_speaker_hint_title">Razine glasnoće nakon isključivanja</string>
+    <string name="device_speaker_hint_message">Želite da se vaše razine glasnoće vrate kada se Bluetooth uređaj isključi? Dodajte \"Zvučnik uređaja\" kao upravljani uređaj — njegove razine glasnoće primjenjuju se kada se zvuk prebaci natrag na vaš telefon.</string>
+    <string name="device_speaker_hint_action">Dodaj</string>
+    <string name="review_app_body">Želiš li ostaviti recenziju za BVM? ❤️</string>
+    <string name="review_app_review_action">Ocijeni</string>
+    <string name="review_app_dismiss_action">Možda kasnije</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Kupnja otkazana</string>
     <string name="error_iap_unavailable_message">Kupnje unutar aplikacije nisu dostupne</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nem találhatók nem kezelt eszközök</string>
     <string name="discover_all_devices_managed_msg">Minden párosított eszközöd kezelt! Kell egy új?</string>
     <string name="discover_pair_new_device_action">Új eszköz párosítása</string>
+    <string name="discover_device_speaker_desc">A telefon beépített hangszórója. Hangereje akkor érvényesül, amikor a hang visszakapcsolódik a telefonra, például a Bluetooth-eszköz lecsatlakozása után.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Eszköz beállítása</string>
     <string name="devices_device_config_section_general_label">Általános</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Eszköz hozzáadása</string>
     <string name="label_just_a_moment_please">Egy pillanat, kérlek.</string>
     <string name="label_notification_channel_status">Állapot</string>
+    <string name="monitor_notification_starting">Indítás…</string>
     <string name="action_set">Beállítás</string>
     <string name="action_cancel">Mégse</string>
     <string name="label_invalid_input">Érvénytelen adat</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Törlés</string>
     <string name="general_cancel_action">Mégse</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Elvetés</string>
+    <string name="general_progress_loading">Betöltés…</string>
     <string name="general_configure_action">Konfigurálás</string>
     <string name="battery_optimization_hint_title">Akkumulátor optimalizálás</string>
     <string name="battery_optimization_hint_message">Az akkumulátor optimalizálás engedélyezett és megakadályozhatja a megfelelő működést. Fontold meg a letiltásukat.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Ne zavarj hozzáférés</string>
     <string name="dnd_access_hint_message">Ne zavarj hozzáférés nélkül a csengőhang, az értesítés és a Ne zavarj módus beállításai nem alkalmazhatók, amikor az eszközeid csatlakoznak.</string>
     <string name="dnd_access_fix_action">Hozzáférés megadása</string>
+    <string name="device_speaker_hint_title">Hangerő lecsatlakozás után</string>
+    <string name="device_speaker_hint_message">Szeretnéd, ha a hangerőid helyreállnának, amikor egy Bluetooth-eszköz lecsatlakozik? Add az „Eszköz hangszórója”-t egy kezelt eszközként – hangereje akkor érvényesül, amikor a hang visszakapcsolódik a telefonra.</string>
+    <string name="device_speaker_hint_action">Hozzáadás</string>
+    <string name="review_app_body">Szeretnél véleményt hagyni a BVM-ről? ❤️</string>
+    <string name="review_app_review_action">Áttekintés</string>
+    <string name="review_app_dismiss_action">Talán később</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Vásárlás megszakítva</string>
     <string name="error_iap_unavailable_message">Az alkalmazáson belüli vásárlások nem elérhetőek</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Կառավարելիք սարքեր չեն գտնվել</string>
     <string name="discover_all_devices_managed_msg">Ձեր բոլոր զուգակցված սարքերը կառավարվում են: Ուզո՞ւմ եք ավելացնել նոր:</string>
     <string name="discover_pair_new_device_action">Զուգակցել նոր սարք</string>
+    <string name="discover_device_speaker_desc">Այս հեռախոսի սեփական բարձրախոս։ Դրա ծավալները կիրառվում են, երբ աուդիոն վերադառնում է հեռախոսին, օր.՞ Bluetooth սարքի անջատվելուց հետո։</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Սարքի կարգաբերում</string>
     <string name="devices_device_config_section_general_label">Ընդհանուր</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Ավելացնել սարք</string>
     <string name="label_just_a_moment_please">Մի վայրկյան, խնդրում եմ:</string>
     <string name="label_notification_channel_status">Կարգավիճակ</string>
+    <string name="monitor_notification_starting">Մեկնարկում է…</string>
     <string name="action_set">Սահմանել</string>
     <string name="action_cancel">Չեղարկել</string>
     <string name="label_invalid_input">Անվավեր մուտք</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Ջնջել</string>
     <string name="general_cancel_action">Չեղարկել</string>
     <string name="general_ok_action">բարի</string>
+    <string name="general_dismiss_action">Մերժել</string>
+    <string name="general_progress_loading">Բեռնում…</string>
     <string name="general_configure_action">Կարգավորել</string>
     <string name="battery_optimization_hint_title">Մարտկոցի օպտիմալացում</string>
     <string name="battery_optimization_hint_message">Մարտկոցի օպտիմալացումները ինկնակակվածն լինելու կարող կան խոչինդոտել նորմալ աշխատանքին։ Մտածեք անջատելու մասին։</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">«Մի անհանգստացրեք» հասանելիություն</string>
     <string name="dnd_access_hint_message">Առանց «Մի անհանգստացրեք» հասանելիության, զնգակի, ծանուցման և DND ռեժիմի կարգավորումները հնարավոր չի լինի կիրառել, երբ ձեր սարքերը միանան:</string>
     <string name="dnd_access_fix_action">Մուտք տալ</string>
+    <string name="device_speaker_hint_title">Ծավալներ անջատվելուց հետո</string>
+    <string name="device_speaker_hint_message">Ցանկանում եք ձեր ծավալները վերականգնել, երբ Bluetooth սարքը անջատվի։ Ավելացրեք \"Սարքի բարձրախոս\" որպես կառավարվող սարք — դրա ծավալները կիրառվում են, երբ աուդիոն վերադառնում է ձեր հեռախոսին։</string>
+    <string name="device_speaker_hint_action">Ավելացնել</string>
+    <string name="review_app_body">Ցանկանա՞ք գնահատական թողնել BVM-ի համար? ❤️</string>
+    <string name="review_app_review_action">Գնահատական</string>
+    <string name="review_app_dismiss_action">Գուցե ավելի ուշ</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Գնումն չեղյալ է</string>
     <string name="error_iap_unavailable_message">Լրացկի գնումները հասանելի չեն</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -404,6 +404,7 @@
     <string name="device_speaker_hint_message">Ingin volume Anda dipulihkan saat perangkat Bluetooth terputus? Tambahkan \"Pelantang Perangkat\" sebagai perangkat yang dikelola — volume-nya diterapkan saat audio beralih kembali ke ponsel Anda.</string>
     <string name="device_speaker_hint_action">Tambahkan</string>
     <string name="review_app_body">Bersediakah Anda menulis ulasan untuk BVM? ❤️</string>
+    <string name="review_app_review_action">Ulasan</string>
     <string name="review_app_dismiss_action">Lain kali</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Pembelian dibatalkan</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Tidak ada perangkat yang belum dikelola</string>
     <string name="discover_all_devices_managed_msg">Semua perangkat yang dipasangkan sudah dikelola! Butuh yang baru?</string>
     <string name="discover_pair_new_device_action">Pasangkan perangkat baru</string>
+    <string name="discover_device_speaker_desc">Pelantang ponsel ini sendiri. Volume-nya diterapkan saat audio beralih kembali ke ponsel, misalnya setelah perangkat Bluetooth Anda terputus.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfigurasi perangkat</string>
     <string name="devices_device_config_section_general_label">Umum</string>
@@ -311,6 +312,7 @@
     <string name="label_add_device">Tambah perangkat</string>
     <string name="label_just_a_moment_please">Mohon tunggu.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Memulai…</string>
     <string name="action_set">Atur</string>
     <string name="action_cancel">Batal</string>
     <string name="label_invalid_input">Masukan tak sahih</string>
@@ -385,6 +387,8 @@
     <string name="general_delete_action">Hapus</string>
     <string name="general_cancel_action">Batal</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Tutup</string>
+    <string name="general_progress_loading">Memuat…</string>
     <string name="general_configure_action">Konfigurasi</string>
     <string name="battery_optimization_hint_title">Optimasi baterai</string>
     <string name="battery_optimization_hint_message">Optimasi baterai diaktifkan dan dapat mencegah operasi yang tepat. Pertimbangkan untuk menonaktifkannya.</string>
@@ -396,6 +400,11 @@
     <string name="dnd_access_hint_title">Akses Jangan Ganggu</string>
     <string name="dnd_access_hint_message">Tanpa akses Jangan Ganggu, pengaturan nada dering, notifikasi, dan mode JG tidak dapat diterapkan saat perangkat Anda terhubung.</string>
     <string name="dnd_access_fix_action">Berikan akses</string>
+    <string name="device_speaker_hint_title">Volume setelah terputus</string>
+    <string name="device_speaker_hint_message">Ingin volume Anda dipulihkan saat perangkat Bluetooth terputus? Tambahkan \"Pelantang Perangkat\" sebagai perangkat yang dikelola — volume-nya diterapkan saat audio beralih kembali ke ponsel Anda.</string>
+    <string name="device_speaker_hint_action">Tambahkan</string>
+    <string name="review_app_body">Bersediakah Anda menulis ulasan untuk BVM? ❤️</string>
+    <string name="review_app_dismiss_action">Lain kali</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Pembelian dibatalkan</string>
     <string name="error_iap_unavailable_message">Pembelian dalam aplikasi tidak tersedia</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Engin óstýrð tæki fundust</string>
     <string name="discover_all_devices_managed_msg">Öll pöruð tæki þín eru stýrð! Þarftu nýtt?</string>
     <string name="discover_pair_new_device_action">Para nýtt tæki</string>
+    <string name="discover_device_speaker_desc">Eigin hátalari þessa sími. Hljóðstyrk hans er notaður þegar hljóð skiptir aftur til símans, t.d. eftir að Bluetooth tækinu þínu er aftengst.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Tækjastillingar</string>
     <string name="devices_device_config_section_general_label">Almennt</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Bæta við tæki</string>
     <string name="label_just_a_moment_please">Augnablik, takk.</string>
     <string name="label_notification_channel_status">Staða</string>
+    <string name="monitor_notification_starting">Ræsir…</string>
     <string name="action_set">Stilla</string>
     <string name="action_cancel">Hætta við</string>
     <string name="label_invalid_input">Ógilt inntak</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Eyða</string>
     <string name="general_cancel_action">Hætta við</string>
     <string name="general_ok_action">Í lagi</string>
+    <string name="general_dismiss_action">Hafna</string>
+    <string name="general_progress_loading">Hleður…</string>
     <string name="general_configure_action">Stilla</string>
     <string name="battery_optimization_hint_title">Rafhlöðufínstilling</string>
     <string name="battery_optimization_hint_message">Rafhlöðufínstillingar eru virkar og geta komið í veg fyrir rétta virkni. Íhugið að slökkva á þem.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Aðgangur að „Trufla ekki“</string>
     <string name="dnd_access_hint_message">Án aðgangs að „Trufla ekki“ er ekki hægt að nota stillingar fyrir hringitón, tilkynningar og „Trufla ekki“-stillingar þegar tækin þín tengjast.</string>
     <string name="dnd_access_fix_action">Veita aðgang</string>
+    <string name="device_speaker_hint_title">Hljóðstyrk eftir aftengslu</string>
+    <string name="device_speaker_hint_message">Viltu að hljóðstyrk þinn sé endurreistur þegar Bluetooth tæki aftengist? Bættu við \"Símháltalara\" sem stjórnað tæki — hljóðstyrk hans er notaður þegar hljóð skiptir aftur til símans þíns.</string>
+    <string name="device_speaker_hint_action">Bæta við</string>
+    <string name="review_app_body">Viltu skilja eftir umsögn um BVM? ❤️</string>
+    <string name="review_app_review_action">Umsögn</string>
+    <string name="review_app_dismiss_action">Kannski síðar</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Kaup afturkallað</string>
     <string name="error_iap_unavailable_message">Kaup í forriti eru ekki tiltæk</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nessun dispositivo non gestito trovato</string>
     <string name="discover_all_devices_managed_msg">Tutti i tuoi dispositivi accoppiati sono gestiti! Te ne serve uno nuovo?</string>
     <string name="discover_pair_new_device_action">Accoppia nuovo dispositivo</string>
+    <string name="discover_device_speaker_desc">L\'altoparlante del telefono stesso. I suoi volumi vengono applicati quando l\'audio torna al telefono, ad es. dopo che il dispositivo Bluetooth si disconnette.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configurazione dispositivo</string>
     <string name="devices_device_config_section_general_label">Generale</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Aggiungi un dispositivo</string>
     <string name="label_just_a_moment_please">Solo un momento, per favore.</string>
     <string name="label_notification_channel_status">Stato</string>
+    <string name="monitor_notification_starting">Avvio in corso…</string>
     <string name="action_set">Imposta</string>
     <string name="action_cancel">Annulla</string>
     <string name="label_invalid_input">Input non valido</string>
@@ -390,6 +392,7 @@
     <string name="general_delete_action">Elimina</string>
     <string name="general_cancel_action">Annulla</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_progress_loading">Caricamento…</string>
     <string name="general_configure_action">Configura</string>
     <string name="battery_optimization_hint_title">Ottimizzazione batteria</string>
     <string name="battery_optimization_hint_message">Le ottimizzazioni della batteria sono abilitate e possono impedire il corretto funzionamento. Considera di disabilitarle.</string>
@@ -401,6 +404,12 @@
     <string name="dnd_access_hint_title">Accesso a Non disturbare</string>
     <string name="dnd_access_hint_message">Senza accesso a Non disturbare, le impostazioni di suoneria, notifiche e modalita Non disturbare non possono essere applicate quando i tuoi dispositivi si connettono.</string>
     <string name="dnd_access_fix_action">Consenti accesso</string>
+    <string name="device_speaker_hint_title">Volumi dopo la disconnessione</string>
+    <string name="device_speaker_hint_message">Vuoi che i tuoi volumi vengano ripristinati quando un dispositivo Bluetooth si disconnette? Aggiungi \"Altoparlante del dispositivo\" come dispositivo gestito — i suoi volumi vengono applicati quando l\'audio torna al telefono.</string>
+    <string name="device_speaker_hint_action">Aggiungi</string>
+    <string name="review_app_body">Vuoi lasciare una recensione su BVM? ❤️</string>
+    <string name="review_app_review_action">Recensione</string>
+    <string name="review_app_dismiss_action">Forse più tardi</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Acquisto annullato</string>
     <string name="error_iap_unavailable_message">Gli acquisti in-app non sono disponibili</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -392,7 +392,7 @@
     <string name="general_delete_action">Elimina</string>
     <string name="general_cancel_action">Annulla</string>
     <string name="general_ok_action">OK</string>
-    <string name="general_dismiss_action">Rimuovere</string>
+    <string name="general_dismiss_action">Ignora</string>
     <string name="general_progress_loading">Caricamento…</string>
     <string name="general_configure_action">Configura</string>
     <string name="battery_optimization_hint_title">Ottimizzazione batteria</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -392,6 +392,7 @@
     <string name="general_delete_action">Elimina</string>
     <string name="general_cancel_action">Annulla</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Rimuovere</string>
     <string name="general_progress_loading">Caricamento…</string>
     <string name="general_configure_action">Configura</string>
     <string name="battery_optimization_hint_title">Ottimizzazione batteria</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">לא נמצאו מכשירים לא מנוהלים</string>
     <string name="discover_all_devices_managed_msg">כל המכשירים המצומדים שלכם מנוהלים! צריכים חדש?</string>
     <string name="discover_pair_new_device_action">צמד מכשיר חדש</string>
+    <string name="discover_device_speaker_desc">הרמקול של הטלפון הזה. עוצמות הקול שלו מוחלות כאשר האודיו חוזר לטלפון, למשל לאחר ניתוק מכשיר ה-Bluetooth שלך.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">תצורת מכשיר</string>
     <string name="devices_device_config_section_general_label">כללי</string>
@@ -323,6 +324,7 @@
     <string name="label_add_device">הוספת התקן</string>
     <string name="label_just_a_moment_please">אנא המתינו.</string>
     <string name="label_notification_channel_status">מצב</string>
+    <string name="monitor_notification_starting">מתחיל…</string>
     <string name="action_set">קביעה</string>
     <string name="action_cancel">ביטול</string>
     <string name="label_invalid_input">קלט לא תקין</string>
@@ -400,6 +402,8 @@
     <string name="general_delete_action">מחק</string>
     <string name="general_cancel_action">בטל</string>
     <string name="general_ok_action">אישור</string>
+    <string name="general_dismiss_action">דחה</string>
+    <string name="general_progress_loading">טוען…</string>
     <string name="general_configure_action">הגדר</string>
     <string name="battery_optimization_hint_title">אימוץ סוללה</string>
     <string name="battery_optimization_hint_message">אימוצי סוללה מופעלים ועלולים למנוע פעילות תקינה. שקלו להשביתם.</string>
@@ -411,6 +415,12 @@
     <string name="dnd_access_hint_title">גישה למצב \"נא לא להפריע\"</string>
     <string name="dnd_access_hint_message">ללא גישה למצב אל תפריע, לא ניתן להחיל הגדרות צלצול, התראות ומצב DND כאשר המכשירים שלך מתחברים.</string>
     <string name="dnd_access_fix_action">אשר גישה</string>
+    <string name="device_speaker_hint_title">עוצמות הקול לאחר הניתוק</string>
+    <string name="device_speaker_hint_message">רוצה שעוצמות הקול שלך יוחזרו כאשר מכשיר Bluetooth מתנתק? הוסף את \"רמקול המכשיר\" כמכשיר מנוהל - עוצמות הקול שלו מוחלות כאשר האודיו חוזר לטלפון שלך.</string>
+    <string name="device_speaker_hint_action">הוסף</string>
+    <string name="review_app_body">האם תרצה להשאיר ביקורת ל-BVM? ❤️</string>
+    <string name="review_app_review_action">סקירה</string>
+    <string name="review_app_dismiss_action">אולי מאוחר יותר</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">רכישה בוטלה</string>
     <string name="error_iap_unavailable_message">רכישות בתוך האפליקציה לא זמינות</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -387,6 +387,7 @@
     <string name="general_delete_action">削除</string>
     <string name="general_cancel_action">キャンセル</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">閉じる</string>
     <string name="general_progress_loading">読み込み中…</string>
     <string name="general_configure_action">設定</string>
     <string name="battery_optimization_hint_title">バッテリー最適化</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">管理されていないデバイスが見つかりません</string>
     <string name="discover_all_devices_managed_msg">ペアリングされたデバイスはすべて管理されています！新しいのが必要ですか？</string>
     <string name="discover_pair_new_device_action">新しいデバイスをペアリング</string>
+    <string name="discover_device_speaker_desc">この電話自体のスピーカー。Bluetooth デバイスが切断された後など、オーディオが電話に戻されるとき、そのボリュームが適用されます。</string>
     <!-- Devices -->
     <string name="devices_device_config_label">デバイス設定</string>
     <string name="devices_device_config_section_general_label">一般</string>
@@ -311,6 +312,7 @@
     <string name="label_add_device">デバイスを追加</string>
     <string name="label_just_a_moment_please">少々お待ちください。</string>
     <string name="label_notification_channel_status">状態</string>
+    <string name="monitor_notification_starting">起動中…</string>
     <string name="action_set">セット</string>
     <string name="action_cancel">キャンセル</string>
     <string name="label_invalid_input">無効な入力</string>
@@ -385,6 +387,7 @@
     <string name="general_delete_action">削除</string>
     <string name="general_cancel_action">キャンセル</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_progress_loading">読み込み中…</string>
     <string name="general_configure_action">設定</string>
     <string name="battery_optimization_hint_title">バッテリー最適化</string>
     <string name="battery_optimization_hint_message">バッテリー最適化が有効になっており、正常な動作を妨げる可能性があります。無効にすることを検討してください。</string>
@@ -396,6 +399,12 @@
     <string name="dnd_access_hint_title">サイレントモードへのアクセス</string>
     <string name="dnd_access_hint_message">サイレントモードへのアクセスがないと、デバイスの接続時に着信音、通知、DND モードの設定が適用されません。</string>
     <string name="dnd_access_fix_action">アクセスを許可</string>
+    <string name="device_speaker_hint_title">切断後のボリューム</string>
+    <string name="device_speaker_hint_message">Bluetooth デバイスが切断されたときにボリュームを復元したいですか？「デバイススピーカー」を管理対象デバイスとして追加すると、オーディオが電話に戻されるとき、そのボリュームが適用されます。</string>
+    <string name="device_speaker_hint_action">追加</string>
+    <string name="review_app_body">BVMをレビューしませんか？ ❤️</string>
+    <string name="review_app_review_action">レビュー</string>
+    <string name="review_app_dismiss_action">また後で</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">購入がキャンセルされました</string>
     <string name="error_iap_unavailable_message">アプリ内購入が利用できません</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">მართვის გარეშე მოწყობილობები ვერ მოიძებნა</string>
     <string name="discover_all_devices_managed_msg">ყველა თქვენი დაწყვილებული მოწყობილობა მართვის ქვეშაა! გჭირდებათ ახალი?</string>
     <string name="discover_pair_new_device_action">ახალი მოწყობილობის დაწყვილება</string>
+    <string name="discover_device_speaker_desc">ამ ტელეფონის საკუთარი სპიკერი. მისი ხმის დონე გამოიყენება, როდესაც აუდიო ტელეფონზე დაბრუნდება, მაგ., თქვენი Bluetooth მოწყობილობის გათიშვის შემდეგ.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">მოწყობილობის კონფიგურაცია</string>
     <string name="devices_device_config_section_general_label">ზოგადი</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">მოწყობილობის დამატება</string>
     <string name="label_just_a_moment_please">ერთი წუთი, გთხოვთ.</string>
     <string name="label_notification_channel_status">სტატუსი</string>
+    <string name="monitor_notification_starting">იწყება…</string>
     <string name="action_set">დაყენება</string>
     <string name="action_cancel">გაუქმება</string>
     <string name="label_invalid_input">არასწორი შეყვანა</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">წაშლა</string>
     <string name="general_cancel_action">გაუქმება</string>
     <string name="general_ok_action">კარგი</string>
+    <string name="general_dismiss_action">გაუქმება</string>
+    <string name="general_progress_loading">იტვირთება…</string>
     <string name="general_configure_action">კონფიგურირება</string>
     <string name="battery_optimization_hint_title">ბატარეის ოპტიმიზაცია</string>
     <string name="battery_optimization_hint_message">ბატარეის ოპტიმიზაციები ჩართულია და შეიძლება ხელი შეუშალოს სწორ ოპერაციას. განიხილეთ მათი გამორთვა.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">\"არ შეაწუხოთ\" წვდომა</string>
     <string name="dnd_access_hint_message">\"არ შეაწუხოთ\" წვდომის გარეშე, რეკვის სიგნალი, შეტყობინება და DND რეჯიმის პარამეტრები ვერ გამოყენებულ იქნება მოწყობილობების დაკავშირებისას.</string>
     <string name="dnd_access_fix_action">წვდომის მიცემა</string>
+    <string name="device_speaker_hint_title">ხმის დონე გათიშვის შემდეგ</string>
+    <string name="device_speaker_hint_message">გსურთ თქვენი ხმის დონე დაბრუნდეს, როდესაც Bluetooth მოწყობილობა გათიშება? დამატეთ \"მოწყობილობის სპიკერი\" როგორც მართვადი მოწყობილობა — მისი ხმის დონე გამოიყენება, როდესაც აუდიო თქვენს ტელეფონზე დაბრუნდება.</string>
+    <string name="device_speaker_hint_action">დამატება</string>
+    <string name="review_app_body">გნებავთ დატოვოთ BVM-ს მიმოხილვა? ❤️</string>
+    <string name="review_app_review_action">მიმოხილვა</string>
+    <string name="review_app_dismiss_action">შესაძლოა მოგვიანებით</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">შეძენა გაუქმდა</string>
     <string name="error_iap_unavailable_message">აპში შეძენა ხელმისაწვდომი არ არის</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">រកមិនឃើញឧបករណ៍ដែលមិនបានគ្រប់គ្រង</string>
     <string name="discover_all_devices_managed_msg">ឧបករណ៍ដែលបានផ្សារភ្ជាប់ទាំងអស់របស់អ្នកត្រូវបានគ្រប់គ្រង! ត្រូវការឧបករណ៍ថ្មីទេ?</string>
     <string name="discover_pair_new_device_action">ផ្សារភ្ជាប់ឧបករណ៍ថ្មី</string>
+    <string name="discover_device_speaker_desc">ស្ពីករ​របស់​ទូរស័ព្ទ។ កម្រិត​សម្លេង​របស់វា​ត្រូវ​បាន​ប្រើ​នៅ​ពេល​សម្លេង​ប្តូរ​ត្រឡប់​ទៅ​ទូរស័ព្ទ ដូច​ជា​បន្ទាប់​ពី​ឧបករណ៍​ប៊ុលធូស​របស់​អ្នក​ផ្ដាច់។</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ការកំណត់ឧបករណ៍</string>
     <string name="devices_device_config_section_general_label">ជាទូទៅ</string>
@@ -311,6 +312,7 @@
     <string name="label_add_device">បន្ថែមឧបករណ៍</string>
     <string name="label_just_a_moment_please">សូមរង់ចាំបន្តិច។</string>
     <string name="label_notification_channel_status">ស្ថានភាព</string>
+    <string name="monitor_notification_starting">កំពុងចាប់ផ្តើម…</string>
     <string name="action_set">កំណត់</string>
     <string name="action_cancel">បោះបង់</string>
     <string name="label_invalid_input">ធាតុបញ្ចូលមិនត្រឹមត្រូវ</string>
@@ -385,6 +387,8 @@
     <string name="general_delete_action">លុប</string>
     <string name="general_cancel_action">បោះបង់</string>
     <string name="general_ok_action">យល់ព្រម</string>
+    <string name="general_dismiss_action">បដិសេធ</string>
+    <string name="general_progress_loading">កំពុងផ្ទុក…</string>
     <string name="general_configure_action">កំណត់</string>
     <string name="battery_optimization_hint_title">ការបង្កើនប្រសិទ្ធភាពថ្ម</string>
     <string name="battery_optimization_hint_message">ការបង្កើនប្រសិទ្ធភាពថ្មត្រូវបានបើកដំណើរការ ហើយអាចរារាំងការដំណើរការត្រឹមត្រូវ។ សូមពិចារណាបិទមុខងារនេះ។</string>
@@ -396,6 +400,12 @@
     <string name="dnd_access_hint_title">ការចូលប្រើ​ \"កុំរំខាន\"</string>
     <string name="dnd_access_hint_message">បើរគ្មានការចូលប្រើ​ \"កុំរំខាន\" តែ ការកំណត់សំលេងរោតើ ការជូនដំណឺង និងរប័យ DND មិនអាចអនុវត្តបាននៅពេលឧបករណ៍របស់អនកភ្ជាប់តែ។</string>
     <string name="dnd_access_fix_action">ផ្តល់សិទ្ធិចូលប្រើ</string>
+    <string name="device_speaker_hint_title">កម្រិតសម្លេងបន្ទាប់ពីផ្តាច់</string>
+    <string name="device_speaker_hint_message">ចង់ឱ្យកម្រិតសម្លេងរបស់អ្នកត្រូវបានស្ដារឡើងវិញនៅពេលដែលឧបករណ៍ Bluetooth ផ្តាច់ទេ? បន្ថែម \"Device speaker\" ជាឧបករណ៍គ្រប់គ្រង — កម្រិតសម្លេងរបស់វាត្រូវបានអនុវត្តនៅពេលដែលសម្លេងប្តូរត្រឡប់ទៅទូរស័ព្ទរបស់អ្នក។</string>
+    <string name="device_speaker_hint_action">បន្ថែម</string>
+    <string name="review_app_body">តើ​អ្នក​ចង់​វាយតម្លៃ BVM មែនទេ? ❤️</string>
+    <string name="review_app_review_action">វាយតម្លៃ</string>
+    <string name="review_app_dismiss_action">ប្រហែលពេលក្រោយ</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">ការទិញត្រូវបានបោះបង់</string>
     <string name="error_iap_unavailable_message">ការទិញក្នុងកម្មវិធីមិនអាចប្រើបានទេ</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Ti cîhazên nebirêvebir nehatin dîtin</string>
     <string name="discover_all_devices_managed_msg">Hemû cîhazên weya hevbestekirî tên birêvebirin! Ji nûvekiyek hewce dike?</string>
     <string name="discover_pair_new_device_action">Cîhazekî nû hevbeste bike</string>
+    <string name="discover_device_speaker_desc">Bipêjek xwe ya vê telefon. Helûskên wê dema deng vegerê telefon di sepandin, mînakî piştî ku amûra Bluetooth-a te veqetiya.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Mîhengkarîn cîhazê</string>
     <string name="devices_device_config_section_general_label">Gishtgir</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Cîhazê bizêde bike</string>
     <string name="label_just_a_moment_please">Wax bikin, ji kerema xwe.</string>
     <string name="label_notification_channel_status">Dema niha</string>
+    <string name="monitor_notification_starting">Vegu tê de…</string>
     <string name="action_set">Saz bike</string>
     <string name="action_cancel">Betal bike</string>
     <string name="label_invalid_input">Ketina ne derbasdar</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Jê bike</string>
     <string name="general_cancel_action">Betal bike</string>
     <string name="general_ok_action">Baş e</string>
+    <string name="general_dismiss_action">Bişûmke</string>
+    <string name="general_progress_loading">Barkirinê…</string>
     <string name="general_configure_action">Mîheng bike</string>
     <string name="battery_optimization_hint_title">Optimîzasyona battery</string>
     <string name="battery_optimization_hint_message">Optimîzasyona battery aktif e.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Destresa Nexwazîna Acizkarî</string>
     <string name="dnd_access_hint_message">Bê destresa Nexwazîna Acizkarî, mîhengên dengê zengilê, agahdarî, û moda Nexwazîna Acizkarî nikarin were sepandin gava cihazên te ve dibin.</string>
     <string name="dnd_access_fix_action">Destresê bide</string>
+    <string name="device_speaker_hint_title">Helûsk piştî veqetandinê</string>
+    <string name="device_speaker_hint_message">Tu dixwazî helûskên xwe vegerîn dema amûra Bluetooth-a veqetya? \"Bipêjek amûrê\" wek amûra rêvebir zêde bike — helûskên wê dema deng vegerê telefona te di sepandin.</string>
+    <string name="device_speaker_hint_action">Zêde bike</string>
+    <string name="review_app_body">Tu dixwazî ji bo BVM-ê vê pîrsguhekê tu bikî? ❤️</string>
+    <string name="review_app_review_action">Pîrsguhek</string>
+    <string name="review_app_dismiss_action">Paşê dibe</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Kirîn hatî betal kirin</string>
     <string name="error_iap_unavailable_message">Kirêna di bernameê de berdest nîne</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">ನಿರ್ವಹಿಸದ ಸಾಧನಗಳು ಕಂಡುಬಂದಿಲ್ಲ</string>
     <string name="discover_all_devices_managed_msg">ನಿಮ್ಮ ಎಲ್ಲಾ ಜೋಡಿಯಾದ ಸಾಧನಗಳು ನಿರ್ವಹಿಸಲ್ಪಡುತ್ತಿವೆ! ಹೊಸದು ಬೇಕೇ?</string>
     <string name="discover_pair_new_device_action">ಹೊಸ ಸಾಧನ ಜೋಡಿಸಿ</string>
+    <string name="discover_device_speaker_desc">ಈ ಫೋನ್‌ನ ಸ್ವಂತ ಸ್ಪೀಕರ್. ಆಡಿಯೋ ಫೋನ್‌ಗೆ ಮತ್ತೆ ಬದಲಾಗಿದಾಗ ಅದರ ವಾಲ್ಯೂಮ್‌ಗಳನ್ನು ಅನ್ವಯ ಮಾಡಲಾಗುತ್ತದೆ, ಉದಾ. ನಿಮ್ಮ Bluetooth ಸಾಧನ ಸಂಪರ್ಕ ಕಡಿತವಾದ ನಂತರ.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ಸಾಧನ ಅನುಸ್ಥಾಪನೆ</string>
     <string name="devices_device_config_section_general_label">ಸಾಮಾನ್ಯ</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">ಸಾಧನ ಸೇರಿಸಿ</string>
     <string name="label_just_a_moment_please">ಒಂದು ಕ್ಷಣ, ದಯವಿಟ್ಟು.</string>
     <string name="label_notification_channel_status">ಸ್ಥಿತಿ</string>
+    <string name="monitor_notification_starting">ಪ್ರಾರಂಭಿಸುತ್ತಿದೆ…</string>
     <string name="action_set">ಹೊಂದಿಸಿ</string>
     <string name="action_cancel">ರದ್ದುಮಾಡಿ</string>
     <string name="label_invalid_input">ಅಮಾನ್ಯ ಇನ್ಪುಟ್</string>
@@ -391,6 +393,8 @@
     <string name="general_delete_action">ಅಳಿಸು</string>
     <string name="general_cancel_action">ರದ್ದುಮಾಡಿ</string>
     <string name="general_ok_action">ಸರಿ</string>
+    <string name="general_dismiss_action">ವಜಾ ಮಾಡಿ</string>
+    <string name="general_progress_loading">ಲೋಡ್ ಆಗುತ್ತಿದೆ…</string>
     <string name="general_configure_action">ಕಾನ್ಫಿಗರ್ ಮಾಡಿ</string>
     <string name="battery_optimization_hint_title">ಬ್ಯಾಟರಿ ಆಪ್ಟಿಮೈಜೇಶನ್</string>
     <string name="battery_optimization_hint_message">ಬ್ಯಾಟರಿ ಆಪ್ಟಿಮೈಜೇಶನ್‌ಗಳು ಸಕ್ರಿಯವಾಗಿವೆ ಮತ್ತು ಸರಿಯಾದ ಕಾರ್ಯಾಚರಣೆಗೆ ತಡೆಯಾಗಬಹುದು. ಅವುಗಳನ್ನು ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲು ಪರಿಗಣಿಸಿ</string>
@@ -402,6 +406,12 @@
     <string name="dnd_access_hint_title">ಡೂ ನಾಟ್ ಡಿಸ್ಟರ್ಬ್ ಪ್ರವೇಶ</string>
     <string name="dnd_access_hint_message">ಡೂ ನಾಟ್ ಡಿಸ್ಟರ್ಬ್ ಪ್ರವೇಶವಿಲ್ಲದೆ, ನಿಮ್ಮ ಸಾಧನಗಳು ಸಂಪರ್ಕಗೊಂಡಾಗ ರಿಂಗ್‌ಟೋನ್, ಅಧಿಸೂಚನೆ ಮತ್ತು DND ಮೋಡ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಅನ್ವಯಿಸಲು ಸಾಧ್ಯವಿಲ್ಲ.</string>
     <string name="dnd_access_fix_action">ಪ್ರವೇಶ ನೀಡಿ</string>
+    <string name="device_speaker_hint_title">ಸಂಪರ್ಕ ಕಡಿತಗೊಂಡ ನಂತರ ವಾಲ್ಯೂಮ್‌ಗಳು</string>
+    <string name="device_speaker_hint_message">Bluetooth ಸಾಧನ ಸಂಪರ್ಕ ಕಡಿತಗೊಂಡಾಗ ನಿಮ್ಮ ವಾಲ್ಯೂಮ್‌ಗಳನ್ನು ಪುನರುಸ್ಥಾಪಿತ ಮಾಡಲು ಬಯಸುತ್ತೀರೇ? \"ಸಾಧನ ಸ್ಪೀಕರ್\" ಅನ್ನು ನಿರ್ವಹಿತ ಸಾಧನವಾಗಿ ಸೇರಿಸಿ — ಆಡಿಯೋ ನಿಮ್ಮ ಫೋನ್‌ಗೆ ಮತ್ತೆ ಬದಲಾಯಿತಾಗ ಅದರ ವಾಲ್ಯೂಮ್‌ಗಳು ಅನ್ವಯ ಮಾಡಲಾಗುತ್ತದೆ.</string>
+    <string name="device_speaker_hint_action">ಸೇರಿಸಿ</string>
+    <string name="review_app_body">ನೀವು BVM ಗೆ ವಿಮರ್ಶೆ ಬಿಡಲು ಬಯಸುತ್ತೀರಾ? ❤️</string>
+    <string name="review_app_review_action">ವಿಮರ್ಶೆ</string>
+    <string name="review_app_dismiss_action">ಬೇಕಾದರೆ ನಂತರ</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">ಖರೀದು ರದ್ದಾಗಿದೆ</string>
     <string name="error_iap_unavailable_message">ಅಪ್ ಒಳಗೆ ಖರೀದುಗಳು ಲಭ್ಯವಿಲ್ಲ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">관리되지 않는 디바이스를 찾을 수 없습니다</string>
     <string name="discover_all_devices_managed_msg">모든 페어링된 기기가 이미 관리되고 있어요! 새로운 기기가 필요하신가요?</string>
     <string name="discover_pair_new_device_action">새 기기 페어링</string>
+    <string name="discover_device_speaker_desc">이 휴대폰의 자체 스피커입니다. 오디오가 휴대폰으로 전환될 때(예: Bluetooth 기기 연결 해제 후) 음량이 적용됩니다.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">디바이스 설정</string>
     <string name="devices_device_config_section_general_label">일반</string>
@@ -311,6 +312,7 @@
     <string name="label_add_device">디바이스 추가</string>
     <string name="label_just_a_moment_please">잠시만 기다려주세요.</string>
     <string name="label_notification_channel_status">상태</string>
+    <string name="monitor_notification_starting">시작 중입니다…</string>
     <string name="action_set">설정</string>
     <string name="action_cancel">취소</string>
     <string name="label_invalid_input">잘못된 입력</string>
@@ -385,6 +387,8 @@
     <string name="general_delete_action">삭제</string>
     <string name="general_cancel_action">취소</string>
     <string name="general_ok_action">확인</string>
+    <string name="general_dismiss_action">닫기</string>
+    <string name="general_progress_loading">불러오는 중…</string>
     <string name="general_configure_action">구성</string>
     <string name="battery_optimization_hint_title">배터리 최적화</string>
     <string name="battery_optimization_hint_message">배터리 최적화가 켜져 있어 정상 동작을 방해할 수 있습니다. 끄기를 고려해보세요.</string>
@@ -396,6 +400,12 @@
     <string name="dnd_access_hint_title">방해 금지 접근 권한</string>
     <string name="dnd_access_hint_message">방해 금지 접근 권한이 없으면 기기가 연결될 때 벨소리, 알림, 방해 금지 모드 설정을 적용할 수 없습니다.</string>
     <string name="dnd_access_fix_action">접근 권한 부여</string>
+    <string name="device_speaker_hint_title">연결 해제 후 음량</string>
+    <string name="device_speaker_hint_message">Bluetooth 기기가 연결 해제될 때 음량을 복원하고 싶으신가요? \"기기 스피커\"를 관리 기기로 추가하세요 — 오디오가 휴대폰으로 전환될 때 음량이 적용됩니다.</string>
+    <string name="device_speaker_hint_action">추가</string>
+    <string name="review_app_body">BVM 리뷰를 남겨주시겠어요? ❤️</string>
+    <string name="review_app_review_action">리뷰</string>
+    <string name="review_app_dismiss_action">다음에 해요</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">구매 취소됨</string>
     <string name="error_iap_unavailable_message">인앱 구매를 이용할 수 없습니다</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Башкарылбаган түзмөктөр табылган жок</string>
     <string name="discover_all_devices_managed_msg">Бардык жупташтырылган түзмөктөрүңүз башкарылууда! Жаңы бирин кошосузбу?</string>
     <string name="discover_pair_new_device_action">Жаңы түзмөктү жупташтыруу</string>
+    <string name="discover_device_speaker_desc">Телефондун өзүнүн докладчы. Анын үндөрү аудио телефонго артка кайтканда колдонулат, мисалы Bluetooth түзмөгүңүз ажыратылгандан кийин.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Түзмөктүн конфигурациясы</string>
     <string name="devices_device_config_section_general_label">Жалпы</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Түзмөк кошуу</string>
     <string name="label_just_a_moment_please">Бир мүнөт, сураныч.</string>
     <string name="label_notification_channel_status">Абал</string>
+    <string name="monitor_notification_starting">Иштелип жатат…</string>
     <string name="action_set">Коюуу</string>
     <string name="action_cancel">Жокко чыгаруу</string>
     <string name="label_invalid_input">Жараксыз киргизүү</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Жойуу</string>
     <string name="general_cancel_action">Жокко чыгаруу</string>
     <string name="general_ok_action">Жарайлык</string>
+    <string name="general_dismiss_action">Жабуу</string>
+    <string name="general_progress_loading">Жүктөлүп жатат…</string>
     <string name="general_configure_action">Конфигурациялоо</string>
     <string name="battery_optimization_hint_title">Батарея оптимизациясы</string>
     <string name="battery_optimization_hint_message">Батарея оптимизациялары иштетилген жана туура иштешине тоскоол коюшу мүмкүн. Аларды өчүрүп коюунуну карап көрүңүз.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">\"Тынчтыктыма тоскоол болбо\" мүмкүнчүлүгүнө уруксат</string>
     <string name="dnd_access_hint_message">\"Тынчтыктыма тоскоол болбо\" мүмкүнчүлүгүнсүз, шыңгыроо үнү, билдирүү жана DND режим жөндөөлөрү түзмөктөрүңүз туташканда колдонула албайт.</string>
     <string name="dnd_access_fix_action">Уруксат берүү</string>
+    <string name="device_speaker_hint_title">Ажыратылгандан кийинки үндөр</string>
+    <string name="device_speaker_hint_message">Bluetooth түзмөгүңүз ажыратылганда үндөрүңүз калыбына келсе деп ойлойсузбу? \"Түзмөк докладчы\" каза кыла турган түзмөк катары кошуңуз — анын үндөрү аудио сиздин телефонго артка кайтканда колдонулат.</string>
+    <string name="device_speaker_hint_action">Кошуу</string>
+    <string name="review_app_body">BVM үчүн рецензия жазасыңарбы? ❤️</string>
+    <string name="review_app_review_action">Рецензия</string>
+    <string name="review_app_dismiss_action">Кийин</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Сатып алуу бекер кылынды</string>
     <string name="error_iap_unavailable_message">Колдонмо ишинде сатып алуу мүмкүн эмес</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">ບໍ່ພົບອຸປະກອນທີ່ບໍ່ໄດ້ຈັດການ</string>
     <string name="discover_all_devices_managed_msg">ອຸປະກອນທີ່ຈັບຄູ່ທັງໝົດຂອງທ່ານຖືກຈັດການແລ້ວ! ຕ້ອງການໃໝ່ບໍ?</string>
     <string name="discover_pair_new_device_action">ຈັບຄູ່ອຸປະກອນໃໝ່</string>
+    <string name="discover_device_speaker_desc">ລຳໂພງຂອງໂທລະສັບນີ້ເອງ. ລະດັບສຽງຂອງມັນຖືກໃຊ້ໃນເວລາທີ່ສຽງກັບຄືນສູ່ໂທລະສັບ, ຕົວຍ່າງ ໜຼັງຈາກທີ່ອຸປະກອນ Bluetooth ຂອງທ່ານຕັດການເຊື່ອມຕໍ່.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ການຕັ້ງຄ່າອຸປະກອນ</string>
     <string name="devices_device_config_section_general_label">ທົ່ວໄປ</string>
@@ -311,6 +312,7 @@
     <string name="label_add_device">ເພີ່ມອຸປະກອນ</string>
     <string name="label_just_a_moment_please">ສ଱ກຄູ່ ກະລຸນາ.</string>
     <string name="label_notification_channel_status">ສະຖານະ</string>
+    <string name="monitor_notification_starting">ກຳລັງເລີ່ມຕົ້ນ...</string>
     <string name="action_set">ຕັ້ງ</string>
     <string name="action_cancel">ຍົກເລີກ</string>
     <string name="label_invalid_input">ຂໍ້ມູນທີ່ປ້ອນບໍ່ຖືກຕ້ອງ</string>
@@ -385,6 +387,8 @@
     <string name="general_delete_action">ລຶບ</string>
     <string name="general_cancel_action">ຍົກເລີກ</string>
     <string name="general_ok_action">ຕົກລອງ</string>
+    <string name="general_dismiss_action">ປະຕິເສດ</string>
+    <string name="general_progress_loading">ກຳລັງໂຫຼດ...</string>
     <string name="general_configure_action">ຕັ້ງຄ່າ</string>
     <string name="battery_optimization_hint_title">ການອຫນຸເທບັດເຕຣີ</string>
     <string name="battery_optimization_hint_message">ການອຫນຸເທບັດເຕຣີເອີນໃຊ້ງານແລະອາດເປີດກັ້ນການທຳງານ. ກະລຸນາປິດການອຫນຸເທ.</string>
@@ -396,6 +400,12 @@
     <string name="dnd_access_hint_title">ການເຂົ້າເຖິງ Do Not Disturb</string>
     <string name="dnd_access_hint_message">ໂດຍບໍ່ມີການເຂົ້າເຖິງ Do Not Disturb, ການຕັ້ງຄ່າສຽງໂທລະສັບ, ການແຈ້ງເຕືອນ ແລະ ໂໝດ DND ບໍ່ສາມາດໃຊ້ໄດ້ເມື່ອອຸປະກອນຂອງທ່ານເຊື່ອມຕໍ່.</string>
     <string name="dnd_access_fix_action">ໃຫ້ການເຂົ້າເຖິງ</string>
+    <string name="device_speaker_hint_title">ສຽງຫຼັງຈາກຕັດການເຊື່ອມຕໍ່</string>
+    <string name="device_speaker_hint_message">ຕໍ້ງການໃຫ້ສຽງຂອງທ່ານກັບຄືນໃນເວລາທີ່ອຸປະກອນ Bluetooth ຕັດການເຊື່ອມຕໍ່ບໍ? ເພີ່ມ \"ລຳໂພງອຸປະກອນ\" ເປັນອຸປະກອນທີ່ຈັດການ — ລະດັບສຽງຂອງມັນຖືກໃຊ້ໃນເວລາທີ່ສຽງກັບຄືນສູ່ໂທລະສັບຂອງທ່ານ.</string>
+    <string name="device_speaker_hint_action">ເພີ່ມ</string>
+    <string name="review_app_body">ທ່ານຈະໃຫ້ຄຳເຫັນໃຫ້ BVM ບໍ? ❤️</string>
+    <string name="review_app_review_action">ຄຳເຫັນ</string>
+    <string name="review_app_dismiss_action">ບາງທີພາຍຫຼັງ</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">ການຊື້ຖືກຍກເລີກ</string>
     <string name="error_iap_unavailable_message">ການຊື້ພາຍໃນແອັບບໍ່ພອ້ມໃຊ້ງານ</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nevaldomi įrenginiai nerasti</string>
     <string name="discover_all_devices_managed_msg">Visi suporuoti įrenginiai valdomi! Reikia naujo?</string>
     <string name="discover_pair_new_device_action">Suporuoti naują įrenginį</string>
+    <string name="discover_device_speaker_desc">Jūsų telefono savasis garsiakalbis. Jo garsumai yra taikomi, kai garsas persijungia atgal į telefoną, pvz., po to, kai jūsų „Bluetooth“ įrenginys atsijungia.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Įrenginio konfigūracija</string>
     <string name="devices_device_config_section_general_label">Bendra</string>
@@ -323,6 +324,7 @@
     <string name="label_add_device">Pridėti įrenginį</string>
     <string name="label_just_a_moment_please">Luktelkite.</string>
     <string name="label_notification_channel_status">Būsena</string>
+    <string name="monitor_notification_starting">Pradedama…</string>
     <string name="action_set">Nustatyti</string>
     <string name="action_cancel">Atšaukti</string>
     <string name="label_invalid_input">Netinkama įvestis</string>
@@ -400,6 +402,8 @@
     <string name="general_delete_action">Ištrinti</string>
     <string name="general_cancel_action">Atšaukti</string>
     <string name="general_ok_action">Gerai</string>
+    <string name="general_dismiss_action">Atšaukti</string>
+    <string name="general_progress_loading">Įkeliama…</string>
     <string name="general_configure_action">Konfigūruoti</string>
     <string name="battery_optimization_hint_title">Baterijos optimizavimas</string>
     <string name="battery_optimization_hint_message">Baterijos optimizavimas įjungtas ir gali trukdyti tinkamam veikimui. Apsvarstykite galimybę jį išjungti.</string>
@@ -411,6 +415,12 @@
     <string name="dnd_access_hint_title">Prieiga prie režimo Netrukdyti</string>
     <string name="dnd_access_hint_message">Be prieigos prie „Netrukdyti“, skambėjimo tono, pranešimų ir DND režimo nustatymai negali būti pritaikomi, kai jūsų įrenginiai prisijungia.</string>
     <string name="dnd_access_fix_action">Suteikti prieigą</string>
+    <string name="device_speaker_hint_title">Garsumai po atjungimo</string>
+    <string name="device_speaker_hint_message">Norite, kad jūsų garsumai būtų atkurti, kai „Bluetooth“ įrenginys atsijungia? Pridėkite „Įrenginio garsiakalbį“ kaip valdomą įrenginį — jo garsumai yra taikomi, kai garsas persijungia atgal į jūsų telefoną.</string>
+    <string name="device_speaker_hint_action">Pridėti</string>
+    <string name="review_app_body">Ar norėtum palikti BVM apžvalgą? ❤️</string>
+    <string name="review_app_review_action">Apžvalga</string>
+    <string name="review_app_dismiss_action">Galbūt vėliau</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Pirkimas atšauktas</string>
     <string name="error_iap_unavailable_message">Pirkimai programoje nepasiekiami</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nav atrasts neviena nepārvalditā ierīce</string>
     <string name="discover_all_devices_managed_msg">Visas jūsu savienotās ierīces tiek pārvaldītas! Vajag jaunu?</string>
     <string name="discover_pair_new_device_action">Savienot jaunu ierīci</string>
+    <string name="discover_device_speaker_desc">Tālruņa savs skaļrunis. Tā skaļumi tiek piemēroti, kad audio pārslēdzas atpakaļ uz tālruni, piemēram, pēc Bluetooth ierīces atvienošanas.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Ierīces konfigurācija</string>
     <string name="devices_device_config_section_general_label">Vispārīgi</string>
@@ -319,6 +320,7 @@
     <string name="label_add_device">Pievienot ierīci</string>
     <string name="label_just_a_moment_please">Uzgaņiet, lūdzu.</string>
     <string name="label_notification_channel_status">Stāvoklis</string>
+    <string name="monitor_notification_starting">Uzsāk...</string>
     <string name="action_set">Iestatīt</string>
     <string name="action_cancel">Atcelt</string>
     <string name="label_invalid_input">Nederīga ievade</string>
@@ -395,6 +397,8 @@
     <string name="general_delete_action">Dzēst</string>
     <string name="general_cancel_action">Atcelt</string>
     <string name="general_ok_action">Labi</string>
+    <string name="general_dismiss_action">Noraidīt</string>
+    <string name="general_progress_loading">Ielāde...</string>
     <string name="general_configure_action">Konfigurēt</string>
     <string name="battery_optimization_hint_title">Akumlatora optimizācija</string>
     <string name="battery_optimization_hint_message">Akumlatora optimizācijas ir iespējotas un var trāukcēt pareizu darbību. Apsveriet to atspējošanu.</string>
@@ -406,6 +410,12 @@
     <string name="dnd_access_hint_title">Netraukt piekļuves</string>
     <string name="dnd_access_hint_message">Bez Netraukt piekļuves, zvana signāla, paziņojumu un Netraukt režīma iestatījumus nevar lietot, kad jūsu ierīces piesledzas.</string>
     <string name="dnd_access_fix_action">Piešķirt piekļuvi</string>
+    <string name="device_speaker_hint_title">Skaļumi pēc atvienošanas</string>
+    <string name="device_speaker_hint_message">Vai vēlaties, lai jūsu skaļumi tiktu atjaunoti, atvienojot Bluetooth ierīci? Pievienojiet \"Ierīces skaļrunis\" kā pārvaldītu ierīci — tā skaļumi tiek piemēroti, kad audio pārslēdzas atpakaļ uz jūsu tālruni.</string>
+    <string name="device_speaker_hint_action">Pievienot</string>
+    <string name="review_app_body">Vai gribi atstāt BVM atsauksmi? ❤️</string>
+    <string name="review_app_review_action">Atsauksme</string>
+    <string name="review_app_dismiss_action">Varbūt vēlāk</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Pirkums atcelts</string>
     <string name="error_iap_unavailable_message">Pirkumi lietotnē nav pieejami</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Нема пронајдено неуправувани уреди</string>
     <string name="discover_all_devices_managed_msg">Сите твои спарени уреди се управувани! Треба нов?</string>
     <string name="discover_pair_new_device_action">Спари нов уред</string>
+    <string name="discover_device_speaker_desc">Вградениот звучник на телефонот. Неговите волумени се применуваат кога аудио се враќа на телефонот, нпр. откако се прекине вашиот Bluetooth уред.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Конфигурација на уредот</string>
     <string name="devices_device_config_section_general_label">Генерално</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Додај уред</string>
     <string name="label_just_a_moment_please">Само еден момент, ве молиме.</string>
     <string name="label_notification_channel_status">Статус</string>
+    <string name="monitor_notification_starting">Стартување…</string>
     <string name="action_set">Поставете</string>
     <string name="action_cancel">Откажи</string>
     <string name="label_invalid_input">Невалиден внес</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Избриши</string>
     <string name="general_cancel_action">Откажи</string>
     <string name="general_ok_action">ОК</string>
+    <string name="general_dismiss_action">Отфрли</string>
+    <string name="general_progress_loading">Вчитување…</string>
     <string name="general_configure_action">Конфигурирај</string>
     <string name="battery_optimization_hint_title">Оптимизација на батерија</string>
     <string name="battery_optimization_hint_message">Оптимизациите на батеријата се вклучени и може да спречат правилно функционирање. Размисли за нивно исклучување.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Пристап до Не вознемирувај</string>
     <string name="dnd_access_hint_message">Без пристап до Не вознемирувај, поставките за ѕвонење, известување и режимот Не вознемирувај не можат да се применат кога вашите уреди се поврзуваат.</string>
     <string name="dnd_access_fix_action">Дозволи пристап</string>
+    <string name="device_speaker_hint_title">Волумени по прекинување</string>
+    <string name="device_speaker_hint_message">Сакате ли вашите волумени да се враќаат кога Bluetooth уредот се прекине? Додајте го \"Звучникот на уред\" како управуван уред — неговите волумени се применуваат кога аудио се враќа на вашиот телефон.</string>
+    <string name="device_speaker_hint_action">Додај</string>
+    <string name="review_app_body">Сакаш ли да напишеш преглед на BVM? ❤️</string>
+    <string name="review_app_review_action">Преглед</string>
+    <string name="review_app_dismiss_action">Можеби подоцна</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Купувањето е откажано</string>
     <string name="error_iap_unavailable_message">Купувањата во апликацијата не се достапни</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">നിർവ്വഹിക്കാത്ത ഉപകരണങ്ങൾ കണ്ടെത്തിയില്ല</string>
     <string name="discover_all_devices_managed_msg">നിങ്ങളുടെ എല്ലാ ജോടിചേർത്ത ഉപകരണങ്ങളും നിർവ്വഹിക്കുന്നു! ഒരു പുതിയത് വേണോ?</string>
     <string name="discover_pair_new_device_action">പുതിയ ഉപകരണം ജോടിചേർക്കുക</string>
+    <string name="discover_device_speaker_desc">ഈ ഫോണിന്റെ സ്വന്ത സ്പീക്കർ. നിങ്ങളുടെ Bluetooth ഡിവൈസ് വിച്ഛേദിക്കുമ്പോൾ അതിന്റെ വോളിയങ്ങൾ ഫോണിലേക്ക് ഓഡിയോ മടങ്ങുമ്പോൾ പ്രയോഗിക്കുന്നു.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ഉപകരണ ക്രമീകരണം</string>
     <string name="devices_device_config_section_general_label">പൊതുവായ</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">ഉപകരണം ചേർക്കുക</string>
     <string name="label_just_a_moment_please">ഒരു നിമിഷം, ദയവായി.</string>
     <string name="label_notification_channel_status">നില</string>
+    <string name="monitor_notification_starting">ആരംഭിക്കുന്നു…</string>
     <string name="action_set">സജ്ജീകരിക്കുക</string>
     <string name="action_cancel">റദ്ദ്ചെയ്യുക</string>
     <string name="label_invalid_input">അസാധുവായ ഇൻപുട്ട്</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">ഇല്ലാതാക്കുക</string>
     <string name="general_cancel_action">റദ്ദ്ചെയ്യുക</string>
     <string name="general_ok_action">ശരി</string>
+    <string name="general_dismiss_action">തള്ളിക്കളയുക</string>
+    <string name="general_progress_loading">ലോഡ് ചെയ്യുന്നു…</string>
     <string name="general_configure_action">ക്രമീകരിക്കുക</string>
     <string name="battery_optimization_hint_title">ബാറ്റരി ഒപ്റ്റിമൈസേഷൻ</string>
     <string name="battery_optimization_hint_message">ബാറ്ററി ഒപ്റ്റിമൈസേഷനുകൾ പ്രവർത്തനക്ഷമമാണ്, അത് ശരിയായ പ്രവർത്തനം തടയാനിടയാണ്. അവ പ്രവർത്തനരഹിതമാക്കാൻ പരിഗണിക്കുക.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">സ്ക്രീൻ കിളയ്ക്കൾ മറക്കീ അക്സെസ് (Do Not Disturb)</string>
     <string name="dnd_access_hint_message">Do Not Disturb ആക്സെസ് ഇല്ലാതെ, താങ്കളുടെ ഉപകരണങ്ങൾ കണക്‍റ്റ് ചെയ്യുമ്പോൾ രിംഗ്ടോണ്‍, നോടിഫിക്കേഷൻ, DND മോഡ് ക്രമീകരണങ്ങൾ പ്രയോഗിക്കാൻ കഴിയുകയില്ല.</string>
     <string name="dnd_access_fix_action">Grant access</string>
+    <string name="device_speaker_hint_title">വിച്ഛേദനത്തിനുശേഷമുള്ള വോളിയങ്ങൾ</string>
+    <string name="device_speaker_hint_message">Bluetooth ഡിവൈസ് വിച്ഛേദിക്കുമ്പോൾ നിങ്ങളുടെ വോളിയങ്ങൾ പുനഃസ്ഥാപിക്കപ്പെടണമെന്ന് ആഗ്രഹിക്കുന്നുണ്ടോ? \"ഡിവൈസ് സ്പീക്കർ\" നിയന്ത്രിതമായ ഡിവൈസായി ചേർക്കുക — നിങ്ങളുടെ ഫോണിലേക്ക് ഓഡിയോ മടങ്ങുമ്പോൾ അതിന്റെ വോളിയങ്ങൾ പ്രയോഗിക്കുന്നു.</string>
+    <string name="device_speaker_hint_action">ചേർക്കുക</string>
+    <string name="review_app_body">BVM-നെ കുറിച്ച് ഒരു നിരൂപണം നൽകാൻ ഇഷ്ടമുണ്ടോ? ❤️</string>
+    <string name="review_app_review_action">നിരൂപണം</string>
+    <string name="review_app_dismiss_action">പിന്നീട്</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">വാങ്ങൽ റദ്ദാകി</string>
     <string name="error_iap_unavailable_message">ആപ്പിനുള്ളിലെ വാങ്ങലുകൾ ലഭ്യമല്ല</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Удаалагдаагүй төхөөрөмжий олдсонгүй</string>
     <string name="discover_all_devices_managed_msg">Таны харилцан бүх төхөөрөмжийг удааладаж байна! Шинэ нэг нэмжийг хариалцуулах гэж</string>
     <string name="discover_pair_new_device_action">Шинэ төхөөрөмжийг харилцах</string>
+    <string name="discover_device_speaker_desc">Энэ утасны өөрийн чанга яригч. Түүний эзлэхүүнүүд аудио утас руу эргэж ирэхэд хэрэглэгдэнэ, жишээлбэл таны Bluetooth төхөөрөмж салсны дараа.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Төхөөрөмжийн тохиргуулалт</string>
     <string name="devices_device_config_section_general_label">Ерөнхийлэл</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Төхөөрөмжий нэмэх</string>
     <string name="label_just_a_moment_please">Нэг зураар хүлээнүү.</string>
     <string name="label_notification_channel_status">Төлөв</string>
+    <string name="monitor_notification_starting">Эхэлж байна…</string>
     <string name="action_set">Тохируулах</string>
     <string name="action_cancel">Цуцлах</string>
     <string name="label_invalid_input">Буруу оролт</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Устгах</string>
     <string name="general_cancel_action">Цуцлах</string>
     <string name="general_ok_action">Зөвшөөрөх</string>
+    <string name="general_dismiss_action">Хаах</string>
+    <string name="general_progress_loading">Ачаалж байна…</string>
     <string name="general_configure_action">Тохируулах</string>
     <string name="battery_optimization_hint_title">Батарейн оптимчлал</string>
     <string name="battery_optimization_hint_message">Батарейн оптимчлал идэвхүүлсэн бөгөөд зөв үйлажиллагахаас сэргийлж болно. Тэдгээгийг унтраахыг анхаарай.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Тасалдахгүй горимт авах эрх</string>
     <string name="dnd_access_hint_message">Тасалдахгүй горимт авах эрхгүйгээр хүү звон, мэдэгдэлгээрийн цонхиу, ТӢГ төршлийн тохиргуултыг таны төхөөрөмжүүд холбогдоход ашиглана хэрэгжүй.</string>
     <string name="dnd_access_fix_action">Хандалт олгох</string>
+    <string name="device_speaker_hint_title">Салгасны дараа эзлэхүүнүүд</string>
+    <string name="device_speaker_hint_message">Bluetooth төхөөрөмж салах үед таны эзлэхүүнүүд сэргээгдэхийг хүсэж байна уу? \"Төхөөрөмжийн чанга яригч\"-ийг удирдлагатай төхөөрөмж болгон нэмнэ үү — түүний эзлэхүүнүүд аудио та утас руу эргэж ирэхэд хэрэглэгдэнэ.</string>
+    <string name="device_speaker_hint_action">Нэмэх</string>
+    <string name="review_app_body">Та BVM-д үнэлгээ үлдээхийг хүсч байна уу? ❤️</string>
+    <string name="review_app_review_action">Үнэлгээ</string>
+    <string name="review_app_dismiss_action">Дараа нь магадгүй</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Худалдалцаагүй болсон</string>
     <string name="error_iap_unavailable_message">Апп дотоодх худалдалцаа боломжгүй</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">कोणतेही अव्यवस्थापित डिव्हाइस आढळले नाही</string>
     <string name="discover_all_devices_managed_msg">तुमची सर्व जोडलेली डिव्हाइस व्यवस्थापित आहेत! नवीन हवे आहे का?</string>
     <string name="discover_pair_new_device_action">नवीन डिव्हाइस जोडा</string>
+    <string name="discover_device_speaker_desc">या फोनचा स्वतःचा स्पीकर. जेव्हा ऑडिओ फोनवर परत स्विच होते तेव्हा त्याचे व्हॉल्यूम लागू होतात, उदा. तुमचे Bluetooth डिव्हाइस डिस्कनेक्ट झाल्यानंतर.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">डिव्हाइस कॉन्फिगरेशन</string>
     <string name="devices_device_config_section_general_label">सामान्य</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">डिव्हाइस जोडा</string>
     <string name="label_just_a_moment_please">एक क्षण, कृपया.</string>
     <string name="label_notification_channel_status">स्थिती</string>
+    <string name="monitor_notification_starting">शुरू होत आहे…</string>
     <string name="action_set">सेट करा</string>
     <string name="action_cancel">रद्द करा</string>
     <string name="label_invalid_input">अवैध इनपुट</string>
@@ -391,6 +393,8 @@
     <string name="general_delete_action">हटवा</string>
     <string name="general_cancel_action">रद्द करा</string>
     <string name="general_ok_action">ठीक आहे</string>
+    <string name="general_dismiss_action">खारिज करा</string>
+    <string name="general_progress_loading">लोड होत आहे…</string>
     <string name="general_configure_action">कॉन्फिगर करा</string>
     <string name="battery_optimization_hint_title">बॅटरी ऑप्टिमायझेशन</string>
     <string name="battery_optimization_hint_message">बॅटरी ऑप्टिमायझेशन सक्षम आहेत आणि योग्य ऑपरेशनला प्रतिबंध करू शकतात. ते अक्षम करण्याचा विचार करा.</string>
@@ -402,6 +406,12 @@
     <string name="dnd_access_hint_title">व्यत्यय मोड प्रवेश</string>
     <string name="dnd_access_hint_message">व्यत्यय मोड प्रवेशाशिवाय, रिंगटोन, सूचना आणि व्यत्यय मोड सेटिंग्ज तुमच्या डिव्हाइससह कनेक्ट होताना लागू केल्या जाऊ शकत नाहीत.</string>
     <string name="dnd_access_fix_action">प्रवेश मंजूर करा</string>
+    <string name="device_speaker_hint_title">डिस्कनेक्ट केल्यानंतर व्हॉल्यूम</string>
+    <string name="device_speaker_hint_message">Bluetooth डिव्हाइस डिस्कनेक्ट होताना तुमचे व्हॉल्यूम पुनर्स्थापित हवेत का? “डिव्हाइस स्पीकर” हे व्यवस्थापित डिव्हाइस म्हणून जोडा — जेव्हा ऑडिओ तुमच्या फोनवर परत स्विच होते तेव्हा त्याचे व्हॉल्यूम लागू होतात.</string>
+    <string name="device_speaker_hint_action">जोडा</string>
+    <string name="review_app_body">BVM ला रिव्यू द्यायचे आहे का? ❤️</string>
+    <string name="review_app_review_action">रिव्यू</string>
+    <string name="review_app_dismiss_action">मग नंतर</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">खरेदी रद्द केली</string>
     <string name="error_iap_unavailable_message">इन-अॅप खरेदी उपलब्ध नाहीत</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Tiada peranti tidak terurus dijumpai</string>
     <string name="discover_all_devices_managed_msg">Semua peranti berpasangan anda diurus! Perlukan yang baru?</string>
     <string name="discover_pair_new_device_action">Pasangkan peranti baru</string>
+    <string name="discover_device_speaker_desc">Pembesar suara milik telefon ini. Volumnya digunakan apabila audio beralih kembali ke telefon, cth. selepas peranti Bluetooth anda terputus.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfigurasi peranti</string>
     <string name="devices_device_config_section_general_label">Umum</string>
@@ -311,6 +312,7 @@
     <string name="label_add_device">Tambah peranti</string>
     <string name="label_just_a_moment_please">Sila tunggu sebentar.</string>
     <string name="label_notification_channel_status">Status Semasa</string>
+    <string name="monitor_notification_starting">Memulai…</string>
     <string name="action_set">Tetapkan</string>
     <string name="action_cancel">Batal</string>
     <string name="label_invalid_input">Input tidak sah</string>
@@ -385,6 +387,8 @@
     <string name="general_delete_action">Padam</string>
     <string name="general_cancel_action">Batal</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Tolak</string>
+    <string name="general_progress_loading">Memuatkan…</string>
     <string name="general_configure_action">Konfigurasikan</string>
     <string name="battery_optimization_hint_title">Pengoptimuman bateri</string>
     <string name="battery_optimization_hint_message">Pengoptimuman bateri didayakan dan mungkin menghalang operasi yang betul. Pertimbang untuk nyahdayakannya.</string>
@@ -396,6 +400,12 @@
     <string name="dnd_access_hint_title">Akses Jangan Ganggu</string>
     <string name="dnd_access_hint_message">Tanpa akses Jangan Ganggu, tetapan nada dering, pemberitahuan, dan mod JG tidak dapat diterapkan apabila peranti anda disambungkan.</string>
     <string name="dnd_access_fix_action">Berikan akses</string>
+    <string name="device_speaker_hint_title">Volum selepas pemutusan sambungan</string>
+    <string name="device_speaker_hint_message">Mahu volum anda dipulihkan apabila peranti Bluetooth terputus? Tambahkan \"Pembesar suara peranti\" sebagai peranti yang diurus — volumnya digunakan apabila audio beralih kembali ke telefon anda.</string>
+    <string name="device_speaker_hint_action">Tambah</string>
+    <string name="review_app_body">Ingin meninggalkan ulasan untuk BVM? ❤️</string>
+    <string name="review_app_review_action">Ulas aplikasi</string>
+    <string name="review_app_dismiss_action">Tidak, terima kasih</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Pembelian dibatalkan</string>
     <string name="error_iap_unavailable_message">Pembelian dalam apl tidak tersedia</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">စီမံမထားသော ကိရိယာ မတွေ့ပါ</string>
     <string name="discover_all_devices_managed_msg">ချိတ်ဆက်ထားသည့် ကိရိယာ အားလုံး စီမံပြီးပါပြီ! အသစ်တစ်ခု လိုပါသလား?</string>
     <string name="discover_pair_new_device_action">ကိရိယာ အသစ် တွဲချိတ်မည်</string>
+    <string name="discover_device_speaker_desc">ဤဖုန်း၏ကိုယ်ပိုင်စပီကာ။ အသံသည် ဖုန်းသို့ပြန်ပြောင်းလဲသောအခါ ၎င်း၏အသံအတိုးအကျယ်များ အသုံးချထားသည်၊ ဥပမာ၊ သင်၏Bluetooth စက်ပစ္စည်း ချိတ်ဆက်မှုအဆုံးသတ်ပြီးနောက်။</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ကိရိယာ ဖွဲ့စည်းမှု</string>
     <string name="devices_device_config_section_general_label">အထွေထွေ</string>
@@ -311,6 +312,7 @@
     <string name="label_add_device">ကိရိယာ ထည့်မည်</string>
     <string name="label_just_a_moment_please">ခဏစောင့်ပါ</string>
     <string name="label_notification_channel_status">အခြေအနေ</string>
+    <string name="monitor_notification_starting">စတင်နေပါသည်…</string>
     <string name="action_set">သတ်မှတ်မည်</string>
     <string name="action_cancel">ပယ်ဖျက်</string>
     <string name="label_invalid_input">မမှန်ကန်သော ထည့်သွင်းမှု</string>
@@ -385,6 +387,8 @@
     <string name="general_delete_action">ဖျက်မည်</string>
     <string name="general_cancel_action">ပယ်ဖျက်</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">ပယ်ဖျက်ပါ</string>
+    <string name="general_progress_loading">တင်နေပါသည်…</string>
     <string name="general_configure_action">ပြင်ဆင်မည်</string>
     <string name="battery_optimization_hint_title">ဘက်ထရီ ပိုမိုကောင်းမွန်အောင် ပြုလုပ်ခြင်း</string>
     <string name="battery_optimization_hint_message">ဘက်ထရီ ပိုမိုကောင်းမွန်အောင် ပြုလုပ်ခြင်း ဖွင့်ထားပြီး မှန်ကန်သော လုပ်ဆောင်မှုကို တားဆီးနိုင်သည်။ ပိတ်ရန် စဉ်းစားပါ။</string>
@@ -396,6 +400,12 @@
     <string name="dnd_access_hint_title">မနှောင့်ယှက်ရ ဝင်ရောက်ခွင့်</string>
     <string name="dnd_access_hint_message">မနှောင့်ယှက်ရ ဝင်ရောက်ခွင့်မရှိဘဲ၊ သင့်စက်ပစ္စည်းများ ချိတ်ဆက်သည့်အခါ ဖုန်းမြည်သံ၊ အကြောင်းကြားချက်နှင့် DND မုဒ် ဆက်တင်များကို သုံးစွဲ၍မရနိုင်ပါ။</string>
     <string name="dnd_access_fix_action">အသုံးပြုခွင့်ပေးပါ</string>
+    <string name="device_speaker_hint_title">ချိတ်ဆက်မှုအဆုံးသတ်ပြီးနောက် အသံများ</string>
+    <string name="device_speaker_hint_message">Bluetooth စက်ပစ္စည်း ချိတ်ဆက်မှုအဆုံးသတ်သောအခါ သင်၏အသံများ ပြန်လည်ရယူလိုပါသလား။ \"Device speaker\" ကို စီမံခန့်ခွဲထားသောစက်ပစ္စည်းအဖြစ် ထည့်သွင်းပါ — ၎င်း၏အသံများသည် အသံသည် သင်၏ဖုန်းသို့ပြန်ပြောင်းလဲသောအခါ အသုံးချထားသည်။</string>
+    <string name="device_speaker_hint_action">ထည့်သွင်း</string>
+    <string name="review_app_body">BVM အတွက် သုံးသပ်ချက် ချန်ထားလိုပါသလား။ ❤️</string>
+    <string name="review_app_review_action">သုံးသပ်ချက် ပေးရန်</string>
+    <string name="review_app_dismiss_action">နောက်ပိုင်းမှ</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">ဝယ်ယူမှု ပယ်ဖျက်ခဲ့သည်</string>
     <string name="error_iap_unavailable_message">အပ် အတွင်း ဝယ်ယူမှုများ မရနိုင်</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">कुनै अव्यवस्थित उपकरण फेला परेन</string>
     <string name="discover_all_devices_managed_msg">तपाईंका सबै जोडिएका उपकरणहरू व्यवस्थित छन्! नयाँ चाहिन्छ?</string>
     <string name="discover_pair_new_device_action">नयाँ उपकरण जोड्नुहोस्</string>
+    <string name="discover_device_speaker_desc">यो फोनको आफ्नो स्पिकर। यसको भलिउमहरू लागू हुन्छन् जब अडियो फोनमा फेरि स्विच हुन्छ, उदाहरणार्थ आपको Bluetooth उपकरण काट हुन्छ पछि।</string>
     <!-- Devices -->
     <string name="devices_device_config_label">उपकरण कन्फिगरेसन</string>
     <string name="devices_device_config_section_general_label">सामान्य</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">उपकरण थप्नुहोस्</string>
     <string name="label_just_a_moment_please">एक क्षण पर्खनुहोस्।</string>
     <string name="label_notification_channel_status">स्थिति</string>
+    <string name="monitor_notification_starting">सुरु हो दै…</string>
     <string name="action_set">सेट गर्नुहोस्</string>
     <string name="action_cancel">रद्द गर्नुहोस्</string>
     <string name="label_invalid_input">अवैध इनपुट</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">मेटाउनुहोस्</string>
     <string name="general_cancel_action">रद्द गर्नुहोस्</string>
     <string name="general_ok_action">ठिक छ</string>
+    <string name="general_dismiss_action">बन्द गर्नुहोस्</string>
+    <string name="general_progress_loading">लोड गर्दै…</string>
     <string name="general_configure_action">कन्फिगर गर्नुहोस्</string>
     <string name="battery_optimization_hint_title">ब्याट्री अप्टिमाइजेसन</string>
     <string name="battery_optimization_hint_message">ब्याट्री अप्टिमाइजेसनहरू सक्षम छन् र उचित सञ्चालनलाई रोक्न सक्छ। तिनीहरू अक्षम गर्ने विचार गर्नुहोस्।</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">बाधा नगर्नुहोस् पहुँच</string>
     <string name="dnd_access_hint_message">बाधा नगर्नुहोस् पहुँच बिना, तपाईंका यन्त्रहरू जडान हुँदा रिङटोन, सूचना, र DND मोड सेटिङहरू लागू गर्न सकिँदैन।</string>
     <string name="dnd_access_fix_action">पहुँच दिनुहोस्</string>
+    <string name="device_speaker_hint_title">डिस्कनेक्ट गरेपछि भलिउमहरू</string>
+    <string name="device_speaker_hint_message">Bluetooth उपकरण काट हुँदा भलिउमहरू पुनर्स्थापन गर्न चाहानुहुन्छ? \"Device speaker\" लाई प्रबन्धित उपकरण को रूपमा जोड्नुहोस् — यसको भलिउमहरू लागू हुन्छन् जब अडियो आपको फोनमा फेरि स्विच हुन्छ।</string>
+    <string name="device_speaker_hint_action">जोड्नुहोस्</string>
+    <string name="review_app_body">के तपाईं BVM को लागि समीक्षा दिन चाहनुहुन्छ? ❤️</string>
+    <string name="review_app_review_action">समीक्षा</string>
+    <string name="review_app_dismiss_action">पछि गर्ने</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">खरिद रद्द गरियो</string>
     <string name="error_iap_unavailable_message">इन-एप खरिदहरू उपलब्ध छैनन्</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Geen onbeheerde apparaten gevonden</string>
     <string name="discover_all_devices_managed_msg">Al je gekoppelde apparaten worden beheerd! Tijd voor een nieuwe?</string>
     <string name="discover_pair_new_device_action">Nieuw apparaat koppelen</string>
+    <string name="discover_device_speaker_desc">De eigen spreker van deze telefoon. De volumes ervan worden toegepast wanneer audio terugschakelt naar de telefoon, bijvoorbeeld nadat je Bluetooth-apparaat wordt verbroken.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Apparaatconfiguratie</string>
     <string name="devices_device_config_section_general_label">Algemeen</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Apparaat toevoegen</string>
     <string name="label_just_a_moment_please">Een ogenblik, alstublieft.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Aan de slag…</string>
     <string name="action_set">Stel in</string>
     <string name="action_cancel">Annuleren</string>
     <string name="label_invalid_input">Ongeldige invoer</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Verwijderen</string>
     <string name="general_cancel_action">Annuleren</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Afwijzen</string>
+    <string name="general_progress_loading">Bezig met laden…</string>
     <string name="general_configure_action">Configureren</string>
     <string name="battery_optimization_hint_title">Batterijoptimalisatie</string>
     <string name="battery_optimization_hint_message">Batterijoptimalisaties zijn ingeschakeld en kunnen de juiste werking verstoren. Overweeg ze uit te schakelen.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Niet storen-toegang</string>
     <string name="dnd_access_hint_message">Zonder Niet storen-toegang kunnen beltoon-, meldings- en Niet storen-instellingen niet worden toegepast wanneer je apparaten verbinding maken.</string>
     <string name="dnd_access_fix_action">Toegang verlenen</string>
+    <string name="device_speaker_hint_title">Volumes na verbreking</string>
+    <string name="device_speaker_hint_message">Wil je je volumes herstellen wanneer een Bluetooth-apparaat wordt verbroken? Voeg \"Apparaatluidspreker\" toe als beheerd apparaat — de volumes ervan worden toegepast wanneer audio terugschakelt naar je telefoon.</string>
+    <string name="device_speaker_hint_action">Toevoegen</string>
+    <string name="review_app_body">Wil je BVM een beoordeling achterlaten? ❤️</string>
+    <string name="review_app_review_action">Beoordeling</string>
+    <string name="review_app_dismiss_action">Misschien later</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Aankoop geannuleerd</string>
     <string name="error_iap_unavailable_message">In-app aankopen zijn niet beschikbaar</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Ingen uhåndterte enheter funnet</string>
     <string name="discover_all_devices_managed_msg">Alle de parkoblede enhetene dine håndteres allerede! Trenger du en ny en?</string>
     <string name="discover_pair_new_device_action">Koble til ny enhet</string>
+    <string name="discover_device_speaker_desc">Denne telefonens egen høyttaler. Volumene brukes når lyden byttes tilbake til telefonen, f.eks. etter at Bluetooth-enheten din kobles fra.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Enhetskonfigurasjon</string>
     <string name="devices_device_config_section_general_label">Generelt</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Legg til enhet</string>
     <string name="label_just_a_moment_please">Bare et øyeblikk.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Starter opp…</string>
     <string name="action_set">Sett</string>
     <string name="action_cancel">Avbryt</string>
     <string name="label_invalid_input">Ugyldig inndata</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Slett</string>
     <string name="general_cancel_action">Avbryt</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Lukk</string>
+    <string name="general_progress_loading">Laster…</string>
     <string name="general_configure_action">Konfigurer</string>
     <string name="battery_optimization_hint_title">Batterioptimalisering</string>
     <string name="battery_optimization_hint_message">Batterioptimaliseringer er aktivert og kan forhindre riktig drift. Vurder å deaktivere dem.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Ikke forstyrr-tilgang</string>
     <string name="dnd_access_hint_message">Uten tilgang til Ikke forstyrr kan ikke ringetone-, varslings- og Ikke forstyrr-modusinnstillinger brukes når enhetene dine kobler til.</string>
     <string name="dnd_access_fix_action">Gi tilgang</string>
+    <string name="device_speaker_hint_title">Volum etter frakobling</string>
+    <string name="device_speaker_hint_message">Vil du at volumene dine skal gjenopprettes når en Bluetooth-enhet kobles fra? Legg til «Enhetshøyttaler» som en administrert enhet — volumene brukes når lyden byttes tilbake til telefonen.</string>
+    <string name="device_speaker_hint_action">Legg til</string>
+    <string name="review_app_body">Vil du gi BVM en anmeldelse? ❤️</string>
+    <string name="review_app_review_action">Anmeldelse</string>
+    <string name="review_app_dismiss_action">Kanskje senere</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Kjøp avbrutt</string>
     <string name="error_iap_unavailable_message">Kjøp i appen er ikke tilgjengelig</string>

--- a/app/src/main/res/values-pcm-rNG/strings.xml
+++ b/app/src/main/res/values-pcm-rNG/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">No unmanaged devices found</string>
     <string name="discover_all_devices_managed_msg">All your paired devices dey managed! You need new one?</string>
     <string name="discover_pair_new_device_action">Pair new device</string>
+    <string name="discover_device_speaker_desc">Di phone speaker. E apply di volumes when audio switch back to phone, like afta your Bluetooth device disconnect.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Device configuration</string>
     <string name="devices_device_config_section_general_label">General</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Add device</string>
     <string name="label_just_a_moment_please">Wait small, abeg.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Dey start…</string>
     <string name="action_set">Set</string>
     <string name="action_cancel">Cancel</string>
     <string name="label_invalid_input">Invalid input</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Delete</string>
     <string name="general_cancel_action">Cancel</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Comot</string>
+    <string name="general_progress_loading">Dey load…</string>
     <string name="general_configure_action">Configure</string>
     <string name="battery_optimization_hint_title">Battery optimization</string>
     <string name="battery_optimization_hint_message">Battery optimizations dey enabled and fit prevent di app from working properly. Consider disable dem.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Do Not Disturb access</string>
     <string name="dnd_access_hint_message">Without Do Not Disturb access, ringtone, notification, and DND mode settings no go fit work wen your devices connect.</string>
     <string name="dnd_access_fix_action">Give access</string>
+    <string name="device_speaker_hint_title">Volumes afta disconnect</string>
+    <string name="device_speaker_hint_message">You want your volumes come back when Bluetooth device disconnect? Add \'Device speaker\' as managed device — e go apply di volumes when audio switch back to your phone.</string>
+    <string name="device_speaker_hint_action">Add</string>
+    <string name="review_app_body">You go like leave BVM review? ❤️</string>
+    <string name="review_app_review_action">Review</string>
+    <string name="review_app_dismiss_action">Later nau</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Purchase cancelled</string>
     <string name="error_iap_unavailable_message">In-app purchases no dey available</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nie znaleziono niezarządzanych urządzeń</string>
     <string name="discover_all_devices_managed_msg">Wszystkie twoje sparowane urządzenia są już zarządzane! Potrzebujesz nowego?</string>
     <string name="discover_pair_new_device_action">Sparuj nowe urządzenie</string>
+    <string name="discover_device_speaker_desc">Wbudowany głośnik telefonu. Jego głośności są stosowane, gdy dźwięk wraca do telefonu, np. po rozłączeniu urządzenia Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfiguracja urządzenia</string>
     <string name="devices_device_config_section_general_label">Ogólne</string>
@@ -324,6 +325,7 @@ Karol Szastok (K4r0lSz);</string>
     <string name="label_add_device">Dodaj urządzenie</string>
     <string name="label_just_a_moment_please">Chwileczkę.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Uruchamianie…</string>
     <string name="action_set">Ustaw</string>
     <string name="action_cancel">Anuluj</string>
     <string name="label_invalid_input">Nieprawidłowa wartość</string>
@@ -401,6 +403,8 @@ Karol Szastok (K4r0lSz);</string>
     <string name="general_delete_action">Usuń</string>
     <string name="general_cancel_action">Anuluj</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Zamknij</string>
+    <string name="general_progress_loading">Ładowanie…</string>
     <string name="general_configure_action">Konfiguruj</string>
     <string name="battery_optimization_hint_title">Optymalizacja baterii</string>
     <string name="battery_optimization_hint_message">Optymalizacje baterii są włączone i mogą przeszkódzić w prawidłowym działaniu. Rozważ ich wyłączenie.</string>
@@ -412,6 +416,12 @@ Karol Szastok (K4r0lSz);</string>
     <string name="dnd_access_hint_title">Dostęp do trybu Nie przeszkadzać</string>
     <string name="dnd_access_hint_message">Bez dostępu do trybu Nie przeszkadzać nie można zastosować ustawień dzwonka, powiadomień i trybu DND podczas łączenia urządzeń.</string>
     <string name="dnd_access_fix_action">Udziel dostępu</string>
+    <string name="device_speaker_hint_title">Głośności po rozłączeniu</string>
+    <string name="device_speaker_hint_message">Chcesz przywrócić głośności po rozłączeniu urządzenia Bluetooth? Dodaj „Głośnik urządzenia” jako zarządzane urządzenie — jego głośności są stosowane, gdy dźwięk wraca do twojego telefonu.</string>
+    <string name="device_speaker_hint_action">Dodaj</string>
+    <string name="review_app_body">Wystawisz opinię dla BVM? ❤️</string>
+    <string name="review_app_review_action">Oceń</string>
+    <string name="review_app_dismiss_action">Może później</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Zakup anulowany</string>
     <string name="error_iap_unavailable_message">Zakupy w aplikacji nie są dostępne</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nenhum dispositivo não gerenciado encontrado</string>
     <string name="discover_all_devices_managed_msg">Todos os seus dispositivos pareados já estão gerenciados! Precisa de um novo?</string>
     <string name="discover_pair_new_device_action">Parear novo dispositivo</string>
+    <string name="discover_device_speaker_desc">O próprio alto-falante do telefone. Seus volumes são aplicados quando o áudio volta ao telefone, por ex. após seu dispositivo Bluetooth desconectar.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuração do dispositivo</string>
     <string name="devices_device_config_section_general_label">Geral</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Adicionar dispositivo</string>
     <string name="label_just_a_moment_please">Um momento, por favor.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Iniciando…</string>
     <string name="action_set">Definir</string>
     <string name="action_cancel">Cancelar</string>
     <string name="label_invalid_input">Entrada inválida</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Excluir</string>
     <string name="general_cancel_action">Cancelar</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Dispensar</string>
+    <string name="general_progress_loading">Carregando…</string>
     <string name="general_configure_action">Configurar</string>
     <string name="battery_optimization_hint_title">Otimização de bateria</string>
     <string name="battery_optimization_hint_message">As otimizações de bateria estão ativadas e podem impedir o funcionamento adequado. Considere desativá-las.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Acesso ao Não Perturbe</string>
     <string name="dnd_access_hint_message">Sem acesso ao Não Perturbe, as configurações de toque, notificação e modo NP não podem ser aplicadas quando seus dispositivos conectam.</string>
     <string name="dnd_access_fix_action">Permitir acesso</string>
+    <string name="device_speaker_hint_title">Volumes após desconexão</string>
+    <string name="device_speaker_hint_message">Quer que seus volumes sejam restaurados quando um dispositivo Bluetooth se desconectar? Adicione \"Alto-falante do dispositivo\" como um dispositivo gerenciado — seus volumes são aplicados quando o áudio volta ao seu telefone.</string>
+    <string name="device_speaker_hint_action">Adicionar</string>
+    <string name="review_app_body">Você gostaria de deixar uma avaliação do BVM? ❤️</string>
+    <string name="review_app_review_action">Avaliar</string>
+    <string name="review_app_dismiss_action">Talvez depois</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Compra cancelada</string>
     <string name="error_iap_unavailable_message">Compras no app não estão disponíveis</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nenhum dispositivo não gerido encontrado</string>
     <string name="discover_all_devices_managed_msg">Todos os seus dispositivos emparelhados estão geridos! Precisa de um novo?</string>
     <string name="discover_pair_new_device_action">Emparelhar novo dispositivo</string>
+    <string name="discover_device_speaker_desc">O altifalante integrado do telefone. Os seus volumes são aplicados quando o áudio regressa ao telefone, por exemplo, após o seu dispositivo Bluetooth se desligar.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuração do dispositivo</string>
     <string name="devices_device_config_section_general_label">Geral</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Adicionar dispositivo</string>
     <string name="label_just_a_moment_please">Aguarde um pouco.</string>
     <string name="label_notification_channel_status">Estado</string>
+    <string name="monitor_notification_starting">A iniciar…</string>
     <string name="action_set">Definir</string>
     <string name="action_cancel">Cancelar</string>
     <string name="label_invalid_input">Entrada inválida</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Eliminar</string>
     <string name="general_cancel_action">Cancelar</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Dispensar</string>
+    <string name="general_progress_loading">A carregar…</string>
     <string name="general_configure_action">Configurar</string>
     <string name="battery_optimization_hint_title">Otimização da bateria</string>
     <string name="battery_optimization_hint_message">As otimizações da bateria estão ativas e podem impedir o funcionamento adequado. Considera desativá-las.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Acesso ao Não Incomodar</string>
     <string name="dnd_access_hint_message">Sem acesso ao Não Incomodar, as definições de toque, notificação e modo Não Incomodar não podem ser aplicadas quando os teus dispositivos se ligam.</string>
     <string name="dnd_access_fix_action">Conceder acesso</string>
+    <string name="device_speaker_hint_title">Volumes após desligação</string>
+    <string name="device_speaker_hint_message">Quer que os seus volumes sejam restaurados quando um dispositivo Bluetooth se desligar? Adicione \"Altifalante do dispositivo\" como um dispositivo gerido — os seus volumes são aplicados quando o áudio regressa ao seu telefone.</string>
+    <string name="device_speaker_hint_action">Adicionar</string>
+    <string name="review_app_body">Gostaria de avaliar o BVM? ❤️</string>
+    <string name="review_app_review_action">Avaliar</string>
+    <string name="review_app_dismiss_action">Talvez mais tarde</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Compra cancelada</string>
     <string name="error_iap_unavailable_message">Compras na aplicação não estão disponíveis</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nagins apparats betg administrads chattads</string>
     <string name="discover_all_devices_managed_msg">Tuts tes apparats accopplads èn administrads! Dovras in nov?</string>
     <string name="discover_pair_new_device_action">Accopplar nov apparat</string>
+    <string name="discover_device_speaker_desc">La proprisa lavaglia dal telefon. Sias volumen vegn applitgada tgidoñ che l\'audio cuntrescha novamain ala lavaglia dal telefon, p.ex. sdraa che tia apparail Bluetooth sa deconnecta.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuraziún da l\'apparat</string>
     <string name="devices_device_config_section_general_label">General</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Agiuntar apparat</string>
     <string name="label_just_a_moment_please">In mument, per plaschair.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Davart uschieus…</string>
     <string name="action_set">Fixar</string>
     <string name="action_cancel">Interrumper</string>
     <string name="label_invalid_input">Intrada invalida</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Stizzar</string>
     <string name="general_cancel_action">Interrumper</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Fermar</string>
+    <string name="general_progress_loading">Chargond…</string>
     <string name="general_configure_action">Configurar</string>
     <string name="battery_optimization_hint_title">Optimisaziún da battaria</string>
     <string name="battery_optimization_hint_message">Las optimisaziuns da battaria èn activadas e pon evitar il funcziun correct. Considera da deactivarlas.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Access a «Na disturbar»</string>
     <string name="dnd_access_hint_message">Senza access a «Na disturbar», las reglazions per sonnaria, notificaziuns ed il modus DND na pon betg vegnir applitgadas cur che vos apparats sa connectan.</string>
     <string name="dnd_access_fix_action">Conceder access</string>
+    <string name="device_speaker_hint_title">Volumen sdraa la deconnexiun</string>
+    <string name="device_speaker_hint_message">Vul ti che tias volumen vegnan restauradas tgidoñ che üna apparail Bluetooth sa deconnecta? Agiunscha \"Lavaglia dal apparail\" sco üna apparail administrada — sias volumen vegn applitgada tgidoñ che l\'audio cuntrescha novamain ala tia lavaglia dal telefon.</string>
+    <string name="device_speaker_hint_action">Agiunscha</string>
+    <string name="review_app_body">Vuls tu laschar ina recenziun per BVM? ❤️</string>
+    <string name="review_app_review_action">Recenziun</string>
+    <string name="review_app_dismiss_action">Magari pli tard</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Cumpra annullada</string>
     <string name="error_iap_unavailable_message">Cumpras en l\'app na sun betg disponiblas</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nu s-au găsit dispozitive negestionate</string>
     <string name="discover_all_devices_managed_msg">Toate dispozitivele tale asociate sunt gestionate! Ai nevoie de unul nou?</string>
     <string name="discover_pair_new_device_action">Asociază dispozitiv nou</string>
+    <string name="discover_device_speaker_desc">Difuzorul propriu al telefonului. Volumele sale sunt aplicate când audio se comută înapoi la telefon, de exemplu după ce dispozitivul Bluetooth se deconectează.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configurația dispozitivului</string>
     <string name="devices_device_config_section_general_label">General</string>
@@ -319,6 +320,7 @@
     <string name="label_add_device">Adaugă dispozitiv</string>
     <string name="label_just_a_moment_please">O clipă, te rog.</string>
     <string name="label_notification_channel_status">Stare</string>
+    <string name="monitor_notification_starting">Se pornește…</string>
     <string name="action_set">Setează</string>
     <string name="action_cancel">Anulează</string>
     <string name="label_invalid_input">Date de intrare nevalide</string>
@@ -395,6 +397,8 @@
     <string name="general_delete_action">Șterge</string>
     <string name="general_cancel_action">Anulează</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Respinge</string>
+    <string name="general_progress_loading">Se încarcă…</string>
     <string name="general_configure_action">Configurează</string>
     <string name="battery_optimization_hint_title">Optimizarea bateriei</string>
     <string name="battery_optimization_hint_message">Optimizările de baterie sunt activate și pot preveni funcționarea corectă. Ia în considerare dezactivarea lor.</string>
@@ -406,6 +410,12 @@
     <string name="dnd_access_hint_title">Acces la Nu deranja</string>
     <string name="dnd_access_hint_message">Fără acces la Nu deranja, setările pentru ton de apel, notificări și modul Nu deranja nu pot fi aplicate când dispozitivele tale se conectează.</string>
     <string name="dnd_access_fix_action">Acordă accesul</string>
+    <string name="device_speaker_hint_title">Volume după deconectare</string>
+    <string name="device_speaker_hint_message">Vrei ca volumele tale să fie restaurate când un dispozitiv Bluetooth se deconectează? Adaugă \"Difuzor dispozitiv\" ca dispozitiv gestionat — volumele sale sunt aplicate când audio se comută înapoi la telefonul tău.</string>
+    <string name="device_speaker_hint_action">Adaugă</string>
+    <string name="review_app_body">Doriți să lăsați aplicației BVM o recenzie? ❤️</string>
+    <string name="review_app_review_action">Revizuire</string>
+    <string name="review_app_dismiss_action">Poate mai târziu</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Achiziţie anulată</string>
     <string name="error_iap_unavailable_message">Achiziţiile din aplicație nu sunt disponibile</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Нет неуправляемых устройств</string>
     <string name="discover_all_devices_managed_msg">Все твои подключенные устройства уже управляются! Нужно новое?</string>
     <string name="discover_pair_new_device_action">Подключить новое устройство</string>
+    <string name="discover_device_speaker_desc">Встроенный динамик телефона. Его громкость применяется, когда звук переключается обратно на телефон, например, после отключения устройства Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Настройки устройства</string>
     <string name="devices_device_config_section_general_label">Общее</string>
@@ -323,6 +324,7 @@
     <string name="label_add_device">Добавить устройство</string>
     <string name="label_just_a_moment_please">Минуточку, пожалуйста.</string>
     <string name="label_notification_channel_status">Состояние</string>
+    <string name="monitor_notification_starting">Запуск…</string>
     <string name="action_set">Установка</string>
     <string name="action_cancel">Отмена</string>
     <string name="label_invalid_input">Недопустимый ввод</string>
@@ -400,6 +402,8 @@
     <string name="general_delete_action">Удалить</string>
     <string name="general_cancel_action">Отмена</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Отклонить</string>
+    <string name="general_progress_loading">Загрузка…</string>
     <string name="general_configure_action">Настроить</string>
     <string name="battery_optimization_hint_title">Оптимизация батареи</string>
     <string name="battery_optimization_hint_message">Оптимизация батареи включена и может мешать нормальной работе. Рассмотри возможность отключения.</string>
@@ -411,6 +415,12 @@
     <string name="dnd_access_hint_title">Доступ к режиму «Не беспокоить»</string>
     <string name="dnd_access_hint_message">Без доступа к режиму «Не беспокоить» нельзя применить настройки звонка, уведомлений и режима «Не беспокоить» при подключении устройств.</string>
     <string name="dnd_access_fix_action">Предоставить доступ</string>
+    <string name="device_speaker_hint_title">Громкость после отключения</string>
+    <string name="device_speaker_hint_message">Хотите, чтобы громкость восстанавливалась при отключении устройства Bluetooth? Добавьте «Динамик устройства» как управляемое устройство — его громкость применяется, когда звук переключается обратно на ваш телефон.</string>
+    <string name="device_speaker_hint_action">Добавить</string>
+    <string name="review_app_body">Вы хотите оставить отзыв для BVM? ❤️</string>
+    <string name="review_app_review_action">Отзыв</string>
+    <string name="review_app_dismiss_action">Возможно, позже</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Покупка отменена</string>
     <string name="error_iap_unavailable_message">Покупки в приложении недоступны</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nessun dispositivu non gestidu trovàdu</string>
     <string name="discover_all_devices_managed_msg">Totu sos dispositivos accoppiàdos tuos sunt gestidos! Bi cheres unu nou?</string>
     <string name="discover_pair_new_device_action">Accòppia nou dispositivu</string>
+    <string name="discover_device_speaker_desc">Su parlante de sa tua telefonada. Sos volmenes sunt aplicados cuan su sonu cambiat in sa telefonada, p.e. dae su disconnect de sa tua aplicatzione Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuratzione de su dispositivu</string>
     <string name="devices_device_config_section_general_label">Generali</string>
@@ -405,6 +406,7 @@
     <string name="dnd_access_hint_message">Sena s\'acesetu Non disturbare, is impostatziones de soneria, notificatziones e modu Non disturbare no podent èssere aplicadas cando is tuos dispositivus si connetant.</string>
     <string name="dnd_access_fix_action">Cuncèdere s\'atzessu</string>
     <string name="device_speaker_hint_title">Volmenes dae su disconnect</string>
+    <string name="device_speaker_hint_message">Boltas sa tua volmenes a essiri restoraus cuan una aplicatzione Bluetooth disconectat? Agiunghe \"Parlante de dispositivo\" comente aplicatzione amministrada — sos volmenes sunt aplicados cuan su sonu cambiat in sa tua telefonada.</string>
     <string name="device_speaker_hint_action">Agiunghe</string>
     <string name="review_app_body">Boles làssare una revisione a BVM? ❤️</string>
     <string name="review_app_review_action">Revisione</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -27,7 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nessun dispositivu non gestidu trovàdu</string>
     <string name="discover_all_devices_managed_msg">Totu sos dispositivos accoppiàdos tuos sunt gestidos! Bi cheres unu nou?</string>
     <string name="discover_pair_new_device_action">Accòppia nou dispositivu</string>
-    <string name="discover_device_speaker_desc">Su parlante de sa tua telefonada. Sos volmenes sunt aplicados cuan su sonu cambiat in sa telefonada, p.e. dae su disconnect de sa tua aplicatzione Bluetooth.</string>
+    <string name="discover_device_speaker_desc">Su parlante de sa tua telefonada. Sos volmenes sunt aplicados cuan su sonu cambiat in sa telefonada, p.e. dae su disconnect de su tuo dispositivu Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuratzione de su dispositivu</string>
     <string name="devices_device_config_section_general_label">Generali</string>
@@ -406,7 +406,7 @@
     <string name="dnd_access_hint_message">Sena s\'acesetu Non disturbare, is impostatziones de soneria, notificatziones e modu Non disturbare no podent èssere aplicadas cando is tuos dispositivus si connetant.</string>
     <string name="dnd_access_fix_action">Cuncèdere s\'atzessu</string>
     <string name="device_speaker_hint_title">Volmenes dae su disconnect</string>
-    <string name="device_speaker_hint_message">Boltas sa tua volmenes a essiri restoraus cuan una aplicatzione Bluetooth disconectat? Agiunghe \"Parlante de dispositivo\" comente aplicatzione amministrada — sos volmenes sunt aplicados cuan su sonu cambiat in sa tua telefonada.</string>
+    <string name="device_speaker_hint_message">Boltas sa tua volmenes a essiri restoraus cuan unu dispositivu Bluetooth disconectat? Agiunghe \"Parlante de dispositivo\" comente dispositivu amministradu — sos volmenes sunt aplicados cuan su sonu cambiat in sa tua telefonada.</string>
     <string name="device_speaker_hint_action">Agiunghe</string>
     <string name="review_app_body">Boles làssare una revisione a BVM? ❤️</string>
     <string name="review_app_review_action">Revisione</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -315,6 +315,7 @@
     <string name="label_add_device">Aggiunghe dispositivu</string>
     <string name="label_just_a_moment_please">Unu momentu, prite.</string>
     <string name="label_notification_channel_status">Istadu</string>
+    <string name="monitor_notification_starting">Iniciende…</string>
     <string name="action_set">Imposta</string>
     <string name="action_cancel">Annùlla</string>
     <string name="label_invalid_input">Input non vàlidu</string>
@@ -390,6 +391,8 @@
     <string name="general_delete_action">Càncella</string>
     <string name="general_cancel_action">Annùlla</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Serrare</string>
+    <string name="general_progress_loading">Carrighende…</string>
     <string name="general_configure_action">Configura</string>
     <string name="battery_optimization_hint_title">Ottimizatzione de bateria</string>
     <string name="battery_optimization_hint_message">Sas ottimizatziones de bateria sunt abilitàdas e podent prevènnere su funtzionamentu currètu. Cunsìdera de disabilitarelas.</string>
@@ -401,6 +404,11 @@
     <string name="dnd_access_hint_title">Acesetu Non disturbare</string>
     <string name="dnd_access_hint_message">Sena s\'acesetu Non disturbare, is impostatziones de soneria, notificatziones e modu Non disturbare no podent èssere aplicadas cando is tuos dispositivus si connetant.</string>
     <string name="dnd_access_fix_action">Cuncèdere s\'atzessu</string>
+    <string name="device_speaker_hint_title">Volmenes dae su disconnect</string>
+    <string name="device_speaker_hint_action">Agiunghe</string>
+    <string name="review_app_body">Boles làssare una revisione a BVM? ❤️</string>
+    <string name="review_app_review_action">Revisione</string>
+    <string name="review_app_dismiss_action">Forsis più in antis</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Acchìstu annullàdu</string>
     <string name="error_iap_unavailable_message">Sos acchìstos in-app non sunt disponìbbiles</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">කළමනා නොකළ උපාංග හමු නොවිණි</string>
     <string name="discover_all_devices_managed_msg">ඔබේ සියලු සම්බන්ධ කළ උපාංගයන් කළමනා කෙරෙයි! අලුත් එකක් ඕනෑද?</string>
     <string name="discover_pair_new_device_action">නව උපාංගයක් සම්බන්ධ කරන්න</string>
+    <string name="discover_device_speaker_desc">මේ ජංගම දූරකතනයේ තමන්ගේ ශබ්දකය. ශබ්ද ජංගම දූරකතනයට ආපසු මාරු වූ විට එහි පරිමාවන් යෙදේ, උදා. ඔබේ Bluetooth උපාංගය විසංයෝගිත වූ පසු.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">උපාංග සැකසුම</string>
     <string name="devices_device_config_section_general_label">සාමාන්‍ය</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">උපාංගය එකතු කරන්න</string>
     <string name="label_just_a_moment_please">ටිකක් ඉන්න.</string>
     <string name="label_notification_channel_status">තත්වය</string>
+    <string name="monitor_notification_starting">ආරම්භ කරමින්…</string>
     <string name="action_set">සකසන්න</string>
     <string name="action_cancel">අවලංගු කරන්න</string>
     <string name="label_invalid_input">වලංගු නොවන ආදානයකි</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">මකන්න</string>
     <string name="general_cancel_action">අවලංගු</string>
     <string name="general_ok_action">හරි</string>
+    <string name="general_dismiss_action">ඉවතලන්න</string>
+    <string name="general_progress_loading">පූරණය කරමින්…</string>
     <string name="general_configure_action">ව්‍යවස්ථාපනය</string>
     <string name="battery_optimization_hint_title">බැටරි ප්‍රශස්තකරණය</string>
     <string name="battery_optimization_hint_message">බැටරි ප්‍රශස්තකරණ සබල කර ඇති අතර නිසි ක්‍රියාකාරිත්වය වළක්වා ගත හැකිය. ඒවා අක්‍රිය කිරීම සලකා බලන්න.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">බාධා නොකරන්න ප්‍රවේශය</string>
     <string name="dnd_access_hint_message">බාධා නොකරන්න ප්‍රවේශය නොමැතිව, ඔබේ උපාංග සම්බන්ධ වූ විට රිං ශබ්දය, දැනුම්දීම් සහ DND මාදිලි සැකසුම් යෙදිය නොහැකිය.</string>
     <string name="dnd_access_fix_action">ප්‍රවේශය ලබාදෙන්න</string>
+    <string name="device_speaker_hint_title">විසංයෝගනයට පසු පරිමාවන්</string>
+    <string name="device_speaker_hint_message">Bluetooth උපාංගයක් විසංයෝගිත වූ විට ඔබේ පරිමාවන් ප්‍රතිසංස්කරණය කිරීමට අවශ්‍ය ද? \"Device speaker\" පිළිවෙළු සිටින උපාංගයක් ලෙස එක් කරන්න — ශබ්ද ඔබේ ජංගම දූරකතනයට ආපසු මාරු වූ විට එහි පරිමාවන් යෙදේ.</string>
+    <string name="device_speaker_hint_action">එක් කරන්න</string>
+    <string name="review_app_body">ඔබ BVM සඳහා සමාලෝචනයක් ලිවීමට කැමතිද?️ ❤️</string>
+    <string name="review_app_review_action">සමාලෝචනය</string>
+    <string name="review_app_dismiss_action">පසුව සමහර විට</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">මිලදී ගැනීම අවලංගු කළා</string>
     <string name="error_iap_unavailable_message">යෙදුම් ඇතුළත මිලදී ගැනීම් නොලබා ගත හැකිය</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nenašli sa žiadne nespravované zariadenia</string>
     <string name="discover_all_devices_managed_msg">Všetky spárované zariadenia sú spravované! Potrebuješ nové?</string>
     <string name="discover_pair_new_device_action">Spárovať nové zariadenie</string>
+    <string name="discover_device_speaker_desc">Vlastný reproduktor telefónu. Jeho hlasitosti sa aplikujú, keď sa zvuk prepne späť na telefón, napr. po odpojení zariadenia Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfigurácia zariadenia</string>
     <string name="devices_device_config_section_general_label">Všeobecné</string>
@@ -323,6 +324,7 @@
     <string name="label_add_device">Pridať zariadenie</string>
     <string name="label_just_a_moment_please">Chvíľočku, prosím.</string>
     <string name="label_notification_channel_status">Stav</string>
+    <string name="monitor_notification_starting">Spúšťa sa…</string>
     <string name="action_set">Nastaviť</string>
     <string name="action_cancel">Zrušiť</string>
     <string name="label_invalid_input">Neplatný vstup</string>
@@ -400,6 +402,8 @@
     <string name="general_delete_action">Odstrániť</string>
     <string name="general_cancel_action">Zrušiť</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Odmietnuť</string>
+    <string name="general_progress_loading">Načítava…</string>
     <string name="general_configure_action">Konfigurovať</string>
     <string name="battery_optimization_hint_title">Optimalizácia batérie</string>
     <string name="battery_optimization_hint_message">Optimalizácie batérie sú zapnuté a môžu zabrániť správnemu fungovaniu. Zvážte ich vypnutie.</string>
@@ -411,6 +415,12 @@
     <string name="dnd_access_hint_title">Prístup k režimu Nerušiť</string>
     <string name="dnd_access_hint_message">Bez prístupu k Nerušiť nie je možné použiť nastavenia zvonenia, upozornení a režimu Nerušiť pri pripojení vašich zariadení.</string>
     <string name="dnd_access_fix_action">Povoliť prístup</string>
+    <string name="device_speaker_hint_title">Hlasitosti po odpojení</string>
+    <string name="device_speaker_hint_message">Chcete, aby sa vaše hlasitosti obnovili, keď sa zariadenie Bluetooth odpojí? Pridajte „Reproduktor zariadenia“ ako spravované zariadenie — jeho hlasitosti sa aplikujú, keď sa zvuk prepne späť na váš telefón.</string>
+    <string name="device_speaker_hint_action">Pridať</string>
+    <string name="review_app_body">Chceli by ste zanechať recenziu BVM? ❤️</string>
+    <string name="review_app_review_action">Ohodnotiť</string>
+    <string name="review_app_dismiss_action">Možno pozdejšie</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Nákup zrušený</string>
     <string name="error_iap_unavailable_message">Nákupy v aplikácii nie sú dostupné</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Ni najdenih neupravljanih naprav</string>
     <string name="discover_all_devices_managed_msg">Vse vaše seznanjene naprave so upravljane! Želite dodati novo?</string>
     <string name="discover_pair_new_device_action">Seznani novo napravo</string>
+    <string name="discover_device_speaker_desc">Lastni zvočnik telefona. Njegove glasnosti se uporabijo, ko se avdio vrne na telefon, npr. po preklopu vaše naprave Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfiguracija naprave</string>
     <string name="devices_device_config_section_general_label">Splošno</string>
@@ -323,6 +324,7 @@
     <string name="label_add_device">Dodaj napravo</string>
     <string name="label_just_a_moment_please">Prosim, trenutek.</string>
     <string name="label_notification_channel_status">Stanje</string>
+    <string name="monitor_notification_starting">Zaganjanje…</string>
     <string name="action_set">Nastavi</string>
     <string name="action_cancel">Prekliči</string>
     <string name="label_invalid_input">Neveljaven vnos.</string>
@@ -400,6 +402,8 @@
     <string name="general_delete_action">Izbriši</string>
     <string name="general_cancel_action">Prekliči</string>
     <string name="general_ok_action">V redu</string>
+    <string name="general_dismiss_action">Opusti</string>
+    <string name="general_progress_loading">Nalaganje…</string>
     <string name="general_configure_action">Konfiguriraj</string>
     <string name="battery_optimization_hint_title">Optimizacija baterije</string>
     <string name="battery_optimization_hint_message">Optimizacije baterije so omogočene in lahko preprečijo pravilno delovanje. Razmislite o njihovem onemogočanju.</string>
@@ -411,6 +415,12 @@
     <string name="dnd_access_hint_title">Dostop do »Ne moti«</string>
     <string name="dnd_access_hint_message">Brez dostopa do »Ne moti« nastavitve zvonca, obvestil in načina »Ne moti« ne morejo biti uporabljene ob povezavi vaših naprav.</string>
     <string name="dnd_access_fix_action">Odobri dostop</string>
+    <string name="device_speaker_hint_title">Glasnosti po prekinitvi</string>
+    <string name="device_speaker_hint_message">Želite, da se vaše glasnosti obnovijo, ko se naprava Bluetooth prekine? Dodajte \"Zvočnik naprave\" kot upravljano napravo — njegove glasnosti se uporabijo, ko se avdio vrne na vaš telefon.</string>
+    <string name="device_speaker_hint_action">Dodajte</string>
+    <string name="review_app_body">Bi radi ocenili BVM? ❤️</string>
+    <string name="review_app_review_action">Oceni</string>
+    <string name="review_app_dismiss_action">Morda kasneje</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Nakup prekinjen</string>
     <string name="error_iap_unavailable_message">Nakupi v aplikaciji niso na voljo</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Nuk u gjetën pajisje të pamenaxhuara</string>
     <string name="discover_all_devices_managed_msg">Të gjitha pajisjet e tua të çiftuara janë të menaxhuara! Ke nevojë për një të re?</string>
     <string name="discover_pair_new_device_action">Çiftua pajisje të re</string>
+    <string name="discover_device_speaker_desc">Altoparlanti i vetë i këtij telefoni. Volumet e tij zbatohen kur audio kthehet në telefon, p.sh. pasi pajisja juaj Bluetooth shkëputohet.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfigurimi i pajisjes</string>
     <string name="devices_device_config_section_general_label">Përgjithshta</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Shto pajisje</string>
     <string name="label_just_a_moment_please">Shëndete, një moment.</string>
     <string name="label_notification_channel_status">Statusi</string>
+    <string name="monitor_notification_starting">Po nisen…</string>
     <string name="action_set">Vendos</string>
     <string name="action_cancel">Anulo</string>
     <string name="label_invalid_input">Hyrje e pavlefshme</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Fshi</string>
     <string name="general_cancel_action">Anulo</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Largoje</string>
+    <string name="general_progress_loading">Po ngarkohet…</string>
     <string name="general_configure_action">Konfiguro</string>
     <string name="battery_optimization_hint_title">Optimizimi i baterisë</string>
     <string name="battery_optimization_hint_message">Optimizatat e baterisë janë të aktivizuara dhe mund të parandalojnë funksionimin e duhur. Konsideroni çaktivizimin e tyre.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Qasja në \"Mos shqetëso\"</string>
     <string name="dnd_access_hint_message">Pa qasje në \"Mos shqetëso\", cilësimet e ziles, njoftimeve dhe modalitetit DND nuk mund të aplikohen kur pajisjet tuaja lidhen.</string>
     <string name="dnd_access_fix_action">Lejo qasje</string>
+    <string name="device_speaker_hint_title">Volumet pas shkëputjes</string>
+    <string name="device_speaker_hint_message">Dëshironi që volumet tuaja të rikthehen kur një pajisje Bluetooth shkëputohet? Shtoni \"Altoparlanti i pajisjes\" si pajisje e administruar — volumet e tij zbatohen kur audio kthehet në telefonin tuaj.</string>
+    <string name="device_speaker_hint_action">Shto</string>
+    <string name="review_app_body">Dëshironi t\'i lini një koment BVM? ❤️</string>
+    <string name="review_app_review_action">Rishikimi</string>
+    <string name="review_app_dismiss_action">Ndoshta më vonë</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Blerjeja u anulua</string>
     <string name="error_iap_unavailable_message">Blerjet brenda aplikacionit nuk janë të disponueshme</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Ниједан неуправљан уређај није понађен</string>
     <string name="discover_all_devices_managed_msg">Сви ваши спарени уређаји су већ управљани! Требате нови?</string>
     <string name="discover_pair_new_device_action">Упари нови уређај</string>
+    <string name="discover_device_speaker_desc">Сопствени звучник телефона. Јачине звука се примењују када се звук врати на телефон, нпр. након што се твој Bluetooth уређај откачи.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Конфигурација уређаја</string>
     <string name="devices_device_config_section_general_label">Oпште</string>
@@ -319,6 +320,7 @@
     <string name="label_add_device">Додај уређај</string>
     <string name="label_just_a_moment_please">Моментице, молим.</string>
     <string name="label_notification_channel_status">Статус</string>
+    <string name="monitor_notification_starting">Покретање…</string>
     <string name="action_set">Постави</string>
     <string name="action_cancel">Откажи</string>
     <string name="label_invalid_input">Неисправан унос</string>
@@ -395,6 +397,8 @@
     <string name="general_delete_action">Обриши</string>
     <string name="general_cancel_action">Откажи</string>
     <string name="general_ok_action">У реду</string>
+    <string name="general_dismiss_action">Одбаци</string>
+    <string name="general_progress_loading">Учитавање…</string>
     <string name="general_configure_action">Подеси</string>
     <string name="battery_optimization_hint_title">Оптимизација батерије</string>
     <string name="battery_optimization_hint_message">Оптимизација батерије је омогућена и може спречити исправан рад. Размотри искључивање.</string>
@@ -406,6 +410,12 @@
     <string name="dnd_access_hint_title">Приступ режиму Не узнемиравај</string>
     <string name="dnd_access_hint_message">Без приступа режиму „Не узнемирај“, подешавања звона, обавештења и DND режима не могу бити примењена када се твоји уређаји повежу.</string>
     <string name="dnd_access_fix_action">Додели приступ</string>
+    <string name="device_speaker_hint_title">Јачине звука након откачињавања</string>
+    <string name="device_speaker_hint_message">Желиш да се твоје јачине звука врате када се Bluetooth уређај откачи? Додај „Звучник уређаја“ као управљан уређај — његове јачине звука се примењују када се звук врати на твој телефон.</string>
+    <string name="device_speaker_hint_action">Додај</string>
+    <string name="review_app_body">Желиш ли оставити рецензију за BVM? ❤️</string>
+    <string name="review_app_review_action">Оцени</string>
+    <string name="review_app_dismiss_action">Можда касније</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Куповина отказана</string>
     <string name="error_iap_unavailable_message">Куповине у апликацији нису доступне</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Inga ohanterade enheter hittades</string>
     <string name="discover_all_devices_managed_msg">Alla dina parade enheter hanteras redan! Behöver du en ny?</string>
     <string name="discover_pair_new_device_action">Para ny enhet</string>
+    <string name="discover_device_speaker_desc">Telefonens egen högtalare. Dess volymer tillämpas när ljud växlar tillbaka till telefonen, t.ex. efter att din Bluetooth-enhet kopplas från.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Enhetskonfiguration</string>
     <string name="devices_device_config_section_general_label">Allmänt</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Lägg till enhet</string>
     <string name="label_just_a_moment_please">Ett ögonblick tack.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="monitor_notification_starting">Startar upp…</string>
     <string name="action_set">Välj</string>
     <string name="action_cancel">Avbryt</string>
     <string name="label_invalid_input">Felaktig input</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Radera</string>
     <string name="general_cancel_action">Avbryt</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Avfärda</string>
+    <string name="general_progress_loading">Läser in…</string>
     <string name="general_configure_action">Konfigurera</string>
     <string name="battery_optimization_hint_title">Batterioptimering</string>
     <string name="battery_optimization_hint_message">Batterioptimering är aktiverad och kan hindra korrekt drift. Överväg att inaktivera dem.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Åtkomst till Stör ej</string>
     <string name="dnd_access_hint_message">Utan Stör ej-åtkomst kan inställningar för ringsignal, aviseringar och Stör ej-läge inte tillämpas när dina enheter ansluter.</string>
     <string name="dnd_access_fix_action">Ge tillgång</string>
+    <string name="device_speaker_hint_title">Volymer efter frånkoppling</string>
+    <string name="device_speaker_hint_message">Vill du att dina volymer återställs när en Bluetooth-enhet kopplas från? Lägg till \"Enhetshögtalare\" som en hanterad enhet – dess volymer tillämpas när ljud växlar tillbaka till din telefon.</string>
+    <string name="device_speaker_hint_action">Lägg till</string>
+    <string name="review_app_body">Skulle du vilja lämna BVM en recension? ❤️</string>
+    <string name="review_app_review_action">Recensera</string>
+    <string name="review_app_dismiss_action">Kanske senare</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Köp avbrutet</string>
     <string name="error_iap_unavailable_message">Köp i appen är inte tillgängliga</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -390,6 +390,8 @@
     <string name="general_delete_action">Futa</string>
     <string name="general_cancel_action">Ghairi</string>
     <string name="general_ok_action">Sawa</string>
+    <string name="general_dismiss_action">Ondoa</string>
+    <string name="general_progress_loading">Inapakia…</string>
     <string name="general_configure_action">Sanidi</string>
     <string name="battery_optimization_hint_title">Uboreshaji wa betri</string>
     <string name="battery_optimization_hint_message">Uboreshaji wa betri umewezeshwa na unaweza kuzuia utendaji sahihi. Fikiria kuuzima.</string>
@@ -401,6 +403,10 @@
     <string name="dnd_access_hint_title">Ufikiaji wa Usisumbue</string>
     <string name="dnd_access_hint_message">Bila ufikiaji wa Usisumbue, mipangilio ya sauti ya simu, arifa, na hali ya DND haiwezi kutumika wakati vifaa vyako vinapoungana.</string>
     <string name="dnd_access_fix_action">Ruhusu ufikiaji</string>
+    <string name="device_speaker_hint_action">Ongeza</string>
+    <string name="review_app_body">Je, ungependa kuacha mapitio ya BVM? ❤️</string>
+    <string name="review_app_review_action">Mapitio</string>
+    <string name="review_app_dismiss_action">Labda baadaye</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Ununuzi umefutwa</string>
     <string name="error_iap_unavailable_message">Manunuzi ndani ya programu hayapatikani</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Hakuna vifaa visivyodhibitiwa vilivyopatikana</string>
     <string name="discover_all_devices_managed_msg">Vifaa vyako vyote vilivyounganishwa vinadhibitiwa! Unahitaji kipya?</string>
     <string name="discover_pair_new_device_action">Unganisha kifaa kipya</string>
+    <string name="discover_device_speaker_desc">Spikari ya simu yenyewe. Kiwango cha sauti chake kinatumika wakati sauti inaburudika kwa simu, kwa mfano baada ya kifaa chako cha Bluetooth kutengana.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Usanidi wa kifaa</string>
     <string name="devices_device_config_section_general_label">Jumla</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Ongeza kifaa</string>
     <string name="label_just_a_moment_please">Subiri kidogo, tafadhali.</string>
     <string name="label_notification_channel_status">Hali</string>
+    <string name="monitor_notification_starting">Inaanza…</string>
     <string name="action_set">Weka</string>
     <string name="action_cancel">Ghairi</string>
     <string name="label_invalid_input">Uingizaji usio halali</string>
@@ -403,6 +405,8 @@
     <string name="dnd_access_hint_title">Ufikiaji wa Usisumbue</string>
     <string name="dnd_access_hint_message">Bila ufikiaji wa Usisumbue, mipangilio ya sauti ya simu, arifa, na hali ya DND haiwezi kutumika wakati vifaa vyako vinapoungana.</string>
     <string name="dnd_access_fix_action">Ruhusu ufikiaji</string>
+    <string name="device_speaker_hint_title">Kiwango cha sauti baada ya kutengana</string>
+    <string name="device_speaker_hint_message">Unataka kiwango cha sauti chako kurudishwa wakati kifaa cha Bluetooth kinatengana? Ongeza \"Spikari ya kifaa\" kama kifaa kilichosimamiwa — kiwango cha sauti chake kinatumika wakati sauti inaburudika kwa simu yako.</string>
     <string name="device_speaker_hint_action">Ongeza</string>
     <string name="review_app_body">Je, ungependa kuacha mapitio ya BVM? ❤️</string>
     <string name="review_app_review_action">Mapitio</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">நிர்வகிக்கப்படாத சாதனங்கள் ஏதும் காணப்படவில்லை</string>
     <string name="discover_all_devices_managed_msg">உங்கள் எல்லா இணைக்கப்பட்ட சாதனங்களும் நிர்வகிக்கப்படுகின்றன! புதிதாக ஒன்று தேவையா?</string>
     <string name="discover_pair_new_device_action">புதிய சாதனத்தை இணைக்கவும்</string>
+    <string name="discover_device_speaker_desc">இந்த ஃபோனின் சொந்த ஸ்பீக்கர். ஆடியோ ஃபோனுக்கு மீண்டும் மாறும் போது அதன் ஒலிகள் பயன்படுத்தப்படுகிறது, எ.கா. உங்கள் ப்ளூடூத் சாதனம் துண்டிக்கப்பட்ட பின்னர்.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">சாதன அமைப்பு</string>
     <string name="devices_device_config_section_general_label">பொது</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">சாதனம் சேர்க்கவும்</string>
     <string name="label_just_a_moment_please">ஒரு நிமிடம் தாமதிக்கவும்.</string>
     <string name="label_notification_channel_status">நிலை</string>
+    <string name="monitor_notification_starting">தொடங்குகிறது…</string>
     <string name="action_set">அமை</string>
     <string name="action_cancel">ரத்து செய்</string>
     <string name="label_invalid_input">தவறான உள்ளீடு</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">நீக்கு</string>
     <string name="general_cancel_action">ரத்து செய்</string>
     <string name="general_ok_action">சரி</string>
+    <string name="general_dismiss_action">நிராகரி</string>
+    <string name="general_progress_loading">ஏற்றுகிறது…</string>
     <string name="general_configure_action">கட்டமை</string>
     <string name="battery_optimization_hint_title">பட்டரி மேம்பாடு</string>
     <string name="battery_optimization_hint_message">பட்டரி மேம்பாடுகள் இயக்கப்பட்டுள்ளன மற்றும் சரியான இயக்கத்தைத் தடுக்கலாம். அவற்றை குறைக்கலாம்.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">தொந்தரவு செய்யாதீர்கள் அணுகல்</string>
     <string name="dnd_access_hint_message">தொந்தரவு செய்யாதீர்கள் அணுகல் இல்லாமல், உங்கள் சாதனங்கள் இணைக்கப்படும்போது ரிங்டோன், அறிவிப்பு மற்றும் DND முறை அமைப்புகளை பயன்படுத்த முடியாது.</string>
     <string name="dnd_access_fix_action">அணுகலை வழங்கு</string>
+    <string name="device_speaker_hint_title">முறிப்பின் பிறகு ஒலிகள்</string>
+    <string name="device_speaker_hint_message">ப்ளூடூத் சாதனம் முறிந்தபோது உங்கள் ஒலிகள் மீட்டெடுக்க வேண்டுமா? \"சாதன ஸ்பீக்கர்\" ஐ நிர்வகிக்கப்பட்ட சாதனமாக சேர்க்கவும் — ஆடியோ உங்கள் ஃபோனுக்கு மீண்டும் மாறும் போது அதன் ஒலிகள் பயன்படுத்தப்படுகிறது.</string>
+    <string name="device_speaker_hint_action">சேர்க்கவும்</string>
+    <string name="review_app_body">நீங்கள் BVM க்கு மார்வை வழங்க விரும்புகிறீர்களா? ❤️</string>
+    <string name="review_app_review_action">மார்வு</string>
+    <string name="review_app_dismiss_action">பிறகு வேளையில்</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">கொள்முடிவு ரத்துசெய்யப்பட்டது</string>
     <string name="error_iap_unavailable_message">ஆப்் உள்ளை கொள்முடிவுகள் கிடையவில்லை</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">నిర్వహించబడని పరికరాలు కనుగొనబడలేదు</string>
     <string name="discover_all_devices_managed_msg">మీ అన్ని జోడించిన పరికరాలు నిర్వహించబడుతున్నాయి! కొత్తది కావాలా?</string>
     <string name="discover_pair_new_device_action">కొత్త పరికరాన్ని జత చేయండి</string>
+    <string name="discover_device_speaker_desc">ఈ ఫోన్ యొక్క స్వంత స్పీకర్. ఆడియో ఫోన్‌కు తిరిగి మారినప్పుడు దాని వాల్యూమ్‌లు వర్తించబడతాయి, ఉదా. మీ Bluetooth పరికరం డిస్‌కనెక్ట్ చేయబడిన తరువాత.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">పరికర కాన్ఫిగరేషన్</string>
     <string name="devices_device_config_section_general_label">సాధారణ</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">పరికరం జోడించు</string>
     <string name="label_just_a_moment_please">ఒక్క క్షణం, దయచేసి.</string>
     <string name="label_notification_channel_status">స్థితి</string>
+    <string name="monitor_notification_starting">ప్రారంభిస్తోంది…</string>
     <string name="action_set">సెట్ చేయి</string>
     <string name="action_cancel">రద్దు చేయండి</string>
     <string name="label_invalid_input">చెల్లని ఇన్‌పుట్</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">తొలగించండి</string>
     <string name="general_cancel_action">రద్దు చేయండి</string>
     <string name="general_ok_action">సరే</string>
+    <string name="general_dismiss_action">తీసివేయండి</string>
+    <string name="general_progress_loading">లోడ్ చేస్తుంది…</string>
     <string name="general_configure_action">కాన్ఫిగర్ చేయి</string>
     <string name="battery_optimization_hint_title">బ్యాటరీ ఆప్టిమైజేషన్</string>
     <string name="battery_optimization_hint_message">బ్యాటరీ ఆప్టిమైజేషన్‌లు ప్రారంభించబడ్డాయి మరియు సరైన పనితీరును నిరోధించవచ్చు. వాటిని నిలిపివేయడాన్ని పరిగణించండి.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">డు నాట్ డిస్టర్బ్ యాక్సెస్</string>
     <string name="dnd_access_hint_message">డు నాట్ డిస్టర్బ్ యాక్సెస్ లేకుండా, మీ డివైస్‌లు కనెక్ట్ అయినప్పుడు రింగ్‌టోన్, నోటిఫికేషన్ మరియు DND మోడ్ సెట్టింగ్‌లు వర్తించవు.</string>
     <string name="dnd_access_fix_action">యాక్సెస్ మంజూరు చేయండి</string>
+    <string name="device_speaker_hint_title">డిస్‌కనెక్ట్ తరువాత వాల్యూమ్‌లు</string>
+    <string name="device_speaker_hint_message">Bluetooth పరికరం డిస్‌కనెక్ట్ చేయబడినప్పుడు మీ వాల్యూమ్‌లు పునరుద్ధరించబడాలనుకుంటున్నారా? \"పరికర స్పీకర్\"ను నిర్వహించిన పరికరం వలె జోడించండి — ఆడియో మీ ఫోన్‌కు తిరిగి మారినప్పుడు దాని వాల్యూమ్‌లు వర్తించబడతాయి.</string>
+    <string name="device_speaker_hint_action">జోడించు</string>
+    <string name="review_app_body">మీరు BVM కోసం సమీక్ష వ్రాయాలనుకుంటారా?️ ❤️</string>
+    <string name="review_app_review_action">సమీక్ష</string>
+    <string name="review_app_dismiss_action">తరువాత ఆగామి</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">కొనుగోలు రద్దు చేయబడింది</string>
     <string name="error_iap_unavailable_message">యాప్-లో కొనుగోళ్ళు అందుబాటులో లేవు</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">ไม่พบอุปกรณ์ที่ยังไม่ได้จัดการ</string>
     <string name="discover_all_devices_managed_msg">อุปกรณ์ที่จับคู่ทั้งหมดถูกจัดการแล้ว! ต้องการอันใหม่มั้ย?</string>
     <string name="discover_pair_new_device_action">จับคู่อุปกรณ์ใหม่</string>
+    <string name="discover_device_speaker_desc">ลำโพงของโทรศัพท์เครื่องนี้ ระดับเสียงจะถูกนำไปใช้เมื่อเสียงสลับกลับไปยังโทรศัพท์ เช่น หลังจากอุปกรณ์ Bluetooth ของคุณตัดการเชื่อมต่อ</string>
     <!-- Devices -->
     <string name="devices_device_config_label">การตั้งค่าอุปกรณ์</string>
     <string name="devices_device_config_section_general_label">ทั่วไป</string>
@@ -311,6 +312,7 @@
     <string name="label_add_device">เพิ่มอุปกรณ์</string>
     <string name="label_just_a_moment_please">โปรดรอสักครู่</string>
     <string name="label_notification_channel_status">สถานะ</string>
+    <string name="monitor_notification_starting">กำลังเริ่มต้น…</string>
     <string name="action_set">ตั้งค่า</string>
     <string name="action_cancel">ยกเลิก</string>
     <string name="label_invalid_input">ใส่ไม่ถูกต้อง</string>
@@ -385,6 +387,8 @@
     <string name="general_delete_action">ลบ</string>
     <string name="general_cancel_action">ยกเลิก</string>
     <string name="general_ok_action">ตกลง</string>
+    <string name="general_dismiss_action">ปิด</string>
+    <string name="general_progress_loading">กำลังโหลด…</string>
     <string name="general_configure_action">กำหนดค่า</string>
     <string name="battery_optimization_hint_title">การเพิ่มประสิทธิภาพแบตเตอรี่</string>
     <string name="battery_optimization_hint_message">การเพิ่มประสิทธิภาพแบตเตอรี่เปิดใช้งานอยู่และอาจป้องกันการทำงานที่ถูกต้อง พิจารณาปิดการใช้งาน</string>
@@ -396,6 +400,12 @@
     <string name="dnd_access_hint_title">การเข้าถึง Do Not Disturb</string>
     <string name="dnd_access_hint_message">หากไม่มีการเข้าถึง Do Not Disturb การตั้งค่าเสียงเรียกเข้า การแจ้งเตือน และโหมด DND จะไม่ถูกใช้งานเมื่ออุปกรณ์ของคุณเชื่อมต่อ</string>
     <string name="dnd_access_fix_action">ให้สิทธิ์การเข้าถึง</string>
+    <string name="device_speaker_hint_title">ระดับเสียงหลังการตัดการเชื่อมต่อ</string>
+    <string name="device_speaker_hint_message">ต้องการให้ระดับเสียงของคุณคืนค่าเมื่ออุปกรณ์ Bluetooth ตัดการเชื่อมต่อหรือไม่? เพิ่ม \"Device speaker\" เป็นอุปกรณ์ที่จัดการ — ระดับเสียงจะถูกนำไปใช้เมื่อเสียงสลับกลับไปยังโทรศัพท์ของคุณ</string>
+    <string name="device_speaker_hint_action">เพิ่ม</string>
+    <string name="review_app_body">คุณต้องการให้คะแนน BVM หรือไม่? ❤️</string>
+    <string name="review_app_review_action">รีวิว</string>
+    <string name="review_app_dismiss_action">อาจในคราวหน้า</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">ยกเลิกการซื้อ</string>
     <string name="error_iap_unavailable_message">ไม่สามารถซื้อในแอปได้</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Yönetilmeyen cihaz bulunamadı</string>
     <string name="discover_all_devices_managed_msg">Tüm eşleştirilmiş cihazların yönetiliyor! Yeni bir tane mi lazım?</string>
     <string name="discover_pair_new_device_action">Yeni cihaz eşleştir</string>
+    <string name="discover_device_speaker_desc">Telefonun kendi hoparlörü. Ses telefona geri döndüğünde (örneğin Bluetooth cihazınızın bağlantısı kesildiğinde) ses seviyeleri uygulanır.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Cihaz yapılandırması</string>
     <string name="devices_device_config_section_general_label">Genel</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Cihaz ekle</string>
     <string name="label_just_a_moment_please">Bir dakika, lütfen.</string>
     <string name="label_notification_channel_status">Durum</string>
+    <string name="monitor_notification_starting">Başlatılıyor…</string>
     <string name="action_set">Ayarla</string>
     <string name="action_cancel">İptal</string>
     <string name="label_invalid_input">Geçersiz giriş</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Sil</string>
     <string name="general_cancel_action">İptal</string>
     <string name="general_ok_action">Tamam</string>
+    <string name="general_dismiss_action">Yoksay</string>
+    <string name="general_progress_loading">Yükleniyor…</string>
     <string name="general_configure_action">Yapılandır</string>
     <string name="battery_optimization_hint_title">Pil optimizasyonu</string>
     <string name="battery_optimization_hint_message">Pil optimizasyonları etkin ve düzgün çalışmayı engelleyebilir. Bunları devre dışı bırakmayı düşün.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Rahatsız Etme erişimi</string>
     <string name="dnd_access_hint_message">Rahatsız Etme erişimi olmadan, cihazlarınız bağlandığında zıl sesi, bildirim ve Rahatsız Etme modu ayarları uygulanamaz.</string>
     <string name="dnd_access_fix_action">Erişim izni ver</string>
+    <string name="device_speaker_hint_title">Bağlantı kesilince ses seviyeleri</string>
+    <string name="device_speaker_hint_message">Bluetooth cihazının bağlantısı kesildiğinde ses seviyeleriniz geri yüklenmesini mi istiyorsunuz? \"Cihaz hoparlörü\"nü yönetilen bir cihaz olarak ekleyin — ses telefona geri döndüğünde ses seviyeleri uygulanır.</string>
+    <string name="device_speaker_hint_action">Ekle</string>
+    <string name="review_app_body">BVM\'e bir inceleme bırakmak ister misin? ❤️</string>
+    <string name="review_app_review_action">Değerlendir</string>
+    <string name="review_app_dismiss_action">Belki daha sonra</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Satın alma iptal edildi</string>
     <string name="error_iap_unavailable_message">Uygulama içi satın almalar mevcut değil</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Не знайдено некерованих пристроїв</string>
     <string name="discover_all_devices_managed_msg">Усі твої спарені пристрої вже керуються! Потрібен новий?</string>
     <string name="discover_pair_new_device_action">Спарити новий пристрій</string>
+    <string name="discover_device_speaker_desc">Вбудований динамік телефону. Його гучність застосовується, коли звук переключається назад на телефон, наприклад, після відключення пристрою Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Конфігурація пристрою</string>
     <string name="devices_device_config_section_general_label">Загальні</string>
@@ -323,6 +324,7 @@
     <string name="label_add_device">Додати пристрій</string>
     <string name="label_just_a_moment_please">Хвилинку...</string>
     <string name="label_notification_channel_status">Стан</string>
+    <string name="monitor_notification_starting">Запуск…</string>
     <string name="action_set">Налаштувати</string>
     <string name="action_cancel">Скасувати</string>
     <string name="label_invalid_input">Невірний ввід</string>
@@ -400,6 +402,8 @@
     <string name="general_delete_action">Видалити</string>
     <string name="general_cancel_action">Скасувати</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Відхилити</string>
+    <string name="general_progress_loading">Завантаження…</string>
     <string name="general_configure_action">Налаштувати</string>
     <string name="battery_optimization_hint_title">Оптимізація батареї</string>
     <string name="battery_optimization_hint_message">Оптимізації батареї увімкнені і можуть заважати нормальній роботі. Розглянь можливість їх вимкнення.</string>
@@ -411,6 +415,12 @@
     <string name="dnd_access_hint_title">Доступ до режиму «Не турбувати»</string>
     <string name="dnd_access_hint_message">Без доступу до режиму «Не турбувати» неможливо застосувати налаштування дзвінка, сповіщень і режиму DND під час підключення ваших пристроїв.</string>
     <string name="dnd_access_fix_action">Надати доступ</string>
+    <string name="device_speaker_hint_title">Гучність після відключення</string>
+    <string name="device_speaker_hint_message">Хочете, щоб ваша гучність була відновлена при відключенні пристрою Bluetooth? Додайте «Device speaker» як керований пристрій — його гучність застосовується, коли звук переключається назад на ваш телефон.</string>
+    <string name="device_speaker_hint_action">Додати</string>
+    <string name="review_app_body">Бажаєш залишити відгук про BVM? ❤️</string>
+    <string name="review_app_review_action">Огляд</string>
+    <string name="review_app_dismiss_action">Можливо пізніше</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Покупку скасовано</string>
     <string name="error_iap_unavailable_message">Покупки в додатку недоступні</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">کوئی غیر منظم ڈیوائس نہیں ملی</string>
     <string name="discover_all_devices_managed_msg">آپ کی تمام جوڑی گئی ڈیوائسیں منظم ہیں! کوئی نئی ڈیوائس چاہیے؟</string>
     <string name="discover_pair_new_device_action">نئی ڈیوائس جوڑیں</string>
+    <string name="discover_device_speaker_desc">یہ فون کا اپنا اسپیکر۔ جب آڈیو فون پر واپس آتا ہے تو اس کے حجم کو لاگو کیا جاتا ہے، مثال کے طور پر آپ کے Bluetooth ڈیوائس کے منقطع ہونے کے بعد۔</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ڈیوائس کی ترتیب</string>
     <string name="devices_device_config_section_general_label">عمومی</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">ڈیوائس شامل کریں</string>
     <string name="label_just_a_moment_please">بس ایک لمحہ۔</string>
     <string name="label_notification_channel_status">حیثیت</string>
+    <string name="monitor_notification_starting">شروع ہو رہا ہے…</string>
     <string name="action_set">سیٹ کریں</string>
     <string name="action_cancel">منسوخ کریں</string>
     <string name="label_invalid_input">غلط ان پٹ</string>
@@ -390,6 +392,7 @@
     <string name="general_delete_action">حذف کریں</string>
     <string name="general_cancel_action">منسوخ کریں</string>
     <string name="general_ok_action">ٹھیک ہے</string>
+    <string name="general_progress_loading">لوڈ ہو رہا ہے…</string>
     <string name="general_configure_action">ترتیب دیں</string>
     <string name="battery_optimization_hint_title">بیٹری آپٹیمائزیشن</string>
     <string name="battery_optimization_hint_message">بیٹری آپٹیمائزیشنز فعال ہیں اور صحیح کام کاج روک سکتی ہیں۔ انہیں بند کرنے کی کوشش کریں۔</string>
@@ -401,6 +404,12 @@
     <string name="dnd_access_hint_title">ڈو ناٹ ڈسٹرب رسائی</string>
     <string name="dnd_access_hint_message">ڈو ناٹ ڈسٹرب رسائی کے بغیر، آپ کے ڈیوائسز سے کنیکٹ ہونے پر رنگ، اطلاع اور ڈی این ڈی موڈ کی سیٹنگز لاگو نہیں ہو سکتیں۔</string>
     <string name="dnd_access_fix_action">رسائی فراہم کریں</string>
+    <string name="device_speaker_hint_title">منقطع کے بعد حجم</string>
+    <string name="device_speaker_hint_message">کیا آپ چاہتے ہیں کہ جب Bluetooth ڈیوائس منقطع ہو تو آپ کا حجم بحال ہو؟ \"Device speaker\" کو ایک منظم شدہ ڈیوائس کے طور پر شامل کریں — اس کے حجم کو لاگو کیا جاتا ہے جب آڈیو آپ کے فون پر واپس آتا ہے۔</string>
+    <string name="device_speaker_hint_action">شامل کریں</string>
+    <string name="review_app_body">کیا آپ BVM کے لیے ریویو چھوڑنا چاہیں گے؟️ ❤️</string>
+    <string name="review_app_review_action">ریویو</string>
+    <string name="review_app_dismiss_action">شاید بعد میں</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">خریداری منسوخ</string>
     <string name="error_iap_unavailable_message">این ایپ خریداری دستیاب نہیں</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -392,6 +392,7 @@
     <string name="general_delete_action">حذف کریں</string>
     <string name="general_cancel_action">منسوخ کریں</string>
     <string name="general_ok_action">ٹھیک ہے</string>
+    <string name="general_dismiss_action">برخاست کریں</string>
     <string name="general_progress_loading">لوڈ ہو رہا ہے…</string>
     <string name="general_configure_action">ترتیب دیں</string>
     <string name="battery_optimization_hint_title">بیٹری آپٹیمائزیشن</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Boshqarilmagan qurilmalar topilmadi</string>
     <string name="discover_all_devices_managed_msg">Barcha juftlashtirilgan qurilmalaringiz boshqarilmoqda! Yangi qurilma kerakmi?</string>
     <string name="discover_pair_new_device_action">Yangi qurilma juftlashtirish</string>
+    <string name="discover_device_speaker_desc">Telefonning o\'z karnaysi. Uning ovoz darajalari audio telefonga qaytganda qo\'llaniladi, masalan, Bluetooth qurilmangiz uzilgandan keyin.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Qurilma sozlamalari</string>
     <string name="devices_device_config_section_general_label">Umumiy</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Qurilma qo\'shish</string>
     <string name="label_just_a_moment_please">Bir lahza, iltimos.</string>
     <string name="label_notification_channel_status">Holat</string>
+    <string name="monitor_notification_starting">Ishga tushmoqda…</string>
     <string name="action_set">O\'rnatish</string>
     <string name="action_cancel">Bekor qilish</string>
     <string name="label_invalid_input">Noto\'g\'ri ma\'lumot</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">O\'chirish</string>
     <string name="general_cancel_action">Bekor qilish</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Yopish</string>
+    <string name="general_progress_loading">Yuklanmoqda…</string>
     <string name="general_configure_action">Sozlash</string>
     <string name="battery_optimization_hint_title">Batareya optimallashuvi</string>
     <string name="battery_optimization_hint_message">Batareya optimallashtirishlari yoqilgan va to\'g\'ri ishlashga to\'sqinlik qilishi mumkin. Ularni o\'chirishni ko\'ring.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Bezovta qilmang rejimiga kirish</string>
     <string name="dnd_access_hint_message">Bezovta qilmang rejimsiz, qo\'ng\'iroq, bildirishnoma va DND rejimi sozlamalari qurilmalaringiz ulanganda qo\'llanilmaydi.</string>
     <string name="dnd_access_fix_action">Ruxsat berish</string>
+    <string name="device_speaker_hint_title">Uzilgandan keyingi ovoz darajalari</string>
+    <string name="device_speaker_hint_message">Bluetooth qurilma uzilganda ovoz darajalari tiklanishini xohlaysizmi? \"Qurilma karnayi\"ni boshqariladigan qurilma sifatida qo\'shing — uning ovoz darajalari audio telefoningizga qaytganda qo\'llaniladi.</string>
+    <string name="device_speaker_hint_action">Qo\'shish</string>
+    <string name="review_app_body">BVM ga sharh qoldirishni xohlaysizmi? ❤️</string>
+    <string name="review_app_review_action">Ko\'rib chiqish</string>
+    <string name="review_app_dismiss_action">Balki keyinroq</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Xarid bekor qilindi</string>
     <string name="error_iap_unavailable_message">Ilovadagi xaridlar mavjud emas</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Không tìm thấy thiết bị chưa được quản lý</string>
     <string name="discover_all_devices_managed_msg">Tất cả thiết bị đã ghép nối đều được quản lý! Cần thiết bị mới?</string>
     <string name="discover_pair_new_device_action">Ghép nối thiết bị mới</string>
+    <string name="discover_device_speaker_desc">Loa của chính chiếc điện thoại này. Âm lượng của nó được áp dụng khi âm thanh chuyển trở lại điện thoại, ví dụ như sau khi thiết bị Bluetooth của bạn ngắt kết nối.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Cấu hình thiết bị</string>
     <string name="devices_device_config_section_general_label">Tổng quan</string>
@@ -313,6 +314,7 @@ TheNothingGuy</string>
     <string name="label_add_device">Thêm thiết bị</string>
     <string name="label_just_a_moment_please">Xin chờ một chút.</string>
     <string name="label_notification_channel_status">Trạng thái</string>
+    <string name="monitor_notification_starting">Khởi động…</string>
     <string name="action_set">Đặt</string>
     <string name="action_cancel">Hủy bỏ</string>
     <string name="label_invalid_input">Dữ liệu nhập không hợp lệ</string>
@@ -388,6 +390,8 @@ TheNothingGuy</string>
     <string name="general_delete_action">Xóa</string>
     <string name="general_cancel_action">Hủy</string>
     <string name="general_ok_action">OK</string>
+    <string name="general_dismiss_action">Bỏ qua</string>
+    <string name="general_progress_loading">Đang tải…</string>
     <string name="general_configure_action">Cấu hình</string>
     <string name="battery_optimization_hint_title">Tối ưu hóa pin</string>
     <string name="battery_optimization_hint_message">Tối ưu hóa pin đang bật và có thể ngăn cản hoạt động bình thường. Hãy cân nhắc tắt chúng.</string>
@@ -399,6 +403,12 @@ TheNothingGuy</string>
     <string name="dnd_access_hint_title">Quyền truy cập Không làm phiền</string>
     <string name="dnd_access_hint_message">Nếu không có quyền truy cập Không làm phiền, cài đặt nhạc chuông, thông báo và chế độ DND sẽ không được áp dụng khi thiết bị của bạn kết nối.</string>
     <string name="dnd_access_fix_action">Cấp quyền truy cập</string>
+    <string name="device_speaker_hint_title">Âm lượng sau khi ngắt kết nối</string>
+    <string name="device_speaker_hint_message">Muốn khôi phục âm lượng của bạn khi một thiết bị Bluetooth ngắt kết nối? Thêm \"Loa thiết bị\" làm thiết bị được quản lý — âm lượng của nó được áp dụng khi âm thanh chuyển trở lại điện thoại của bạn.</string>
+    <string name="device_speaker_hint_action">Thêm</string>
+    <string name="review_app_body">Bạn có muốn để lại đánh giá cho BVM không? ❤️</string>
+    <string name="review_app_review_action">Đánh giá</string>
+    <string name="review_app_dismiss_action">Để sau</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Mua hàng bị hủy</string>
     <string name="error_iap_unavailable_message">Mua hàng trong ứng dụng không khả dụng</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">没有找到未管理的设备</string>
     <string name="discover_all_devices_managed_msg">你所有配对的设备都已管理！需要新的吗？</string>
     <string name="discover_pair_new_device_action">配对新设备</string>
+    <string name="discover_device_speaker_desc">此手机自己的扬声器。当音频切换回手机时（例如蓝牙设备断开连接后），将应用其音量。</string>
     <!-- Devices -->
     <string name="devices_device_config_label">设备配置</string>
     <string name="devices_device_config_section_general_label">常规</string>
@@ -311,6 +312,7 @@
     <string name="label_add_device">添加设备</string>
     <string name="label_just_a_moment_please">请稍等一下。</string>
     <string name="label_notification_channel_status">状态</string>
+    <string name="monitor_notification_starting">正在启动…</string>
     <string name="action_set">应用</string>
     <string name="action_cancel">取消</string>
     <string name="label_invalid_input">输入的内容无效</string>
@@ -385,6 +387,8 @@
     <string name="general_delete_action">删除</string>
     <string name="general_cancel_action">取消</string>
     <string name="general_ok_action">确定</string>
+    <string name="general_dismiss_action">取消</string>
+    <string name="general_progress_loading">正在加载…</string>
     <string name="general_configure_action">配置</string>
     <string name="battery_optimization_hint_title">电池优化</string>
     <string name="battery_optimization_hint_message">已启用电池优化，可能会阻止正常操作。请考虑禁用它们。</string>
@@ -396,6 +400,12 @@
     <string name="dnd_access_hint_title">勿扰模式访问权限</string>
     <string name="dnd_access_hint_message">如果没有免打扰权限，当设备连接时将无法应用铃声、通知和免打扰模式设置。</string>
     <string name="dnd_access_fix_action">授予权限</string>
+    <string name="device_speaker_hint_title">断开连接后的音量</string>
+    <string name="device_speaker_hint_message">想在蓝牙设备断开连接时恢复你的音量？添加“设备扬声器”作为受管设备——当音频切换回你的手机时，将应用其音量。</string>
+    <string name="device_speaker_hint_action">添加</string>
+    <string name="review_app_body">想给 BVM 写一条评论吗？❤️</string>
+    <string name="review_app_review_action">评论</string>
+    <string name="review_app_dismiss_action">稍后再说</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">购买已取消</string>
     <string name="error_iap_unavailable_message">应用内购买不可用</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">找不到未管理的裝置</string>
     <string name="discover_all_devices_managed_msg">你所有配對的裝置都已管理！需要新的？</string>
     <string name="discover_pair_new_device_action">配對新裝置</string>
+    <string name="discover_device_speaker_desc">此手機本身的揚聲器。當音訊切換回手機時，其音量會被套用，例如在藍牙裝置斷開連線後。</string>
     <!-- Devices -->
     <string name="devices_device_config_label">裝置設定</string>
     <string name="devices_device_config_section_general_label">一般</string>
@@ -311,6 +312,7 @@
     <string name="label_add_device">新增裝置</string>
     <string name="label_just_a_moment_please">請稍候。</string>
     <string name="label_notification_channel_status">狀態</string>
+    <string name="monitor_notification_starting">正在啟動…</string>
     <string name="action_set">設定</string>
     <string name="action_cancel">取消</string>
     <string name="label_invalid_input">無效輸入</string>
@@ -385,6 +387,8 @@
     <string name="general_delete_action">刪除</string>
     <string name="general_cancel_action">取消</string>
     <string name="general_ok_action">確定</string>
+    <string name="general_dismiss_action">關閉</string>
+    <string name="general_progress_loading">正在載入…</string>
     <string name="general_configure_action">設定</string>
     <string name="battery_optimization_hint_title">電池游淡優化</string>
     <string name="battery_optimization_hint_message">電池游淡優化已啟用，可能影響正常運作。請考慮關閉。</string>
@@ -396,6 +400,12 @@
     <string name="dnd_access_hint_title">請勿打擾存取權</string>
     <string name="dnd_access_hint_message">若未取得「請勿打擾」存取權，當您的裝置連接時，將無法套用鈴聲、通知及「請勿打擾」模式設定。</string>
     <string name="dnd_access_fix_action">授予存取權</string>
+    <string name="device_speaker_hint_title">斷開連線後的音量</string>
+    <string name="device_speaker_hint_message">想在藍牙裝置斷開連線時恢復你的音量？將「裝置揚聲器」新增為受管理的裝置 — 當音訊切換回你的手機時，其音量會被套用。</string>
+    <string name="device_speaker_hint_action">新增</string>
+    <string name="review_app_body">你想為 BVM 留下評論嗎？ ❤️</string>
+    <string name="review_app_review_action">評論</string>
+    <string name="review_app_dismiss_action">稍後再說</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">購買已取消</string>
     <string name="error_iap_unavailable_message">應用內購買不可用</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -26,6 +26,7 @@
     <string name="discover_no_unmnaged_devices_msg">找不到未管理的裝置</string>
     <string name="discover_all_devices_managed_msg">您的所有配對裝置都已管理！需要配對新裝置嗎？</string>
     <string name="discover_pair_new_device_action">配對新裝置</string>
+    <string name="discover_device_speaker_desc">此手機的揚聲器。當音訊切換回手機時（例如藍牙設備斷開連接後），會應用其音量。</string>
     <!-- Devices -->
     <string name="devices_device_config_label">裝置設定</string>
     <string name="devices_device_config_section_general_label">一般</string>
@@ -310,6 +311,7 @@
     <string name="label_add_device">新增裝置</string>
     <string name="label_just_a_moment_please">請稍等一下。</string>
     <string name="label_notification_channel_status">狀態</string>
+    <string name="monitor_notification_starting">正在啟動…</string>
     <string name="action_set">設定</string>
     <string name="action_cancel">取消</string>
     <string name="label_invalid_input">無效的輸入</string>
@@ -384,6 +386,8 @@
     <string name="general_delete_action">刪除</string>
     <string name="general_cancel_action">取消</string>
     <string name="general_ok_action">確定</string>
+    <string name="general_dismiss_action">關閉</string>
+    <string name="general_progress_loading">正在載入…</string>
     <string name="general_configure_action">設定</string>
     <string name="battery_optimization_hint_title">電池最佳化</string>
     <string name="battery_optimization_hint_message">電池最佳化已啟用，可能會影響正常運作。請考慮停用它們。</string>
@@ -395,6 +399,12 @@
     <string name="dnd_access_hint_title">請勿打擾存取權限</string>
     <string name="dnd_access_hint_message">若未取得「請勿打擾」存取權限，當您的裝置連接時，將無法套用鈴聲、通知及「請勿打擾」模式設定。</string>
     <string name="dnd_access_fix_action">授予存取權</string>
+    <string name="device_speaker_hint_title">斷開連接後的音量</string>
+    <string name="device_speaker_hint_message">想在藍牙設備斷開連接時恢復你的音量？將「設備揚聲器」新增為受管理設備 — 當音訊切換回你的手機時，會應用其音量。</string>
+    <string name="device_speaker_hint_action">新增</string>
+    <string name="review_app_body">你想為 BVM 留下評論嗎？❤️</string>
+    <string name="review_app_review_action">評論</string>
+    <string name="review_app_dismiss_action">稍後再說</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">購買已取消</string>
     <string name="error_iap_unavailable_message">無法使用應用程式內購買</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -27,6 +27,7 @@
     <string name="discover_no_unmnaged_devices_msg">Azikho izidivayisi ezingaphathwa ezitholakele</string>
     <string name="discover_all_devices_managed_msg">Wonke amadivayisi akho asebenzisana nawo aphathwa! Udinga elisha?</string>
     <string name="discover_pair_new_device_action">Hlanganisa idivayisi entsha</string>
+    <string name="discover_device_speaker_desc">Isahluko sefowuni sayo. Umthwali waso usetshenziswa lapho umsindo ubuya efowunini, isibonelo, emva kokuthi isixwayiso sakho se-Bluetooth siqedele ukunxibelelana.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Ukucwaninga kwedivayisi</string>
     <string name="devices_device_config_section_general_label">Okujwayelekile</string>
@@ -315,6 +316,7 @@
     <string name="label_add_device">Engeza idivayisi</string>
     <string name="label_just_a_moment_please">Isikhashana nje, sicela.</string>
     <string name="label_notification_channel_status">Isimo</string>
+    <string name="monitor_notification_starting">Iqalaqala...</string>
     <string name="action_set">Setha</string>
     <string name="action_cancel">Yekisa</string>
     <string name="label_invalid_input">Okokufaka okungalungile</string>
@@ -390,6 +392,8 @@
     <string name="general_delete_action">Susa</string>
     <string name="general_cancel_action">Yekisa</string>
     <string name="general_ok_action">KULUNGILE</string>
+    <string name="general_dismiss_action">Lahla</string>
+    <string name="general_progress_loading">Iyalayisha...</string>
     <string name="general_configure_action">Lungiselela</string>
     <string name="battery_optimization_hint_title">Ukuqinisekisa ibhethri</string>
     <string name="battery_optimization_hint_message">Ukuqinisekisa ibhethri kukhona futhi kungavimbela ukusebenza kahle. Cabanga ukucisha zona.</string>
@@ -401,6 +405,12 @@
     <string name="dnd_access_hint_title">Ukufinyelela kwe-Do Not Disturb</string>
     <string name="dnd_access_hint_message">Ngaphandle kokufinyelela kwe-Do Not Disturb, izilungiselelo zeringithoni, isaziso, kanye ne-DND mode azikwazi ukusetshenziswana lapho amadivayisi akho exhuma.</string>
     <string name="dnd_access_fix_action">Nikeza ukufinyelela</string>
+    <string name="device_speaker_hint_title">Umthwali emva kokuqedela ukunxibelelana</string>
+    <string name="device_speaker_hint_message">Ufuna umthwali wakho ubuyele lapho isixwayiso se-Bluetooth siqedela ukunxibelelana? Engeza \"Isahluko sesixwayiso\" njengesikhwama esiphathwayo — umthwali waso usetshenziswa lapho umsindo ubuya efowunini yakho.</string>
+    <string name="device_speaker_hint_action">Engeza</string>
+    <string name="review_app_body">Ungathanda ukushiyela i-BVM ukubuyekeza? ❤️</string>
+    <string name="review_app_review_action">Buyekeza</string>
+    <string name="review_app_dismiss_action">Mhlawumbe kamuva</string>
     <!-- IAP Error Messages -->
     <string name="error_iap_cancelled_message">Ukuthenga kukhanseliwe</string>
     <string name="error_iap_unavailable_message">Ukuthenga phakathi kohlelo akutholakali</string>


### PR DESCRIPTION
## Summary
- Restored the bullet-point line breaks in the upgrade screen's feature list, which were rendering as one run-on line in most non-English languages.
- Corrected a handful of mistranslated labels and buttons (e.g. "Dismiss", "Review", "Yearly subscription") in Swahili, Sinhala, Japanese, Italian, Indonesian, Urdu, and Sardinian.
- Fixed the translations at the source so the corrections stick, then pulled the corrected text into the app.
