### PR TITLE
Fix the Settings upgrade row disagreeing with the composed app title

### DIFF
--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Dankie dat jy oopbron ontwikkeling ondersteun ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Al terug? Jou ondersteuning hou BVM aan die lewe!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Bekyk jou ondersteunerstatus</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Jy is op die gratis weergawe</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">ክፍት ምንጭ ልማትን ስለደገፉ እናመሰግናለን ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">አልበጅ ተመለሱ? የ።ቡቡ፡ ስሮት BVMን ብርህ ዘተዃል።</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">ደጋፊ ሁኔታዎን ይመልከቱ</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">ነፃ ወለታ ወደ ይህ ደርሰዋል።</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">شكراً على دعمك لتطوير المصادر المفتوحة ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">عدت بالفعل؟ دعمك يبقي BVM حياً!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">عرض حالة الداعم الخاصة بك</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">أنت على النسخة المجانية</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Açıq mənbə inkişafını dəstəklədiyiniz üçün təşəkkür edirik ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Artıq qayıtdınız? Dəstəyiniz BVM-i yaşatır!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Dəstəkçi statusunuza baxın</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Siz pulsuz versiyada olursunuz</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Дзякуй за падтрымку распрацоўкі з адкрытым зыходным кодам ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Ужо задавольна? Ваша падтрымка трымае BVM ў жыцці!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Праглядзець ваш статус спонсара</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Вы на бясплатнай версіі</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Благодаря ви, че подкрепяте разработката с отворен код ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Вече се върнахте? Вашата подкрепа поддържа BVM живо!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Вижте статуса си на поддържник</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Вие сте на безплатната версия</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">ওপেন সোর্স ডেভেলপমেন্ট সমর্থন করার জন্য আপনাকে ধন্যবাদ ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ইতিমধ্যে ফিরে গেলেন? আপনার সমর্থন BVM জীবিত রাখে!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">আপনার সমর্থক স্ট্যাটাস দেখুন</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">আপনি বিনামূল্যে সংস্করণে আছেন</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Gràcies per donar suport al desenvolupament de codi obert ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Ja heu tornat? El vostre suport manté viu el BVM!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Consulteu el vostre estat de col·laborador</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Estàs en la versió gratuïta</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Děkujeme vám za podporu vývoje open-source ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Už jste zpět? Vaše podpora udržuje BVM naživu!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Zobrazit stav podporovatele</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Používáte bezplatnou verzi</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Tak, fordi du støtter open source-udvikling ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Tilbage allerede? Din støtte holder BVM i live!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Se din supporter-status</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Du er på den gratis version</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Vielen Dank für Deine Unterstützung der Open-Source-Entwicklung ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Schon zurück? Deine Unterstützung hält BVM am Leben!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Deinen Unterstützerstatus ansehen</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Du hast die kostenlose Version</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Σας ευχαριστούμε που υποστηρίζετε την ανάπτυξη ανοιχτού κώδικα ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Ήρθες πίσω τόσο γρήγορα; Η υποστήριξή σου κρατάει το BVM ζωντανό!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Δες την κατάσταση υποστηρικτή σου</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Είστε στην δωρεάν έκδοση</string>

--- a/app/src/foss/res/values-eo-rUY/strings.xml
+++ b/app/src/foss/res/values-eo-rUY/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Dankon pro subteno de malfermita kodo ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Jam reen? Via subteno konservas BVM viva!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Vidu vian subtenantan staton</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Vi estas en la senpaga versio</string>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo de código abierto ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">¿Ya te vas? ¡Tu apoyo mantiene vivo a BVM!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Mirá tu estado de colaborador</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Estás en la versión gratuita</string>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo libre ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">¿Ya te vas? ¡Tu apoyo mantiene vivo a BVM!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Consulta tu estado de colaborador</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Estás usando la versión gratuita</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Gracias por apoyar el desarrollo del código abierto ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">¿Ya de vuelta? ¡Tu apoyo mantiene BVM vivo!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Consulta tu estado de colaborador</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Estás en la versión gratuita</string>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Aitäh, et toetate avatud lähtekoodiga arendamist ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Juba tagasi? Sinu toetus hoiab BVM elus!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Vaata oma toetaja staatust</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Kasutad tasuta versiooni</string>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Eskerrik asko iturburu irekiko garapena babesten duzulako ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Itzuli al zara jada? Zure laguntzak BVM bizirik mantentzen du!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Ikusi zure laguntzaile-egoera</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Bertsioan libre zaude</string>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">از شما برای حمایت از توسعه منبع باز سپاسگزاریم ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">زود بازگشتی؟ حمایت شما BVM را زنده نگه می‌دارد!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">وضعیت حامی خود را مشاهده کنید</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">شما در نسخه رایگان هستید</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Kiitos avoimen lähdekoodin kehityksen tukemisesta ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Palasit jo? Tukesi pitää BVM:n hengissä!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Katso tukijatilasi</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Käytät ilmaista versiota</string>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Salamat sa pagsuporta sa open-source development ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Bumalik na agad? Ang iyong suporta ay nagpapanatiling buhay ang BVM!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Tingnan ang iyong supporter status</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Nasa free version ka</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Merci de soutenir le développement libre ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Déjà de retour ? Votre soutien maintient BVM en vie !</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Consultez votre statut de contributeur</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Vous êtes sur la version gratuite</string>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Grazas por apoiar o desenvolvemento de código aberto ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">¿Xa de volta? O teu apoio mantén BVM vivo!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Ver o teu estado de colaborador</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Estás na versión gratuíta</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">ओपन-सोर्स विकास ❤️ का समर्थन करने के लिए धन्यवाद</string>
     <string name="upgrade_screen_sponsor_too_fast">वापस आ गए? आपका सहयोग BVM को जीवित रखता है!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">अपनी समर्थक स्थिति देखें</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">आप मुफ्त संस्करण पर हैं</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Hvala vam što podržavate razvoj otvorenog koda ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Već se vraćate? Vaša podrška održava BVM živim!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Pogledajte svoj status podupiratelja</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Koristite besplatnu verziju</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Köszönjük, hogy támogatod a nyílt forráskódú fejlesztést ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Már vissza is tértél? A támogatásod életben tartja a BVM-et!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Támogatói állapotod megtekintése</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Az ingyenes verzión vagy</string>

--- a/app/src/foss/res/values-hy-rAM/strings.xml
+++ b/app/src/foss/res/values-hy-rAM/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Շնորհակալություն բաց կոդով զարգացումը աջակցելու համար ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Արդեն հետ եք՞ Դզեր աժակցությունը կենդանի ե BVM ապրելում։</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Դիտեք ձեր աջակցողի կարգավիճակը</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Դուք անվճար տարբերակի վրա եք</string>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Terima kasih karena telah mendukung pengembangan sumber terbuka ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Sudah balik? Dukunganmu membuat BVM tetap hidup!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Lihat status pendukung Anda</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Anda berada di versi gratis</string>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Takk fyrir að styðja opna hugbúnaðarþróun ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Kominn aftur strax? Stuðningur þinn heldur BVM lifandi!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Skoða stuðningsstöðu þína</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Þú ert á ókeypis útgáfunni</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Grazie per aver supportato lo sviluppo open-source ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Già di ritorno? Il tuo supporto mantiene BVM in vita!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Visualizza il tuo stato di sostenitore</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Sei sulla versione gratuita</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">תודה שתמכת בפיתוח קוד פתוח ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">חזרת כבר? התמיכה שלך שומרת על BVM בחיים!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">הצגת סטטוס התומך שלכם</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">אתה בגרסה החינמית</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">オープンソースでの開発に協力してくれてありがとうございます ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">もう戻ってきた？あなたのサポートが BVM を支えています！</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">サポーターステータスを確認</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">無料版をご利用中です</string>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">გმადლობთ ღია კოდის განვითარების მხარდაჭერისთვის ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">უკვე დაბრუნდით? თქვენი მხარდაძერება BVM-ს სიცოცხლეს!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">იხილეთ თქვენი მხარდამჭერის სტატუსი</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">თქვენ უფასო ვერსიას იყენებთ</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">សូមអរគុណសម្រាប់ការគាំទ្រការអភិវឌ្ឍន៍ប្រភពបើកចំហ ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ត្រឡប់ក្រោយរួចហើយ? ការគាំទ្ររបស់អ្នកជួយរក្សា BVM ឱ្យដំណើរការ!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">មើលស្ថានភាពអ្នកគាំទ្ររបស់អ្នក</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">អ្នកគឺស្ថិតក្នុងកំណែឥតគិតថ្លៃ</string>

