### PR TITLE
General: Fix the Latvian upgraded title showing the wrong app abbreviation

### DIFF
--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Vereis BVM FOSS</string>
     <string name="upgrade_prompt_title">Opgradeer na BVM FOSS</string>
     <string name="upgrade_prompt_body">Ontsluit addisionele funksies en word \'n beskermheer om voortgesette ontwikkeling te ondersteun!</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS ያስፈሉ።</string>
     <string name="upgrade_prompt_title">ወደ BVM FOSS ክበቱ</string>
     <string name="upgrade_prompt_body">ተጨማሪ ባህሪያትን ይክፈቱ እና ቀጣይ ልማትን ለመደገፍ ደጋፊ ይሁኑ!</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">يتطلب BVM FOSS</string>
     <string name="upgrade_prompt_title">الترقية إلى BVM FOSS</string>
     <string name="upgrade_prompt_body">افتح ميزات إضافية وكن راعياً لدعم التطوير المستمر!</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS tələb olunur</string>
     <string name="upgrade_prompt_title">BVM FOSS-a yüksəldin</string>
     <string name="upgrade_prompt_body">Əlavə xüsusiyyətləri açın və davamlı inkişafı dəstəkləmək üçün himayədar olun!</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Патрабуе BVM FOSS</string>
     <string name="upgrade_prompt_title">Перайсці на BVM FOSS</string>
     <string name="upgrade_prompt_body">Адкрыйце дадатковыя функцыі і станьце спонсарам, каб падтрымаць далейшую распрацоўку!</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Изисква BVM FOSS</string>
     <string name="upgrade_prompt_title">Надграждане до BVM FOSS</string>
     <string name="upgrade_prompt_body">Отключете допълнителни функции и станете покровител, за да подкрепите непрекъснатото развитие!</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS প্রয়োজন</string>
     <string name="upgrade_prompt_title">BVM FOSS-এ আপগ্রেড করুন</string>
     <string name="upgrade_prompt_body">অতিরিক্ত ফিচার আনলক করুন এবং ক্রমাগত বিকাশকে সমর্থন করার জন্য একজন পৃষ্ঠপোষক হন!</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Requereix BVM FOSS</string>
     <string name="upgrade_prompt_title">Millora a BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloquegeu funcions addicionals i convertiu-vos en mecenes per donar suport al continuïtat del suport!</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Vyžaduje BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgradovat na BVM FOSS</string>
     <string name="upgrade_prompt_body">Odemkněte další funkce a staňte se patronem, který podpoří další vývoj!</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Kræver BVM FOSS</string>
     <string name="upgrade_prompt_title">Opgrader til BVM FOSS</string>
     <string name="upgrade_prompt_body">Lås op for flere funktioner, og bliv patron for at støtte den fortsatte udvikling!</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Erfordert BVM FOSS</string>
     <string name="upgrade_prompt_title">Auf BVM FOSS upgraden</string>
     <string name="upgrade_prompt_body">Schalte zusätzliche Funktionen frei und werde Patron, um die Weiterentwicklung zu unterstützen!</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Απαιτεί το BVM FOSS</string>
     <string name="upgrade_prompt_title">Αναβαθμίστε στο BVM FOSS</string>
     <string name="upgrade_prompt_body">Ξεκλειδώστε πρόσθετες δυνατότητες και γίνετε patron για να υποστηρίξετε τη συνεχή ανάπτυξη!</string>

