### PR TITLE
Update app translations from Crowdin

### DIFF
--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Werk jaarlik by. Kanselleer enige tyd in Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Lewenslange ontgrendeling</string>
     <string name="upgrade_screen_iap_offer_body">Betaal eenkeer en besit Pro vir altyd.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Jy het %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Jy besit %1$s vir altyd.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Jou %1$s-inskripsie is aktief.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Jou inskripsie is nie ingestel om te vernuwe nie, so jy kan nou na die eenmalige aankoop oorskakel. Let op: dit is \'n aparte las wat jou inskripsie nie sal kanselleer of terugbetaal nie, so gebruik dieselfde Google-rekening vir albei.</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">ዓመት ነግ ታደድ. Google Play ውስጥ ማቋረጥ ይችሉ.</string>
     <string name="upgrade_screen_iap_offer_title">ሕይወት ሙሉ ሽቅ</string>
     <string name="upgrade_screen_iap_offer_body">አንድ ጊዜ ክፈል Pro ሕይወት ሙሉ ይሆን።</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">%1$s አለብዎ ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">እርስዎ %1$s ሕይወት ሙሉ ይይዝሉ።</string>
     <string name="upgrade_screen_owned_hero_sub_body">እርስዎ %1$s ደንገስ ንቁ ነው።</string>
     <string name="upgrade_screen_owned_iap_purchase_note">ወደ ደንገስ አሁን ማሪትዎ ተዘጋጅ አለ, ስለዚህ ወደ አንድ ጊዜ ግዢ ቀይር ይችሉ. ተጠንቂ: ይህ አንድ የተለየ ክፈያ ሂሳብ ወይም refund ደንገስ, ስለዚህ ሁለቱም ተመሳሳይ Google ሂሳብ ይጠቀም.</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">يتجدد سنويًا. ألغِ الاشتراك في أي وقت عبر Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">فتح مدى الحياة</string>
     <string name="upgrade_screen_iap_offer_body">ادفع مرة واحدة وامتلك Pro للأبد.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">لديك %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">تمتلك %1$s للأبد.</string>
     <string name="upgrade_screen_owned_hero_sub_body">اشتراك %1$s الخاص بك نشط.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">اشتراكك غير مضبوط على التجديد، لذا يمكنك التبديل إلى الشراء لمرة واحدة الآن. تنبيه: إنها رسوم منفصلة لن تلغي أو ترد اشتراكك، لذا استخدم نفس حساب Google لكليهما.</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Hər il yenilənir. İstənilən vaxt Google Play-də ləğv edin.</string>
     <string name="upgrade_screen_iap_offer_title">Ömürlük açılış</string>
     <string name="upgrade_screen_iap_offer_body">Bir dəfə ödəyin və Pro-nu əbədi olaraq sahibləşin.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Sənin %1$s var ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Siz %1$s-ni əbədi olaraq sahibləşirsiniz.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Sizin %1$s abonəliyi fəal.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Sizin abonəlikiniz yenilənmək üçün təyin edilməmişdir, buna görə indi bir dəfə alışa keçə bilərsiz. Xahiş edirik qeyd edin: bu, sizin abonəlikinizi ləğv etməyəcək və ya geri qaytarmayacaq ayrı bir ödəniş olacaqdır, buna görə hər ikisi üçün eyni Google hesabını istifadə edin.</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Аднаўляецца кожны год. Адмяніце ў любы час ў Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Развязаны на жыццё</string>
     <string name="upgrade_screen_iap_offer_body">Заплаціце адзін раз і валодайце Pro вечна.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">У цябе ёсць %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Вы валодаеце %1$s вечна.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ваша падпіска на %1$s актыўна.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Ваша падпіска не наладжана на аднаўленне, таму вы можаце зараз перайсці на адноразавую пакупку. Увага: гэта адзельны платёж, адмена якога не адменіт вашу падпіцу, таму выкарыстоўвайце адзін ліч Google для абодвух.</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Подновява се ежегодно. Отмяна по всяко време в Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Пожизнено отключване</string>
     <string name="upgrade_screen_iap_offer_body">Платете веднъж и имайте Pro завинаги.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Имате %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Вие имате %1$s завинаги.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Вашият %1$s абонамент е активен.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Вашият абонамент не е настроен за подновяване, така че можете да преминете към еднократната покупка сега. Внимание: това е отделна такса, която няма да отмени или възстанови вашия абонамент, така че използвайте един и същ Google акаунт за двата.</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">বার্ষিক নবায়ন করুন। Google Play-এ যেকোনো সময় বাতিল করুন।</string>
     <string name="upgrade_screen_iap_offer_title">আজীবন আনলক</string>
     <string name="upgrade_screen_iap_offer_body">একবার পেমেন্ট করুন এবং চিরকাল Pro মালিক হন।</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">আপনার %1$s আছে ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">আপনি %1$s চিরকাল মালিক।</string>
     <string name="upgrade_screen_owned_hero_sub_body">আপনার %1$s সাবস্ক্রিপশন সক্রিয়।</string>
     <string name="upgrade_screen_owned_iap_purchase_note">আপনার সাবস্ক্রিপশন নবায়নের জন্য সেট করা নেই, তাই আপনি এখন এককালীন ক্রয়ে স্যুইচ করতে পারেন। মনোযোগ দিন: এটি একটি আলাদা চার্জ যা আপনার সাবস্ক্রিপশন বাতিল বা রিফান্ড করবে না, তাই উভয়ের জন্য একই Google অ্যাকাউন্ট ব্যবহার করুন।</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Es renova anualment. Cancel·leu en qualsevol moment al Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Desbloqueig de per vida</string>
     <string name="upgrade_screen_iap_offer_body">Paga una vegada i posseeix Pro per sempre.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tens %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Posseixes %1$s per sempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">La teva subscripció %1$s està activa.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">La teva subscripció no està configurada per renovar-se, així que ara pots canviar a la compra única. Avís: és un càrrec separat que no cancel·larà ni reemborsar la teva subscripció, així que utilitza el mateix compte de Google per a tots dos.</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Obnovuje se ročně. Zrušit lze kdykoli v Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Trvalé odemčení</string>
     <string name="upgrade_screen_iap_offer_body">Zaplaťte jednou a vlastněte Pro navždy.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Máš %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Vlastníte %1$s navždy.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Vaše předplatné %1$s je aktivní.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Vaše předplatné není nastaveno na obnovení, takže nyní můžete přejít na jednorázový nákup. Pozor: jedná se o oddělený poplatek, který neodstráni ani nevrátí vaše předplatné, takže pro obě možnosti použijte stejný účet Google.</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Fornyes årligt. Annuller når som helst i Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Livstidslås op</string>
     <string name="upgrade_screen_iap_offer_body">Betal én gang og få Pro for evigt.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Du har %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Du ejer %1$s for evigt.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Dit %1$s-abonnement er aktivt.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Dit abonnement er ikke indstillet til at blive fornyet, så du kan skifte til engangskøbet nu. Pas på: det er en separat afgift, som ikke annullerer eller refunderer dit abonnement, så brug den samme Google-konto til begge dele.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Verlängert sich jährlich. Jederzeit über Google Play kündbar.</string>
     <string name="upgrade_screen_iap_offer_title">Einmalkauf</string>
     <string name="upgrade_screen_iap_offer_body">Einmal bezahlen und Pro dauerhaft nutzen.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Du hast %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Du besitzt %1$s für immer.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Dein %1$s-Abonnement ist aktiv.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Dein Abonnement ist nicht auf Verlängerung eingestellt, daher kannst du jetzt zum Einmalkauf wechseln. Achtung: Es ist eine separate Gebühr, die dein Abonnement nicht storniert oder erstattet, daher nutze für beide dasselbe Google-Konto.</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Ανανεώνεται ετησίως. Ακύρωση ανά πάσα στιγμή στο Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Ξεκλείδωμα για πάντα</string>
     <string name="upgrade_screen_iap_offer_body">Πληρώστε μια φορά και κατέχετε Pro για πάντα.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Έχεις %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Κατέχετε %1$s για πάντα.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Η συνδρομή σας %1$s είναι ενεργή.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Η συνδρομή σας δεν έχει ρυθμιστεί για ανανέωση, οπότε μπορείτε να κάνετε εναλλαγή στην αγορά μίας φοράς τώρα. Προσοχή: είναι ξεχωριστή χρέωση που δεν θα ακυρώσει ή επιστρέψει τη συνδρομή σας, επομένως χρησιμοποιήστε το ίδιο λογαριασμό Google και για τα δύο.</string>