--- a/app/src/foss/res/values-kmr-rTR/strings.xml
+++ b/app/src/foss/res/values-kmr-rTR/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Spas ji bo pishtgiriya çavkaniya vekirî</string>
     <string name="upgrade_screen_sponsor_too_fast">Vegeriyaye? Pishtgiriya te BVM zindî dihêle!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Statûya piştgirêrê xwe bibînin</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Tu li ser vêjean azad yî</string>

--- a/app/src/foss/res/values-kn-rIN/strings.xml
+++ b/app/src/foss/res/values-kn-rIN/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">ಓಪನ್-ಸೋರ್ಸ್ ಅಭಿವರ್ಧನೆಗೆ ಬೆಂಬಲಿಸಿದ್ದಕ್ಕೆ ಧನ್ಯವಾದಗಳು ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ಇಷ್ಟು ಬೇಗನೇ ಹಿಂದೆ? ನಿಮ್ಮ ಬೆಂಬಲು BVM ಅನ್ನು ಬಳಿಯಾಗಿಸುತ್ತದೆ!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">ನಿಮ್ಮ ಬೆಂಬಲಕಾರ ಸ್ಥಿತಿಯನ್ನು ವೀಕ್ಷಿಸಿ</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">ನೀವು ಉಚಿತ ಆವೃತ್ತಿಯಲ್ಲಿ ಇದ್ದೀರಿ</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">오픈소스 개발을 지원해주셔서 감사합니다 ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">벌써 돌아오셨군요? 여러분의 지원이 BVM을 살아있게 합니다!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">후원자 상태 보기</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">무료 버전을 사용 중입니다</string>

--- a/app/src/foss/res/values-ky-rKG/strings.xml
+++ b/app/src/foss/res/values-ky-rKG/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Ачык код ишкерленишти колдоодогунуңуз үчүн рахмат ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Альдынан кайтып келдиңизби? Сиздин колдоо БВМди жашат устайт!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Колдоочу статусун көрүңүз</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Сиз бесплатка версиясында болосуз</string>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">ຂອບໃຈສໍາລັບການສະໜັບສະໜູນການພັດທະນາແຫຼ່ງເປີດ ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ກັບມາແລ້ວຫຣືອ? ການສນັບສນຸນຂອງທ່ານບຳຣຸງ BVM ໄດ້!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">ເບິ່ງສະຖານະຜູ້ສະໝັບສະໝູນຂອງທ່ານ</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">ທ່ານຍູ່ໃນຮູບແບບຟຣີ</string>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Ačiū, kad remiате atvirojo kodo plėtrą ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Jau grįžote? Jūsų parama palaiko BVM gyvą!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Peržiūrėkite savo rėmėjo būseną</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Jūs naudojatės nemokama versija</string>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Paldies par atklātā koda attīstības atbalstīšanu ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Jau atpakaļ? Jūsu atbalsts uztur BSP dzīvu!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Skatīt savu atbalstītāja statusu</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Jūs esat bezmaksas versijā</string>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Ви благодариме што го поддржувате развојот на отворен код ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Веќе се вратија? Вашата поддршка го одржува BVM на живот!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Погледнете го вашиот статус на поддржувач</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Вие сте на бесплатната верзија</string>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">ഓപ്പൺ സോഴ്‌സ് വികസനത്തെ പിന്തുണച്ചതിന് നന്ദി ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ഇത്രയും വേഗം പിന്തിരിച്ചു? നിങ്ങളുടെ പിന്തുണ BVM നിലനിർത്തുന്നു!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">നിങ്ങളുടെ സപ്പോർടർ സ്റ്റാറ്റസ് കാണുക</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">നിങ്ങൾ സ്വതന്ത്ര പതിപ്പ് ഉപയോഗിക്കുന്നു</string>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Нээлттэй эхийн хөгжлийг дэмжсэнд баярлалаа ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Аль буцлаа вүү? Таны дэмжләлт BVM-иг амьд байлгадаг!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Дэмжигчийн статусаа үзэх</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Та үнэгүй хувилбарт байна</string>

--- a/app/src/foss/res/values-mr-rIN/strings.xml
+++ b/app/src/foss/res/values-mr-rIN/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">ओपन-सोर्स विकासाला पाठिंबा दिल्याबद्दल धन्यवाद ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">आधीच माघारी? तुमच्या सहयोगाने BVM जिवंत राहते!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">आपली समर्थक स्थिती पहा</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">तुम्ही मुक्त आवृत्तीवर आहात</string>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Terima kasih kerana menyokong pembangunan sumber terbuka ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Dah balik? Sokongan anda menghidupkan BVM!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Lihat status penyokong anda</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Anda berada di versi percuma</string>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">ပွင့်လင်းရင်းမြစ် ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးပေးသည့်အတွက် ကျေးဇူးတင်ပါသည် ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ပြန်ရောက်လာပြီးလား? သင့၏ ထောက်ပံ့ထားမှုသည် BVM ကို ရှင်သနသောဆီပါ!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">သင်၏တောက်ခံသူအဆင့်ကိုကြည့်ရှုပါ</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">သင်သည် အခမဲ့ဗားရှင်းတွင် ရှိပါသည်</string>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">खुला स्रोत विकासलाई समर्थन गरेकोमा धन्यवाद ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">फेरि फर्किए? तपाईंको सहयोगले BVM जिवित राख्छ!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">आफ्नो समर्थक स्थिति हेर्नुहोस्</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">तपाई नि: शुल्क संस्करण मा हुनुहुन्छु</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Bedankt voor het ondersteunen van open-sourceontwikkeling ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Al terug? Jouw steun houdt BVM levend!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Bekijk je ondersteunersstatus</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Je bent op de gratis versie</string>

--- a/app/src/foss/res/values-no/strings.xml
+++ b/app/src/foss/res/values-no/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Takk for at du støtter utviklingen som har åpen kildekode ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Tilbake allerede? Din støtte holder BVM i live!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Se din støtterstatus</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Du bruker den gratis versjonen</string>

--- a/app/src/foss/res/values-pcm-rNG/strings.xml
+++ b/app/src/foss/res/values-pcm-rNG/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Thank you for supporting open-source development</string>
     <string name="upgrade_screen_sponsor_too_fast">You don come back? Your support dey keep BVM alive!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">See your supporter status</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">You dey use free version</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Dziękuję za wsparcie rozwoju oprogramowania otwarto źródłowego❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Już wróciłeś? Twoje wsparcie utrzymuje BVM przy życiu!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Zobacz status swojego wsparcia</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Jesteś na darmowej wersji</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Obrigado por apoiar o desenvolvimento de código aberto ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Voltou tão rápido? Seu apoio mantém o BVM vivo!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Visualizar seu status de apoiador</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Você está na versão gratuita</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Obrigado por apoiar o desenvolvimento de código aberto ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Já voltou? O seu apoio mantém o BVM vivo!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Ver o teu estado de apoiante</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Tem a versão gratuita</string>