--- a/app/src/foss/res/values-eo-rUY/strings.xml
+++ b/app/src/foss/res/values-eo-rUY/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Postulas BVM FOSS</string>
     <string name="upgrade_prompt_title">Plibonigi al BVM FOSS</string>
     <string name="upgrade_prompt_body">Malŝlosi pliajn funkciojn kaj fiĝiĝi patrono por subteni daŭran disvolvadon!</string>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Requiere BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">¡Desbloqueá funciones adicionales y hacete patreon para ayudar a continuar el desarrollo!</string>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Requiere BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">¡Desbloquea funciones adicionales y conviértete en pratrocinador para apoyar el desarrollo continuo!</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Requiere BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">¡Desbloquea las funciones adicionales y conviértete en patrocinador para apoyar el desarrollo continuo!</string>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Vajab BVM FOSS versiooni</string>
     <string name="upgrade_prompt_title">Uuenda BVM FOSS-iks</string>
     <string name="upgrade_prompt_body">Lubage lisavõimalused ja hakake toetajaks, et edendada arendamist.</string>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS beharrezkoa da</string>
     <string name="upgrade_prompt_title">Berritu BVM FOSS-era</string>
     <string name="upgrade_prompt_body">Eginbide gehigarriak desblokeatu eta babesle izan etengabeko garapena laguntzeko!</string>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">نیاز به BVM FOSS دارد</string>
     <string name="upgrade_prompt_title">ارتقاء به BVM FOSS</string>
     <string name="upgrade_prompt_body">قفل ویژگی های اضافی را باز کنید و برای حمایت از توسعه مداوم، حامی شوید!</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Vaatii BVM FOSS:in</string>
     <string name="upgrade_prompt_title">Päivitä BVM FOSS:iin</string>
     <string name="upgrade_prompt_body">Avaa lisäominaisuuksia ja ryhdy tukijaksi tukeaksesi jatkuvaa kehitystä!</string>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Nangangailangan ng BVM FOSS</string>
     <string name="upgrade_prompt_title">I-upgrade sa BVM FOSS</string>
     <string name="upgrade_prompt_body">I-unlock ang mga karagdagang feature at maging patron para suportahan ang patuloy na development!</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Nécessite BVM FOSS</string>
     <string name="upgrade_prompt_title">Passer à BVM FOSS</string>
     <string name="upgrade_prompt_body">Débloquez des fonctions supplémentaires et devenez mécène pour soutenir le développement continu.</string>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Require BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloquea características adicionais e convértete en mecenas para apoiar o desenvolvemento continuo!</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS आवश्यक है</string>
     <string name="upgrade_prompt_title">BVM FOSS में अपग्रेड करें</string>
     <string name="upgrade_prompt_body">अतिरिक्त सुविधाओं को अनलॉक करें और निरंतर विकास का समर्थन करने के लिए संरक्षक बनें!</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Zahtijeva BVM FOSS</string>
     <string name="upgrade_prompt_title">Nadogradite na BVM FOSS</string>
     <string name="upgrade_prompt_body">Otključajte dodatne značajke i postanite pokrovitelj kako biste podržali daljnji razvoj!</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS szükséges</string>
     <string name="upgrade_prompt_title">Frissítés BVM FOSS-ra</string>
     <string name="upgrade_prompt_body">Fedezze fel a további funkciókat, és legyen patron támogató, hogy támogassa a folyamatos fejlesztést!</string>

--- a/app/src/foss/res/values-hy-rAM/strings.xml
+++ b/app/src/foss/res/values-hy-rAM/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Պահանջվում է BVM FOSS</string>
     <string name="upgrade_prompt_title">Անցնել BVM FOSS-ին</string>
     <string name="upgrade_prompt_body">Բացեք լրացուցիչ գործառույթներ և դարձեք հովանավոր՝ շարունակական զարգացումը աջակցելու համար:</string>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Membutuhkan BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgrade ke BVM FOSS</string>
     <string name="upgrade_prompt_body">Buka fitur-fitur tambahan dan jadilah penyokong yang mendukung pengembangan yang berkelanjutan!</string>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Krefst BVM FOSS</string>
     <string name="upgrade_prompt_title">Uppfæra í BVM FOSS</string>
     <string name="upgrade_prompt_body">Opnaðu viðbótareiginleika og vertu styrktaraðili til að styðja áframhaldandi þróun!</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Richiede BVM FOSS</string>
     <string name="upgrade_prompt_title">Aggiorna a BVM FOSS</string>
     <string name="upgrade_prompt_body">Sblocca funzioni aggiuntive e diventa un sostenitore per supportare lo sviluppo continuo!</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">דורש BVM FOSS</string>
     <string name="upgrade_prompt_title">שדרג ל-BVM FOSS</string>
     <string name="upgrade_prompt_body">בטל נעילה של תכונות נוספות והפוך לפטרון לתמיכה בהמשך הפיתוח!</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS が必要です</string>
     <string name="upgrade_prompt_title">BVM FOSS にアップグレード</string>
     <string name="upgrade_prompt_body">開発を続けるためパトロンになって追加機能を解除してください</string>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">საჭიროა BVM FOSS</string>
     <string name="upgrade_prompt_title">გადაიდგეს BVM FOSS-ზე</string>
     <string name="upgrade_prompt_body">განბლოკეთ დამატებითი ფუნქციები და გახდით მფარველი მუდმივი განვითარების მხარდასაჭერად!</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">ត្រូវការ BVM FOSS</string>
     <string name="upgrade_prompt_title">ធ្វើឱ្យប្រសើរទៅ BVM FOSS</string>
     <string name="upgrade_prompt_body">ដោះសោមុខងារបន្ថែម និងក្លាយជាអ្នកឧបត្ថម្ភដើម្បីគាំទ្រការអភិវឌ្ឍន៍បន្ត!</string>