--- a/app/src/gplay/res/values-eo-rUY/strings.xml
+++ b/app/src/gplay/res/values-eo-rUY/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Renoviĝas ĉiujare. Nuligu en ajna momento en Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Eterna malŝloseco</string>
     <string name="upgrade_screen_iap_offer_body">Pagu unu fojon kaj posedi Pro por ĉiam.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Vi havas %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Vi posedas %1$s por ĉiam.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Via %1$s abono estas aktiva.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Via abono ne estas agordita renoviĝi, do vi povas ŝanĝi al la unufoja aĉeto nun. Averto: ĝi estas aparta ĉargo, kiu ne nuligus aŭ repagus vian abonon, do uzu la saman Google-konton por ambaŭ.</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Se renueva anualmente. Cancelá en cualquier momento en Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Desbloqueo de por vida</string>
     <string name="upgrade_screen_iap_offer_body">Pagá una sola vez y tenés Pro para siempre.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tenés %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tenés %1$s para siempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tu suscripción a %1$s está activa.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Tu suscripción no está configurada para renovarse, así que podés cambiar a la compra única ahora. Aviso: es un cargo separado que no cancelará ni reembolsará tu suscripción, así que usá la misma cuenta de Google para ambas.</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Se renueva anualmente. Cancela en cualquier momento desde Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Desbloqueo de por vida</string>
     <string name="upgrade_screen_iap_offer_body">Paga una sola vez y ten Pro de por vida.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tienes %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tienes %1$s de por vida.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tu suscripción a %1$s está activa.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Tu suscripción no está configurada para renovarse, así que ahora puedes cambiar a la compra única. Aviso: es un cargo separado que no cancelará ni reembolsará tu suscripción, así que usa la misma cuenta de Google para ambas.</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Se renueva anualmente. Cancela en cualquier momento en Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Desbloqueo de por vida</string>
     <string name="upgrade_screen_iap_offer_body">Paga una sola vez y disfruta de Pro para siempre.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tienes %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tienes %1$s para siempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tu suscripción %1$s está activa.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Tu suscripción no está configurada para renovarse, así que puedes cambiar a la compra de una sola vez ahora. Atención: es un cargo separado que no cancelará ni reembolsará tu suscripción, así que usa la misma cuenta de Google para ambas.</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Uueneb igal aastal. Saate igal ajal Google Plays loobuda.</string>
     <string name="upgrade_screen_iap_offer_title">Igavene avamine</string>
     <string name="upgrade_screen_iap_offer_body">Maksa üks kord ja omanda Pro igaveseks.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Sul on %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Omad %1$s igaveseks.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Sinu %1$s tellimus on aktiivne.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Sinu tellimus pole seatud uuendamisele, seega saad nüüd ühekordsele ostule üle minna. Tähelepanu: see on eraldi kulumine, mis ei tühista ega refundee sinu tellimust, seega kasuta mõlema jaoks sama Google\'i kontot.</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Urtean behin berritsi. Atzera dezakezu Google Play-n nahi duzun unean.</string>
     <string name="upgrade_screen_iap_offer_title">Betirako desblokeo</string>
     <string name="upgrade_screen_iap_offer_body">Behin ordaindu eta Pro betirako.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Zure %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">%1$s betirako dituzu.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Zure %1$s harpidetzak aktibo daude.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Zure harpidetza ez dago berritsi ezarrita, beraz orain aldatu dezakezu ordain bakarrean. Kontuan: ordain bakarra berezia da eta ez du zure harpidetzari uko egingo, beraz kontua berean ordaindu beharko duzu.</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">هر سال تجدید می‌شود. در هر زمان در Google Play لغو کنید.</string>
     <string name="upgrade_screen_iap_offer_title">باز کردن دائمی</string>
     <string name="upgrade_screen_iap_offer_body">یک بار پرداخت کنید و Pro را برای همیشه داشته باشید.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">%1$s شما فعال است ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">شما برای همیشه %1$s را مالک هستید.</string>
     <string name="upgrade_screen_owned_hero_sub_body">اشتراک %1$s شما فعال است.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">اشتراک شما برای تجدید تنظیم نشده است، بنابراین اکنون می‌توانید به خریدهای یک‌باره تغییر دهید. توجه داشته باشید: این یک هزینه جداگانه است که اشتراک شما را لغو یا بازپرداخت نخواهد کرد، بنابراین برای هر دو از همان حساب Google استفاده کنید.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Uusitaan vuosittain. Peruuta milloin tahansa Google Playssa.</string>
     <string name="upgrade_screen_iap_offer_title">Elinikäinen avaus</string>
     <string name="upgrade_screen_iap_offer_body">Maksa kerran ja omista Pro ikuisesti.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Sinulla on %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Omistat %1$s ikuisesti.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tilauksesi %1$s on aktiivinen.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Tilauksesi ei ole asetettu uusiutumaan, joten voit nyt vaihtaa kertamaksuun. Huomio: se on erillinen maksu, joka ei peruuta tai palauta tilaustasi, joten käytä molemmissa samaa Google-tiliä.</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Nag-renew taun-taon. Maaaring kanselahin anumang oras sa Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Pangmatagalang unlock</string>
     <string name="upgrade_screen_iap_offer_body">Magbayad nang minsan at magmamay-ari ng Pro magpakailanman.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Mayroon kang %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Magmamay-ari ka ng %1$s magpakailanman.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ang iyong %1$s subscription ay aktibo.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Ang iyong subscription ay hindi itinakda na mag-renew, kaya maaari ka nang lumipat sa one-time purchase ngayon. Abiso: ito ay isang hiwalay na bayad na hindi magkakansel o magbabigay ng refund sa iyong subscription, kaya gamitin ang parehong Google account para sa pareho.</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Se renouvelle chaque année. Annulez à tout moment dans Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Déverrouillage à vie</string>
     <string name="upgrade_screen_iap_offer_body">Payez une fois et possédez Pro à jamais.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tu as %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Vous possédez %1$s à jamais.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Votre abonnement %1$s est actif.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Votre abonnement n\'est pas défini pour se renouveler, vous pouvez donc passer à l\'achat unique maintenant. Attention : c\'est un frais séparé qui n\'annulera ni ne remboursera votre abonnement, alors utilisez le même compte Google pour les deux.</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Renova anualmente. Cancela en calquera momento en Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Desbloqueo de por vida</string>
     <string name="upgrade_screen_iap_offer_body">Paga unha vez e terás Pro para sempre.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tes %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Posees %1$s para sempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">A túa subscrición de %1$s está activa.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">A túa subscrición non está configurada para renovarse, polo que podes cambiar á compra única agora. Aviso: é un cargo separado que non cancelará nin reembolsará a túa subscrición, polo que usa a mesma conta de Google para as dúas.</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">वार्षिक नवीनीकरण होता है। Google Play में कभी भी रद्द करें।</string>
     <string name="upgrade_screen_iap_offer_title">आजीवन अनलॉक</string>
     <string name="upgrade_screen_iap_offer_body">एक बार भुगतान करें और Pro को हमेशा के लिए रखें।</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">आपका %1$s सक्रिय है ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">आप %1$s को हमेशा के लिए रखते हैं।</string>
     <string name="upgrade_screen_owned_hero_sub_body">आपकी %1$s सदस्यता सक्रिय है।</string>
     <string name="upgrade_screen_owned_iap_purchase_note">आपकी सदस्यता नवीनीकरण के लिए सेट नहीं है, इसलिए आप अब एकबारी खरीद पर स्विच कर सकते हैं। ध्यान दें: यह एक अलग शुल्क है जो आपकी सदस्यता को रद्द या वापस नहीं करेगा, इसलिए दोनों के लिए एक ही Google खाते का उपयोग करें।</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Obnavlja se godišnje. Otkazite bilo kada u Google Play-u.</string>
     <string name="upgrade_screen_iap_offer_title">Doživotno otključavanje</string>
     <string name="upgrade_screen_iap_offer_body">Platite jednom i imajte Pro zauvijek.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Imaš %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Posjedujete %1$s zauvijek.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Vaša %1$s pretplata je aktivna.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Vaša pretplata nije postavljena na obnovu, pa možete sada preći na jednokratnu kupovinu. Napomena: to je odvojena naknada koja neće otkazati ili vratiti novac vaše pretplate, pa koristite isti Google račun za oba.</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Évente megújul. Bármikor törölheted a Google Play-ben.</string>
     <string name="upgrade_screen_iap_offer_title">Élettartam feloldás</string>
     <string name="upgrade_screen_iap_offer_body">Fizess egyszer, és a Pro funkciókat örökre megtartod.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Megvan %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Az %1$s örökre a tiéd.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Az %1$s előfizetésed aktív.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Az előfizetésed nem fog megújulni, így mostantól az egyszeri vásárlásra válthatsz. Figyelem: ez egy külön díj, amely nem szünteti meg és nem adja vissza az előfizetésed, ezért mindkettőhöz ugyanazt a Google-fiókot használd.</string>

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Վերամեկնարկվում տարեկան։ Ցանկացած ժամանակ չեղարկել Google Play-ում։</string>
     <string name="upgrade_screen_iap_offer_title">Ցմահ արձակում</string>
     <string name="upgrade_screen_iap_offer_body">Միանգամ վճարեք և տիրապետեք Pro-ին ընդմեր։</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Դու ունես %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Դուք տիրապետում եք %1$s-ին ընդմեր։</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ձեր %1$s բաժանորդագրությունը ակտիվ է։</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Ձեր բաժանորդագրությունը սահմանված չէ վերամեկնարկվելու համար, այնպես որ դուք կարող եք հիմա անցել միանգամյա ձեռքբերմանը։ Ուշադրություն. դա առանձին վճար է, որը չի չեղարկի կամ հետ չի կտա ձեր բաժանորդագրությունը, այնպես որ օգտագործեք նույն Google հաշիվը երկուսի համար։</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Diperbarui setiap tahun. Batalkan kapan saja di Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Akses seumur hidup</string>
     <string name="upgrade_screen_iap_offer_body">Bayar sekali dan miliki Pro selamanya.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Kamu punya %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Anda memiliki %1$s selamanya.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Langganan %1$s Anda aktif.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Langganan Anda tidak diatur untuk diperbarui, jadi Anda dapat beralih ke pembelian sekali bayar sekarang. Perhatian: ini adalah tagihan terpisah yang tidak akan membatalkan atau memberikan pengembalian dana untuk langganan Anda, jadi gunakan akun Google yang sama untuk keduanya.</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Endurnýist ár hvert. Segðu upp hvenær sem er í Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Ævarleigu aðgangur</string>
     <string name="upgrade_screen_iap_offer_body">Borga einu sinni og eiga Pro endalaust.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Þú átt %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Þú átt %1$s endalaust.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Þín %1$s áskrift er virk.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Þín áskrift er ekki stillt til endurnýjunar, svo þú getur skipt yfir í einfalda kaup nú. Viðvörun: þetta er sérstakt gjald sem mun ekki hætta við eða endurgreiða áskriftina þína, svo notaðu sama Google reikning fyrir bæði.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Si rinnova annualmente. Puoi disdire in qualsiasi momento in Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Sblocco permanente</string>
     <string name="upgrade_screen_iap_offer_body">Paga una volta e possiedi Pro per sempre.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Hai %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Possiedi %1$s per sempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Il tuo abbonamento %1$s è attivo.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Il tuo abbonamento non è impostato per il rinnovo, quindi puoi passare all\'acquisto una tantum adesso. Attenzione: è un addebito separato che non annullerà o rimborserà l\'abbonamento, quindi usa lo stesso account Google per entrambi.</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">מתחדש מדי שנה. בטל בכל עת ב-Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">פתיחה לכל החיים</string>
     <string name="upgrade_screen_iap_offer_body">שלם פעם אחת והחזק Pro לתמיד.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">יש לך %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">אתה מחזיק את %1$s לתמיד.</string>
     <string name="upgrade_screen_owned_hero_sub_body">המנוי שלך %1$s פעיל.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">המנוי שלך אינו מוגדר להתחדש, כך שתוכל לעבור לרכישה חד-פעמית עכשיו. זהירות: זו חיוב נפרד שלא יבטל או יחזיר את המנוי שלך, כך השתמש באותו חשבון Google לשניהם.</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">毎年更新されます。Google Play からいつでもキャンセルできます。</string>
     <string name="upgrade_screen_iap_offer_title">生涯ロック解除</string>
     <string name="upgrade_screen_iap_offer_body">1 回の支払いで Pro を永遠に所有できます。</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">%1$s です ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">%1$s を永遠に所有しています。</string>
     <string name="upgrade_screen_owned_hero_sub_body">あなたの %1$s サブスクリプションは有効です。</string>
     <string name="upgrade_screen_owned_iap_purchase_note">サブスクリプションが更新されるように設定されていないため、今は 1 回限りの購入に切り替えられます。注意：これは別の課金であり、サブスクリプションのキャンセルや払い戻しは行われません。両方に同じ Google アカウントを使用してください。</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">აახლოვდება ყოველი წელი. გაუქმება შესაძლებელია ნებისმიერ დროს Google Play-ში.</string>
     <string name="upgrade_screen_iap_offer_title">სამუდამო გახსნა</string>
     <string name="upgrade_screen_iap_offer_body">გადაიხადეთ ერთხელ და Pro სამუდამოდ თქვენი იქნება.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">თქვენი %1$s აქტიურია ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">თქვენ ფლობთ %1$s სამუდამოდ.</string>
     <string name="upgrade_screen_owned_hero_sub_body">თქვენი %1$s გამოწერა აქტიურია.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">თქვენი გამოწერა არ არის დაყენებული აახლოვებისთვის, ამიტომ ახლა შეგიძლიათ გადაერთოთ ერთჯერადი ყიდვაზე. ყურადღება: ეს არის ცალკე გადახდა, რომელიც არ გააუქმებს ან არ დააბრუნებს თქვენი გამოწერას, ამიტომ გამოიყენეთ ერთი და იგივე Google ანგარიში ორივესთვის.</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">បង្កើតឡើងវិញរៀងរាល់ឆ្នាំ។ បោះបង់នៅពេលណាក៏បាននៅក្នុង Google Play។</string>
     <string name="upgrade_screen_iap_offer_title">ការដោះលែកមានអាយុកាលជីវិត</string>
     <string name="upgrade_screen_iap_offer_body">ទូទាត់ម្តងហើយ ហើយមាន Pro រៀងរាល់ដង។</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">អ្នកមាន %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">អ្នកគឺម្ចាស់ %1$s រៀងរាល់ដង។</string>
     <string name="upgrade_screen_owned_hero_sub_body">ការលេខិកលក្ខណ៍ %1$s របស់អ្នកកំពុងសកម្ម។</string>
     <string name="upgrade_screen_owned_iap_purchase_note">ការលេខិកលក្ខណ៍របស់អ្នកមិនត្រូវបានកំណត់ដើម្បីបង្កើតឡើងវិញ ដូច្នេះអ្នកអាចប្តូរទៅការទិញម្តងដងឥឡូវនេះ។ ក្រលម៖ វាគឺជាការគិតថ្លៃដាច់ដោយឡែក ដែលលុបរំលាយ ឬសង្វិញការលេខិកលក្ខណ៍របស់អ្នកនឹងមិនកើតឡើងទេ ដូច្នេះប្រើគណនី Google ដដែលសម្រាប់ទាំងពីរ។</string>

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Her sal nûborn dike. Her dem de di Google Play de betal bike.</string>
     <string name="upgrade_screen_iap_offer_title">Azadî ya belavê</string>
     <string name="upgrade_screen_iap_offer_body">Carekî bide û Pro-yî eternê xwedî bike.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tu %1$s heye ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tu %1$s eternê xwedî dikî.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Abonementeya %1$s ya te çalak e.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Abonementeya te nabe ku nûborn bibe, ji ber vê tu niha dikarî derbasî kirrîna yekcarî yî. Baldar: ew jor a cuda ye ku nabe ku abonementeya te betal bibe an jî gerîyê bide, ji ber vê hesaba Google ya heman ji bo her du bikarbîne.</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">ವಾರ್ಷಿಕವಾಗಿ ನವೀಕರಣವಾಗುತ್ತದೆ. Google Play ನಲ್ಲಿ ಯಾವುದೇ ಸಮಯದಲ್ಲಿ ರದ್ದುಮಾಡಿ.</string>
     <string name="upgrade_screen_iap_offer_title">ಜೀವನಕಾಲದ ಅನ್‌ಲಾಕ್</string>
     <string name="upgrade_screen_iap_offer_body">ಒಮ್ಮೆ ಪಾವತಿ ಮಾಡಿ, ಶಾಶ್ವತವಾಗಿ ಪ್ರೋ ಪಡೆ.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">ನೀವು %1$s ಹೊಂದಿದ್ದೀರಿ ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">ನೀವು %1$s ಅನ್ನು ಶಾಶ್ವತವಾಗಿ ಹೊಂದಿದ್ದೀರಿ.</string>
     <string name="upgrade_screen_owned_hero_sub_body">ನಿಮ್ಮ %1$s ಸಂಚಯ ಸಕ್ರಿಯವಾಗಿದೆ.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">ನಿಮ್ಮ ಸದಸ್ಯತೆ ನವೀಕರಣಕ್ಕಾಗಿ ಹೊಂದಿಸಲಾಗಿಲ್ಲ, ಆದ್ದರಿಂದ ನೀವು ಈಗ ಏಕ-ಬಾರಿ ಖರೀದಿಗೆ ಬದಲಾಯಿಸಬಹುದು. ಗಮನಿಸಿ: ಇದು ಪ್ರತ್ಯೇಕ ಶುಲ್ಕವಾಗಿದ್ದು, ಇದು ನಿಮ್ಮ ಸದಸ್ಯತೆಯನ್ನು ರದ್ದುಗೊಳಿಸುವುದಿಲ್ಲ ಅಥವಾ ಮರುಪಾವತಿಸುವುದಿಲ್ಲ, ಆದ್ದರಿಂದ ಎರಡಕ್ಕೂ ಅದೇ Google ಖಾತೆಯನ್ನು ಬಳಸಿ.</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">매년 갱신됩니다. Google Play에서 언제든지 취소할 수 있습니다.</string>
     <string name="upgrade_screen_iap_offer_title">평생 잠금 해제</string>
     <string name="upgrade_screen_iap_offer_body">한 번 결제하고 Pro를 영구적으로 소유하세요.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">%1$s를 가지고 있어요 ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">%1$s를 영구적으로 소유하고 있습니다.</string>
     <string name="upgrade_screen_owned_hero_sub_body">%1$s 구독이 활성화되어 있습니다.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">구독이 자동 갱신으로 설정되지 않았으므로 이제 일회성 구매로 전환할 수 있습니다. 주의: 이것은 구독을 취소하거나 환불하지 않으며 별도로 청구되는 요금이므로 두 결제 모두에 동일한 Google 계정을 사용하세요.</string>

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Жыл сайын жаңыланат. Google Play-де каалаган убакта жокко чыгарыңыз.</string>
     <string name="upgrade_screen_iap_offer_title">Өмүр бою ачуу</string>
     <string name="upgrade_screen_iap_offer_body">Бирок төлөп, Pro менен өмүр бою ээсинде болуңуз.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Сизде %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Сиз %1$s өмүр бою ээси болосуз.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Сиздин %1$s жазылуу активдүү.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Сиздин жазылууңуз жаңыланса да коюлган жок, ошондуктан сиз азыр бир жолу төлөөгө өтүп алаарсыңыз. Көңүл салыңыз: бул жазылууңузду жокко чыгарбайт же сатындыраат эмес жараяа болсо, эки үчүн тең бирдей Google аккаунтун колдонуңуз.</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">ປັບປຸງໃໝ່ປະຈໍາປີ. ສາມາດຍົກເລີກໄດ້ທຸກເວລາໃນ Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">ປົ່ອຍໃຫ້ຕະຫຼອດໄປ</string>
     <string name="upgrade_screen_iap_offer_body">ຈ່າຍຄັ້ງດຽວ ແລະເປັນເຈົ້າຂອງ Pro ຕະຫຼອດໄປ.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">ທ່ານມີ %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">ທ່ານເປັນເຈົ້າຂອງ %1$s ຕະຫຼອດໄປ.</string>
     <string name="upgrade_screen_owned_hero_sub_body">ການໂຄສະລາ %1$s ຂອງທ່ານໃຊ້ງານຍູ່.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">ໂຄສະລາຂອງທ່ານບໍ່ໄດ້ຕັ້ງໄວ້ເພື່ອປັບປຸງໃໝ່, ດັ່ງນັ້ນທ່ານສາມາດປ່ຝນໄປຊື້ຄັ້ງດຽວໄດ້ດຽວນີ້. ລະວັງ: ມັນເປັນຄ່າໃຊ້ຈ່າຍແຍກຕ່າງໝາກທີ່ຈະບໍ່ຍົກເລີກ ໜືອ ຄືນເງິນໂຄສະລາຂອງທ່ານ, ດັ່ງນັ້ນໃຊ້ Google ບັນຊີ ດຽວກັນສຳລັບທັ້ງສອງ.</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Atsinaujina kasmet. Galite atšaukti bet kada per „Google Play“.</string>
     <string name="upgrade_screen_iap_offer_title">Amžinas atrakinimas</string>
     <string name="upgrade_screen_iap_offer_body">Mokėkite vieną kartą ir turėkite Pro amžinai.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Turi %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Jūs turite %1$s amžinai.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Jūsų %1$s prenumerata yra aktyvi.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Jūsų prenumerata nėra nustatyta atsinaujinti, todėl dabar galite pereiti prie vienkartinio pirkinio. Atkreipkite dėmesį: tai atskiras mokestis, kuris nenutrauks ir negrąžins jūsų prenumeratos, todėl naudokite tą pačią „Google“ paskyrą abiem.</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Atjaunojas katru gadu. Jebkurā brīdī to varat atteikt no Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Mūžīga atbloķēšana</string>
     <string name="upgrade_screen_iap_offer_body">Maksājiet vienreiz un Pro būs jūsu uz mūžu.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tev ir %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Jums pieder %1$s uz mūžu.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Jūsu %1$s abonēšana ir aktīva.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Jūsu abonēšana nav iestatīta atjaunošanai, tāpēc varat pārslēgties uz vienreizēju pirkumu tagad. Pievērsiet uzmanību: tā ir atsevišķa maksāšana, kas neatceļ vai neatgriezīs jūsu abonēšanu, tāpēc izmantojiet vienu un to pašu Google kontu abiem.</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Се обновува годишно. Откажете во секој момент преку Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Доживотно одблокување</string>
     <string name="upgrade_screen_iap_offer_body">Платете еднаш и владејте Pro заувек.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Го имаш %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Владеете %1$s заувек.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Вашата %1$s претплата е активна.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Вашата претплата не е поставена да се обновува, така да можете да преминете на еднократна куповина сега. Забелешка: тоа е одделна наплата која нема да ја откаже или врати вашата претплата, затоа користете ја истата Google сметка за обе.</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">വർഷത്തിലൊരിക്കൽ പുതുക്കുന്നു. Google Play-ൽ എപ്പോൾ വേണ്ടലും റദ്ദ് ചെയ്യുക.</string>
     <string name="upgrade_screen_iap_offer_title">ജീവിതകാല അൺലോക്ക്</string>
     <string name="upgrade_screen_iap_offer_body">ഒരിക്കൽ നൽകുക നിന്നും Pro നിരന്തരം സ്വാധീനിക്കുക.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">നിങ്ങൾക്ക് %1$s ഉണ്ട് ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">നിങ്ങൾ %1$s നിരന്തരം ഉടമകളാണ്.</string>
     <string name="upgrade_screen_owned_hero_sub_body">നിങ്ങളുടെ %1$s സബ്സ്ക്രിപ്ഷൻ സജീവമാണ്.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ പുതുക്കുന്നതിനായി സജ്ജീകരിച്ചിട്ടില്ല, അതിനാൽ നിങ്ങൾ ഇപ്പോൾ ഒരിക്കൽ വാങ്ങലിലേക്ക് മാറാൻ കഴിയും. ശ്രദ്ധിക്കുക: ഇത് ഒരു വ്യത്യസ്ത ചാർജ് ആണ് അത് നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ റദ്ദ് അല്ലെങ്കിൽ വിനിയോഗം ചെയ്യില്ല, അതിനാൽ രണ്ടിനും ഒരേ Google അക്കൗണ്ട് ഉപയോഗിക്കുക.</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Жил бүр сэргээгдэнэ. Google Play-ээс ямар ч үед цуцлаж болно.</string>
     <string name="upgrade_screen_iap_offer_title">Бүх нас болгоны түлхүүц задлах</string>
     <string name="upgrade_screen_iap_offer_body">Нэг удаа төлөөд Pro-г бүх нас болгоны эзэмших.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Та %1$s авсан ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Та %1$s-г бүх нас болгоны эзэмшинэ.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Таны %1$s захиалга идэвхтэй байна.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Таны захиалга сэргээгдэхийн тулд тогтоогдоогүй байгаа тул одоо нэг удаа худалдаж авахад шилжүүлж болно. Анхааруулга: энэ нь таны захиалгыг цуцлахгүй эсвэл буцаан олгохгүй тусдаа төлбөр байгаа тул хоёуланд нь ижил Google данс ашигла.</string>

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">वार्षिक नवीनीकरण होते. Google Play मध्ये कधीही रद्द करा.</string>
     <string name="upgrade_screen_iap_offer_title">आजीवन अनलॉक</string>
     <string name="upgrade_screen_iap_offer_body">एकदा देय द्या, Pro चिरकाळ आपला होईल.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">तुमच्याकडे %1$s आहे ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">तुम्ही %1$s चिरकाळ मालकीचे आहात.</string>
     <string name="upgrade_screen_owned_hero_sub_body">तुमची %1$s सदस्यता सक्रिय आहे.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">तुमची सदस्यता नवीनीकरणासाठी सेट केलेली नाही, म्हणून तुम्ही आता एकस्व खरेदीवर स्विच करू शकता. सूचना: हे एक वेगळे शुल्क आहे जे तुमची सदस्यता रद्द किंवा परत करणार नाही, त्यामुळे दोन्हीसाठी समान Google खाते वापरा.</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Diperbaharui setiap tahun. Batalkan pada bila-bila masa di Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Pembukaan seumur hidup</string>
     <string name="upgrade_screen_iap_offer_body">Bayar sekali dan miliki Pro selamanya.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Kamu sudah punya %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Anda memiliki %1$s selamanya.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Langganan %1$s anda aktif.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Langganan anda tidak ditetapkan untuk memperbaharui, jadi anda boleh beralih ke pembelian sekali sahaja sekarang. Perhatian: ia adalah caj berasingan yang tidak akan membatalkan atau mengembalikan wang langganan anda, gunakan akaun Google yang sama untuk kedua-duanya.</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">နှစ်စဉ်သုံးဆောင်းခွင်။ Google Play တွင် အချိန်မည်သည့်အခါမျိုးတွင် ပယ်ဖျက်နိုင်ပါသည်။</string>
     <string name="upgrade_screen_iap_offer_title">အစဉ်အမြဲဖွင့်လှစ်ခြင်း</string>
     <string name="upgrade_screen_iap_offer_body">တစ်ကြိမ်ငွေချေ ပြီး Pro ကို အစဉ်အမြဲ ပိုင်ဆိုင်ပါ။</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">သင့် %1$s ရှိတယ် ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">သင်သည် %1$s ကို အစဉ်အမြဲ ပိုင်ဆိုင်ပါသည်။</string>
     <string name="upgrade_screen_owned_hero_sub_body">သင်၏ %1$s စာရင်းသွင်းမှု ရှင်သန်လျက်ရှိပါသည်။</string>
     <string name="upgrade_screen_owned_iap_purchase_note">သင်၏စာရင်းသွင်းမှု သုံးဆောင်းရန် သတ်မှတ်မထားသောကြောင့် သုံးဆောင်းခွင်တစ်ကြိမ်သို့ သင်ပြောင်းလဲနိုင်ပါသည်။ သတိပေးချက်- ၎င်းသည် သင်၏စာရင်းသွင်းမှုကို ပယ်ဖျက်ခြင်း သို့မဟုတ် ငွေပြန်အခ်င်းမပေးသည့် သီးခြားငွေချေခြင်းဖြစ်သောကြောင့် နှစ်ခုစလုံးအတွက် တူညီသော Google အကောင့်ကို အသုံးပြုပါ။</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">वार्षिक नवीनीकरण हुन्छ। Google Play मा कुनै पनि समयमा रद्द गर्नुहोस्।</string>
     <string name="upgrade_screen_iap_offer_title">आजीवन अनलक</string>
     <string name="upgrade_screen_iap_offer_body">एक पटक भुक्तानी गर्नुहोस् र Pro सदैव आफ्नो बनाउनुहोस्।</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">तिमीसँग %1$s ❤️ छ</string>
     <string name="upgrade_screen_owned_hero_iap_body">तपाई %1$s सदैव आफ्नो बनाउनुहुन्छु।</string>
     <string name="upgrade_screen_owned_hero_sub_body">आपको %1$s सदस्यता सक्रिय छ।</string>
     <string name="upgrade_screen_owned_iap_purchase_note">आपको सदस्यता नवीनीकरणको लागि सेट गरिएको छैन, त्सैले तपाई अब एक पटकको खरीदमा स्विच गर्न सक्नुहुन्छु। ध्यान दिनुहोस्: यो अलग शुल्क हो जसले आपको सदस्यता रद्द वा फिर्ता नदिइ, दुबैको लागि एक जस्तै Google खाता प्रयोग गर्नुहोस्।</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Wordt jaarlijks verlengd. Annuleer op elk moment via Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Levenslange ontgrendeling</string>
     <string name="upgrade_screen_iap_offer_body">Betaal eenmaal en heb Pro voor altijd.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Je hebt %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Je bezit %1$s voor altijd.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Je %1$s-abonnement is actief.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Je abonnement staat niet ingesteld om te vernieuwen, dus je kunt nu naar de eenmalige aankoop overstappen. Let op: dit is een aparte aankoop die je abonnement niet annuleert of terugbetaalt, dus gebruik hetzelfde Google-account voor beide.</string>