--- a/app/src/foss/res/values-rm/strings.xml
+++ b/app/src/foss/res/values-rm/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Grazia per sustegnair il svilup open-source ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Turnà? Tia sustegnaziun mantegna BVM viv!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Mira tia status da supporter</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Ti es en la versiun gratuita</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Mulțumesc că îmi suporți această dezvoltare open-source❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Ai revenit deja? Sprijinul tău menține BVM în viață!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Verifică starea ta de suporter</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Ești pe versiunea gratuită</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Спасибо за поддержку разработки с открытым исходным кодом ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Уже вернулись? Ваша поддержка помогает BVM жить!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Посмотреть статус поддержки</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Вы используете бесплатную версию</string>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Gràtzias pro sustènnere s\'isvilupu de còdighe abertu ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Giai torradu? Su sustegnu tuo mantenat BVM in vida!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Bili su tuo istadu de suportador</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Ses in sa bertzione libera</string>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">විවෘත මූලාශ්‍ර සංවර්ධනයට සහාය දීම ගැන ස්තූතියි ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">මදින්ම පැරලි? ඔබේ සහාය BVM ජීවත් වෙයි!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">ඔබගේ සහායක තත්වය බලන්න</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">ඔබ නිරීක්ෂණ සංස්කරණයට සිටින්න</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Ďakujem za podporu vývoja open-source ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Už späť? Vaša podpora udržiava BVM nažive!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Zobraziť svoj stav podporovateľa</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Ste na bezplatnej verzii</string>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Hvala za podporo odprtokodnemu razvoju ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Že nazaj? Vaša podpora ohranja BVM pri življenju!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Oglejte si status podpornika</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Ste na brezplačni različici</string>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Faleminderit për mbështetjen e zhvillimit me burim të hapur ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Kthehesh tashmë? Mbështetja juaj e mban BVM gjallë!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Shikoni statusin e mbështetësit tuaj</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Ju jeni në versionin falas</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Хвала вам што подржавате развој отвореног кода ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Већ одлазиш? Твоја подршка одржава BVM живим!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Прегледајте статус подржавача</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Користиш бесплатну верзију</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Tack för att du stöder utveckling med öppen källkod ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Tillbaka redan? Ditt stöd håller BVM vid liv!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Visa din stödjestatus</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Du använder gratisversionen</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Asante kwa kuunga mkono maendeleo ya chanzo wazi ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Umirudi tayari? Msaada wako unaihifadhi BVM hai!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Tazama hali yako ya mchangiaji</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Wewe uko kwa toleo la bure</string>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">திறந்த மூல மேம்பாட்டை ஆதரித்ததற்கு நன்றி ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ஏற்கனவே திரும்பிவிட்டீர்களா? உங்கள் மொத்தம் BVMஐ உயிரோடு வைக்கிறது!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">உங்கள் ஆதரவாளர் நிலையைக் காணவும்</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">நீங்கள் இலவச பதிப்பில் உள்ளீர்கள்</string>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">ఓపెన్ సోర్స్ అభివృద్ధికి మద్దతు ఇచ్చినందుకు ధన్యవాదాలు ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ఇప్పుడే వెనక్కు వెళ్తున్నారా? మీ సహాయంతో BVM జీవంతో ఉంటుంది!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">మీ సపోర్టర్ స్థితిని చూడండి</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">మీరు ఉచిత సంస్కరణలో ఉన్నారు</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">ขอบคุณสำหรับการสนับสนุนการพัฒนาโอเพ่นซอร์ส ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast"></string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">ดูสถานะผู้สนับสนุนของคุณ</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">คุณใช้เวอร์ชันฟรี</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Açık kaynak gelişimini desteklediğiniz için teşekkür ederiz ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Geri mi döndünüz? Desteğiniz BVM\'yi ayakta tutuyor!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Destekçi durumunuzu görüntüleyin</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Ücretsiz sürümü kullanıyorsunuz</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Дякуємо за підтримку розробки з відкритим кодом ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Вже повернулися? Ваша підтримка допомагає BVM продовжувати свою роботу!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Переглянути свій статус прихильника</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Ви використовуєте безплатну версію</string>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">اوپن سورس ڈیولپمنٹ کی حمایت کرنے کا شکریہ ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">ابھی واپس؟ آپ کی حمایت BVM کو زندہ رکھتی ہے!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">اپنی سپورٹر حالت دیکھیں</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">آپ مفت ورژن پر ہیں</string>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Ochiq manba rivojlanishini qo\'llab-quvvatlaganingiz uchun rahmat ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Allaqachon ketayapsizmi? Sizning qo\'llab-quvvatlashingiz BVM ni tirik saqlaydi!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Tarafdor statusini ko\'ring</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Siz bepul versiyadasiz</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Cảm ơn bạn đã hỗ trợ phát triển mã nguồn mở ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Quay lại rồi? Sự ủng hộ của bạn giúp BVM tồn tại!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Xem trạng thái người ủng hộ của bạn</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Bạn đang sử dụng phiên bản miễn phí</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">感谢您支持开源开发 ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">这么快就回来了？您的支持让 BVM 持续运行！</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">查看您的支持者状态</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">你使用的是免费版本</string>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">感謝您對開放原始碼開發的支持 ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">已經回去了？你的支持讓 BVM 持續運行！</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">查看您的支援者狀態</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">你正在使用免費版本</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">感謝您對開放原始碼開發的支持 ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">這麼快就回來了？你的支持讓 BVM 得以持續！</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">查看您的支持者狀態</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">你正在使用免費版本</string>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -15,7 +15,6 @@
     <string name="upgrade_screen_thanks_toast">Ngiyabonga ngokusekela ukuthuthukiswa komthombo ovulekile ❤️</string>
     <string name="upgrade_screen_sponsor_too_fast">Ubuyile kakade? Ukusekela kwakho kugcina i-BVM iphila!</string>
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">Buka isimo sakho se-supporter</string>
     <!-- Free status view -->
     <string name="upgrade_screen_status_free_title">Ungakho ichasiyoni engenalo intengo</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_sponsor_too_fast">Back already? Your support keeps BVM alive!</string>
 
     <!-- Settings status row (also defined in the Google Play flavor with Pro wording) -->
-    <string name="settings_upgrade_status_title">BVM FOSS</string>
     <string name="settings_upgrade_status_desc">View your supporter status</string>
 
     <!-- Free status view -->

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sinkronisasie kan tyd neem. Probeer herlaai, maak Google Play kas skoon of wag net.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Veelvuldige rekeninge kan Google Play verwar. Meld af van ander rekeninge of installeer deur die Google Play webwerf, wat assosiasies met \'n spesifieke rekening dwing.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Bekyk jou Pro-status</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Eenmalige aankoop</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">የPlay Store ሲምሪዝሽን ጊዜ ሊወስድ ይችላል። እንደገና ማስጀመር፣ የGoogle Play መሸጎጫ ማጥራት ወይም ብቻ መጠበቅ ይሞክሩ።</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ብዙ መለያዎች Google Play ማምታታት ይችላሉ። ከሌሎች መለያዎች ይወጡ ወይም በGoogle Play ድርጣቢያ በኩል ይጫኑ፣ ይህም ከተወሰነ መለያ ጋር ግንኙነቶችን ያስገድዳል።</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Pro ሁኔታዎ ይመልከቱ</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">አንድ ጊዜ ግዢ</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">قد تستغرق مزامنة متجر التشغيل وقتاً طويلا. حاول إعادة التشغيل، مسح ذاكرة التخزين المؤقت لـ Google Play أو الانتظار قليلا.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">الحسابات المتعددة يمكنها إرباك Google Play. سجّل الخروج من الحسابات الأخرى أو ثبّت من خلال موقع Google Play، الذي يفرض الرّبط مع حساب معين.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">عرض حالة Pro الخاصة بك</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">شراء مرة واحدة</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sinxronlaşdırması vaxt ala bilər. Yenidən başlatmağı, Google Play keşini təmizləməyi və ya sadəcə gözləməyi sınayın.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Çoxlu hesablar Google Play-i çaşdıra bilər. Digər hesablardan çıxın və ya Google Play veb saytı vasitəsilə quraşdırın ki, bu da müəyyən hesabla əlaqələri məcbur edir.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Pro statusunuza baxın</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Birdəfəlik alış</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Сінхранізацыя з Play Store можа заняць пэўны час. Паспрабуйце перазагрузіцца, ачысціць кэш Google Play або проста пачакаць.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Некалькі ўліковых запісаў могуць заблытаць Google Play. Выйдзіце з іншых уліковых запісаў або ўсталюйце праз вэб-сайт Google Play, які вызначае сувязь з пэўным уліковым запісам.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Праглядзець ваш Pro-статус</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Аднаразовая пакупка</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизацията на Play Store може да отнеме време. Опитайте рестартиране, изчистване на кеша на Google Play или просто изчакайте.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Множествените акаунти могат да объркат Google Play. Излезте от други акаунти или инсталирайте чрез уебсайта на Google Play, който принуждава асоциации с конкретен акаунт.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Вижте своя Pro статус</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Еднократна покупка</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">প্লে স্টোর সিঙ্ক্রোনাইজেশনে সময় লাগতে পারে। রিবুট করার চেষ্টা করুন, Google Play ক্যাশে সাফ করুন বা অপেক্ষা করুন।</string>
     <string name="upgrade_screen_restore_multiaccount_hint">একাধিক অ্যাকাউন্ট Google Play কে বিভ্রান্ত করতে পারে। অন্যান্য অ্যাকাউন্ট থেকে লগ আউট করুন বা Google Play ওয়েবসাইটের মাধ্যমে ইনস্টল করুন, যা একটি নির্দিষ্ট অ্যাকাউন্টের সাথে যুক্ত হতে বাধ্য করে।</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">আপনার Pro স্ট্যাটাস দেখুন</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">এককালীন ক্রয়</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronització del Play Store pot trigar un temps. Proveu de reiniciar, esborrar la memòria cau del Google Play o simplement espereu.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Diversos comptes poden confondre el Google Play. Tanqueu la sessió d\'altres comptes o instal·leu-lo a través del lloc web del Google Play, que obliga a associar-los amb un compte específic.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Consulteu el vostre estat Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Synchronizace Obchodu Play může chvíli trvat. Zkuste restartovat, vymazat mezipaměť Google Play nebo prostě počkat.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Více účtů může zmást Google Play. Odhlaste se z ostatních účtů nebo nainstalujte přes webové stránky Google Play, což vynucuje asociace s konkrétním účtem.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Zobrazit stav Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Jednorázový nákup</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Synkronisering af Play Butik kan tage tid. Prøv at genstarte, rydde Google Play-cachen eller bare vent.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Flere konti kan forvirre Google Play. Log ud af andre konti, eller installer via Google Play-hjemmesiden, som fremtvinger tilknytning til en bestemt konto.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Se din Pro-status</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Engangskøb</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Die Synchronisation im Play Store kann etwas dauern. Versuch es mit einem Neustart, leere den Google Play Cache oder warte einfach.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Mehrere Konten können Google Play durcheinanderbringen. Melde dich von anderen Konten ab oder installiere über die Google Play-Website, um die Zuordnung zu einem bestimmten Konto zu erzwingen.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Deinen Pro-Status ansehen</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Einmaliger Kauf</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Ο συγχρονισμός του Play Store ενδέχεται να πάρει χρόνο. Δοκιμάστε να κάνετε επανεκκίνηση, να καθαρίσετε την προσωρινή μνήμη του Google Play ή απλώς να περιμένετε.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Πολλοί λογαριασμοί μπορεί να μπερδέψουν το Google Play. Αποσυνδεθείτε από άλλους λογαριασμούς ή εγκαταστήστε το μέσω του ιστότοπου Google Play, κάτι που αναγκάζει τους συσχετισμούς με έναν συγκεκριμένο λογαριασμό.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Δες την κατάσταση Pro σου</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Εφάπαξ αγορά</string>