--- a/app/src/foss/res/values-kmr-rTR/strings.xml
+++ b/app/src/foss/res/values-kmr-rTR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS hewce dike</string>
     <string name="upgrade_prompt_title">Biçe BVM FOSS</string>
     <string name="upgrade_prompt_body">Taybetmendîên zêde veke!</string>

--- a/app/src/foss/res/values-kn-rIN/strings.xml
+++ b/app/src/foss/res/values-kn-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS ಅಗತ್ಯ</string>
     <string name="upgrade_prompt_title">BVM FOSS ಗೆ ದರ್ಜೆಯೇರಿ</string>
     <string name="upgrade_prompt_body">ಹೆಚ್ಚಿನ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಅನ್ಲಾಕ್ ಮಾಡಿ ಮತ್ತು ನಿರಂತರ ಅಭಿವರ್ಧನೆಗೆ ಬೆಂಬಲಿಸಲು ಪ್ರಾಯೋಜಕರಾಗಿ!</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS가 필요합니다</string>
     <string name="upgrade_prompt_title">BVM FOSS로 업그레이드</string>
     <string name="upgrade_prompt_body">후원자가 되어 앱 개발을 지원하고 추가 기능을 잠금해제 하세요!</string>

--- a/app/src/foss/res/values-ky-rKG/strings.xml
+++ b/app/src/foss/res/values-ky-rKG/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS талап кылат</string>
     <string name="upgrade_prompt_title">BVM FOSS га өтүү</string>
     <string name="upgrade_prompt_body">Кошумча функцияларды ачыңыз жана үзгөлтүрүлгөн ишкерленишти колдоо үчүн патрон болуңуз!</string>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">ຕ້ອງການ BVM FOSS</string>
     <string name="upgrade_prompt_title">ອັບເກຣດເປັນ BVM FOSS</string>
     <string name="upgrade_prompt_body">ປົດລັອກຄຸນສົມບັດເພີ່ມເຕີມ ແລະ ກາຍເປັນຜູ້ອຸປະຖໍາເພື່ອສະໜັບສະໜູນການພັດທະນາຢ່າງຕໍ່ເນື່ອງ!</string>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Reikia BVM FOSS</string>
     <string name="upgrade_prompt_title">Atnaujinti į BVM FOSS</string>
     <string name="upgrade_prompt_body">Atrakinkite papildomas funkcijas ir tapkite globėju, kad palaikytumėte tolesnį plėtojimą!</string>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BSP FOSS</string>
     <string name="upgrade_feature_requires_pro">Nepieciešams BSP FOSS</string>
     <string name="upgrade_prompt_title">Jaunināt uz BSP FOSS</string>
     <string name="upgrade_prompt_body">Atslēdz papildu iespējas un kļūsti par aizbildni, lai atbalstītu izstrādes nepārtrauktību!</string>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Потребен е BVM FOSS</string>
     <string name="upgrade_prompt_title">Надгради на BVM FOSS</string>
     <string name="upgrade_prompt_body">Отклучете дополнителни функции и станете покровител за да го поддржите континуираниот развој!</string>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS ആവശ്യമാണ്</string>
     <string name="upgrade_prompt_title">BVM FOSS യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrade_prompt_body">കൂടുതൽ സവിശേഷതകൾ അൺലോക്കുചെയ്‌ത് തുടർ വികസനത്തെ പിന്തുണയ്ക്കുന്നതിന് ഒരു പാട്രോൺ ആകുക!</string>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS шаардлагана</string>
     <string name="upgrade_prompt_title">BVM FOSS рүү шилжээх</string>
     <string name="upgrade_prompt_body">Нэмэлт боломжуудыг нээж, тасралтгүй хөгжлийг дэмжихийн тулд ивээн тэтгэгч болоорой!</string>