--- a/app/src/gplay/res/values-no/strings.xml
+++ b/app/src/gplay/res/values-no/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Fornyes årlig. Avbryt når som helst i Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Livsvarig opplåsning</string>
     <string name="upgrade_screen_iap_offer_body">Betal en gang og eie Pro for alltid.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Du har %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Du eier %1$s for alltid.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Abonnementet ditt %1$s er aktivt.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Abonnementet ditt er ikke satt til å fornyes, så du kan bytte til engangskjøpet nå. Viktig: det er en separat kostnad som ikke vil avbryte eller refundere abonnementet ditt, så bruk samme Google-konto for begge deler.</string>

--- a/app/src/gplay/res/values-pcm-rNG/strings.xml
+++ b/app/src/gplay/res/values-pcm-rNG/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">E renew every year. Cancel am anytime for Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Forever unlock</string>
     <string name="upgrade_screen_iap_offer_body">Pay just once and Pro go be yours forever.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">You get %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">You don own %1$s forever.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Your %1$s subscription active.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Your subscription no set to renew, so you fit switch to one-time purchase now. Hear me: e go charge you separate and e no go cancel or refund your subscription, so use di same Google account for both.</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Odnawiane co roku. Anuluj w dowolnym momencie w Sklepie Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Dożywotne odblokowywanie</string>
     <string name="upgrade_screen_iap_offer_body">Zapłać raz i posiadaj Pro na zawsze.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Masz %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Posiadasz %1$s na zawsze.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Twoja subskrypcja %1$s jest aktywna.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Twoja subskrypcja nie jest ustawiona na odnowienie, więc możesz teraz przełączyć się na jednorazowy zakup. Ostrzeżenie: to oddzielna opłata, która nie anuluje ani nie zwróci pieniędzy z twojej subskrypcji, więc użyj tego samego konta Google dla obu.</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Renova anualmente. Cancele a qualquer momento no Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Desbloqueio vitalício</string>
     <string name="upgrade_screen_iap_offer_body">Pague uma vez e tenha Pro para sempre.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Você tem %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Você possui %1$s para sempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Sua assinatura %1$s está ativa.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Sua assinatura não está configurada para renovar, então você pode mudar para a compra única agora. Atenção: é uma cobrança separada que não cancelará ou reembolsará sua assinatura, então use a mesma conta do Google para ambas.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Renova anualmente. Cancele a qualquer momento no Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Desbloqueio vitalício</string>
     <string name="upgrade_screen_iap_offer_body">Pague uma vez e possua Pro para sempre.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tens %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tem %1$s para sempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">A sua subscrição %1$s está ativa.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">A sua subscrição não está configurada para renovar, portanto pode mudar para a compra única agora. Tenha em conta: é uma cobrança separada que não cancelará nem reembolsará a sua subscrição, portanto use a mesma conta Google para ambas.</string>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Sa renovescha cull\'ann. Cancella en tgel moment en Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Deblierada per sempre</string>
     <string name="upgrade_screen_iap_offer_body">Paiescha üna giada e possedascha Pro per sempre.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Ti has %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ti possedascha %1$s per sempre.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tia abonament %1$s è activ.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Tia abonament n\'è betg confiturada per renovescha, perquai che ti pudais tschanger ala cumpra ina giada. Attenziun: tia è ina ladschada separada che n\'canchellescha betg tia abonament e n\'refundida betg, perquai che ti duratscha la medesma cunt da Google per entrambi.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Se reînnuiește anual. Anulează oricând în Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Deblocare pe viață</string>
     <string name="upgrade_screen_iap_offer_body">Plătește o dată și deține Pro pentru totdeauna.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Ai %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Deții %1$s pentru totdeauna.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Abonamentul tău %1$s este activ.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Abonamentul tău nu este setat să se reînnuiască, deci poți trece la achiziția unică acum. Atenție: este o taxă separată care nu va anula sau returna abonamentul tău, deci folosește același cont Google pentru ambele.</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Возобновляется ежегодно. Отменить можно в любой момент в Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Пожизненная активация</string>
     <string name="upgrade_screen_iap_offer_body">Оплатите один раз и владейте Pro навсегда.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">У тебя %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Вы владеете %1$s навсегда.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ваша подписка %1$s активна.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Ваша подписка не настроена на продление, поэтому вы можете переключиться на единовременную покупку. Внимание: это отдельный платеж, который не отменит и не вернет вашу подписку, поэтому используйте один и тот же аккаунт Google для обоих вариантов.</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Se renovaz anualmente. Annulla in calet in Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Disblocu de vida</string>
     <string name="upgrade_screen_iap_offer_body">Paga una borta e possess Pro pro semper.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Tenes %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Tu possidis %1$s pro semper.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Tua sottoscritzione %1$s est attiva.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Tua sottoscritzione no est cunfigurada pro renovatzione, assa t\'as pòdis cambiare a una cumpra una borta. Atentzione: est un cariggu separadu chi no at annulla o resfuindit tua sottoscritzione, assa etzas a mesma cunta Google pro ambas.</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">වාර්ෂිකව නවීකරණය කරන්න. Google Play හි ඕනෑම අවස්ථාවක අවලංගු කරන්න.</string>
     <string name="upgrade_screen_iap_offer_title">ජීවිතකාල අගුළු හැරීම</string>
     <string name="upgrade_screen_iap_offer_body">එක්වර ගෙවන්න සහ ඉතිරි කාලය Pro හිමිකරන්න.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">ඔබට %1$s තිබේ ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">ඔබ %1$s ඉතිරි කාලය හිමිකරන්න.</string>
     <string name="upgrade_screen_owned_hero_sub_body">ඔබේ %1$s දිගටි ගිණුම සක්‍රිය.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">ඔබේ දිගටි ගිණුම නවීකරණය කිරීමට සකස්ස කර නැත, එබැවින් ඔබ දැන් එක්වර ගෙවීමට මාරු කළ හැක. අවධාන: එය ඔබේ දිගටි ගිණුම අවලංගු කරන්නේ හෝ ආපසු ගෙවන්නේ නැති වෙනම ගෙවීමක්, එබැවින් සමස්ත Google ගිණුම භාවිතා කරන්න.</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Obnovuje sa každoročne. Zrušte kedykoľvek v Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Doživotné odomknutie</string>
     <string name="upgrade_screen_iap_offer_body">Zaplaťte raz a vlastnite Pro navždy.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Máš %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Vlastníš %1$s navždy.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Vaše predplatné %1$s je aktívne.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Vaše predplatné nie je nastavené na obnovenie, takže teraz môžete prejsť na jednorazový nákup. Upozornenie: ide o samostatný poplatok, ktorý nezruší ani nevráti vaše predplatné, takže na obe položky použite rovnaký účet Google.</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Obnavlja se letno. Prekličite kadar koli v Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Trajno odklenjevanje</string>
     <string name="upgrade_screen_iap_offer_body">Plačajte enkrat in imate Pro za vedno.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Imaš %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Imate %1$s za vedno.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Vaša %1$s naročnina je aktivna.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Vaša naročnina ni nastavljena za obnavljanje, zato se lahko zdaj preklopite na enkratni nakup. Opozorilo: to je ločena pristojbina, ki ne bo preklicala ali povrnila vaše naročnine, zato za obe uporabite isti račun Google.</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Rinovon çdo vit. Anuloni në çdo kohë në Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Shbllokimi përjetësor</string>
     <string name="upgrade_screen_iap_offer_body">Paguani një herë dhe zotëroni Pro përgjithmonë.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Ke %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ju zotëroni %1$s përgjithmonë.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Abonamenti juaj %1$s është aktiv.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Abonamenti juaj nuk është caktuar për rinovim, kështu që mund të kaloni në blerje njëherësh tani. Kujdes: është një tarifë e veçantë që nuk do të anulojë ose rimbursojë abonimin tuaj, kështu që përdorni të njëjtin llogari Google për të dyja.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Обнавља се годишње. Откажи у било којем тренутку на Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Доживотна куповина</string>
     <string name="upgrade_screen_iap_offer_body">Плати једном и поседуј Pro заувек.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Имаш %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Поседујеш %1$s заувек.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Твоја %1$s претплата је активна.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Твоја претплата није подешена за обнављање, па можеш сада прећи на једнократну куповину. Пажња: то је одвојена наплата која неће отказати или вратити твоју претплату, па користи исти Google налог за обоје.</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Förnyas årligen. Avbryt när som helst i Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Livstidsåtkomst</string>
     <string name="upgrade_screen_iap_offer_body">Betala en gång och äg Pro för alltid.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Du har %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Du äger %1$s för alltid.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Din %1$s-prenumeration är aktiv.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Din prenumeration är inte inställd på förnyelse, så du kan byta till engångsköp nu. OBS: Det är en separat avgift som inte avbryter eller återbetalar din prenumeration, så använd samma Google-konto för båda.</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Inajipi upya kila mwaka. Ghairi wakati wowote katika Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Kufungua milele</string>
     <string name="upgrade_screen_iap_offer_body">Lipa mara moja na kumiliki Pro milele.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Una %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Unamiliki %1$s milele.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Usajili wako wa %1$s unaendelea.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Usajili wako haujawekwa kujirudisha upya, kwa hivyo unaweza kubadili kwenda ununuzi wa mara moja sasa. Kumbuka: ni malipo tofauti ambayo hayataghairi au kurudisha pesa za usajili wako, kwa hivyo tumia akaunti moja ya Google kwa zote mbili.</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">ஆண்டுக்கு புதுப்பிக்கப்படுகிறது. Google Play இல் எந்த நேரத்திலும் ரத்து செய்யலாம்.</string>
     <string name="upgrade_screen_iap_offer_title">வாழ்நாள் திறக்கல்</string>
     <string name="upgrade_screen_iap_offer_body">ஒரு முறை பணம் செலுத்தவும் மற்றும் Pro ஐ என்றென்றும் சொந்தமாக வைத்துக்கொள்ளவும்.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">உங்களிடம் %1$s உள்ளது ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">நீங்கள் %1$s ஐ என்றென்றும் சொந்தமாக வைத்துக்கொள்ளுகிறீர்கள்.</string>
     <string name="upgrade_screen_owned_hero_sub_body">உங்கள் %1$s சந்தா செயல்பாட்டுக்குள் உள்ளது.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">உங்கள் சந்தா புதுப்பிக்க அமைக்கப்படவில்லை, எனவே நீங்கள் இப்போது ஒரு முறை வாங்குதலுக்கு மாற்றலாம். முன்னெச்சரிக்கை: இது உங்கள் சந்தாவை ரத்து செய்யாமல் அல்லது திருப்பி செலுத்தாமல் ஒரு தனிப்பட்ட கட்டணம், எனவே இரண்டிற்கும் ஒரே Google கணக்கைப் பயன்படுத்தவும்.</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">ఏటా పునరుద్ధరిస్తుంది. Google Play లో ఎప్పుడైనా రద్దు చేయవచ్చు.</string>
     <string name="upgrade_screen_iap_offer_title">జీవితకాల అన్‌లాక్</string>
     <string name="upgrade_screen_iap_offer_body">ఒకసారి చెల్లించండి మరియు Pro ను శాశ్వతంగా సొంతం చేసుకోండి.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">మీ వద్ద %1$s ఉంది ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">మీరు %1$s ను శాశ్వతంగా సొంతం చేసుకున్నారు.</string>
     <string name="upgrade_screen_owned_hero_sub_body">మీ %1$s సభ్యత్వం క్రియాశీలంగా ఉంది.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">మీ సభ్యత్వం పునరుద్ధరించటానికి సెట్ చేయబడలేదు, కాబట్టి మీరు ఇప్పుడు ఒకసారి కొనుగోలుకు మారవచ్చు. గమనించండి: ఇది ప్రత్యేక ఛార్జ్, ఇది మీ సభ్యత్వాన్ని రద్దు చేయదు లేదా నిర్వసూల చేయదు, కాబట్టి రెండింటికీ ఒకే Google ఖాతాను ఉపయోగించండి.</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">ต่ออายุรายปี คุณสามารถยกเลิกได้ตลอดเวลาใน Google Play</string>
     <string name="upgrade_screen_iap_offer_title">ปลดล็อกตลอดชีวิต</string>
     <string name="upgrade_screen_iap_offer_body">จ่ายเพียงครั้งเดียวและเป็นเจ้าของ Pro ตลอดไป</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">คุณมี %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">คุณเป็นเจ้าของ %1$s ตลอดไป</string>
     <string name="upgrade_screen_owned_hero_sub_body">การสมัครสมาชิก %1$s ของคุณใช้งานได้</string>
     <string name="upgrade_screen_owned_iap_purchase_note">การสมัครสมาชิกของคุณไม่ได้ตั้งค่าให้ต่ออายุ ดังนั้นคุณสามารถเปลี่ยนไปเป็นการซื้อครั้งเดียวได้แล้ว โปรดทราบ: เป็นการเรียกเก็บเงินแยกต่างหากซึ่งจะไม่ยกเลิกหรือคืนเงินการสมัครสมาชิกของคุณ ดังนั้นให้ใช้บัญชี Google เดียวกันสำหรับทั้งสองแบบ</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Yıllık olarak yenilenir. Google Play\'den istediğiniz zaman iptal edin.</string>
     <string name="upgrade_screen_iap_offer_title">Yaşam boyu kilit açma</string>
     <string name="upgrade_screen_iap_offer_body">Bir kez ödeyip Pro\'ya sonsuza kadar sahip olun.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">%1$s\'in var ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">%1$s\'a sonsuza kadar sahipsiniz.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Sizin %1$s aboneliğiniz aktif.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Aboneliğiniz yenilenecek şekilde ayarlanmamış, bu nedenle şimdi tek seferlik satın almaya geçebilirsiniz. Dikkat: bu, aboneliğinizi iptal etmeyecek veya geri ödeme yapmayacak ayrı bir ücrettir, bu nedenle her ikisi için aynı Google hesabını kullanın.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Автоматично продовжується щороку. Скасуйте будь-коли в Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Довічне розблокування</string>
     <string name="upgrade_screen_iap_offer_body">Сплатьте один раз і користуйтесь Pro назавжди.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">У вас є %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Ви володієте %1$s назавжди.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Ваша %1$s підписка активна.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Ваша підписка не встановлена на автоматичне продовження, тому ви можете зараз перейти на одноразову покупку. Увага: це окремий платіж, який не скасує вашу поточну підписку та не поверне кошти за неї, тому використовуйте один і той самий обліковий запис Google для обох.</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">سالانہ تجدید ہوتا ہے۔ Google Play میں کسی بھی وقت منسوخ کریں۔</string>
     <string name="upgrade_screen_iap_offer_title">زندگی بھر کی رہائی</string>
     <string name="upgrade_screen_iap_offer_body">ایک بار ادائیگی کریں اور Pro کو ہمیشہ کے لیے رکھیں۔</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">آپ کے پاس %1$s ہے ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">آپ %1$s کو ہمیشہ کے لیے رکھتے ہیں۔</string>
     <string name="upgrade_screen_owned_hero_sub_body">آپ کی %1$s رکنیت فعال ہے۔</string>
     <string name="upgrade_screen_owned_iap_purchase_note">آپ کی رکنیت تجدید کے لیے سیٹ نہیں ہے، تو آپ اب ایک بار خریداری میں تبدیل کر سکتے ہیں۔ احتیاط: یہ الگ چارج ہے جو آپ کی رکنیت کو منسوخ یا واپس نہیں کرے گا، تو دونوں کے لیے ایک جیسا Google اکاؤنٹ استعمال کریں۔</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Yilga qayta yangilanadi. Google Play\'da istalgan vaqtda bekor qilish mumkin.</string>
     <string name="upgrade_screen_iap_offer_title">Umrbod yoqish</string>
     <string name="upgrade_screen_iap_offer_body">Bir marta to\'lang va abadiy Pro egasi bo\'ling.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Sizda %1$s bor ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Siz %1$s ni abadiy egallaysiz.</string>
     <string name="upgrade_screen_owned_hero_sub_body">%1$s obunangiz faol.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Obunangiz qayta yangilanishga o\'rnatilmagan, shuning uchun endi bir martalik xaridga o\'tishingiz mumkin. Diqqat: bu alohida to\'lov bo\'lib, obunangizni bekor qilmaydi yoki pulini qaytarmaydi, shuning uchun ikkalasi uchun ham bir xil Google hisobidan foydalaning.</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Gia hạn hàng năm. Hủy bất kỳ lúc nào trong Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Mở khóa vĩnh viễn</string>
     <string name="upgrade_screen_iap_offer_body">Trả một lần và sở hữu Pro mãi mãi.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">Bạn có %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Bạn sở hữu %1$s mãi mãi.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Đăng ký %1$s của bạn đang hoạt động.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Đăng ký của bạn không được đặt để gia hạn, vì vậy bạn có thể chuyển sang mua một lần ngay bây giờ. Chú ý: đây là một khoản phí riêng biệt sẽ không hủy hoặc hoàn lại đăng ký của bạn, vì vậy hãy sử dụng cùng một tài khoản Google cho cả hai.</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">每年续订。可随时在Google Play中取消。</string>
     <string name="upgrade_screen_iap_offer_title">终身解锁</string>
     <string name="upgrade_screen_iap_offer_body">一次性付款，永久拥有Pro。</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">你有 %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">你永久拥有%1$s。</string>
     <string name="upgrade_screen_owned_hero_sub_body">你的%1$s订阅已激活。</string>
     <string name="upgrade_screen_owned_iap_purchase_note">你的订阅未设置为续订，因此现在可以切换到一次性购买。提醒：这是单独的一笔费用，不会取消或退款你的订阅，因此请在两者上使用相同的Google账户。</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">按年續約。可隨時在 Google Play 中取消。</string>
     <string name="upgrade_screen_iap_offer_title">永久解鎖</string>
     <string name="upgrade_screen_iap_offer_body">一次付款，永久擁有 Pro。</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">你已擁有 %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">你永久擁有 %1$s。</string>
     <string name="upgrade_screen_owned_hero_sub_body">你的 %1$s 訂閱已啟用。</string>
     <string name="upgrade_screen_owned_iap_purchase_note">你的訂閱未設定續約，所以你現在可以改用一次性購買。提醒：這是單獨收費的，不會取消或退款你的訂閱，所以請對兩者使用相同的 Google 帳戶。</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">每年自動續約。可隨時在 Google Play 中取消。</string>
     <string name="upgrade_screen_iap_offer_title">終身解鎖</string>
     <string name="upgrade_screen_iap_offer_body">一次付費，永久擁有 Pro。</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">你有 %1$s ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">你永久擁有 %1$s。</string>
     <string name="upgrade_screen_owned_hero_sub_body">你的 %1$s 訂閱正在使用中。</string>
     <string name="upgrade_screen_owned_iap_purchase_note">你的訂閱未設定為自動續約，所以你現在可以切換到一次性購買。提醒：這是單獨費用，不會取消或退款你的訂閱，所以請使用相同的 Google 帳號購買兩者。</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -64,6 +64,8 @@
     <string name="upgrade_screen_subscription_offer_body_no_trial">Kutheshwa kabusha ngonyaka. Khansela nganoma iyiphi isikhathi ku-Google Play.</string>
     <string name="upgrade_screen_iap_offer_title">Ukuvula ngokusisele</string>
     <string name="upgrade_screen_iap_offer_body">Khokha kanye futhi unabe ne-Pro ngokusisele.</string>