--- a/app/src/gplay/res/values-eo-rUY/strings.xml
+++ b/app/src/gplay/res/values-eo-rUY/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">La sinkronigado de Play Store povas daŭri. Provu restarigi, forigi la kaŝmemoron de Google Play aŭ simple atendi.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Multoblaj kontoj povas konfuzi Google Play. Elsalutu el aliaj kontoj aŭ instalu per la retejo de Google Play, kiu devigas asociadon kun specifa konto.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Vidu vian Pro-staton</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Unufoja aĉeto</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronización de Play Store puede llevar un tiempo. Intenta reiniciar, limpiar la caché de Google Play o simplemente esperar.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Varias cuentas pueden confundir a Google Play. Cierra la sesión de otras cuentas o instala a través del sitio web de Google Play, que obliga las asociaciones con una cuenta específica.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Mirá tu estado Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronización de Play Store puede tomar tiempo. Intenta reiniciar, limpiar el caché de Google Play o simplemente esperar.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Las múltiples cuentas pueden confundir a Google Play. Cierra sesión en otras cuentas o instala a través del sitio web de Google Play, que fuerza asociaciones con una cuenta específica.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Consulta tu estado Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronización de Play Store puede tardar. Prueba a reiniciar, borrar la caché de Google Play o simplemente espera.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Varias cuentas pueden confundir a Google Play. Cierra la sesión de otras cuentas o instala a través del sitio web de Google Play, que obliga las asociaciones con una cuenta específica.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Consulta tu estado Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play poe ajakohastamine võib võtta aega. Ürita taaskäivitada, tühjendada Google\'i poe vahemälu või lihtsalt oota.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Google\'i pood ei pruugi mitme kontoga toime tulla. Logi teistelt kontodelt välja või paigalda Google\'i poe veebilehe kaudu, mis tuvastab seose kindla kontoga.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Vaata oma Pro olekut</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Ühekordne ost</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Storeren sinkronizazioak denbora behar izan dezake. Saiatu berrabiarazten, Google Play katxea ezabatzen edo, besterik gabe, itxaron.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Kontu anitzek Google Play nahas dezakete. Beste kontu batzuetatik atera edo Google Play webgunearen bidez instalatu, eta horrek elkarteak kontu zehatz batekin behartzen ditu.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Ikusi zure Pro egoera</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Erosketa bakarra</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">ممکن است همگام‌سازی فروشگاه Google Play کمی زمان ببرد. سعی کنید دستگاه خود را مجدداً راه‌اندازی کنید، کش برنامه Google Play را پاک کنید یا کمی صبر کنید.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">داشتن حساب‌های متعدد می‌تواند Google Play را گیج کند. از سایر حساب‌ها خارج شوید یا از طریق وب‌سایت Google Play نصب کنید، که انجمن‌ها را با یک حساب خاص تحمیل می‌کند.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">وضعیت Pro خود را مشاهده کنید</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">خرید یکباره</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store -synkronointi voi kestää. Kokeile uudelleenkäynnistystä, Google Play -välimuistin tyhjentämistä tai vain odottamista.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Useat tilit voivat hämmentää Google Playta. Kirjaudu ulos muista tileistä tai asenna Google Play -verkkosivuston kautta, joka pakottaa yhteydet tiettyyn tiliin.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Katso Pro-tilasi</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Kertaostos</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Ang Play Store synchronization ay maaaring tumagal ng oras. Subukang mag-reboot, i-clear ang Google Play cache o maghintay lamang.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Ang maramihang mga account ay maaaring makalito sa Google Play. Mag-log out mula sa ibang mga account o mag-install sa pamamagitan ng Google Play website, na napipilitang nakipag-ugnayan sa isang partikular na account.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Tingnan ang iyong Pro status</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">One-time na pagbili</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">La synchronisation avec Google Play peut prendre du temps. Essayez de redémarrer votre appareil, de vider le cache de Google Play ou simplement d’attendre.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Plusieurs comptes peuvent perturber Google Play. Déconnectez-vous des autres comptes ou installez l’appli en utilisant le site Web de Google Play, ce qui force l’association avec un compte précis.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Consultez votre statut Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Achat unique</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">A sincronización de Play Store pode levar tempo. Proba reiniciar, limpar a caché de Google Play ou simplemente esperar.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Múltiples contas poden confundir Google Play. Pecha sesión noutras contas ou instala a través do sitio web de Google Play, que forza asociacións cunha conta específica.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Ver o teu estado Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store सिंक्रोनाइज़ेशन में समय लग सकता है। रीबूट करने, Google Play कैश साफ़ करने या बस प्रतीक्षा करने का प्रयास करें।</string>
     <string name="upgrade_screen_restore_multiaccount_hint">कई खाते Google Play को भ्रमित कर सकते हैं। अन्य खातों से लॉग आउट करें या Google Play वेबसाइट के माध्यम से इंस्टॉल करें, जो एक विशिष्ट खाते के साथ संबंध को बाध्य करता है।</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">अपनी Pro स्थिति देखें</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">एक-बार खरीदे</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Sinkronizacija Trgovine Play može potrajati. Pokušajte ponovno pokrenuti uređaj, očistiti predmemoriju Google Playa ili jednostavno pričekajte.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Više računa može zbuniti Google Play. Odjavite se s drugih računa ili instalirajte putem Google Play web stranice, što prisiljava povezivanje s određenim računom.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Pogledajte svoj Pro status</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Jednokratna kupnja</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">A Play Áruház szinkronizálása időbe telhet. Próbáld meg az újraindítást, a Google Play gyorsítótárának törlését vagy egyszerűen várj.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">A több fiók összezavarhatja a Google Play-t. Jelentkezz ki más fiókokból, vagy telepítsd a Google Play weboldalán keresztül, amely kikényszeríti a meghatározott fiókkal való társítást.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Pro állapotod megtekintése</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Egyszeri vásárlás</string>

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store համաժամանակեցումը կարող է ժամանակ խլել: Փորձեք վերագործարկել, մաքրել Google Play քեշը կամ պարզապես սպասել:</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Բազմաթիվ հաշիվները կարող են շփոթեցնել Google Play-ին: Դուրս եկեք այլ հաշիվներից կամ տեղադրեք Google Play կայքի միջոցով, որը ստիպում է կապեր կոնկրետ հաշվի հետ:</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Դիտեք ձեր Pro կարգավիճակը</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Միանգամյա գնում</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Sinkronisasi Play Store mungkin memerlukan waktu. Coba restart, bersihkan cache Google Play, atau tunggu sebentar.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Beberapa akun dapat membingungkan Google Play. Keluar dari akun lain atau pasang aplikasi melalui situs web Google Play, yang memaksa penghubungan dengan akun tertentu.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Lihat status Pro Anda</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Sekali bayar</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store samstilling getur tekið tíma. Reyndu að endurræsa, hreinsa Google Play skyndiminni eða bara bíða.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Margir reikningar geta ruglað Google Play. Skráðu þig út úr öðrum reikningum eða settu upp í gegnum Google Play vefsíðuna, sem neyðir tengsl við ákveðinn reikning.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Skoða Pro-stöðu þína</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Einskiptiskaup</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronizzazione del Play Store potrebbe richiedere tempo. Prova a riavviare, cancellare la cache di Google Play o semplicemente ad aspettare.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Più account possono confondere Google Play. Esci dagli altri account o installare da PC attraverso il sito web di Google Play, che costringe le associazioni con un account specifico.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Visualizza il tuo stato Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Acquisto una tantum</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">הסנכרון של גוגל פליי עשוי לקחת זמן. נסה לאתחל מחדש, לנקות את המטמון של גוגל פליי או פשוט המתן.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">חשבונות מרובים יכולים לבלבל את Google Play. התנתק מחשבונות אחרים או התקן דרך אתר Google Play, מה שמאלץ שיוכים עם חשבון ספציפי.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">הצגת סטטוס ה-Pro שלכם</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">רכישה חד-פעמית</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Playストアの同期には時間がかかる場合があります。 そのまましばらくお待ちください。改善されない場合は、再起動するか、Playストアのキャッシュを削除してみてください。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">複数のGoogleアカウントでログインしてあると、Playストアで不具合が発生する場合があります。 他のアカウントからログアウトするか、Web版Playストアからインストールすることで、正常にGoogleアカウントとの連携がされます。</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Proステータスを確認</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">1 回限りの購入</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store სინქრონიზაციას შეიძლება დრო დასჭირდეს. სცადეთ გადატვირთვა, Google Play ქეშის გასუფთავება ან უბრალოდ დაელოდეთ.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">მრავალი ანგარიში შეიძლება აბნევდეს Google Play-ს. გამოდით სხვა ანგარიშებიდან ან დააინსტალირეთ Google Play ვებსაიტის მეშვეობით, რაც აიძულებს კონკრეტულ ანგარიშთან ასოციაციას.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">იხილეთ თქვენი Pro სტატუსი</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">ერთჯერადი შეძენა</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">ការធ្វើសមកាលកម្ម Play Store អាចចំណាយពេល។ សាកល្បងចាប់ផ្តើមឡើងវិញ សម្អាតឃ្លាំងសម្ងាត់ Google Play ឬគ្រាន់តែរង់ចាំ។</string>
     <string name="upgrade_screen_restore_multiaccount_hint">គណនីច្រើនអាចធ្វើឱ្យ Google Play ច្រឡំ។ ចេញពីគណនីផ្សេងទៀត ឬដំឡើងតាមរយៈគេហទំព័រ Google Play ដែលបង្ខំការភ្ជាប់ជាមួយគណនីជាក់លាក់។</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">មើលស្ថានភាព Pro របស់អ្នក</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">ការជាវតែម្ដងរួច</string>

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Hevdengkirina Play Store dibe ku wext bigire. Vegere, cache ya Google Play pak bike an tenê bisekine.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Hesabên gelek dikarin Google Play tevlihev bikin. Ji hesabên din derkeve an bi malpera Google Play saz bike.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Rewşa Pro-ya xwe bibîne</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Kîrîna yek carê</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store ಸಿಂಕ್ರೈನಿಕರಣಕ್ಕೆ ಸಮಯ ಕೆಲವುತ್ತದೆ. ಮರುಬುಟ್ ಮಾಡಿ, Google Play ಕ್ಯಾಚೆ ತೆರವುಮಾಡಿ ಅಥವಾ ಕಾಯಿರಿ.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ಬಹುಖಾತೆಗಳು Google Play ಅನ್ನು ಗೊಂದಲಗೊಳಿಸಬಹುದು. ಇತರ ಖಾತೆಗಳಿಂದ ಲಾಗ್ ಆಉಟ್ ಮಾಡಿ ಅಥವಾ Google Play ವೆಬ್ ತಾಣದ ಮೂಲಕ ಇನ್ಸ್ಟಾಲ್ ಮಾಡಿ.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">ನಿಮ್ಮ ಪ್ರೋ ಸ್ಥಿತಿ ನೋಡಿ</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">ಏಕ-ಕಾಲೀನ ಖರೀದಿ</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play 스토어 동기화는 시간이 걸릴 수 있습니다. 재부팅하거나 Google Play 캐시를 지우거나 잠시 기다려 보세요.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">기기에 등록된 여러 개의 계정으로 인해 Google Play가 혼동될 수 있습니다. 다른 계정을 로그아웃하거나 Google Play 웹사이트를 통해 설치하면 특정 계정과 강제로 연결됩니다.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Pro 상태 보기</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">영구적 구매</string>

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store синхрондоо уакыт алышы мүмкүн. Чүмүрлөө, Google Play кэшин тазалоону немесе жой күтүүдү бүлкүүнүз карап көрүңүз.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Бирден көп аккаунт Google Play арачан чаташтырат. Башка аккаунттардан чыгыңыз немесе белгилүү аккаунт менен байланышты мәжбүрлеечи Google Play вебсайты аркылу уруксаттырында орнотуңуз.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Сиздин Pro абалын көрүңүз</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Бир жолку сатып алуу</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">ການຊິງຄ໌ Play Store ອາດໃຊ້ເວລາ. ລອງຣີບູດ, ລ້າງແຄສ Google Play ຫຼືພຽງແຕ່ລໍຖ້າ.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ບັນຊີຫຼາຍບັນຊີສາມາດເຮັດໃຫ້ Google Play ສັບສົນ. ອອກຈາກລະບົບຈາກບັນຊີອື່ນ ຫຼືຕິດຕັ້ງຜ່ານເວັບໄຊ Google Play, ເຊິ່ງບັງຄັບການເຊື່ອມໂຍງກັບບັນຊີສະເພາະ.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">ເບິ່ງສະຖານະ Pro ຂອງທ່ານ</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">ການຊື້ຄັ້ງດຽວ</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sinchronizacija gali užtrukti. Pabandykite paleisti iš naujo, išvalyti Google Play talpyklą arba tiesiog palaukti.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Kelios paskyros gali supainioti Google Play. Atsijunkite nuo kitų paskyrų arba įdiekite per Google Play svetainę, kuri priverčia susieti su konkrečia paskyra.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Peržiūrėkite savo Pro būseną</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Vienkartinis pirkimas</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sinhronizācija var aizņemt laiku. Mēģiniet restartēt, notīrīt Google Play kešatmiņu vai vienkārši uzgaidīt.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Vairāki konti var sajaukt Google Play. Izejiet no citiem kontiem vai instalējiet caur Google Play tīmekļa vietni, kas piespiedu kārtā izveido asociācijas ar konkrētu kontu.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Skatīt savu Pro statusu</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Vienreizējs pirkums</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизацијата на Play Store може да потрае. Обидете се да рестартирате, исчистете ја кеш меморијата на Google Play или едноставно почекајте.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Повеќе сметки можат да го збунат Google Play. Одјавете се од другите сметки или инсталирајте преку веб-страницата на Google Play, што принудува асоцијации со конкретна сметка.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Погледнете го вашиот Pro статус</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Еднократна купувачка</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play സ്റ്റോർ സിൻക്രൊണൈസേഷൻ സമയമെടുത്തേക്കാം. റീബൂട്ട് ചെയ്യുക, Google Play കാഷെ മായ്‌ക്കുക അല്ലെങ്കിൽ കാത്തിരിക്കുക.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">ഒന്നിലധികം അക്കൗണ്ടുകൾ Google Play-യെ ആശയക്കുഴപ്പത്തിലാക്കാം. മറ്റ് അക്കൗണ്ടുകളിൽ നിന്ന് ലോഗൗട്ട് ചെയ്യുക അല്ലെങ്കിൽ Google Play വെബ്‌സൈറ്റ് വഴി ഇൻസ്റ്റാൾ ചെയ്യുക, ഇത് ഒരു നിർദ്ദിഷ്ട അക്കൗണ്ടുമായുള്ള ബന്ധം നിർബന്ധമാക്കുന്നു.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">നിങ്ങളുടെ Pro സ്ഥിതി കാണുക</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">ഒറ്റത്തവണ വാങ്ങൽ</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store синк хийхэд хугацаа шаардагдаж магадгүй. Дахин эхлүүлэх, Google Play кэшийг цэвэрлэх эсвэл зүгээр хүлээхийг оролдоно уу.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Олон бүртгэл Google Play-г төөрөгдүүлж болно. Бусад бүртгэлээс гарах эсвэл Google Play вэбсайтаар дамжуулан суулгах нь тодорхой бүртгэлтэй холбоосыг албадаж өгдөг.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Таны Pro статусыг үзэх</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Нэг удаагийн худалдан авалт</string>

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store सिंक्रोनायझेशनला वेळ लागू शकतो. रीबूट करण्याचा, Google Play कॅश साफ करण्याचा प्रयत्न करा किंवा फक्त थांबा.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">अनेक खाती Google Play ला गोंधळात टाकू शकतात. इतर खात्यांतून लॉग आउट व्हा किंवा Google Play वेबसाइटवरून इन्स्टॉल करा, जे विशिष्ट खात्याशी संबंध जोडण्यास भाग पाडते.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">आपली Pro स्थिती पहा</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">एकवेळी खरेदी</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Penyegerakan Play Store mungkin mengambil masa. Cuba but semula, kosongkan cache Google Play atau tunggu sahaja.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Pelbagai akaun boleh mengelirukan Google Play. Log keluar dari akaun lain atau pasang melalui laman web Google Play, yang memaksa perkaitan dengan akaun tertentu.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Lihat status Pro anda</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Belian sekali</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sync လုပ်ရန် အချိန်ယူနိုင်ပါသည်။ ပြန်လည်စတင်ခြင်း၊ Google Play cache ရှင်းလင်းခြင်း သို့မဟုတ် ရိုးရိုးစောင့်ဆိုင်းခြင်း ပြုလုပ်ကြည့်ပါ။</string>
     <string name="upgrade_screen_restore_multiaccount_hint">အကောင့်များစွာသည် Google Play ကို ရှုပ်ထွေးစေနိုင်သည်။ အခြားအကောင့်များမှ ထွက်ပါ သို့မဟုတ် Google Play ဝဘ်ဆိုဒ်မှတစ်ဆင့် ထည့်သွင်းပါ၊ ၎င်းသည် သတ်မှတ်ထားသော အကောင့်နှင့် ချိတ်ဆက်မှုကို တွန်းအားပေးသည်။</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">သင်၏Pro အခြေအနေကိုကြည့်ရှုပါ</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">တစ်ကြိမ်တည်း ဝယ်ယူမှု</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store सिङ्कमा समय लाग्न सक्छ। रिबुट गर्ने, Google Play क्यास खाली गर्ने वा केवल पर्खने प्रयास गर्नुहोस्।</string>
     <string name="upgrade_screen_restore_multiaccount_hint">धेरै खाताहरूले Google Play लाई भ्रमित गर्न सक्छ। अन्य खाताहरूबाट लग आउट गर्नुहोस् वा Google Play वेबसाइट मार्फत स्थापना गर्नुहोस्, जसले विशिष्ट खातासँग सम्बन्धहरू बल गर्दछ।</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">आफ्नो Pro स्थिति हेर्नुहोस्</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">एक-पटक खरिद</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Synchronisatie via de Play Store kan enige tijd duren. Probeer opnieuw op te starten, de Google Play cache te wissen of wacht gewoon.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Meerdere accounts kunnen Google Play in verwarring brengen. Meld je af bij andere accounts of installeer deze via de website van Google Play, waardoor koppelingen met een specifiek account worden afgedwongen.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Bekijk je Pro-status</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Eenmalige aankoop</string>