--- a/app/src/foss/res/values-mr-rIN/strings.xml
+++ b/app/src/foss/res/values-mr-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS आवश्यक आहे</string>
     <string name="upgrade_prompt_title">BVM FOSS वर अपग्रेड करा</string>
     <string name="upgrade_prompt_body">अद्यावत वैशिष्ट्ये अनलॉक करा आणि सतत विकासास सहाय्य करण्यासाठी प्रायोजक व्हा!</string>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Memerlukan BVM FOSS</string>
     <string name="upgrade_prompt_title">Naik taraf ke BVM FOSS</string>
     <string name="upgrade_prompt_body">Buka kunci ciri tambahan dan menjadi penaung untuk menyokong pembangunan berterusan!</string>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS လိုအပ်သည်</string>
     <string name="upgrade_prompt_title">BVM FOSS သို့ အဆင့်မြှင့်ပါ</string>
     <string name="upgrade_prompt_body">အပိုဝန်ဆောင်မှုများကို ဖွင့်ပြီး ဆက်လက်ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးရန် ကူညီသူဖြစ်လာပါ!</string>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS आवश्यक छ</string>
     <string name="upgrade_prompt_title">BVM FOSS मा अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_prompt_body">थप सुविधाहरू अनलक गर्नुहोस् र निरन्तर विकासलाई समर्थन गर्न संरक्षक बन्नुहोस्!</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Vereist BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgrade naar BVM FOSS</string>
     <string name="upgrade_prompt_body">Ontgrendel extra functies en word een patroon om verdere ontwikkeling te ondersteunen!</string>

--- a/app/src/foss/res/values-no/strings.xml
+++ b/app/src/foss/res/values-no/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Krever BVM FOSS</string>
     <string name="upgrade_prompt_title">Oppgrader til BVM FOSS</string>
     <string name="upgrade_prompt_body">Lås opp flere funksjoner og bli en patron for å støtte utviklingen videre!</string>

--- a/app/src/foss/res/values-pcm-rNG/strings.xml
+++ b/app/src/foss/res/values-pcm-rNG/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Need BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgrade to BVM FOSS</string>
     <string name="upgrade_prompt_body">Unlock additional features and become patron to support continued development!</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Wymaga BVM FOSS</string>
     <string name="upgrade_prompt_title">Uaktualnij do BVM FOSS</string>
     <string name="upgrade_prompt_body">Odblokuj dodatkowe funkcje i zostań patronem, aby wesprzeć dalszy rozwój!</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Requer BVM FOSS</string>
     <string name="upgrade_prompt_title">Atualizar para BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloqueie recursos adicionais e torne-se um patrão para apoiar o desenvolvimento contínuo!</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Requer BVM FOSS</string>
     <string name="upgrade_prompt_title">Atualizar para BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloqueie funcionalidades extra e torne-se um patrono para apoiar o desenvolvimento contínuo!</string>