+    <!-- Ownership hero headline, shown once the upgrade is active. %1$s is the complete localized tier name, e.g. "BVM Pro" - keep it as a placeholder and do not translate its contents. Render the sentence idiomatically if that reads better in your language ("X is active", "Your X access is active"), as long as the placeholder survives. -->
+    <string name="upgrade_screen_owned_hero_brand_title">U-%1$s wakho uyasebenza ❤️</string>
     <string name="upgrade_screen_owned_hero_iap_body">Unabe ne-%1$s ngokusisele.</string>
     <string name="upgrade_screen_owned_hero_sub_body">Isikwelekelo se-%1$s sakho siyasebenza.</string>
     <string name="upgrade_screen_owned_iap_purchase_note">Isikwelekelo sakho ayisetheka ukubuya, ngakho ungashintshela ekuthengeni kanye manje. Ziqapela: lingubhili elahlukile engezelwe engayikhanseli noma ingayibuyele ngemali isikwelekelo sakho, ngakho sebenzisa i-akhawunti ye-Google efanayo kuzo zombili.</string>

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Gradeer Op</string>
     <string name="common_upgrade_required_label">Opgradering benodig</string>
     <string name="label_premium_version_required">Premium weergawe benodig</string>
-    <string name="upgrade_feature_requires_pro">Hierdie kenmerk vereis die premium weergawe</string>
-    <string name="upgrade_prompt_upgrade_action">Gradeer op</string>
     <string name="description_intro_purpose">Hierdie program laat Android toe om die volume instellings van verskeie Bluetooth toestelle te onthou.</string>
     <string name="upgrade_benefit_unlimited_devices">Onbeperkte toestelprofile</string>
     <string name="upgrade_benefit_connection_actions">Outoafspeel, toepassing-begin en verbindingswaarskuwings</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">አሻሽል</string>
     <string name="common_upgrade_required_label">ማሻሻያ ያስፈልጋል</string>
     <string name="label_premium_version_required">የዘመን ስሪት ክድምነት</string>