--- a/app/src/gplay/res/values-no/strings.xml
+++ b/app/src/gplay/res/values-no/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Synkronisering med Play Butikk kan ta tid. Prøv å starte på nytt, tømme Google Play bufferen, eller bare vent.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Flere kontoer kan forvirre Google Play. Logg ut av andre kontoer eller installer via Google Play-nettstedet, som tvinger assosiasjoner til en spesifikk konto.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Vis Pro-status</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Engangskjøp</string>

--- a/app/src/gplay/res/values-pcm-rNG/strings.xml
+++ b/app/src/gplay/res/values-pcm-rNG/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store synchronization fit take time. Try reboot, clear Google Play cache or just wait.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Multiple accounts fit confuse Google Play. Log out of other accounts or install through di Google Play website, wey go force association with specific account.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">See your Pro status</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">One-time purchase</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Synchronizacja Sklepu Play może zająć trochę czasu. Spróbuj uruchomić ponownie, wyczyścić pamięć podręczną Google Play lub po prostu poczekać.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Wiele kont może powodować problemy z Google Play. Wyloguj się z innych kont lub zainstaluj aplikację przez stronę Google Play, co wymusi powiązanie z konkretnym kontem.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Zobacz swój status Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Jednorazowy zakup</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">A sincronização da Play Store pode demorar bastante. Tente reiniciar, limpar o cache do Google Play ou simplesmente aguarde.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Várias contas podem confundir o Google Play. Saia de outras contas ou instale através do site do Google Play, o que força associações com uma conta específica.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Ver seu status Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Compra de uma só vez</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">A sincronização com Play Store pode demorar. Tente reiniciar, limpar a cache do Google Play ou simplesmente aguarde.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Várias contas podem confundir o Google Play. Sair das outras contas ou instalar através do site do Google Play, forçando associações com uma conta específica.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Ver o estado do teu Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Compra única</string>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">La sincronisaziun cun il Play Store po prender temp. Emprova da ristar l\'apparat, da stgular il cache da Google Play u simplamain spetga.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Divers contos pon cunfunder Google Play. Sorta dad autri contos u installa via il website da Google Play, che forza l\'assoziaziun cun in conto specific.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Vesair tiu status Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Cumpaira ina giada</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Sincronizarea Magazinului Play poate dura timp. Încercați repornirea, ștergeți memoria cache Google Play sau doar așteptați.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Conturile multiple pot deruta Google Play. Deconectați-vă din alte conturi sau instalați prin site-ul Google Play, care forțează asociațiile cu un anumit cont.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Vizualizează-ți statusul Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Achiziție unică</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизация Play Store может занять некоторое время. Попробуйте перезагрузиться, очистить кэш Google Play или просто подождать.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Множественные аккаунты могут путать Google Play. Выйдите из других аккаунтов или установите через веб-сайт Google Play, который определяет связь с определенной учетной записью.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Посмотреть статус Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Единовременная покупка</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Sa sincronizatzione de Play Store podet leare tempus. Proa a torrare a allùghere, limpiare sa cache de Google Play o simplesmente iseta.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Contos mùltiplos podent cunfùndere Google Play. Essi dae àteros contos o installa dae su situ web de Google Play, chi fortza assotziatziones cun unu contu ispetzìficu.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Controlla sa tua situatzione Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Cùmperu de una borta</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store සමමුහුර්ත කිරීමට කාලය ගත විය හැක. නැවත ආරම්භ කිරීම, Google Play හැඹිලිය මැකීම හෝ සරලව රැඳී සිටීමට උත්සාහ කරන්න.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">බහු ගිණුම් Google Play ව්‍යාකූල කළ හැක. වෙනත් ගිණුම් වලින් පිටවන්න හෝ Google Play වෙබ් අඩවිය හරහා ස්ථාපනය කරන්න, එය නිශ්චිත ගිණුමක් සමඟ සම්බන්ධතා බල කරයි.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">ඔබේ Pro තත්වය බලන්න</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">එක් වරක් මිලදී ගැනීම</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Synchronizácia Obchodu Play môže chvíľu trvať. Skúste reštartovať, vymazať vyrovnávaciu pamäť Google Play alebo jednoducho počkajte.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Viaceré účty môžu zmiasť Google Play. Odhláste sa z iných účtov alebo nainštalujte prostredníctvom webovej stránky Google Play, čo si vynúti priradenie ku konkrétnemu účtu.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Zobraziť stav vášho Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Jednorazový nákup</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Sinhronizacija s Trgovino Play bo morda trajala nekaj časa.  Poizkusite s ponovnim zagnom naprave, čiščenjem predpomnilnika Googla Play ali preprosto počakajte.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Več računov lahko zmede Google Play.  Odjavite se iz drugih računov ali namestite preko spletne strani Google Play, ki vsili povezavo z določenim računom.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Preglejte svoj status Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Enkratni nakup</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Sinkronizimi i Play Store-it mund të marrë kohë. Provoni të rindizni, pastroni cache-in e Google Play ose thjesht prisni.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Llogaritë e shumta mund të habisin Google Play. Dilni nga llogaritë e tjera ose instaloni përmes faqes së internetit të Google Play, gjë që detyron lidhjet me një llogari specifike.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Shikoni statusin tuaj Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Blerje një herë</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронизација Play Store може потрајати. Покушајте поново покретање, брисање Google Play кеша или једноставно сачекајте.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Више налога може збунити Google Play. Одјавите се са других налога или инсталирајте преко Google Play веб сајта, што приморава везе са одређеним налогом.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Погледајте свој Pro статус</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Једнократна куповина</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store-synkronisering kan ta tid. Försök starta om, rensa Google Play-cache eller bara vänta.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Flera konton kan förvirra Google Play. Logga ut från andra konton eller installera via Google Play-webbplatsen, vilket tvingar associationer med ett specifikt konto.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Visa din Pro-status</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Engångsköp</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Ulandanishi wa Play Store unaweza kuchukua muda. Jaribu kuanzisha upya, kusafisha akiba ya Google Play au tu subiri.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Akaunti nyingi zinaweza kuchanganya Google Play. Toka kwenye akaunti zingine au sakinisha kupitia tovuti ya Google Play, ambayo inalazimisha uhusiano na akaunti maalum.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Tazama hali ya Pro yako</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Ununuzi wa mara moja</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store ஒத்திசைவு நேரம் எடுக்கலாம். மறுதொடக்கம் செய்ய, Google Play தற்காலிக சேமிப்பை அழிக்க அல்லது காத்திருக்க முயற்சிக்கவும்.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">பல கணக்குகள் Google Playஐ குழப்பலாம். மற்ற கணக்குகளிலிருந்து வெளியேறவும் அல்லது Google Play வலைத்தளம் வழியாக நிறுவவும், இது குறிப்பிட்ட கணக்குடன் தொடர்புகளை கட்டாயப்படுத்துகிறது.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">உங்கள் Pro நிலையைப் பார்க்கவும்</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">ஒரு முறை வாங்குதல்</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store సమకాలీకరణ సమయం పట్టవచ్చు. రీబూట్ చేయడానికి, Google Play కాష్‌ని క్లియర్ చేయడానికి లేదా కేవలం వేచి ఉండటానికి ప్రయత్నించండి.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">బహుళ ఖాతాలు Google Playని గందరగోళానికి గురి చేయవచ్చు. ఇతర ఖాతాల నుండి లాగ్ అవుట్ చేయండి లేదా Google Play వెబ్‌సైట్ ద్వారా ఇన్‌స్టాల్ చేయండి, ఇది నిర్దిష్ట ఖాతాతో అనుబంధాలను బలవంతం చేస్తుంది.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">మీ ప్రో స్థితిని చూడండి</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">ఒకేసారి కొనేయి</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">การซิงค์ Play Store อาจใช้เวลา ลองรีบูต ล้างแคช Google Play หรือรอสักครู่</string>
     <string name="upgrade_screen_restore_multiaccount_hint">บัญชีหลายบัญชีอาจทำให้ Google Play สับสน ออกจากบัญชีอื่นหรือติดตั้งผ่านเว็บไซต์ Google Play ซึ่งบังคับให้เชื่อมโยงกับบัญชีเฉพาะ</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">ดูสถานะ Pro ของคุณ</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">ซื้อครั้งเดียว</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store senkronizasyonu zaman alabilir. Yeniden başlatmayı, Google Play önbelleğini temizlemeyi deneyin veya sadece bekleyin.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Birden fazla hesap Google Play\'i karıştırabilir. Diğer hesaplardan çıkış yapın veya belirli bir hesapla ilişkilendirmeye zorlayan Google Play web sitesi üzerinden yükleyin.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Pro durumunuzu görüntüleyin</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Tek seferlik satın alma</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Синхронізація Play Store може зайняти деякий час. Спробуйте перезавантажити, очистити кеш Google Play або просто почекати.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Кілька облікових записів можуть заплутати Google Play. Вийдіть з інших облікових записів або встановлюйте через вебсайт Google Play, який примушує асоціювати їх з певним обліковим записом.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Переглянути свій статус Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Одноразова покупка</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store سنک میں وقت لگ سکتا ہے۔ ری بوٹ کرنے، Google Play کیش صاف کرنے یا صرف انتظار کرنے کی کوشش کریں۔</string>
     <string name="upgrade_screen_restore_multiaccount_hint">متعدد اکاؤنٹس Google Play کو الجھا سکتے ہیں۔ دیگر اکاؤنٹس سے لاگ آوٹ کریں یا Google Play ویب سائٹ کے ذریعے انسٹال کریں، جو مخصوص اکاؤنٹ کے ساتھ ایسوسی ایشن کو مجبور کرتا ہے۔</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">اپنی Pro حالت دیکھیں</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">ایک بار کی خریداری</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store sinxronlashtiruvi vaqt olishi mumkin. Qayta ishga tushirish, Google Play keshini tozalash yoki shunchaki kutishni sinab ko\'ring.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Ko\'p hisoblar Google Play-ni chalkashtirib yuborishi mumkin. Boshqa hisoblardan chiqing yoki Google Play veb-sayti orqali o\'rnating, bu esa ma\'lum bir hisob bilan bog\'lanishni majburiy qiladi.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Pro statusini ko\'ring</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Bir martalik xarid</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Đồng bộ hóa Cửa hàng Play có thể mất thời gian. Hãy thử khởi động lại, xóa bộ nhớ đệm của Google Play hoặc chỉ cần đợi.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Nhiều tài khoản có thể gây nhầm lẫn cho Google Play. Đăng xuất khỏi các tài khoản khác hoặc cài đặt thông qua trang web Google Play, trang này buộc liên kết với một tài khoản cụ thể.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Xem trạng thái Pro của bạn</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Thanh toán một lần</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play 商店同步可能需要一些时间。尝试重启设备、清除 Google Play 缓存或稍作等候。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">多个账户可能会导致 Google Play 混乱。注销其他账户或通过 Google Play 网站进行安装，这可强制与特定账户关联。</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">查看您的 Pro 状态</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">一次性购买</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play Store 同步可能需要時間。嘗試重新啟動、清除 Google Play 快取或只是等待。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">多個帳戶可能會混淆 Google Play。從其他帳戶登出或透過 Google Play 網站安裝，這會強制與特定帳戶建立關聯。</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">檢視您的 Pro 狀態</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">一次購買</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Play 商店同步處理可能需要一些時間。請嘗試重新開機、清除 Google Play 快取或只需等候。</string>
     <string name="upgrade_screen_restore_multiaccount_hint">多重帳戶可能會導致 Google Play 混亂。登出其他帳戶或透過 Google Play 網站安裝，這會強制與特定帳戶關聯。</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">查看您的 Pro 狀態</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">一次購買</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -21,7 +21,6 @@
     <string name="upgrade_screen_restore_sync_patience_hint">Ukuvumelanisa kwe-Play Store kungathatha isikhathi. Zama ukuphinde uqalise, ukusula i-cache ye-Google Play noma ulinde nje.</string>
     <string name="upgrade_screen_restore_multiaccount_hint">Ama-akhawunti amaningi angadunga i-Google Play. Phuma kwamanye ama-akhawunti noma ufake ngewebhusayithi ye-Google Play, ephoqa ukuhlobanisa ne-akhawunti ethile.</string>
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">Buka isimo sakho se-Pro</string>
     <!-- Pro status view: owned products -->
     <string name="upgrade_screen_owned_iap_title">Ukuthenga kube kanye</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -25,7 +25,6 @@
     <string name="upgrade_screen_restore_multiaccount_hint">Multiple accounts can confuse Google Play. Log out of other accounts or install through the Google Play website, which forces associations with a specific account.</string>
 
     <!-- Settings status row (also defined in the FOSS flavor with FOSS wording) -->