--- a/app/src/foss/res/values-rm/strings.xml
+++ b/app/src/foss/res/values-rm/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Basegna BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualisar a BVM FOSS</string>
     <string name="upgrade_prompt_body">Deblocha funcziuns supplementaras e daventescha in patronu per sustegnair il svilup ulterior!</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Necesită BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizează la BVM FOSS</string>
     <string name="upgrade_prompt_body">Deblochează funcții suplimentare și devino un patron pentru a suporta dezvoltarea continuată!</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Требуется BVM FOSS</string>
     <string name="upgrade_prompt_title">Обновить до BVM FOSS</string>
     <string name="upgrade_prompt_body">Разблокируйте дополнительные возможности и станьте спонсором, чтобы поддержать разработку приложения!</string>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Riquerit BVM FOSS</string>
     <string name="upgrade_prompt_title">Addobba a BVM FOSS</string>
     <string name="upgrade_prompt_body">Aberri funtzionalidades addizionales e diventa patronu pro sustènnere su isvilupu continuadu!</string>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS අවශ්‍යයි</string>
     <string name="upgrade_prompt_title">BVM FOSS වෙත උත්‍යෝජනය කරන්න</string>
     <string name="upgrade_prompt_body">අමතර විශේෂාංග අඟුල හරිමින් අඛණ්ඩ සංවර්ධනයට සහාය වීමට අනුග්‍රාහකයෙකු වන්න!</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Vyžaduje BVM FOSS</string>
     <string name="upgrade_prompt_title">Prejsť na BVM FOSS</string>
     <string name="upgrade_prompt_body">Odomknite ďalšie funkcie a staňte sa patrónom na podporu ďalšieho vývoja!</string>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Zahteva BVM FOSS</string>
     <string name="upgrade_prompt_title">Nadgradite na BVM FOSS</string>
     <string name="upgrade_prompt_body">Odklenite dodatne funkcije in postanite pokrovitelj, da podprete nadaljnji razvoj!</string>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Kërkon BVM FOSS</string>
     <string name="upgrade_prompt_title">Përmirëso në BVM FOSS</string>
     <string name="upgrade_prompt_body">Çelni veçori shtesë dhe bëhuni një mbrojtës për të mbështetur zhvillimin e vazhdueshëm!</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Захтева BVM FOSS</string>
     <string name="upgrade_prompt_title">Надогради на BVM FOSS</string>
     <string name="upgrade_prompt_body">Откључај додатне функције и постани покровитељ да подржиш континуирани развој!</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Kräver BVM FOSS</string>
     <string name="upgrade_prompt_title">Uppgradera till BVM FOSS</string>
     <string name="upgrade_prompt_body">Lås upp ytterligare funktioner och bli en beskyddare för att stödja fortsatt utveckling!</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Inahitaji BVM FOSS</string>
     <string name="upgrade_prompt_title">Boresha hadi BVM FOSS</string>
     <string name="upgrade_prompt_body">Fungua vipengele vya ziada na uwe mfumo wa kuunga mkono maendeleo ya kuendelea!</string>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS தேவைப்படுகிறது</string>
     <string name="upgrade_prompt_title">BVM FOSSக்கு மேம்படுத்து</string>
     <string name="upgrade_prompt_body">கூடுதல் அம்சங்களைத் திறக்கவும் மற்றும் தொடர்ச்சியான மேம்பாட்டை ஆதரிக்க புரவலராக மாறவும்!</string>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS అవసరం</string>
     <string name="upgrade_prompt_title">BVM FOSS కి అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_prompt_body">అదనపు ఫీచర్లను అన్‌లాక్ చేసి, నిరంతర అభివృద్ధికి మద్దతు ఇవ్వడానికి పేట్రన్ అవ్వండి!</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">ต้องใช้ BVM FOSS</string>
     <string name="upgrade_prompt_title">อัปเกรดเป็น BVM FOSS</string>
     <string name="upgrade_prompt_body">ปลดล็อกฟีเจอร์เพิ่มเติมและเป็นผู้อุปถัมภ์เพื่อสนับสนุนการพัฒนาอย่างต่อเนื่อง!</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS gereklidir</string>
     <string name="upgrade_prompt_title">BVM FOSS\'a Yükselt</string>
     <string name="upgrade_prompt_body">Ek özelliklerin kilidini açın ve sürekli gelişimi desteklemek için bir patron olun!</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Потрібен BVM FOSS</string>
     <string name="upgrade_prompt_title">Оновити до BVM FOSS</string>
     <string name="upgrade_prompt_body">Розблокуйте додаткові функції та станьте спонсором, щоб підтримати подальший розвиток!</string>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS کی ضرورت ہے</string>
     <string name="upgrade_prompt_title">BVM FOSS میں اپ گریڈ کریں</string>
     <string name="upgrade_prompt_body">اضافی خصوصیات کو غیر مقفل کریں اور مسلسل ترقی کی حمایت کے لیے سرپرست بنیں!</string>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">BVM FOSS talab qilinadi</string>
     <string name="upgrade_prompt_title">BVM FOSS ga o\'tish</string>
     <string name="upgrade_prompt_body">Qo\'shimcha xususiyatlarni oching va doimiy rivojlanishni qo\'llab-quvvatlash uchun homiy bo\'ling!</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Yêu cầu BVM FOSS</string>
     <string name="upgrade_prompt_title">Nâng cấp lên BVM FOSS</string>
     <string name="upgrade_prompt_body">Mở khóa các tính năng bổ sung và trở thành người bảo trợ để hỗ trợ sự phát triển liên tục!</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">需要 BVM FOSS</string>
     <string name="upgrade_prompt_title">升级至 BVM FOSS</string>
     <string name="upgrade_prompt_body">解锁附加功能，成为支持持续开发的赞助人！</string>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">需要 BVM FOSS</string>
     <string name="upgrade_prompt_title">升級到 BVM FOSS</string>
     <string name="upgrade_prompt_body">解鎖額外功能，並成為贊助者，以支持持續開發！</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">需要 BVM FOSS</string>
     <string name="upgrade_prompt_title">升級至 BVM FOSS</string>
     <string name="upgrade_prompt_body">解鎖額外功能，並成為贊助者，以支持持續開發！</string>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
     <string name="upgrade_feature_requires_pro">Kudingeka i-BVM FOSS</string>
     <string name="upgrade_prompt_title">Buyekeza kuya ku-BVM FOSS</string>
     <string name="upgrade_prompt_body">Vula izici ezengeziwe futhi ube ngumnikazi ukuze usekele ukuthuthukiswa okuqhubekayo!</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name_upgraded">BVM FOSS</string>