-    <string name="upgrade_feature_requires_pro">ይህ ባ⁚ራ የዘመን ስሪት ይኀላል</string>
-    <string name="upgrade_prompt_upgrade_action">አሻሽል</string>
     <string name="description_intro_purpose">ይህ አፕሊኬስን የAndroid መሣሪያዎት የዓይባይት Bluetooth መሣሪያዎችን ድምፅ እንዲያስታወስ ይያዕዝበታለ።</string>
     <string name="upgrade_benefit_unlimited_devices">ያልተወሰኑ የመሳሪያ መገለጫዎች</string>
     <string name="upgrade_benefit_connection_actions">ራስ-ሰር አጫወት፣ መተግበሪያ ማስጀመሪያ እና የግንኙነት ማስጠንቀቂያዎች</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -346,8 +346,6 @@
     <string name="general_upgrade_action">تحديث</string>
     <string name="common_upgrade_required_label">الترقية مطلوبة</string>
     <string name="label_premium_version_required">يتطلب النسخة الكاملة</string>
-    <string name="upgrade_feature_requires_pro">هذه الميزة تتطلب الإصدار المتميز</string>
-    <string name="upgrade_prompt_upgrade_action">تحديث</string>
     <string name="description_intro_purpose">يسمح هذا التطبيق للأندرويد بتذكر حجم الصوت لمختلف أجهزة البلوتوث.</string>
     <string name="upgrade_benefit_unlimited_devices">ملفات تعريف أجهزة غير محدودة</string>
     <string name="upgrade_benefit_connection_actions">التشغيل التلقائي وإطلاق التطبيق وتنبيهات الاتصال</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Yüksəlt</string>
     <string name="common_upgrade_required_label">Yüksəltmə tələb olunur</string>
     <string name="label_premium_version_required">Premium versiya tələb olunur</string>
-    <string name="upgrade_feature_requires_pro">Bu funksiya premium versiyasını tələb edir</string>
-    <string name="upgrade_prompt_upgrade_action">Yüksəlt</string>
     <string name="description_intro_purpose">Bu tətbiq, Android cihazınıza fərqli Bluetooth cihazının səs səviyyəsini xatırlamasına icazə verər.</string>
     <string name="upgrade_benefit_unlimited_devices">Limitsiz cihaz profilləri</string>
     <string name="upgrade_benefit_connection_actions">Avtomatik oynatma, tətbiq işə salma və bağlantı xəbərdaqlıqları</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -338,8 +338,6 @@
     <string name="general_upgrade_action">Абнавіць</string>
     <string name="common_upgrade_required_label">Патрабуецца абнаўленне</string>
     <string name="label_premium_version_required">Патрабуецца прэміум-версія</string>
-    <string name="upgrade_feature_requires_pro">Гэтая функцыя патрабуе прэміум-версіі</string>
-    <string name="upgrade_prompt_upgrade_action">Абнавіць</string>
     <string name="description_intro_purpose">Гэты дадатак дазваляе вашай прыладзе Android запамінаць гучнасць розных прылад Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Неабмежаваная колькасць профіляў прылад</string>
     <string name="upgrade_benefit_connection_actions">Аўтаўзнаўленне, запуск праграм і абвесткі аб падключэнні</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Ъпгрейд</string>
     <string name="common_upgrade_required_label">Необходимо е надграждане</string>
     <string name="label_premium_version_required">Изисква се премиум версията</string>
-    <string name="upgrade_feature_requires_pro">Тази функция изисква премиум версията</string>
-    <string name="upgrade_prompt_upgrade_action">Ъпгрейд</string>
     <string name="description_intro_purpose">Приложението позволява вашето устройство да запомни силата на звука за различни Bluetooth устройства.</string>
     <string name="upgrade_benefit_unlimited_devices">Неограничени профили на устройства</string>
     <string name="upgrade_benefit_connection_actions">Автоматично пускане, стартиране на приложения и сигнали за връзка</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">আপগ্রেড করুন</string>
     <string name="common_upgrade_required_label">আপগ্রেড প্রয়োজন</string>
     <string name="label_premium_version_required">প্রিমিয়াম সংস্করণ প্রয়োজন</string>
-    <string name="upgrade_feature_requires_pro">এই ফিচারে প্রিমিয়াম সংস্করণ প্রয়োজন</string>
-    <string name="upgrade_prompt_upgrade_action">আপগ্রেড করুন</string>
     <string name="description_intro_purpose">এই অ্যাপ আপনার আন্ড্রয়েড ডিভাইসকে বিভিন্ন ব্লুটুথ ডিভাইসের ভলিউম মনে রাখতে দেয়।</string>
     <string name="upgrade_benefit_unlimited_devices">সীমাহীন ডিভাইস প্রোফাইল</string>
     <string name="upgrade_benefit_connection_actions">অটোপ্লে, অ্যাপ লঞ্চ এবং কানেকশন অ্যালার্ট</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Millora</string>
     <string name="common_upgrade_required_label">Cal actualitzar</string>
     <string name="label_premium_version_required">Cal la versió prèmium</string>
-    <string name="upgrade_feature_requires_pro">Aquesta funció requereix la versió prèmium</string>
-    <string name="upgrade_prompt_upgrade_action">Actualitza</string>
     <string name="description_intro_purpose">Aquesta aplicació permet als dispositius Android recordar el volum de diferents dispositius Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Perfils de dispositiu il·limitats</string>
     <string name="upgrade_benefit_connection_actions">Reproducció automàtica, llançament d’aplicacions i alertes de connexió</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -338,8 +338,6 @@
     <string name="general_upgrade_action">Upgradovat</string>
     <string name="common_upgrade_required_label">Vyžadován upgrade</string>
     <string name="label_premium_version_required">Je vyžadována verze Premium</string>
-    <string name="upgrade_feature_requires_pro">Tato funkce vyžaduje verzi Premium</string>
-    <string name="upgrade_prompt_upgrade_action">Upgradovat</string>
     <string name="description_intro_purpose">Tato aplikace umožňuje zařízení Android zapamatovat si hlasitost různých zařízení Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Neomezené profily zařízení</string>
     <string name="upgrade_benefit_connection_actions">Automatické přehrávání, spuštění aplikace a upozornění na připojení</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Opgrader</string>
     <string name="common_upgrade_required_label">Opgradering påkrævet</string>
     <string name="label_premium_version_required">Premium-versionen påkrævet</string>
-    <string name="upgrade_feature_requires_pro">Denne funktion kræver premium-versionen</string>
-    <string name="upgrade_prompt_upgrade_action">Opgrader</string>
     <string name="description_intro_purpose">Denne app tillader din Android at huske lydstyrken for forskellige Bluetooth-enheder.</string>
     <string name="upgrade_benefit_unlimited_devices">Ubegrænsede enhedsprofiler</string>
     <string name="upgrade_benefit_connection_actions">Autoafspilning, app-start og forbindelsesadvarsler</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Upgrade</string>
     <string name="common_upgrade_required_label">Upgrade erforderlich</string>
     <string name="label_premium_version_required">Premium-Version erforderlich</string>
-    <string name="upgrade_feature_requires_pro">Diese Funktion erfordert die Premium-Version</string>
-    <string name="upgrade_prompt_upgrade_action">Upgraden</string>
     <string name="description_intro_purpose">Diese App erlaubt es Deinem Android-Gerät, die Lautstärke verschiedener Bluetooth-Geräte zu speichern.</string>
     <string name="upgrade_benefit_unlimited_devices">Unbegrenzte Geräteprofile</string>
     <string name="upgrade_benefit_connection_actions">Autoplay, App-Start und Verbindungsbenachrichtigungen</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Αναβάθμιση</string>
     <string name="common_upgrade_required_label">Απαιτείται αναβάθμιση</string>
     <string name="label_premium_version_required">Απαιτείται η Premium έκδοση</string>
-    <string name="upgrade_feature_requires_pro">Αυτή η λειτουργία απαιτεί την έκδοση premium</string>
-    <string name="upgrade_prompt_upgrade_action">Αναβάθμιση</string>
     <string name="description_intro_purpose">Αυτή η εφαρμογή επιτρέπει στην συσκευή Android σας να θυμάται την ένταση όλων των διαφορετικών συσκευών Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Απεριόριστα προφίλ συσκευών</string>
     <string name="upgrade_benefit_connection_actions">Αυτόματη αναπαραγωγή, εκκίνηση εφαρμογής και ειδοποιήσεις σύνδεσης</string>

--- a/app/src/main/res/values-eo-rUY/strings.xml
+++ b/app/src/main/res/values-eo-rUY/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Plibonigi</string>
     <string name="common_upgrade_required_label">Apgrejdo necesa</string>
     <string name="label_premium_version_required">Premiumversio bezonata</string>
-    <string name="upgrade_feature_requires_pro">Ĉi tiu funkcio postulas la premiumversion</string>
-    <string name="upgrade_prompt_upgrade_action">Plibonigi</string>
     <string name="description_intro_purpose">Ĉi tiu apo permesas al via Android-aparato memorigi la volumenon de malsamaj Bluetooth-aparatoj.</string>
     <string name="upgrade_benefit_unlimited_devices">Senlimaj aparataj profiloj</string>
     <string name="upgrade_benefit_connection_actions">Aŭtoludado, lanĉo de aplikaĵo kaj konektaj sciigoj</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Mejorar</string>
     <string name="common_upgrade_required_label">Se requiere actualización</string>
     <string name="label_premium_version_required">Se requiere la versión premium</string>
-    <string name="upgrade_feature_requires_pro">Esta función requiere la versión premium</string>
-    <string name="upgrade_prompt_upgrade_action">Mejorar</string>
     <string name="description_intro_purpose">Esta app permite a tu dispositivo Android recordar el volumen de diferentes dispositivos Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Perfiles de dispositivos ilimitados</string>
     <string name="upgrade_benefit_connection_actions">Reproducción automática, apertura de apps y alertas de conexión</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Actualizar</string>
     <string name="common_upgrade_required_label">Actualización requerida</string>
     <string name="label_premium_version_required">Se requiere versión premium</string>
-    <string name="upgrade_feature_requires_pro">Esta función requiere la versión premium</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizar</string>
     <string name="description_intro_purpose">Esta app permite que tu dispositivo Android recuerde el volumen de diferentes dispositivos Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Perfiles de dispositivo ilimitados</string>
     <string name="upgrade_benefit_connection_actions">Reproducción automática, inicio de app y alertas de conexión</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Actualizar</string>
     <string name="common_upgrade_required_label">Se requiere actualización</string>
     <string name="label_premium_version_required">Versión Premium requerida</string>
-    <string name="upgrade_feature_requires_pro">Esta función requiere la versión premium</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizar</string>
     <string name="description_intro_purpose">Esta aplicación permite que tu dispositivo Android recuerde el volumen de los diferentes dispositivos Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Perfiles de dispositivos ilimitados</string>
     <string name="upgrade_benefit_connection_actions">Reproducción automática, inicio de apps y alertas de conexión</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Täienda</string>
     <string name="common_upgrade_required_label">Uuendamine nõutav</string>
     <string name="label_premium_version_required">Vaja on tasulist versiooni</string>
-    <string name="upgrade_feature_requires_pro">See funktsioon nõuab tasulist versiooni</string>
-    <string name="upgrade_prompt_upgrade_action">Täienda</string>
     <string name="description_intro_purpose">See rakendus võimaldab teie Androidi seadmel meelde jätta erinevaid sinihammast toetavate seadmete heli.</string>
     <string name="upgrade_benefit_unlimited_devices">Piiramatu arv seadmeprofiile</string>
     <string name="upgrade_benefit_connection_actions">Automaatesitus, rakenduse käivitus ja ühendusmärguanded</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Eguneratu</string>
     <string name="common_upgrade_required_label">Berritzea beharrezkoa</string>
     <string name="label_premium_version_required">Premium bertsioa beharrezkoa da</string>
-    <string name="upgrade_feature_requires_pro">Ezaugarri honek premium bertsioa behar du</string>
-    <string name="upgrade_prompt_upgrade_action">Eguneratu</string>
     <string name="description_intro_purpose">Aplikazio honek zure Android gailuari Bluetooth gailu desberdinen bolumena gogoratzeko aukera ematen dio.</string>
     <string name="upgrade_benefit_unlimited_devices">Gailu profil mugagabeak</string>
     <string name="upgrade_benefit_connection_actions">Autoerreproduzioa, aplikazioa abiaraztea eta konexio alertak</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">ارتقاء</string>
     <string name="common_upgrade_required_label">ارتقا لازم است</string>
     <string name="label_premium_version_required">نسخه پریمیوم لازم است</string>
-    <string name="upgrade_feature_requires_pro">این ویژگی نیازمند نسخه پریمیوم است</string>
-    <string name="upgrade_prompt_upgrade_action">ارتقاء</string>
     <string name="description_intro_purpose">این برنامه به دستگاه اندروید شما امکان می‌دهد صدای دستگاه‌های بلوتوث مختلف را به خاطر بسپارد.</string>
     <string name="upgrade_benefit_unlimited_devices">پروفایل‌های دستگاه نامحدود</string>
     <string name="upgrade_benefit_connection_actions">پخش خودکار، راه‌اندازی برنامه و هشدارهای اتصال</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Päivitä</string>
     <string name="common_upgrade_required_label">Päivitys vaaditaan</string>
     <string name="label_premium_version_required">Vaatii premium version</string>
-    <string name="upgrade_feature_requires_pro">Tämä ominaisuus vaatii premium-version</string>
-    <string name="upgrade_prompt_upgrade_action">Päivitä</string>
     <string name="description_intro_purpose">Tämä sovellus mahdollistaa Android laitteesi muistaa erillisten Bluetooth laitteiden äänenvoimakkuuden.</string>
     <string name="upgrade_benefit_unlimited_devices">Rajattomat laiteprofiillit</string>
     <string name="upgrade_benefit_connection_actions">Automaattinen toisto, sovelluksen käynnistys ja yhteysilmoitukset</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">I-upgrade</string>
     <string name="common_upgrade_required_label">Kailangan ng upgrade</string>
     <string name="label_premium_version_required">Kailangan ang bersyong premium</string>
-    <string name="upgrade_feature_requires_pro">Ang feature na ito ay nangangailangan ng bersyong premium</string>
-    <string name="upgrade_prompt_upgrade_action">I-upgrade</string>
     <string name="description_intro_purpose">Binibigyang daan ng app na maalala ng iyong Android device ang mga volume ng iba\'t-ibang mga Bluetooth device.</string>
     <string name="upgrade_benefit_unlimited_devices">Walang limitasyong mga profile ng device</string>
     <string name="upgrade_benefit_connection_actions">Autoplay, paglulunsad ng app at mga alerto sa koneksyon</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Surclasser</string>
     <string name="common_upgrade_required_label">Mise à niveau requise</string>
     <string name="label_premium_version_required">La version Pro est exigée</string>
-    <string name="upgrade_feature_requires_pro">Cette fonctionnalité nécessite la version premium</string>
-    <string name="upgrade_prompt_upgrade_action">Mettre à niveau</string>
     <string name="description_intro_purpose">Cette appli permet à votre appareil Android de mémoriser le volume de différents périphériques Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Profils d’appareils illimités</string>
     <string name="upgrade_benefit_connection_actions">Lecture automatique, lancement d’appli et alertes de connexion</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Actualizar</string>
     <string name="common_upgrade_required_label">Actualización requirida</string>
     <string name="label_premium_version_required">Versión Premium obrigatoria</string>