-    <string name="settings_upgrade_status_title">BVM Pro</string>
     <string name="settings_upgrade_status_desc">View your Pro status</string>
 
     <!-- Pro status view: owned products -->

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreen.kt
@@ -47,6 +47,7 @@ import eu.darken.bluemusic.common.navigation.NavigationDestination
 import eu.darken.bluemusic.common.settings.SettingsBaseItem
 import eu.darken.bluemusic.common.settings.SettingsCategoryHeader
 import eu.darken.bluemusic.common.settings.SettingsDivider
+import eu.darken.bluemusic.upgrade.ui.brandTitleText
 import eu.darken.bluemusic.upgrade.ui.brandTitleTwoTone
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 
@@ -175,7 +176,7 @@ fun SettingsIndexScreen(
                 SettingsBaseItem(
                     icon = Icons.TwoTone.Stars,
                     title = if (state.isUpgraded) {
-                        stringResource(R.string.settings_upgrade_status_title)
+                        brandTitleText(includeQualifier = true)
                     } else {
                         stringResource(R.string.upgrade_prompt_title)
                     },

--- a/app/src/test/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreenTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/ui/settings/SettingsIndexScreenTest.kt
@@ -1,0 +1,72 @@
+package eu.darken.bluemusic.main.ui.settings
+
+import android.content.Context
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.hasScrollAction
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithText
+import androidx.compose.ui.test.performScrollToNode
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+import org.junit.Test
+import org.robolectric.annotation.Config
+import testhelpers.compose.BaseComposeRobolectricTest
+
+/**
+ * Guards the upgraded Settings row against drifting from the composed brand title. The row used to
+ * read its own per-locale resource — a hardcoded copy of the brand that disagreed with the
+ * dashboard and upgrade screen in a third of the locales — so what matters here is that the
+ * rendered row goes through the shared composition, not what the words happen to be.
+ */
+class SettingsIndexScreenTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val composedTitle: String
+        get() = context.getString(
+            R.string.app_name_upgraded_template,
+            context.getString(R.string.app_name_short),
+            context.getString(R.string.app_name_upgrade_postfix),
+        )
+
+    private fun assertUpgradedRowShowsComposedTitle() {
+        composeRule.setContent {
+            PreviewWrapper {
+                SettingsIndexScreen(
+                    state = SettingsViewModel.State(versionText = "test", isUpgraded = true),
+                    snackbarHostState = SnackbarHostState(),
+                    onNavigateUp = {},
+                    onNavigateTo = {},
+                    onOpenUrl = {},
+                    onCopyVersion = {},
+                )
+            }
+        }
+        composeRule.waitForIdle()
+
+        // The row's subtitle is the unique anchor; the title text alone also matches the top bar.
+        composeRule.onNode(hasScrollAction())
+            .performScrollToNode(hasText(context.getString(R.string.settings_upgrade_status_desc)))
+
+        // Exactly two surfaces carry the composed title: the top bar and the upgrade row. A row
+        // that regressed to its own literal would leave the top bar as the only match.
+        composeRule.onAllNodesWithText(composedTitle).assertCountEquals(2)
+    }
+
+    @Test
+    fun `the upgraded settings row renders the composed brand title`() {
+        assertUpgradedRowShowsComposedTitle()
+    }
+
+    // German is a locale whose brand short name differs from the default, so unlike the default
+    // locale (where a hardcoded English copy would coincide with the composition), this variant
+    // fails if the row stops composing from the locale's own resources.
+    @Test
+    @Config(qualifiers = "de")
+    fun `the upgraded settings row renders the composed brand title in German`() {
+        assertUpgradedRowShowsComposedTitle()
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/upgrade/ui/BrandTitleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/upgrade/ui/BrandTitleTest.kt
@@ -103,6 +103,31 @@ class BrandTitleTest : BaseComposeRobolectricTest() {
         result.text shouldBe composed
     }
 
+    // The Settings upgrade row composes its title through brandTitleText, the upgrade screen
+    // through upgradeScreenTitle. The row used to read its own resource key — a hardcoded
+    // per-locale copy of the brand that had drifted from the composed title — so the agreement
+    // between the two surfaces is the property to guard, not any literal.
+    @Test
+    fun `the settings row title agrees with the upgrade screen title`() {
+        lateinit var settingsRow: String
+        lateinit var upgradeFree: AnnotatedString
+        lateinit var upgradeUpgraded: AnnotatedString
+        composeRule.setContent {
+            PreviewWrapper {
+                settingsRow = brandTitleText(includeQualifier = true)
+                upgradeFree = upgradeScreenTitle(upgraded = false)
+                upgradeUpgraded = upgradeScreenTitle(upgraded = true)
+            }
+        }
+        composeRule.waitForIdle()
+
+        settingsRow shouldBe upgradeFree.text
+        settingsRow shouldBe upgradeUpgraded.text
+        settingsRow shouldBe composed
+        // Exactly once: a doubled qualifier would still "agree" across surfaces.
+        Regex(Regex.escape(qualifier)).findAll(settingsRow).count() shouldBe 1
+    }
+
     // The two-tone top-bar title. Both colors are asserted by role, and both ranges by content —
     // the top bars are the surface the original bug shipped on, and a regression that flattened
     // them to one tone (or swapped which part carries which role) would still render correct text.


### PR DESCRIPTION
## What

The upgraded Settings row read `settings_upgrade_status_title` — a hardcoded composed brand string ("BVM Pro" / "BVM FOSS") duplicated per flavour with 77 locale overrides each. It was a second copy of the brand and had drifted from the composed title the dashboard and upgrade screen render via `brandTitle`/`brandTitleText` (`app_name_short` + `app_name_upgrade_postfix` through `app_name_upgraded_template`).

- `SettingsIndexScreen` now composes the row title via `brandTitleText(includeQualifier = true)` — the same composition as every other surface, so the row and the upgrade-screen title can no longer disagree.
- `settings_upgrade_status_title` is deleted from base + all 77 locale overrides in both flavours (156 files) and retired on Crowdin (sources re-uploaded, key confirmed absent).

## Visible changes

18 locales rendered the Settings row differently from the upgrade screen; they now agree. Before → after for the Settings row:

| Flavour | Locale | Was | Now |
|---|---|---|---|
| foss | de | BVM FOSS | BLM FOSS |
| foss | lv | BVM FOSS | BSP FOSS |
| gplay | de | BVM Pro | BLM Pro |
| gplay | lv | BVM Pro | BSP Pro |
| gplay | sv | BVM Pro | BVM Expert |
| gplay | ar | BVM Pro | BVM احترافي |
| gplay | fa | BVM Pro | BVM حرفه‌ای |
| gplay | hi-rIN | BVM Pro | BVM प्रो |
| gplay | iw | BVM Pro | BVM פרו |
| gplay | ka-rGE | BVM Pro | BVM პრო |
| gplay | km-rKH | BVM Pro | BVM ប្រូ |
| gplay | ko | BVM Pro | BVM 프로 |
| gplay | ml-rIN | BVM Pro | BVM പ്രോ |
| gplay | te-rIN | BVM Pro | BVM ప్రొ |
| gplay | th | BVM Pro | BVM โปร |
| gplay | zh-rCN | BVM Pro | BVM 专业版 |
| gplay | zh-rHK | BVM Pro | BVM 專業版 |
| gplay | zh-rTW | BVM Pro | BVM 專業版 |

The Latvian rows are the original defect this effort started from. All 138 other flavour-locale combinations already agreed and are unchanged.

## Tests

- `BrandTitleTest`: new assertion that the settings-row form (`brandTitleText`) agrees with `upgradeScreenTitle` in both upgraded states, with the qualifier appearing exactly once.
- `SettingsIndexScreenTest` (new): renders the actual screen upgraded and asserts the row carries the composed title — in the default locale and in German, a locale whose brand short name differs from the default so a regression to a hardcoded English copy fails instead of coinciding.

## Validation

`testGplayDebugUnitTest`, `testFossDebugUnitTest` (1075 tests, 0 failures), `assembleGplayDebug`, `assembleFossDebug` all pass. Zero occurrences of the key remain in the repo; Crowdin source string search returns empty.