+    <string name="app_name_upgraded" translatable="false">BVM FOSS</string>
     <string name="app_name_upgrade_postfix" translatable="false">FOSS</string>
     <string name="upgrade_badge_label" translatable="false">FOSS</string>
 


### PR DESCRIPTION
## What changed

Fixed the Latvian upgraded title showing the wrong abbreviation for the app. Latvian users saw "BSP FOSS" where the app's brand should read "BVM FOSS" — and inconsistently, since the Settings entry that opens that screen already said "BVM FOSS".

## Technical Context

- This was a regression, not a new defect. Commit `5857c333` ("Stop translating the flavor brand labels") deliberately deleted the per-locale `app_name_upgraded` overrides so the untranslated base value would win everywhere. A later Crowdin import re-added them — `git show` on the two commits shows the identical line removed and then added back.
- Root cause of the recurrence: the base `app_name_upgraded` was declared **without** `translatable="false"`, so Crowdin kept exporting it. Its immediate neighbours `app_name_upgrade_postfix` and `upgrade_badge_label` both carry the attribute, and neither was ever resurrected — the correlation is exact, with 0 locale overrides on the protected keys and 77 on the unprotected one.
- So the fix is both halves: the attribute is what makes it durable, and deleting the 77 overrides alone would be undone by the next sync.
- Scope note: this corrects the upgraded title only. Four other Latvian strings still spell the product "BSP" (`upgrade_screen_title`, `upgrade_prompt_title`, `upgrade_feature_requires_pro`, `upgrade_screen_sponsor_too_fast`). Those are translated prose rather than brand labels — de-translating them would show Latvian users English text, and correcting them in the repo would be overwritten by the next import. They are being handled on the Crowdin side.
- Also observed and deliberately left alone: the gplay source set has three unprotected brand keys (`app_name_upgraded`, `app_name_upgrade_postfix`, `upgrade_badge_label`) with ~77 overrides each. Whether the Play-flavour tier name should be de-translated is a separate product question — a sibling app intentionally localises it — and nothing there is currently drifting or self-contradicting.