-    <string name="upgrade_feature_requires_pro">Esta funcionalidade require a versión Premium</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizar</string>
     <string name="description_intro_purpose">Esta aplicación permite que o teu Android lembre o volume dos diferentes dispositivos bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Perfís de dispositivos ilimitados</string>
     <string name="upgrade_benefit_connection_actions">Reprodución automática, inicio de aplicación e alertas de conexión</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">अपग्रेड</string>
     <string name="common_upgrade_required_label">अपग्रेड आवश्यक है</string>
     <string name="label_premium_version_required">प्रीमियम संस्करण की आवश्यकता है</string>
-    <string name="upgrade_feature_requires_pro">इस फीचर के लिए प्रीमियम वर्जन की आवश्यकता है</string>
-    <string name="upgrade_prompt_upgrade_action">अपग्रेड</string>
     <string name="description_intro_purpose">यह ऐप आपके एंड्रॉइड डिवाइस को विभिन्न ब्लूटूथ उपकरणों की मात्रा याद रखने की अनुमति देता है।</string>
     <string name="upgrade_benefit_unlimited_devices">असीमित डिवाइस प्रोफ़ाइल</string>
     <string name="upgrade_benefit_connection_actions">ऑटोप्ले, ऐप लॉन्च और कनेक्शन अलर्ट</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -334,8 +334,6 @@
     <string name="general_upgrade_action">Nadogradi</string>
     <string name="common_upgrade_required_label">Nadogradnja potrebna</string>
     <string name="label_premium_version_required">Potrebna je premium verzija</string>
-    <string name="upgrade_feature_requires_pro">Ova značajka zahtijeva premium verziju</string>
-    <string name="upgrade_prompt_upgrade_action">Nadogradi</string>
     <string name="description_intro_purpose">Ova aplikacija dopušta Vašem Android uređaju da zapamti glasnoću različitih Bluetooth uređaja.</string>
     <string name="upgrade_benefit_unlimited_devices">Neograničeni profili uređaja</string>
     <string name="upgrade_benefit_connection_actions">Automatska reprodukcija, pokretanje aplikacije i obavijesti o spajanju</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Frissítés</string>
     <string name="common_upgrade_required_label">Frissítés szükséges</string>
     <string name="label_premium_version_required">Prémium verzió szükséges</string>
-    <string name="upgrade_feature_requires_pro">Ez a funkció a prémium verziót igényli</string>
-    <string name="upgrade_prompt_upgrade_action">Frissítés</string>
     <string name="description_intro_purpose">Ez az alkalmazás lehetővé teszi, hogy az Android készüléked emlékezzen a különböző Bluetooth-eszközök hangerejére.</string>
     <string name="upgrade_benefit_unlimited_devices">Korlátlan eszközprofilok</string>
     <string name="upgrade_benefit_connection_actions">Automatikus lejátszás, alkalmazásindítás és kapcsolódási értesítések</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Թարմացնել</string>
     <string name="common_upgrade_required_label">Անհրաժեշտ է բարելավում</string>
     <string name="label_premium_version_required">Պահանջվում է պրեմիում տարբերակ</string>
-    <string name="upgrade_feature_requires_pro">Այս գործալիթյունը պահանջում է պրեմիում տարբերակ</string>
-    <string name="upgrade_prompt_upgrade_action">Թարմացնել</string>
     <string name="description_intro_purpose">Այս հավելվածը թույլ է տալիս ձեր Android սարքին հիշել տարբեր Bluetooth սարքերի ձայնի մակարդակը։</string>
     <string name="upgrade_benefit_unlimited_devices">Անսահմանափակ սարքի պրոֆիլներ</string>
     <string name="upgrade_benefit_connection_actions">Ավտոնվագարկում, հավելվածի գործարկում և կապի ծանուցումներ</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -326,8 +326,6 @@
     <string name="general_upgrade_action">Tingkatkan</string>
     <string name="common_upgrade_required_label">Upgrade diperlukan</string>
     <string name="label_premium_version_required">Versi premium dibutuhkan</string>
-    <string name="upgrade_feature_requires_pro">Fitur ini memerlukan versi premium</string>
-    <string name="upgrade_prompt_upgrade_action">Tingkatkan</string>
     <string name="description_intro_purpose">Aplikasi ini memungkinkan perangkat Android mengingat volume suara untuk perangkat Bluetooth berbeda.</string>
     <string name="upgrade_benefit_unlimited_devices">Profil perangkat tak terbatas</string>
     <string name="upgrade_benefit_connection_actions">Putar otomatis, peluncuran aplikasi, dan notifikasi koneksi</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Uppfæra</string>
     <string name="common_upgrade_required_label">Uppfærsla nauðsynleg</string>
     <string name="label_premium_version_required">Íbuðarútgáfa nauðsynleg</string>
-    <string name="upgrade_feature_requires_pro">Þessi eiginleiki krefst íbuðarútgáfunnar</string>
-    <string name="upgrade_prompt_upgrade_action">Uppfæra</string>
     <string name="description_intro_purpose">Þetta forrit leyfir Android tækinu þínu að muna hljóðstyrk mismunandi Bluetooth tækja.</string>
     <string name="upgrade_benefit_unlimited_devices">Ótakmarkaðar tækjasniðmát</string>
     <string name="upgrade_benefit_connection_actions">Sjálfvirk spilun, ræsing forrits og tengingartilkynningar</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Aggiorna</string>
     <string name="common_upgrade_required_label">Aggiornamento richiesto</string>
     <string name="label_premium_version_required">È richiesta la versione premium</string>
-    <string name="upgrade_feature_requires_pro">Questa funzione richiede la versione premium</string>
-    <string name="upgrade_prompt_upgrade_action">Aggiorna</string>
     <string name="description_intro_purpose">Quest\'app consente al tuo dispositivo Android di ricordare il volume di ogni dispositivo Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Profili dispositivo illimitati</string>
     <string name="upgrade_benefit_connection_actions">Riproduzione automatica, avvio app e avvisi di connessione</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -338,8 +338,6 @@
     <string name="general_upgrade_action">שדרוג</string>
     <string name="common_upgrade_required_label">נדרש שדרוג</string>
     <string name="label_premium_version_required">נדרשת גרסת פרימיום</string>
-    <string name="upgrade_feature_requires_pro">תכונה זו דורשת את גרסת הפרימיום</string>
-    <string name="upgrade_prompt_upgrade_action">שדרג</string>
     <string name="description_intro_purpose">אפליקציה זו מאפשרת למכשיר האנדרואיד שלכם לזכור רמות ווליום של מכשירי Bluetooth שונים.</string>
     <string name="upgrade_benefit_unlimited_devices">פרופילי מכשיר ללא הגבלה</string>
     <string name="upgrade_benefit_connection_actions">ניגון אוטומטי, הפעלת אפליקציה והתראות חיבור</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -326,8 +326,6 @@
     <string name="general_upgrade_action">アップグレード</string>
     <string name="common_upgrade_required_label">アップグレードが必要</string>
     <string name="label_premium_version_required">プレミアム版が必要です</string>
-    <string name="upgrade_feature_requires_pro">この機能にはプレミアム版が必要です</string>
-    <string name="upgrade_prompt_upgrade_action">アップグレード</string>
     <string name="description_intro_purpose">このアプリは、Android端末がBluetoothデバイスごとに音量を記憶できるようにします。</string>
     <string name="upgrade_benefit_unlimited_devices">無制限のデバイスプロファイル</string>
     <string name="upgrade_benefit_connection_actions">自動再生、アプリ起動、接続通知</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">გარემონტება</string>
     <string name="common_upgrade_required_label">საჭიროა განახლება</string>
     <string name="label_premium_version_required">საჭიროა პრემიუმ ვერსია</string>
-    <string name="upgrade_feature_requires_pro">ეს ფუნქცია მოითხოვს პრემიუმ ვერსიას</string>
-    <string name="upgrade_prompt_upgrade_action">გარემონტება</string>
     <string name="description_intro_purpose">ეს აპი საშუალებას აძლევს თქვენს Android მოწყობილობას დაიმახსოვროს სხვადასხვა Bluetooth მოწყობილობის ხმა.</string>
     <string name="upgrade_benefit_unlimited_devices">შეუზღუდავი მოწყობილობის პროფილები</string>
     <string name="upgrade_benefit_connection_actions">ავტომატური დაკვრა, აპის გაშვება და კავშირის შეტყობინებები</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -326,8 +326,6 @@
     <string name="general_upgrade_action">វិសិដ្ឋកម្ម</string>
     <string name="common_upgrade_required_label">តម្រូវការធ្វើឱ្យប្រសើរ</string>
     <string name="label_premium_version_required">ត្រូវការកំណែពិសេស</string>
-    <string name="upgrade_feature_requires_pro">មុខងារនេះតម្រូវឡើយមានកំណែពិសេស</string>
-    <string name="upgrade_prompt_upgrade_action">វិសិដ្ឋកម្ម</string>
     <string name="description_intro_purpose">កម្មវិធីនេះអនុញ្ញាតឱ្យឧបករណ៍ Android របស់អ្នកចងចាំកម្រិតសំឡេងនៃឧបករណ៍ Bluetooth ផ្សើៗ។</string>
     <string name="upgrade_benefit_unlimited_devices">ប្រវត្តិរូបឧបករណ៍គ្មានដែនកំណត់</string>
     <string name="upgrade_benefit_connection_actions">ចាកស្វ័យប្រវត្តិ, ការចាប្តើមកម្មវិធី និងការជូនដំណឹងការតភ្ជាប់</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Nûjen bike</string>
     <string name="common_upgrade_required_label">Bilindkirina pêdivî ye</string>
     <string name="label_premium_version_required">Guhertoya premium hewce ye</string>
-    <string name="upgrade_feature_requires_pro">Ev taybetmend guhertoya premium hewce dike</string>
-    <string name="upgrade_prompt_upgrade_action">Nûjen bike</string>
     <string name="description_intro_purpose">Ev bername dihêle cîhaza Android-a we astên dengê cîhazên Bluetooth ji bîr bike.</string>
     <string name="upgrade_benefit_unlimited_devices">Profîlên cîhazê yên bêsînor</string>
     <string name="upgrade_benefit_connection_actions">Otomatîkî lêdan, vekirin a sepanê û hişyariyên girêdanê</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ</string>
     <string name="common_upgrade_required_label">ಅಪ್‌ಗ್ರೇಡ್ ಅಗತ್ಯವಿದೆ</string>
     <string name="label_premium_version_required">ಪ್ರಿಮಿಯಮ್ ಆವೃತ್ತಿ ಅಗತ್ಯ</string>
-    <string name="upgrade_feature_requires_pro">ಈ ವೈಶಿಷ್ಟ್ಯಕ್ಕೆ ಪ್ರಿಮಿಯಮ್ ಆವೃತ್ತಿ ಅಗತ್ಯ</string>
-    <string name="upgrade_prompt_upgrade_action">ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ</string>
     <string name="description_intro_purpose">ಈ ಅಪ್ಲಿಕೇಶನ್ ನಿಮ್ಮ Android ಸಾಧನಕ್ಕೆ ವಿವಿಧ Bluetooth ಸಾಧನಗಳ ವಾಲ್ಯೂಮ್ ನೆನಪಿಟ್ಟುಕೊಳ್ಳಲು ಅನುಮತಿಸುತ್ತದೆ.</string>
     <string name="upgrade_benefit_unlimited_devices">ಅಪರಿಮಿತ ಸಾಧನ ಪ್ರೊಫೈಲ್‌ಗಳು</string>
     <string name="upgrade_benefit_connection_actions">ಸ್ವಯಂಪ್ಲೇ, ಅಪ್ಲಿಕೇಶನ್ ಲಾಂಚ್ ಮತ್ತು ಸಂಪರ್ಕ ಎಚ್ಚರಿಕೆಗಳು</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -326,8 +326,6 @@
     <string name="general_upgrade_action">업그레이드</string>
     <string name="common_upgrade_required_label">업그레이드 필요</string>
     <string name="label_premium_version_required">프리미엄 버전 필요</string>
-    <string name="upgrade_feature_requires_pro">이 기능은 프리미엄 버전이 필요합니다</string>
-    <string name="upgrade_prompt_upgrade_action">업그레이드</string>
     <string name="description_intro_purpose">이 앱은 안드로이드 디바이스가 각기 다른 블루투스 디바이스의 음량을 기억하도록 해줍니다.</string>
     <string name="upgrade_benefit_unlimited_devices">무제한 기기 프로필</string>
     <string name="upgrade_benefit_connection_actions">자동 재생, 앱 실행 및 연결 알림</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Жаңыртуу</string>
     <string name="common_upgrade_required_label">Жаңылануу кажет</string>
     <string name="label_premium_version_required">Премиум нускасы талап кылынат</string>
-    <string name="upgrade_feature_requires_pro">Бул функция премиум нускасын талап кылат</string>
-    <string name="upgrade_prompt_upgrade_action">Жаңыртуу</string>
     <string name="description_intro_purpose">Бул колдонмо Android түзмөгүңҿзгө ар кандай Bluetooth түзмөктөрүнүн үн деңгээлдерин эстеп калууга мүмкүндүк берет.</string>
     <string name="upgrade_benefit_unlimited_devices">Чексиз түзмөк профилдери</string>
     <string name="upgrade_benefit_connection_actions">Автоойнотуу, колдонмо ишке жүгүртүү жана кошулуу ескертүүләри</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -326,8 +326,6 @@
     <string name="general_upgrade_action">ອັບເກຣດ</string>
     <string name="common_upgrade_required_label">ຕ້ອງການອັບເກຣດ</string>
     <string name="label_premium_version_required">ຕ້ອງການໄ0ວີຊັນພຣີໄ0ມີຍມ</string>
-    <string name="upgrade_feature_requires_pro">ຟີເຈີນີ້ຕ້ອງການເວີຊັນພຣີເມີຍມ</string>
-    <string name="upgrade_prompt_upgrade_action">ອັບເກຣດ</string>
     <string name="description_intro_purpose">ແອັບນີ້ອະນຸຍາດໃຫ້ອຸປະກອນ Android ຂອງທ່ານຈດຈຳລະດັບສຽງຂອງອຸປະກອນ Bluetooth ຕ່າງๆ</string>
     <string name="upgrade_benefit_unlimited_devices">ໂປຣໄຟລ໌ອຸປະກອນບໍ່ຈຳກັດ</string>
     <string name="upgrade_benefit_connection_actions">ຫຼິ້ນອັດຕະໂນມັດ, ເປີດແອັບ ແລະ ການແຈ້ງເຕືອນການເຊື່ອມຕໍ່</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -338,8 +338,6 @@
     <string name="general_upgrade_action">Atnaujinti</string>
     <string name="common_upgrade_required_label">Reikalingas atnaujinimas</string>
     <string name="label_premium_version_required">Būtina Premium versija</string>
-    <string name="upgrade_feature_requires_pro">Šiai funkcijai reikalinga premium versija</string>
-    <string name="upgrade_prompt_upgrade_action">Atnaujinti</string>
     <string name="description_intro_purpose">Ši programa leidžia jūsų Android įrenginiui prisiminti įvairių Bluetooth įrenginių garsumo nustatymus.</string>
     <string name="upgrade_benefit_unlimited_devices">Neriboti įrenginių profiliai</string>
     <string name="upgrade_benefit_connection_actions">Automatinis paleidimas, programų paleidimas ir prisijungimo pranešimai</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -334,8 +334,6 @@
     <string name="general_upgrade_action">Jaunināt</string>
     <string name="common_upgrade_required_label">Nepieciešams jauninājums</string>
     <string name="label_premium_version_required">Nepieciešama premium versija</string>
-    <string name="upgrade_feature_requires_pro">Šī funkcija prasa premium versiju</string>
-    <string name="upgrade_prompt_upgrade_action">Jaunināt</string>
     <string name="description_intro_purpose">Šī lietotne ļauj jūsu Android ierīcei atcerēties dažādu Bluetooth ierīču skaļumus.</string>
     <string name="upgrade_benefit_unlimited_devices">Neierobežots ierīcī profilu skaits</string>
     <string name="upgrade_benefit_connection_actions">Automātiskā atskaņošana, lietotnes palaist un savienojuma brīdinājumi</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Надградба</string>
     <string name="common_upgrade_required_label">Потребна надградба</string>
     <string name="label_premium_version_required">Потребна е премиум верзија</string>
-    <string name="upgrade_feature_requires_pro">Оваа функција бара премиум верзија</string>
-    <string name="upgrade_prompt_upgrade_action">Надгради</string>
     <string name="description_intro_purpose">Оваа апликација дозволува вашиот Андроид уред го памети нивото на глас на различни Блутут уреди.</string>
     <string name="upgrade_benefit_unlimited_devices">Неограничен број профили на уреди</string>
     <string name="upgrade_benefit_connection_actions">Автоматско пуштање, стартување на апликација и известувања за поврзување</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">അപ്ഗ്രേഡുചെയ്യുക</string>
     <string name="common_upgrade_required_label">അപ്‌ഗ്രേഡ് ആവശ്യമാണ്</string>
     <string name="label_premium_version_required">പ്രീമിയം വേർഷൻ ആവശ്യമാണ്</string>
-    <string name="upgrade_feature_requires_pro">ഈ ഫീചർക്ക് പ്രീമിയം വേർഷൻ ആവശ്യമാണ്</string>
-    <string name="upgrade_prompt_upgrade_action">അപ്ഗ്രേഡുചെയ്യുക</string>
     <string name="description_intro_purpose">ഈ ആപ്പ് നിങ്ങളുടെ Android ഉപകരണത്തെ വ്യത്യസ്ത Bluetooth ഉപകരണങ്ങളുടെ വോള്യം ഓർക്കാൻ അനുവദിക്കുന്നു.</string>
     <string name="upgrade_benefit_unlimited_devices">പരിധിയില്ലാത്ത ഉപകരണ പ്രൊഫൈലുകൾ</string>
     <string name="upgrade_benefit_connection_actions">ഓട്ടോപ്ലേ, ആപ്പ് ലോഞ്ച്, കണക്ഷൻ അലർട്ടുകൾ</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Сайжруулах</string>
     <string name="common_upgrade_required_label">Шинэчлэлт шаардлагатай</string>
     <string name="label_premium_version_required">Премиум хувилбар шаардлагана</string>
-    <string name="upgrade_feature_requires_pro">Энэ онцлогд премиум хувилбар шаардлагана</string>
-    <string name="upgrade_prompt_upgrade_action">Сайжруулах</string>
     <string name="description_intro_purpose">Энэ апп таны Android төхөөрөмжийд өөр өөр Bluetooth төхөөрөмжийн дууг санаах боломжийг олгодог.</string>
     <string name="upgrade_benefit_unlimited_devices">Хязгаалаггүй төхөөрөмжийн профайлууд</string>
     <string name="upgrade_benefit_connection_actions">Автомат тоглуулалт, апп нээх, холбооны мэдэгдэл</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">अपग्रेड करा</string>
     <string name="common_upgrade_required_label">अपग्रेड आवश्यक</string>
     <string name="label_premium_version_required">प्रीमियम आवृत्ती आवश्यक</string>
-    <string name="upgrade_feature_requires_pro">या वैशिष्ट्यासाठी प्रीमियम आवृत्ती आवश्यक आहे</string>
-    <string name="upgrade_prompt_upgrade_action">अपग्रेड करा</string>
     <string name="description_intro_purpose">हा अॅप तुमच्या Android डिव्हाइसला वेगवेगळ्या Bluetooth डिव्हाइसचे व्हॉल्युम लक्षात ठेवण्याची परवानगी देतो.</string>
     <string name="upgrade_benefit_unlimited_devices">अमर्यादित डिव्हाइस प्रोफाइल</string>
     <string name="upgrade_benefit_connection_actions">ऑटोप्ले, अ‍ॅप लॉन्च आणि कनेक्शन सूचना</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -326,8 +326,6 @@
     <string name="general_upgrade_action">Naik taraf</string>
     <string name="common_upgrade_required_label">Naik taraf diperlukan</string>
     <string name="label_premium_version_required">Versi premium diperlukan</string>
-    <string name="upgrade_feature_requires_pro">Ciri ini memerlukan versi premium</string>
-    <string name="upgrade_prompt_upgrade_action">Naik taraf</string>
     <string name="description_intro_purpose">Apl ini membolehkan peranti Android anda mengingati volum dari peranti Bluetooth yang berbeza.</string>
     <string name="upgrade_benefit_unlimited_devices">Profil peranti tanpa had</string>
     <string name="upgrade_benefit_connection_actions">Main auto, lancar aplikasi dan amaran sambungan</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -326,8 +326,6 @@
     <string name="general_upgrade_action">အဆင့်မြှင့်တင်မည်</string>
     <string name="common_upgrade_required_label">အဆင့်မြှင့်တင်ရန် လိုအပ်သည်</string>
     <string name="label_premium_version_required">Premium မျိုးကွဲ လိုအပ်သည်</string>
-    <string name="upgrade_feature_requires_pro">ဤ လုပ်ဆောင်ချက်အတွက် premium မျိုးကွဲ လိုအပ်သည်</string>
-    <string name="upgrade_prompt_upgrade_action">အဆင့်မြှင့်တင်မည်</string>
     <string name="description_intro_purpose">ဤအပ်သည် သင့် Android ကိရိယာကို မတူညီသော Bluetooth ကိရိယာများ၏ အသံကို မှတ်မိစေသည်။</string>
     <string name="upgrade_benefit_unlimited_devices">ကန့်သတ်မှုမရှိသော ကိရိယာ ပရိုဖိုင်များ</string>
     <string name="upgrade_benefit_connection_actions">အလိုအလျောက်ဖွင့်ခြင်း၊ အက်ပ်ဖွင့်ခြင်းနှင့် ချိတ်ဆက်မှု သတိပေးချက်များ</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">अपग्रेड गर्नुहोस्</string>
     <string name="common_upgrade_required_label">अपग्रेड आवश्यक छ</string>
     <string name="label_premium_version_required">प्रिमियम संस्करण आवश्यक</string>
-    <string name="upgrade_feature_requires_pro">यो सुविधालाई प्रिमियम संस्करण आवश्यक छ</string>
-    <string name="upgrade_prompt_upgrade_action">अपग्रेड गर्नुहोस्</string>
     <string name="description_intro_purpose">यो एपले तपाईंको Android उपकरणलाई विभिन्न Bluetooth उपकरणहरूको भोल्युम सम्झन दिन्छ।</string>
     <string name="upgrade_benefit_unlimited_devices">असीमित यन्त्र प्रोफाइलहरू</string>
     <string name="upgrade_benefit_connection_actions">अटोप्ले, एप लन्च र कनेक्सन अलर्टहरू</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Upgraden</string>
     <string name="common_upgrade_required_label">Upgrade vereist</string>
     <string name="label_premium_version_required">Premium versie vereist</string>
-    <string name="upgrade_feature_requires_pro">Deze functie vereist de premium versie</string>
-    <string name="upgrade_prompt_upgrade_action">Upgraden</string>
     <string name="description_intro_purpose">Deze app staat je Android toestel toe het volume te onthouden van verschillende Bluetooth-apparaten.</string>
     <string name="upgrade_benefit_unlimited_devices">Onbeperkte apparaatprofielen</string>
     <string name="upgrade_benefit_connection_actions">Autoplay, app starten en verbindingswaarschuwingen</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Oppgrader</string>
     <string name="common_upgrade_required_label">Oppgradering kreves</string>
     <string name="label_premium_version_required">Premiumversjon krevet</string>
-    <string name="upgrade_feature_requires_pro">Denne funksjonen krever premiumversjonen</string>
-    <string name="upgrade_prompt_upgrade_action">Oppgrader</string>
     <string name="description_intro_purpose">Denne appen lar din Android-enhet huske volumet av forskjellige Bluetooth enheter.</string>
     <string name="upgrade_benefit_unlimited_devices">Ubegrenset antall enhetsprofiler</string>
     <string name="upgrade_benefit_connection_actions">Autoavspilling, appstart og tilkoblingsvarsler</string>

--- a/app/src/main/res/values-pcm-rNG/strings.xml
+++ b/app/src/main/res/values-pcm-rNG/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Upgrade</string>
     <string name="common_upgrade_required_label">You need upgrade</string>
     <string name="label_premium_version_required">Premium version required</string>
-    <string name="upgrade_feature_requires_pro">Dis feature need di premium version</string>
-    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
     <string name="description_intro_purpose">Dis app go allow your Android device remember di volume of different Bluetooth devices.</string>
     <string name="upgrade_benefit_unlimited_devices">Unlimited device profiles</string>
     <string name="upgrade_benefit_connection_actions">Autoplay, app launch and connection alerts</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -339,8 +339,6 @@ Karol Szastok (K4r0lSz);</string>
     <string name="general_upgrade_action">Ulepszenie</string>
     <string name="common_upgrade_required_label">Wymagane ulepszenie</string>
     <string name="label_premium_version_required">Wymagana wersja Premium</string>
-    <string name="upgrade_feature_requires_pro">Ta funkcja wymaga wersji premium</string>
-    <string name="upgrade_prompt_upgrade_action">Ulepsz</string>
     <string name="description_intro_purpose">Aplikacja zezwala Androidowi na zapamiętanie głośności dla różnych urządzeń Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Nieograniczone profile urządzeń</string>
     <string name="upgrade_benefit_connection_actions">Autoodtwarzanie, uruchamianie aplikacji i alerty połączeń</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Atualizar</string>
     <string name="common_upgrade_required_label">Atualização necessária</string>
     <string name="label_premium_version_required">Requer versão Premium</string>
-    <string name="upgrade_feature_requires_pro">Este recurso requer a versão premium</string>
-    <string name="upgrade_prompt_upgrade_action">Atualizar</string>
     <string name="description_intro_purpose">Este aplicativo possibilita ao seu dispositivo Android memorizar o volume de diferentes dispositivos Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Perfis de dispositivos ilimitados</string>
     <string name="upgrade_benefit_connection_actions">Reprodução automática, lançamento de aplicativos e alertas de conexão</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Atualizar</string>
     <string name="common_upgrade_required_label">Atualização necessária</string>
     <string name="label_premium_version_required">Necessita da versão Premium</string>
-    <string name="upgrade_feature_requires_pro">Esta funcionalidade requer a versão premium</string>
-    <string name="upgrade_prompt_upgrade_action">Atualizar</string>
     <string name="description_intro_purpose">Esta aplicação permite que o seu dispositivo memorize o volume dos diferentes dispositivos Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Perfis de dispositivos ilimitados</string>
     <string name="upgrade_benefit_connection_actions">Reprodução automática, início de aplicações e alertas de ligação</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Actualisar</string>
     <string name="common_upgrade_required_label">Actualisaziun necessaria</string>
     <string name="label_premium_version_required">Versiun premium necessaria</string>
-    <string name="upgrade_feature_requires_pro">Questa funcziún dastga la versiun premium</string>
-    <string name="upgrade_prompt_upgrade_action">Actualisar</string>
     <string name="description_intro_purpose">Questa app permetta a tiu apparat Android da memorar il volum da differents apparats Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Profils d\'apparat senza limita</string>
     <string name="upgrade_benefit_connection_actions">Autoplay, aviadira d\'app ed avis da connexiun</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -334,8 +334,6 @@
     <string name="general_upgrade_action">Actualizează</string>
     <string name="common_upgrade_required_label">Upgrade necesar</string>
     <string name="label_premium_version_required">Versiune premium necesară</string>
-    <string name="upgrade_feature_requires_pro">Această funcționalitate necesită versiunea premium</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizează</string>
     <string name="description_intro_purpose">Această aplicație permite dispozitivului tău Android să îi amintească volumul diferitelor dispozitive Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Profile nelimitate de dispozitive</string>
     <string name="upgrade_benefit_connection_actions">Redare automată, lansare aplicație și alerte de conexiune</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -338,8 +338,6 @@
     <string name="general_upgrade_action">Обновление</string>
     <string name="common_upgrade_required_label">Требуется обновление</string>
     <string name="label_premium_version_required">Необходима премиум-версия</string>
-    <string name="upgrade_feature_requires_pro">Эта функция требует премиум-версию</string>
-    <string name="upgrade_prompt_upgrade_action">Обновить</string>
     <string name="description_intro_purpose">Приложение позволяет системе Андроид запомнить громкость различных устройств Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Неограниченное количество профилей устройств</string>
     <string name="upgrade_benefit_connection_actions">Автовоспроизведение, запуск приложений и оповещения о подключении</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Aggiornamentu</string>
     <string name="common_upgrade_required_label">Aggiornamentu requeridu</string>
     <string name="label_premium_version_required">Versione premium richièsta</string>
-    <string name="upgrade_feature_requires_pro">Cussa funtzionalidade richièdet sa versione premium</string>
-    <string name="upgrade_prompt_upgrade_action">Aggiornamentu</string>
     <string name="description_intro_purpose">S\'app permìttit a su dispositivu Android tuo de recordare su volume de sos diversos dispositivos Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Profilis de dispositivu illimitaus</string>
     <string name="upgrade_benefit_connection_actions">Riprodutzione automàtica, apertura de app e avisos de connessione</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">උසස් කරන්න</string>
     <string name="common_upgrade_required_label">උත්‍යාජනය අවශ්‍යයි</string>
     <string name="label_premium_version_required">Premium අනුවාදය අවශ්‍යයි</string>
-    <string name="upgrade_feature_requires_pro">මෙම ලක්ෂණය premium අනුවාදය අවශ්‍ය කරයි</string>
-    <string name="upgrade_prompt_upgrade_action">උසස් කරන්න</string>
     <string name="description_intro_purpose">මෙම යෙදුම ඔබේ Android උපාංගයට විවිධ Bluetooth උපාංගයන්හි හඩ මට්ටම් මතක් කර ගැනීමට ඉඩ දෙයි.</string>
     <string name="upgrade_benefit_unlimited_devices">අසීමිත උපාංග පැතිකඩ</string>
     <string name="upgrade_benefit_connection_actions">ස්වයංක්‍රීය ධාවනය, යෙදුම් දියත් කිරීම සහ සම්බන්ධ ඇඟවීම්</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -338,8 +338,6 @@
     <string name="general_upgrade_action">Upgradovať</string>
     <string name="common_upgrade_required_label">Vyžaduje sa upgrade</string>
     <string name="label_premium_version_required">Vyžaduje sa verzia prémium</string>
-    <string name="upgrade_feature_requires_pro">Táto funkcia vyžaduje prémiovú verziu</string>
-    <string name="upgrade_prompt_upgrade_action">Upgradovať</string>
     <string name="description_intro_purpose">Táto aplikácia umožňuje vášmu Android zariadeniu uložiť hlasitosti pre rôzne Bluetooth zariadenia.</string>
     <string name="upgrade_benefit_unlimited_devices">Neobmedzené profily zariadení</string>
     <string name="upgrade_benefit_connection_actions">Automatické prehrávanie, spustenie aplikácie a upozornenia na pripojenie</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -338,8 +338,6 @@
     <string name="general_upgrade_action">Nadgradi</string>
     <string name="common_upgrade_required_label">Zahtevana nadgradnja</string>
     <string name="label_premium_version_required">Zahtevana je premium različica</string>
-    <string name="upgrade_feature_requires_pro">Ta funkcija zahteva premium različico</string>
-    <string name="upgrade_prompt_upgrade_action">Nadgradi</string>
     <string name="description_intro_purpose">Ta aplikacija omogoča vaši napravi Android, da si zapomni glasnost različnih naprav Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Neomejeni profili naprav</string>
     <string name="upgrade_benefit_connection_actions">Samodejno predvajanje, zagon aplikacij in obvestila o povezavi</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Ngriti</string>
     <string name="common_upgrade_required_label">Kërkohet përmirësim</string>
     <string name="label_premium_version_required">Kërkohet versioni premium</string>
-    <string name="upgrade_feature_requires_pro">Ky veçori kërkon versionin premium</string>
-    <string name="upgrade_prompt_upgrade_action">Ngriti</string>
     <string name="description_intro_purpose">Ky aplikacion lejon pajisjen tuaj Android të mbajë mend volumin e pajisjeve të ndryshme Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Profile të pakufizuara pajisje</string>
     <string name="upgrade_benefit_connection_actions">Luajtje automatike, hapje aplikacioni dhe njoftime lidhjeje</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -334,8 +334,6 @@
     <string name="general_upgrade_action">Надогради</string>
     <string name="common_upgrade_required_label">Потребна надоградња</string>
     <string name="label_premium_version_required">Потребна премијум верзија</string>
-    <string name="upgrade_feature_requires_pro">Ова функција захтева премијум верзију</string>
-    <string name="upgrade_prompt_upgrade_action">Надогради</string>
     <string name="description_intro_purpose">Ова апликација омогућава твом Андроид уређају да памти јачину звука различитих Bluetooth уређаја.</string>
     <string name="upgrade_benefit_unlimited_devices">Неограничени профили уређаја</string>
     <string name="upgrade_benefit_connection_actions">Аутоматско пуштање, покретање апликације и упозорења о вези</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Uppgradera</string>
     <string name="common_upgrade_required_label">Uppgradering krävs</string>
     <string name="label_premium_version_required">Premium-versionen krävs</string>
-    <string name="upgrade_feature_requires_pro">Den här funktionen kräver premiumversionen</string>
-    <string name="upgrade_prompt_upgrade_action">Uppgradera</string>
     <string name="description_intro_purpose">Med den här appen kan din Android-enhet komma ihåg volymen för olika Bluetooth-enheter.</string>
     <string name="upgrade_benefit_unlimited_devices">Obegränsade enhetsprofiler</string>
     <string name="upgrade_benefit_connection_actions">Automatisk uppspelning, appstart och anslutningsaviseringar</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Boresha</string>
     <string name="common_upgrade_required_label">Uboreshaji unahitajika</string>
     <string name="label_premium_version_required">Toleo la premium linahitajika</string>
-    <string name="upgrade_feature_requires_pro">Kipengele hiki kinahitaji toleo la premium</string>
-    <string name="upgrade_prompt_upgrade_action">Boresha</string>
     <string name="description_intro_purpose">Programu hii inaruhusu kifaa chako cha Android kukumbuka sauti ya vifaa tofauti vya Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Wasifu usio na kikomo wa vifaa</string>
     <string name="upgrade_benefit_connection_actions">Kucheza kiotomatiki, uzinduzi wa programu na arifa za muunganisho</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">மேம்படுத்து</string>
     <string name="common_upgrade_required_label">மேம்படுத்தல் தேவை</string>
     <string name="label_premium_version_required">ப்ரிமியம் பதிப்பு தேவைய்</string>
-    <string name="upgrade_feature_requires_pro">இந்த சிறப்பியுக்கு ப்ரிமியம் பதிப்பு தேவைப்படுகிறது</string>
-    <string name="upgrade_prompt_upgrade_action">மேம்படுத்து</string>
     <string name="description_intro_purpose">இந்த ஆப்் உங்கள் Android சாதனம் மாற்றமான Bluetooth சாதனங்களின் ஒலி அளவுகளை நினைவில் வைக்க உதவுகிறது.</string>
     <string name="upgrade_benefit_unlimited_devices">வரம்பற்ற சாதன சுயவிவரங்கள்</string>
     <string name="upgrade_benefit_connection_actions">தானியங்கி இயக்கம், பயன்பாட்டு தொடக்கம் மற்றும் இணைப்பு எச்சரிக்கைகள்</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">అప్‌గ్రేడ్ చేయండి</string>
     <string name="common_upgrade_required_label">అప్‌గ్రేడ్ అవసరం</string>
     <string name="label_premium_version_required">ప్రీమియం వెర్షన్ అవసరం</string>
-    <string name="upgrade_feature_requires_pro">ఈ ఫీచర్‌కు ప్రీమియం వెర్షన్ అవసరం</string>
-    <string name="upgrade_prompt_upgrade_action">అప్‌గ్రేడ్ చేయండి</string>
     <string name="description_intro_purpose">ఈ యాప్ మీ Android పరికరం వేర్వేరు Bluetooth పరికరాల వాల్యూమ్‌ను గుర్తుంచుకోవడానికి అనుమతిస్తుంది.</string>
     <string name="upgrade_benefit_unlimited_devices">అపరిమిత పరికర ప్రొఫైల్‌లు</string>
     <string name="upgrade_benefit_connection_actions">ఆటోప్లే, యాప్ లాంచ్ మరియు కనెక్షన్ అలర్ట్‌లు</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -326,8 +326,6 @@
     <string name="general_upgrade_action">อัปเกรด</string>
     <string name="common_upgrade_required_label">ต้องอัปเกรด</string>
     <string name="label_premium_version_required">ต้องการรุ่นพรีเมี่ยม</string>
-    <string name="upgrade_feature_requires_pro">คุณสมบัตินี้ต้องใช้เวอร์ชันพรีเมี่ยม</string>
-    <string name="upgrade_prompt_upgrade_action">อัปเกรด</string>
     <string name="description_intro_purpose">แอปนี้ช่วยให้อุปกรณ์ Android ของคุณจดจำระดับเสียงของอุปกรณ์บลูทูธแต่ละตัว</string>
     <string name="upgrade_benefit_unlimited_devices">โปรไฟล์อุปกรณ์ไม่จำกัด</string>
     <string name="upgrade_benefit_connection_actions">เล่นอัตโนมัติ, เปิดแอป และการแจ้งเตือนการเชื่อมต่อ</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Yükselt</string>
     <string name="common_upgrade_required_label">Yükseltme gerekli</string>
     <string name="label_premium_version_required">Ücretli sürüm gerekli</string>
-    <string name="upgrade_feature_requires_pro">Bu özellik premium sürümü gerektiriyor</string>
-    <string name="upgrade_prompt_upgrade_action">Yükselt</string>
     <string name="description_intro_purpose">Bu uygulama, Android cihazınızın farklı Bluetooth cihazlarının ses seviyesini hatırlamasını sağlar.</string>
     <string name="upgrade_benefit_unlimited_devices">Sınırsız cihaz profili</string>
     <string name="upgrade_benefit_connection_actions">Otomatik oynatma, uygulama başlatma ve bağlantı uyarıları</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -338,8 +338,6 @@
     <string name="general_upgrade_action">Підвищити статус</string>
     <string name="common_upgrade_required_label">Потрібне оновлення</string>
     <string name="label_premium_version_required">Потрібна преміум-версія</string>
-    <string name="upgrade_feature_requires_pro">Ця функція потребує преміум-версії</string>
-    <string name="upgrade_prompt_upgrade_action">Підвищити</string>
     <string name="description_intro_purpose">Додаток дозволяє вашому Android запам\'ятовувати гучність різних пристроїв Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Необмежена кількість профілів пристроїв</string>
     <string name="upgrade_benefit_connection_actions">Автовідтворення, запуск програм та сповіщення про підключення</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">اپ گریڈ کریں</string>
     <string name="common_upgrade_required_label">اپگریڈ ضروری ہے</string>
     <string name="label_premium_version_required">پریمیم ورژن ضروری ہے</string>
-    <string name="upgrade_feature_requires_pro">اس فیچر کے لیے پریمیم ورژن کی ضرورت ہے</string>
-    <string name="upgrade_prompt_upgrade_action">اپ گریڈ کریں</string>
     <string name="description_intro_purpose">یہ ایپ آپ کے اینڈرائیڈ ڈیوائس کو مختلف بلوٹوتھ ڈیوائسز کا والیوم یاد رکھنے دیتی ہے۔</string>
     <string name="upgrade_benefit_unlimited_devices">لامحدود ڈیوائس پروفائلز</string>
     <string name="upgrade_benefit_connection_actions">آٹوپلے، ایپ لانچ اور کنکشن الرٹس</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Yangilash</string>
     <string name="common_upgrade_required_label">Yangilash talab qilinadi</string>
     <string name="label_premium_version_required">Premium versiya talab qilinadi</string>
-    <string name="upgrade_feature_requires_pro">Bu funksiya uchun premium versiya talab qilinadi</string>
-    <string name="upgrade_prompt_upgrade_action">Yangilash</string>
     <string name="description_intro_purpose">Bu ilova Android qurilmangizga turli Bluetooth qurilmalar uchun ovoz darajasini eslab qolish imkonini beradi.</string>
     <string name="upgrade_benefit_unlimited_devices">Cheklanmagan qurilma profillari</string>
     <string name="upgrade_benefit_connection_actions">Avtomatik ijro, ilova ishga tushirish va ulanish ogohlantirishlari</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -328,8 +328,6 @@ TheNothingGuy</string>
     <string name="general_upgrade_action">Nâng cấp</string>
     <string name="common_upgrade_required_label">Yêu cầu nâng cấp</string>
     <string name="label_premium_version_required">Yêu cầu phiên bản trả phí</string>
-    <string name="upgrade_feature_requires_pro">Tính năng này cần phiên bản trả phí</string>
-    <string name="upgrade_prompt_upgrade_action">Nâng cấp</string>
     <string name="description_intro_purpose">Ứng dụng này cho phép Android ghi nhớ mức âm lượng của thiết bị Bluetooth khác nhau.</string>
     <string name="upgrade_benefit_unlimited_devices">Không giới hạn hồ sơ thiết bị</string>
     <string name="upgrade_benefit_connection_actions">Tự phát, mở ứng dụng và cảnh báo kết nối</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -326,8 +326,6 @@
     <string name="general_upgrade_action">升级</string>
     <string name="common_upgrade_required_label">需要升级</string>
     <string name="label_premium_version_required">需要高级版本</string>
-    <string name="upgrade_feature_requires_pro">此功能需要高级版本</string>
-    <string name="upgrade_prompt_upgrade_action">升级</string>
     <string name="description_intro_purpose">此应用可让您的Android设备，记住来自不同蓝牙设备的音量。</string>
     <string name="upgrade_benefit_unlimited_devices">无限设备配置</string>
     <string name="upgrade_benefit_connection_actions">自动播放、启动应用及连接提醒</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -326,8 +326,6 @@
     <string name="general_upgrade_action">升級</string>
     <string name="common_upgrade_required_label">需要升級</string>
     <string name="label_premium_version_required">需要高級版本</string>
-    <string name="upgrade_feature_requires_pro">此功能需要高級版本</string>
-    <string name="upgrade_prompt_upgrade_action">升級</string>
     <string name="description_intro_purpose">此應用讓你的 Android 裝置記住不同藍牙裝置的音量。</string>
     <string name="upgrade_benefit_unlimited_devices">無限裝置設定檔</string>
     <string name="upgrade_benefit_connection_actions">自動播放、啟動應用程式及連線提醒</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="app_name">藍牙音量管理員</string>
     <string name="app_name_short">BVM</string>
     <!-- Upgraded app title. %1$s is the short app name, %2$s the tier qualifier ("Pro" on Google Play, "FOSS" on the open-source build). Reorder or repunctuate for your language; both placeholders must appear exactly once. -->
     <string name="app_name_upgraded_template">%1$s %2$s</string>
@@ -325,8 +326,6 @@
     <string name="general_upgrade_action">升級</string>
     <string name="common_upgrade_required_label">需要升級</string>
     <string name="label_premium_version_required">需要付費版本</string>
-    <string name="upgrade_feature_requires_pro">此功能需要付費版本</string>
-    <string name="upgrade_prompt_upgrade_action">升級</string>
     <string name="description_intro_purpose">這個應用程式允許 Android 記住不同的藍牙裝置的音量。</string>
     <string name="upgrade_benefit_unlimited_devices">無限裝置設定檔</string>
     <string name="upgrade_benefit_connection_actions">自動播放、啟動應用程式與連線提醒</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -330,8 +330,6 @@
     <string name="general_upgrade_action">Thuthukisa</string>
     <string name="common_upgrade_required_label">Ukuphakamisa kuyadingeka</string>
     <string name="label_premium_version_required">Kudingeka inguqulo ye-premium</string>
-    <string name="upgrade_feature_requires_pro">Lesi sici sidinga inguqulo ye-premium</string>
-    <string name="upgrade_prompt_upgrade_action">Thuthukisa</string>
     <string name="description_intro_purpose">Lolu hlelo luvumela idivayisi yakho ye-Android ukukhumbula ivolumu yezidivayisi ezihlukene ze-Bluetooth.</string>
     <string name="upgrade_benefit_unlimited_devices">Amaphrofayela amadivayisi angenamkhawulo</string>
     <string name="upgrade_benefit_connection_actions">Ukudlala ngokuzenzakalela, ukuqalisa uhlelo lokusebenza nezaziso zokulumeka</string>


### PR DESCRIPTION
## What changed
Updated translated strings for all 77 locales, pulled from Crowdin. Adds the translation for the new "owned hero" upgrade-screen title (`upgrade_screen_owned_hero_brand_title`) across every language, and removes two stale translation entries whose English source keys were already deleted.

## Technical Context
- Every locale diff was reviewed by an independent validator pass for vandalism, placeholder corruption (`%1$s` etc.), and encoding issues — none found.
- Two locales (French, Portuguese) use informal address ("tu"/"tu"-form verbs) for the new string while sibling strings on the same screen use formal address. Meaning and placeholders are correct, so these were left as-is rather than reverted; worth a look if formal-register consistency matters for those locales.
- No fastlane store-listing changes were included in this pull (Crowdin had nothing new for those files).