### PR TITLE
Show when a Google Play payment is still being processed

### DIFF
--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -44,8 +44,11 @@ class UpgradeViewModel @Inject constructor(
 
     // Which presentation the screen shows. The manage route (settings "supporter status" entry)
     // gets a status view first; the pitch only appears once a free user asks for the upgrade
-    // options. Upgrading wins over that choice — completing the sponsor flow from the pitch must
-    // land on the upgraded status, not back on the ask. null until the route is bound.
+    // options. Upgrading wins on EVERY route, not just manage: the pitch with its live sponsor
+    // button reads as "sponsoring didn't work" to a fresh supporter, and the thanks toast alone is
+    // too transient for a money moment to have no receipt behind it. On the non-manage routes the
+    // auto-close below follows a frame later, so this is what the user sees in between.
+    // null until the route is bound.
     internal val state: StateFlow<State> = combine(
         routeFlow,
         upgradeRepo.upgradeInfo,
@@ -57,7 +60,7 @@ class UpgradeViewModel @Inject constructor(
             // free version" on the manage route would be a claim the storage couldn't back. The
             // errorEvents overlay reports the failure instead.
             route.manage && !info.isPro && info.error != null -> null
-            route.manage && info.isPro -> FossUpgradeView.STATUS_UPGRADED
+            info.isPro -> FossUpgradeView.STATUS_UPGRADED
             route.manage && !showOptions -> FossUpgradeView.STATUS_FREE
             else -> FossUpgradeView.PITCH
         }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplay.kt
@@ -2,7 +2,6 @@ package eu.darken.bluemusic.upgrade.core
 
 import android.app.Activity
 import com.android.billingclient.api.BillingClient.BillingResponseCode
-import com.android.billingclient.api.Purchase
 import eu.darken.bluemusic.common.coroutine.AppScope
 import eu.darken.bluemusic.common.datastore.value
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.ERROR
@@ -18,6 +17,7 @@ import eu.darken.bluemusic.upgrade.core.billing.BillingData
 import eu.darken.bluemusic.upgrade.core.billing.BillingManager
 import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.bluemusic.upgrade.core.billing.ItemAlreadyOwnedBillingException
+import eu.darken.bluemusic.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.bluemusic.upgrade.core.billing.PurchasedSku
 import eu.darken.bluemusic.upgrade.core.billing.Sku
 import eu.darken.bluemusic.upgrade.core.billing.SkuDetails
@@ -286,9 +286,18 @@ class UpgradeRepoGplay @Inject constructor(
                     // Reconciled only if the restore actually returned the SKU Play claims is
                     // owned — a grace-only isPro doesn't count, the entitlement is still missing.
                     if (restored?.upgrades?.any { it.sku == sku } != true) {
-                        // Couldn't reconcile the entitlement (pending purchase, account mismatch,
-                        // Play quirk) — fall back to the already-owned dialog with restore tips.
-                        onError(e)
+                        if (restored?.pendingSkus?.isNotEmpty() == true) {
+                            // Play blocks re-purchasing a product whose payment it is still
+                            // processing. "Already owned" is technically what Play said, but the
+                            // dialog's restore tips are the wrong advice: nothing to restore, and
+                            // the entitlement lands by itself once the payment clears.
+                            log(TAG, INFO) { "Already-owned recovery found a pending payment" }
+                            onError(PendingPurchaseBillingException(e))
+                        } else {
+                            // Couldn't reconcile the entitlement (account mismatch, Play quirk) —
+                            // fall back to the already-owned dialog with restore tips.
+                            onError(e)
+                        }
                     }
                 }
 
@@ -331,12 +340,15 @@ class UpgradeRepoGplay @Inject constructor(
 
     suspend fun querySkus(vararg skus: Sku): Collection<SkuDetails> = billingManager.querySkus(*skus)
 
-    // Strict subscription lookup for the pre-purchase gate: fresh SUBS-only query with explicit
-    // failure. No grace substitution and no cross-product-type tolerance (unlike refresh() and
+    // Strict purchase-state lookup for the pre-purchase gates: a fresh COMPLETE round-trip with
+    // explicit failure. No grace substitution and no partial tolerance (unlike refresh() and
     // restorePurchaseNow()) — callers must treat any error as "couldn't verify" and fail closed.
-    suspend fun queryCurrentSubscriptions(): Collection<Purchase> {
-        log(TAG) { "queryCurrentSubscriptions()" }
-        return billingManager.querySubscriptions()
+    // Covers both product types and pending payments, because both can make a purchase wrong: a
+    // renewing subscription (double billing) and a payment Play is still processing (Play rejects
+    // the re-purchase).
+    suspend fun verifyPurchaseStateNow(): Info {
+        log(TAG) { "verifyPurchaseStateNow()" }
+        return Info(billingData = billingManager.refreshStrict(), isSettled = true)
     }
 
     override suspend fun refresh() {
@@ -498,8 +510,8 @@ class UpgradeRepoGplay @Inject constructor(
     // Shared Pro/grace mapping used by both the reactive upgradeInfo flow and restorePurchaseNow().
     // Only relinquishes Pro if we haven't had it for a while (grace period). READ-ONLY: this runs on
     // replayed shared-flow data too, so it must never stamp the grace cache — see recordProState().
-    // settled comes from the caller, never from billingData nullness: the grace branch returns an
-    // Info with billingData = null that may well be settled (built from a real empty snapshot).
+    // settled comes from the caller, never from billingData nullness: a null-data Info can be
+    // perfectly settled (a real empty snapshot), and the grace branch carries data through anyway.
     private suspend fun BillingData?.toUpgradeInfo(settled: Boolean): Info {
         // Branch on MAPPED upgrades, not raw purchases: a purchase list containing only products
         // this app doesn't know maps to zero upgrades and must fall through to the grace check —
@@ -515,7 +527,11 @@ class UpgradeRepoGplay @Inject constructor(
         return when {
             (now - lastProStateAt) < graceWindowMs() -> {
                 log(TAG, VERBOSE) { "We are not pro, but were recently, did GPlay try annoy us again?" }
-                Info(gracePeriod = true, billingData = null, isSettled = settled)
+                // billingData is carried through, not dropped: this branch is only reached when the
+                // mapped upgrades are empty, so entitlement stays empty either way — but a pending
+                // payment must stay visible, and a grace user waiting on one is exactly who needs
+                // the explanation.
+                Info(gracePeriod = true, billingData = this, isSettled = settled)
             }
 
             else -> mapped
@@ -559,6 +575,34 @@ class UpgradeRepoGplay @Inject constructor(
             }
             ?.flatten()
             ?: emptySet()
+
+        // Products with a payment Play is still processing. Deliberately NOT part of [isPro] or
+        // [upgrades]: a pending payment grants nothing. It exists so the UI can explain the wait
+        // and lock the purchase buttons — buying the alternative product now would double-charge.
+        val pendingSkus: Collection<Sku> = billingData?.pendingPurchases
+            ?.map { purchase ->
+                purchase.products.mapNotNull { productId ->
+                    val sku = OurSku.PRO_SKUS.singleOrNull { it.id == productId }
+                    if (sku == null) {
+                        log(TAG, WARN) { "Unknown pending product: $productId (${purchase.redacted()})" }
+                        return@mapNotNull null
+                    }
+                    sku
+                }
+            }
+            ?.flatten()
+            ?: emptySet()
+
+        // Any owned purchase Play still bills on a schedule. Deliberately computed from the RAW
+        // PURCHASED purchases instead of [upgrades]: the mapping drops products this app doesn't
+        // know, and the pre-purchase gate must keep blocking on a renewing subscription with an
+        // unknown or legacy product ID — being wrong there means billing the user twice for Pro.
+        // Both product types are scanned; a one-time purchase reports isAutoRenewing = false, so
+        // the broader input cannot produce a false positive.
+        // Computed on access, not in the initializer: an Info is built for every mapping pass, and
+        // only the purchase gate needs this.
+        val hasAutoRenewingSubscription: Boolean
+            get() = billingData?.purchases?.any { it.isAutoRenewing } == true
 
         override val isPro: Boolean = upgrades.isNotEmpty() || gracePeriod
 

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingData.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingData.kt
@@ -1,7 +1,28 @@
 package eu.darken.bluemusic.upgrade.core.billing
 
 import com.android.billingclient.api.Purchase
+import eu.darken.bluemusic.upgrade.core.billing.client.isPurchased
+import eu.darken.bluemusic.upgrade.core.billing.client.isRelevant
 
+/**
+ * Play's purchase state, split by what it may be used for. [purchases] is the entitlement carrier
+ * and PURCHASED-only by construction, so no consumer can grant Pro (or stamp the grace cache) from
+ * a payment Play is still processing; [pendingPurchases] keeps that payment visible to the UI.
+ */
 data class BillingData(
-    val purchases: Collection<Purchase>
-)
+    val purchases: Collection<Purchase>,
+    val pendingPurchases: Collection<Purchase> = emptyList(),
+) {
+
+    companion object {
+        // The one place raw Play data becomes a BillingData: splitting here (instead of at each
+        // consumer) is what keeps "pending never grants Pro" a property of the type. Anything
+        // that is neither PURCHASED nor PENDING is dropped — it is not an entitlement and not a
+        // payment in progress.
+        fun from(raw: Collection<Purchase>): BillingData {
+            val relevant = raw.filter { it.isRelevant }
+            val (purchased, pending) = relevant.partition { it.isPurchased }
+            return BillingData(purchases = purchased, pendingPurchases = pending)
+        }
+    }
+}

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
@@ -418,17 +418,12 @@ class BillingManager @Inject constructor(
         }
     }
 
-    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
-    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
-    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
-    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
-    // useConnection's).
-    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
-        // A partial refresh no longer reaches useConnection's dead-binder detection (it returns
-        // instead of throwing), so the teardown that used to ride the throw path happens here.
-        // Cause chain, not the exception itself: the failure arrives user-friendly-mapped.
-        // Deliberately no holder CAS: the failing connection may already have been replaced, and
-        // the accepted cost of that rare race is one extra failed action while the loop reconnects.
+    // A partial refresh no longer reaches useConnection's dead-binder detection (it returns instead
+    // of throwing), so the teardown that used to ride the throw path happens here. Cause chain, not
+    // the exception itself: the failure arrives user-friendly-mapped. Deliberately no holder CAS:
+    // the failing connection may already have been replaced, and the accepted cost of that rare
+    // race is one extra failed action while the loop reconnects.
+    private fun invalidateOnDeadConnection(refresh: BillingConnection.PurchaseRefresh) {
         val clientError = refresh.partialError?.let {
             (it as? BillingClientException) ?: (it.cause as? BillingClientException)
         }
@@ -436,6 +431,15 @@ class BillingManager @Inject constructor(
             log(TAG, WARN) { "Refresh reported the connection dead (${clientError.result.responseCode}), invalidating." }
             invalidations.trySend(Unit)
         }
+    }
+
+    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
+    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
+    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
+    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
+    // useConnection's).
+    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
+        invalidateOnDeadConnection(refresh)
 
         if (!refresh.isComplete && !refresh.hasConfirmedProPurchase) {
             // A reconciliation that couldn't confirm Pro. Stamped with the refresh's COMMIT time,
@@ -535,6 +539,11 @@ class BillingManager @Inject constructor(
     suspend fun refreshStrict(): BillingData {
         log(TAG) { "refreshStrict()" }
         val fresh = useConnection { refreshPurchases() }
+        // A gate that hit a dying connection must still trigger the reconnect (the throw below
+        // bypasses useConnection's detection, which already returned), or every later purchase
+        // check keeps reusing the corpse. No-op on a complete refresh. The episode clock stays out
+        // of this path: an aborted gate is not a reconciliation outcome.
+        invalidateOnDeadConnection(fresh)
         if (!fresh.isComplete) {
             // partialError is set for every incomplete refresh; the fallback only exists so a
             // future incompleteness without a captured cause still fails closed instead of passing.

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManager.kt
@@ -14,6 +14,7 @@ import eu.darken.bluemusic.common.flow.setupCommonEventHandlers
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingClientException
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnection
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnectionProvider
+import eu.darken.bluemusic.upgrade.core.billing.client.isPurchased
 import eu.darken.bluemusic.upgrade.core.billing.client.redacted
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
@@ -73,13 +74,13 @@ class BillingManager @Inject constructor(
     private val failedOnce = MutableStateFlow(false)
     val isFailureSettled: Flow<Boolean> = failedOnce
 
-    // Fires once per failed connect-loop iteration: connection setup failure, the mandatory initial
-    // refreshPurchases erroring or timing out, an established connection dropping, an action-level
-    // invalidation (SERVICE_DISCONNECTED/SERVICE_TIMEOUT from any useConnection call), or an
-    // unexpected provider completion. Every one is a fresh reconciliation that couldn't confirm Pro.
-    // The connect loop retries these internally and downstream flows just go quiet, so without this
-    // explicit signal the grace episode clock (UpgradeRepoGplay.proUnconfirmedSince) would only
-    // advance on an explicit ON_RESUME refresh().
+    // Fires once per reconciliation that couldn't confirm Pro: a failed connect-loop iteration
+    // (connection setup failure, the mandatory initial refreshPurchases erroring or timing out, an
+    // established connection dropping, an action-level invalidation, an unexpected provider
+    // completion) — and, via processReconciliation, a refresh that COMPLETED but only partially,
+    // without a confirmed Pro purchase. The connect loop retries its failures internally and
+    // downstream flows just go quiet, so without this explicit signal the grace episode clock
+    // (UpgradeRepoGplay.proUnconfirmedSince) would only advance on an explicit ON_RESUME refresh().
     //
     // Each value is the failure's OCCURRENCE time (epoch millis). It has to be, not a bare Unit: the
     // channel buffers, and this feed and freshBillingData are separate flows with no cross-stream
@@ -121,13 +122,18 @@ class BillingManager @Inject constructor(
                                 // isFailureSettled forever with no retry. withTimeoutOrNull, NOT
                                 // withTimeout: TimeoutCancellationException is a
                                 // CancellationException and would kill this loop.
-                                withTimeoutOrNull(INITIAL_REFRESH_TIMEOUT_MS) {
+                                val initialRefresh = withTimeoutOrNull(INITIAL_REFRESH_TIMEOUT_MS) {
                                     connection.refreshPurchases()
                                 } ?: throw BillingException("Initial purchase refresh timed out")
 
                                 failStreak = 0
                                 connectionHolder.value = connection
                                 log(TAG, INFO) { "Billing connection established" }
+                                // AFTER publishing: a partial refresh is still a usable connection
+                                // (a pending-only cold start must not starve billingData), but its
+                                // bookkeeping — episode clock, dead-binder teardown — has to run,
+                                // and an invalidation may only tear down an INSTALLED connection.
+                                processReconciliation(initialRefresh)
                             }
                             // The provider flow stays open for the connection's lifetime; a normal
                             // completion means the connection is gone without an error — treat it
@@ -214,7 +220,7 @@ class BillingManager @Inject constructor(
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
     val billingData: Flow<BillingData> = purchases
-        .map { BillingData(purchases = it) }
+        .map { BillingData.from(it) }
         .shareIn(scope, WhileSubscribed(3000L, 0L), replay = 1)
 
     val purchaseFailures: Flow<BillingResult> = connectionHolder
@@ -235,7 +241,10 @@ class BillingManager @Inject constructor(
                 // every emission here is a real Play round-trip the grace bookkeeping needs.
                 .resubscribeOnFailure("freshBillingData")
         }
-        .map { FreshData(data = BillingData(purchases = it.purchases), isFullSnapshot = it.isFullSnapshot, occurredAt = it.occurredAt) }
+        // Through from() like every other exit, although the connection only ever puts PURCHASED
+        // purchases on this stream: if that invariant ever broke, splitting keeps the grace
+        // bookkeeping from stamping a pending payment as a confirmation.
+        .map { FreshData(data = BillingData.from(it.purchases), isFullSnapshot = it.isFullSnapshot, occurredAt = it.occurredAt) }
         .setupCommonEventHandlers(TAG) { "freshBillingData" }
         // Same belt as `purchases`: an Eagerly shared flow that dies stays dead, and this one feeds
         // both the grace bookkeeping and the ack collector's re-drive signal.
@@ -292,6 +301,14 @@ class BillingManager @Inject constructor(
     // -data signals.
     private suspend fun runAckPass(purchases: Collection<Purchase>) {
         val needAck = purchases.filter {
+            // The canonical list carries pending payments too. Play rejects acknowledging one
+            // PERMANENTLY, so an unfiltered pass would fire a bug report for every pending purchase,
+            // every pass — and there is nothing to acknowledge until the payment completes anyway.
+            if (!it.isPurchased) {
+                log(TAG) { "Not acknowledgeable yet: ${it.redacted()}" }
+                return@filter false
+            }
+
             val needsAck = !it.isAcknowledged
 
             if (needsAck) log(TAG) { "Needs ACK: ${it.redacted()}" }
@@ -401,6 +418,35 @@ class BillingManager @Inject constructor(
         }
     }
 
+    // Everything a COMPLETED refresh owes the rest of the app, in one place: both the connect loop's
+    // initial refresh and manual refresh() calls run through it, so a Restore tap during an outage
+    // feeds the same bookkeeping the connect loop does. Only reached when refreshPurchases returned
+    // (it still throws when it found nothing AND a query failed — that path is the connect loop's /
+    // useConnection's).
+    private fun processReconciliation(refresh: BillingConnection.PurchaseRefresh) {
+        // A partial refresh no longer reaches useConnection's dead-binder detection (it returns
+        // instead of throwing), so the teardown that used to ride the throw path happens here.
+        // Cause chain, not the exception itself: the failure arrives user-friendly-mapped.
+        // Deliberately no holder CAS: the failing connection may already have been replaced, and
+        // the accepted cost of that rare race is one extra failed action while the loop reconnects.
+        val clientError = refresh.partialError?.let {
+            (it as? BillingClientException) ?: (it.cause as? BillingClientException)
+        }
+        if (clientError != null && clientError.result.responseCode in INVALIDATING_CODES) {
+            log(TAG, WARN) { "Refresh reported the connection dead (${clientError.result.responseCode}), invalidating." }
+            invalidations.trySend(Unit)
+        }
+
+        if (!refresh.isComplete && !refresh.hasConfirmedProPurchase) {
+            // A reconciliation that couldn't confirm Pro. Stamped with the refresh's COMMIT time,
+            // never now-at-send: a confirmation that committed between this refresh and the send
+            // (e.g. a pending payment completing) must stay NEWER than this failure, or the grace
+            // episode it closed would be reopened.
+            log(TAG, WARN) { "Partial refresh without a confirmed Pro purchase at ${refresh.occurredAt}" }
+            connectionFailuresChannel.trySend(refresh.occurredAt)
+        }
+    }
+
     private suspend fun <T> useConnection(action: suspend BillingConnection.() -> T): T {
         // Every caller here is active demand (opening the upgrade screen, restore/buy taps,
         // purchase acks) — cut a pending reconnect backoff short. A no-op while healthy.
@@ -479,18 +525,24 @@ class BillingManager @Inject constructor(
         // shared upgradeInfo replay cache. The freshBillingData emission happens inside the
         // reducer's commit, in commit order — not here.
         val fresh = useConnection { refreshPurchases() }
-        return BillingData(purchases = fresh.purchases)
+        processReconciliation(fresh)
+        return BillingData.from(fresh.purchases)
     }
 
-    // Strict SUBS-only query for the pre-purchase subscription gate: unlike refresh(), a failure
-    // here propagates (user-friendly-mapped) instead of being masked by the other product type.
-    suspend fun querySubscriptions(): Collection<Purchase> = try {
-        useConnection { querySubscriptions() }
-    } catch (e: CancellationException) {
-        throw e
-    } catch (e: Exception) {
-        log(TAG, WARN) { "querySubscriptions() failed: ${e.asLog()}" }
-        throw e.tryMapUserFriendly()
+    // Strict variant for the pre-purchase gates: unlike refresh(), anything short of a COMPLETE
+    // reconciliation throws (user-friendly-mapped) instead of returning what it happened to find —
+    // a gate must be able to tell "not owned" apart from "couldn't verify" and fail closed.
+    suspend fun refreshStrict(): BillingData {
+        log(TAG) { "refreshStrict()" }
+        val fresh = useConnection { refreshPurchases() }
+        if (!fresh.isComplete) {
+            // partialError is set for every incomplete refresh; the fallback only exists so a
+            // future incompleteness without a captured cause still fails closed instead of passing.
+            val error = fresh.partialError ?: BillingException("Purchase refresh was incomplete")
+            log(TAG, WARN) { "refreshStrict() incomplete: ${error.asLog()}" }
+            throw error.tryMapUserFriendly()
+        }
+        return BillingData.from(fresh.purchases)
     }
 
     companion object {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/PendingPurchaseBillingException.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/PendingPurchaseBillingException.kt
@@ -1,0 +1,11 @@
+package eu.darken.bluemusic.upgrade.core.billing
+
+/**
+ * A purchase can't proceed because the account already has a payment Play is still processing.
+ *
+ * Typed so the UI can answer with the informational pending dialog instead of the already-owned
+ * error and its restore tips: restoring cannot help — Play refuses to re-sell a product with a
+ * pending payment, and the entitlement arrives on its own once the payment clears.
+ */
+class PendingPurchaseBillingException(cause: Throwable? = null) :
+    BillingException("A purchase with a pending payment already exists.", cause)

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingClientExtensions.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingClientExtensions.kt
@@ -9,6 +9,21 @@ internal val BillingResult.isSuccess: Boolean
     get() = responseCode == BillingClient.BillingResponseCode.OK
 
 /**
+ * Owned right now. The ONLY state that may grant an entitlement, stamp the Pro grace cache or be
+ * acknowledged — a PENDING purchase is a payment Play is still processing, and acknowledging one is
+ * rejected permanently.
+ */
+internal val Purchase.isPurchased: Boolean
+    get() = purchaseState == Purchase.PurchaseState.PURCHASED
+
+/**
+ * Worth carrying in our state at all: owned, or a payment in progress the user should see. Anything
+ * else (UNSPECIFIED_STATE) is dropped at ingestion — it is neither.
+ */
+internal val Purchase.isRelevant: Boolean
+    get() = isPurchased || purchaseState == Purchase.PurchaseState.PENDING
+
+/**
  * Log-safe rendering of a [Purchase].
  *
  * `Purchase.toString()` dumps the original response JSON, which carries the purchase token and the

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnection.kt
@@ -7,7 +7,6 @@ import com.android.billingclient.api.BillingClient.BillingResponseCode
 import com.android.billingclient.api.BillingFlowParams
 import com.android.billingclient.api.BillingResult
 import com.android.billingclient.api.Purchase
-import com.android.billingclient.api.Purchase.PurchaseState
 import com.android.billingclient.api.QueryProductDetailsParams
 import com.android.billingclient.api.QueryProductDetailsResult
 import com.android.billingclient.api.QueryPurchasesParams
@@ -41,11 +40,11 @@ class BillingConnection(
     private val skuTypeOf: (String) -> Sku.Type? = DEFAULT_SKU_TYPE_RESOLVER,
 ) {
 
-    // A purchase proven by an onPurchasesUpdated success event. Additive only: events prove
-    // ownership, never absence. `gen` orders it against queries (a query that STARTED before this
-    // event must not clear it); `type` is resolved at ingestion so a later per-type query that
-    // confirms absence can supersede it (null = product unknown to this app, only a complete
-    // refresh may clear it).
+    // A purchase (owned or with a pending payment) proven by an onPurchasesUpdated success event.
+    // Additive only: events prove existence, never absence. `gen` orders it against queries (a
+    // query that STARTED before this event must not clear it); `type` is resolved at ingestion so a
+    // later per-type query that confirms absence can supersede it (null = product unknown to this
+    // app, only a complete refresh may clear it).
     data class OverlayEntry(
         val purchase: Purchase,
         val gen: Long,
@@ -64,11 +63,11 @@ class BillingConnection(
     ) {
 
         internal fun withEvent(
-            purchased: Collection<Purchase>,
+            relevant: Collection<Purchase>,
             typeOf: (String) -> Sku.Type?,
         ): ReducerState {
             val gen = eventGen + 1
-            val entries = purchased.map { purchase ->
+            val entries = relevant.map { purchase ->
                 OverlayEntry(
                     purchase = purchase,
                     gen = gen,
@@ -169,10 +168,13 @@ class BillingConnection(
                 "onPurchasesUpdated(code=${result.responseCode}, message=${result.debugMessage}, " +
                     "purchases=${purchases?.redacted()})"
             }
-            // PENDING purchases must never surface as owned (or stamp the Pro grace cache).
-            val purchased = purchases.orEmpty().filter { it.purchaseState == PurchaseState.PURCHASED }
+            // The reducer carries PENDING purchases too (the UI must be able to show a payment in
+            // progress), but the fresh stream stays PURCHASED-only: it feeds the entitlement and
+            // grace bookkeeping, which must never see a payment Play hasn't completed.
+            val relevant = purchases.orEmpty().filter { it.isRelevant }
+            val purchased = relevant.filter { it.isPurchased }
             synchronized(reducerLock) {
-                state.value = state.value.withEvent(purchased, skuTypeOf)
+                state.value = state.value.withEvent(relevant, skuTypeOf)
                 if (purchased.isNotEmpty()) {
                     freshUpdatesChannel.trySend(FreshUpdate(purchased, isFullSnapshot = false))
                 }
@@ -193,12 +195,29 @@ class BillingConnection(
         failureChannel.close()
     }
 
-    // The purchases of a refresh plus whether it covered both product types: a partial result (one
-    // query failed) is still authoritative for what it FOUND, but must not be treated as proof of
-    // absence for the type that couldn't be checked.
+    // The full outcome of a refresh: what it committed, what it actually CONFIRMED, and how far it
+    // got. A partial result (one query failed) is still authoritative for what it found, but must
+    // not be treated as proof of absence for the type that couldn't be checked — so callers that
+    // need to fail closed, or to feed the grace episode clock, get the provenance instead of having
+    // to infer it from the merged view.
     data class PurchaseRefresh(
+        // The committed reducer state (queries merged with retained snapshots and surviving
+        // events) — the same view the reactive purchases flow emits.
         val purchases: Collection<Purchase>,
+        // ONLY what these queries returned: never retained state of a failed type, so a consumer
+        // can tell "Play said so just now" from "we still remember this".
+        val confirmed: Collection<Purchase> = emptyList(),
+        // A confirmed PURCHASED purchase of a product this app knows. Fail-safe default: "we
+        // couldn't confirm Pro" is the direction that keeps the grace bookkeeping honest.
+        val hasConfirmedProPurchase: Boolean = false,
         val isComplete: Boolean,
+        // Commit time under reducerLock — the same instant stamped on this refresh's FreshUpdate,
+        // so a confirmation and a later failure signal are ordered by when they HAPPENED.
+        val occurredAt: Long = System.currentTimeMillis(),
+        // Why the refresh is incomplete (the failed type's already user-friendly-mapped
+        // exception), null when complete. Carried rather than thrown: a partial refresh that found
+        // something is still useful, only the caller can decide whether partial is good enough.
+        val partialError: Throwable? = null,
     )
 
     // Serializes concurrent refreshes (manual, background, auto-restore): an older query that got
@@ -214,8 +233,8 @@ class BillingConnection(
         coroutineScope {
             log(TAG) { "refreshPurchases()" }
             val genAtQueryStart = state.value.eventGen
-            val iapJob = async { queryPurchasedProducts(BillingClient.ProductType.INAPP) }
-            val subJob = async { queryPurchasedProducts(BillingClient.ProductType.SUBS) }
+            val iapJob = async { queryRelevantProducts(BillingClient.ProductType.INAPP) }
+            val subJob = async { queryRelevantProducts(BillingClient.ProductType.SUBS) }
             val iap = iapJob.await()
             val sub = subJob.await()
             log(TAG) { "Refreshed IAPs=${iap.getOrNull()?.redacted()}, SUBs=${sub.getOrNull()?.redacted()}" }
@@ -224,6 +243,12 @@ class BillingConnection(
             // authoritative even when its sibling failed — verified absence (e.g. a refunded IAP)
             // must not be discarded just because the SUB query errored.
             val isComplete = iap.isSuccess && sub.isSuccess
+            // Only what the queries CONFIRMED as owned — retained stale data of a failed type, and
+            // pending payments, stay out (both would keep re-stamping the grace window).
+            val confirmed = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty())
+                .filter { it.isPurchased }
+                .sortedByDescending { it.purchaseTime }
+            var committedAt = 0L
             val committed = synchronized(reducerLock) {
                 val next = state.value.withQueryResults(
                     iap = iap.getOrNull(),
@@ -231,17 +256,18 @@ class BillingConnection(
                     genAtQueryStart = genAtQueryStart,
                 )
                 state.value = next
+                committedAt = System.currentTimeMillis()
                 if (iap.isSuccess || sub.isSuccess) {
-                    // Only what the queries CONFIRMED — retained stale data of a failed type stays
-                    // out of the fresh stream (it would keep re-stamping the grace window).
-                    val confirmed = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty())
-                        .sortedByDescending { it.purchaseTime }
-                    // A surviving overlay entry (purchase event newer than the query start, or of
-                    // a failed type) means this result does NOT prove total absence: it must not
-                    // count as a full snapshot, or an empty query racing a fresh purchase event
-                    // would start a false unconfirmed-grace episode.
-                    val provesAbsence = isComplete && next.overlay.isEmpty()
-                    freshUpdatesChannel.trySend(FreshUpdate(confirmed, isFullSnapshot = provesAbsence))
+                    // A surviving OWNED overlay entry (purchase event newer than the query start,
+                    // or of a failed type) means this result does NOT prove total absence: it must
+                    // not count as a full snapshot, or an empty query racing a fresh purchase event
+                    // would start a false unconfirmed-grace episode. A surviving PENDING entry
+                    // proves nothing about ownership, so it must not suppress the bookkeeping
+                    // either — a payment in progress would otherwise freeze the episode clock.
+                    val provesAbsence = isComplete && next.overlay.none { it.purchase.isPurchased }
+                    freshUpdatesChannel.trySend(
+                        FreshUpdate(confirmed, isFullSnapshot = provesAbsence, occurredAt = committedAt)
+                    )
                 }
                 next
             }
@@ -249,31 +275,42 @@ class BillingConnection(
             // Support-log anchor, at INFO because purchase complaints arrive as debug recordings.
             // Logs what these queries CONFIRMED, kept distinct from the committed view: merged()
             // retains a failed type's previous purchases, so reporting it as "what Play returned"
-            // would be the same false-certainty trap the copy elsewhere had to fix. Product IDs
-            // only -- never the Purchase, which carries order and token data.
+            // would be the same false-certainty trap the copy elsewhere had to fix. Pending ids are
+            // listed separately — "bought it, still not Pro" reports are exactly this state.
+            // Product IDs only -- never the Purchase, which carries order and token data.
             log(TAG, INFO) {
-                val confirmedIds = (iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()).flatMap { it.products }
-                "refreshPurchases(): confirmed=$confirmedIds, isComplete=$isComplete, " +
+                val returned = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+                val confirmedIds = returned.filter { it.isPurchased }.flatMap { it.products }
+                val pendingIds = returned.filterNot { it.isPurchased }.flatMap { it.products }
+                "refreshPurchases(): confirmed=$confirmedIds, pending=$pendingIds, isComplete=$isComplete, " +
                     "iapOk=${iap.isSuccess}, subOk=${sub.isSuccess}, merged=${committed.merged().size}"
             }
 
             // Throws when nothing was found and a query failed, so the caller can tell "not
             // owned" apart from "couldn't verify".
-            combinePurchaseResults(iap, sub)
+            combinePurchaseResults(iap, sub, skuTypeOf)
 
             PurchaseRefresh(
                 purchases = committed.merged(),
+                confirmed = confirmed,
+                hasConfirmedProPurchase = confirmed.any { purchase ->
+                    purchase.products.any { skuTypeOf(it) != null }
+                },
                 isComplete = isComplete,
+                occurredAt = committedAt,
+                partialError = iap.exceptionOrNull() ?: sub.exceptionOrNull(),
             )
         }
     }
 
     // Never throws except on cancellation, so a single failing product-type query doesn't cancel
     // the sibling query (or the coroutineScope). The exception is already user-friendly-mapped.
-    private suspend fun queryPurchasedProducts(
+    // Returns owned AND pending purchases; the split by state happens where it matters (fresh
+    // stream, entitlement mapping), so a pending payment stays visible instead of vanishing here.
+    private suspend fun queryRelevantProducts(
         @BillingClient.ProductType type: String,
     ): Result<Collection<Purchase>> = try {
-        Result.success(queryPurchases(type).filter { it.purchaseState == PurchaseState.PURCHASED })
+        Result.success(queryPurchases(type).filter { it.isRelevant })
     } catch (e: CancellationException) {
         throw e
     } catch (e: Exception) {
@@ -307,37 +344,6 @@ class BillingConnection(
         return purchaseData
     }
 
-    // Strict SUBS-only query for the pre-purchase subscription gate: unlike refreshPurchases(),
-    // a failure propagates (no cross-type tolerance) — callers must be able to fail closed on
-    // "couldn't verify". Commits through the reducer like any query, so the reactive purchases
-    // flow picks up the fresh renewal state, and emits a partial fresh update: it proves what the
-    // SUBS query found, never the absence of anything it didn't cover.
-    suspend fun querySubscriptions(): Collection<Purchase> = refreshMutex.withLock {
-        log(TAG) { "querySubscriptions()" }
-        val genAtQueryStart = state.value.eventGen
-        val subs = queryPurchases(BillingClient.ProductType.SUBS)
-            .filter { it.purchaseState == PurchaseState.PURCHASED }
-        val committed = synchronized(reducerLock) {
-            val next = state.value.withQueryResults(
-                iap = null,
-                sub = subs,
-                genAtQueryStart = genAtQueryStart,
-            )
-            state.value = next
-            freshUpdatesChannel.trySend(FreshUpdate(subs, isFullSnapshot = false))
-            next
-        }
-        // The COMMITTED view, not the raw response: a purchase event that arrived after the query
-        // started survives the commit as a newer overlay and must reach the gate too — otherwise a
-        // just-purchased renewing sub could slip past the fail-closed double-billing check.
-        // Non-IAP overlays only; untyped (unknown product) entries stay in on the safe side.
-        val byToken = LinkedHashMap<String, Purchase>()
-        subs.forEach { byToken[it.purchaseToken] = it }
-        committed.overlay
-            .filter { it.type != Sku.Type.IAP }
-            .forEach { byToken[it.purchase.purchaseToken] = it.purchase }
-        byToken.values.sortedByDescending { it.purchaseTime }
-    }
     suspend fun acknowledgePurchase(purchase: Purchase): BillingResult {
         val ack = AcknowledgePurchaseParams.newBuilder().apply {
             setPurchaseToken(purchase.purchaseToken)
@@ -529,16 +535,22 @@ class BillingConnection(
             OurSku.PRO_SKUS.singleOrNull { it.id == productId }?.type
         }
 
-        // Combines the two product-type query results: a purchase found by either type is
-        // authoritative; an error is only propagated when nothing was found, so callers can tell
-        // "not owned" apart from "couldn't verify one product type". Treating any found purchase
-        // as authoritative is safe because every product this app sells is a Pro SKU (see
-        // OurSku.PRO_SKUS). Pure and unit-tested.
+        // Combines the two product-type query results: an error is only propagated when the refresh
+        // learned nothing usable, so callers can tell "not owned" apart from "couldn't verify one
+        // product type". A PURCHASED result of ANY product suppresses the error — every product
+        // this app sells is a Pro SKU (see OurSku.PRO_SKUS), so it is by construction relevant. A
+        // PENDING result only counts when it maps to a KNOWN Pro SKU: it grants nothing, and an
+        // unknown pending product says nothing about the type whose query failed, so treating it
+        // as a find would swallow a real "couldn't verify". Pure and unit-tested.
         internal fun combinePurchaseResults(
             iap: Result<Collection<Purchase>>,
             sub: Result<Collection<Purchase>>,
+            typeOf: (String) -> Sku.Type? = DEFAULT_SKU_TYPE_RESOLVER,
         ): Collection<Purchase> {
-            val found = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+            val returned = iap.getOrNull().orEmpty() + sub.getOrNull().orEmpty()
+            val found = returned.filter { purchase ->
+                purchase.isPurchased || purchase.products.any { typeOf(it) != null }
+            }
             return when {
                 found.isNotEmpty() -> found.sortedByDescending { it.purchaseTime }
                 else -> {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeEvents.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeEvents.kt
@@ -13,5 +13,14 @@ sealed class UpgradeEvents {
      */
     data object RestoreInconclusive : UpgradeEvents()
     data object SubscriptionStillRenewing : UpgradeEvents()
-    data object SubscriptionCheckFailed : UpgradeEvents()
+
+    /**
+     * Play answered, no completed purchase exists, but a payment is still being processed. Purely
+     * informational: nothing to fix, nothing to restore — Pro unlocks by itself once Play clears
+     * the payment, and a new purchase would be rejected (or double-charge) in the meantime.
+     */
+    data object PurchasePending : UpgradeEvents()
+
+    /** The pre-purchase check with Play didn't finish, so the purchase was not started. */
+    data object PurchaseCheckFailed : UpgradeEvents()
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeOwnership.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeOwnership.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.Autorenew
+import androidx.compose.material.icons.twotone.HourglassTop
 import androidx.compose.material.icons.twotone.Verified
 import androidx.compose.material3.Button
 import androidx.compose.material3.CardDefaults
@@ -102,8 +103,10 @@ internal fun UpgradeOwnershipContent(
                 Button(
                     onClick = onIap,
                     // Not gated on iapEnabled: prices may have failed to load while the purchase
-                    // itself would work (the billing flow re-queries details on launch).
-                    enabled = switchUnlocked && uiState.busy == null,
+                    // itself would work (the billing flow re-queries details on launch). A pending
+                    // payment does lock it — Play would reject the purchase, and the pending card
+                    // above carries the explanation.
+                    enabled = switchUnlocked && uiState.busy == null && !uiState.hasPendingPurchase,
                     modifier = Modifier
                         .fillMaxWidth()
                         .testTag(UpgradeScreenTags.GPLAY_IAP),
@@ -246,6 +249,38 @@ internal fun UpgradeGraceCard(
                 Text(stringResource(R.string.upgrade_screen_restore_purchase_action))
             }
         }
+    }
+}
+
+// Shown to EVERY audience while Google Play is still processing a payment: an acquisition user who
+// just bought, an owner buying the other product, and a grace user whose Pro is running out — all
+// three have purchase actions locked and need the same explanation. Calm reassurance styling like
+// the grace card: nothing is wrong, the payment just isn't done.
+@Composable
+internal fun PendingPurchaseCard(
+    modifier: Modifier = Modifier,
+) {
+    UpgradeSectionCard(
+        title = stringResource(R.string.upgrade_screen_pending_card_title),
+        icon = Icons.TwoTone.HourglassTop,
+        modifier = modifier.testTag(UpgradeScreenTags.GPLAY_PENDING),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.secondaryContainer,
+            contentColor = MaterialTheme.colorScheme.onSecondaryContainer,
+        ),
+    ) {
+        Text(
+            text = stringResource(R.string.upgrade_screen_pending_card_body),
+            style = MaterialTheme.typography.bodyMedium,
+        )
+    }
+}
+
+@Preview2
+@Composable
+private fun PendingPurchaseCardPreview() {
+    PreviewWrapper {
+        PendingPurchaseCard()
     }
 }
 

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -63,6 +63,7 @@ fun UpgradeScreenHost(
     var showRestoreInconclusive by rememberSaveable { mutableStateOf(false) }
     var showStillRenewing by rememberSaveable { mutableStateOf(false) }
     var showCheckFailed by rememberSaveable { mutableStateOf(false) }
+    var showPurchasePending by rememberSaveable { mutableStateOf(false) }
 
     LaunchedEffect(vm) {
         vm.events.collect { event ->
@@ -76,7 +77,8 @@ fun UpgradeScreenHost(
                 UpgradeEvents.RestoreFailed -> showRestoreFailed = true
                 UpgradeEvents.RestoreInconclusive -> showRestoreInconclusive = true
                 UpgradeEvents.SubscriptionStillRenewing -> showStillRenewing = true
-                UpgradeEvents.SubscriptionCheckFailed -> showCheckFailed = true
+                UpgradeEvents.PurchaseCheckFailed -> showCheckFailed = true
+                UpgradeEvents.PurchasePending -> showPurchasePending = true
             }
         }
     }
@@ -125,13 +127,17 @@ fun UpgradeScreenHost(
     if (showCheckFailed) {
         AlertDialog(
             onDismissRequest = { showCheckFailed = false },
-            text = { Text(stringResource(R.string.upgrade_screen_sub_check_failed_message)) },
+            text = { Text(stringResource(R.string.upgrade_screen_purchase_check_failed_message)) },
             confirmButton = {
                 TextButton(onClick = { showCheckFailed = false }) {
                     Text(stringResource(R.string.general_dismiss_action))
                 }
             },
         )
+    }
+
+    if (showPurchasePending) {
+        PurchasePendingDialog(onDismiss = { showPurchasePending = false })
     }
 
     val uiState by vm.state.collectAsStateWithLifecycle()
@@ -176,6 +182,34 @@ internal fun RestoreFailedDialog(
             }
         },
     )
+}
+
+/**
+ * Shown when Play is still processing a payment. Purely informational: there is nothing to fix, no
+ * purchase to restore and no support case — the entitlement arrives on its own once the payment
+ * clears, so the dialog offers only a dismiss.
+ */
+@Composable
+internal fun PurchasePendingDialog(
+    onDismiss: () -> Unit = {},
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        text = { Text(stringResource(R.string.upgrade_screen_pending_dialog_message)) },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(R.string.general_dismiss_action))
+            }
+        },
+    )
+}
+
+@Preview2
+@Composable
+private fun PurchasePendingDialogPreview() {
+    PreviewWrapper {
+        PurchasePendingDialog()
+    }
 }
 
 /**
@@ -267,6 +301,12 @@ internal fun UpgradeScreen(
                     )
                 }
             }
+
+            // Above the ownership/acquisition split, because a pending payment cuts across it: the
+            // buyer waiting for their first Pro purchase, the owner switching products and the
+            // grace user (whose offers box is hidden entirely) all need it, and it is the reason
+            // their purchase buttons are locked.
+            if (loaded?.hasPendingPurchase == true) PendingPurchaseCard()
 
             if (ownedState != null) {
                 UpgradeOwnershipContent(
@@ -468,6 +508,24 @@ private fun UpgradeScreenReturningBuyerPreview() {
                 iapEnabled = true,
                 iapPrice = "$24.99",
                 wasPreviouslyPro = true,
+            ),
+        )
+    }
+}
+
+// The acquisition variant of the pending state: card above the offers, both buy buttons locked.
+@Preview2
+@Composable
+private fun UpgradeScreenPendingPreview() {
+    PreviewWrapper {
+        UpgradeScreen(
+            uiState = GplayUpgradeUiState.Loaded(
+                subscriptionAction = SubscriptionAction.STANDARD,
+                subscriptionEnabled = false,
+                subscriptionPrice = "$12.99",
+                iapEnabled = false,
+                iapPrice = "$24.99",
+                hasPendingPurchase = true,
             ),
         )
     }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeUiState.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeUiState.kt
@@ -24,6 +24,9 @@ internal sealed interface GplayUpgradeUiState {
         val ownership: Ownership = Ownership(),
         val grace: GraceHint? = null,
         val wasPreviouslyPro: Boolean = false,
+        // A payment Google Play is still processing. SKU-agnostic on purpose: the card explains the
+        // wait and both purchase actions lock, regardless of which product is pending.
+        val hasPendingPurchase: Boolean = false,
         val busy: BusyOp? = null,
     ) : GplayUpgradeUiState
 }
@@ -78,12 +81,18 @@ internal fun UpgradeRepoGplay.Info.toOwnership() = Ownership(
         ?.let { subs -> SubscriptionOwnership(isAutoRenewing = subs.any { it.purchase.isAutoRenewing }) },
 )
 
+// Any Pro payment Play is still processing. No per-product flag: the one-time purchase and the
+// subscription are alternatives, so a pending payment for either one must lock both — completing
+// both would charge the user twice for the same thing.
+internal fun UpgradeRepoGplay.Info.toPendingFlag(): Boolean = pendingSkus.isNotEmpty()
+
 internal fun toLoadedState(
     iap: SkuDetails?,
     sub: SkuDetails?,
     ownership: Ownership,
     grace: GraceHint? = null,
     wasPreviouslyPro: Boolean = false,
+    hasPendingPurchase: Boolean = false,
     busy: BusyOp? = null,
 ): GplayUpgradeUiState.Loaded {
     val iapOffer = iap?.details?.oneTimePurchaseOfferDetails
@@ -102,15 +111,18 @@ internal fun toLoadedState(
         },
         // Any running entitlement operation (restore, manual or the invisible already-owned
         // recovery, and purchases) pauses the buy actions too — starting a purchase while an
-        // entitlement is being reconciled just races Play into ITEM_ALREADY_OWNED.
+        // entitlement is being reconciled just races Play into ITEM_ALREADY_OWNED. A pending
+        // payment locks BOTH offers for the same reason the card explains: Play refuses the
+        // re-purchase, and the alternative product would double-charge for the same features.
         subscriptionEnabled = (subOffer != null || subOfferTrial != null) &&
-            ownership.subscription == null && busy == null,
+            ownership.subscription == null && busy == null && !hasPendingPurchase,
         subscriptionPrice = subOffer?.pricingPhases?.pricingPhaseList?.lastOrNull()?.formattedPrice,
-        iapEnabled = iapOffer != null && !ownership.hasIap && busy == null,
+        iapEnabled = iapOffer != null && !ownership.hasIap && busy == null && !hasPendingPurchase,
         iapPrice = iapOffer?.formattedPrice,
         ownership = ownership,
         grace = grace,
         wasPreviouslyPro = wasPreviouslyPro,
+        hasPendingPurchase = hasPendingPurchase,
         busy = busy,
     )
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -22,6 +22,7 @@ import eu.darken.bluemusic.upgrade.core.OurSku
 import eu.darken.bluemusic.upgrade.core.UpgradeRepoGplay
 import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.bluemusic.upgrade.core.billing.OfferUnavailableBillingException
+import eu.darken.bluemusic.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.bluemusic.upgrade.core.billing.Sku
 import eu.darken.bluemusic.upgrade.core.billing.SkuDetails
 import kotlinx.coroutines.CancellationException
@@ -151,8 +152,10 @@ class UpgradeViewModel @AssistedInject constructor(
             null
         }
         // Owners and grace users don't depend on offer prices: their status and management
-        // actions render immediately and price problems are not their problem.
-        val priceIndependent = ownership.ownsAnything || grace != null
+        // actions render immediately and price problems are not their problem. A user waiting on a
+        // pending payment is in the same position — the card is their answer, and both offers are
+        // locked anyway, so a price failure must not replace it with an error screen.
+        val priceIndependent = ownership.ownsAnything || grace != null || current.pendingSkus.isNotEmpty()
 
         val done = queries as? SkuQueries.Done
         if (done == null) {
@@ -248,6 +251,7 @@ class UpgradeViewModel @AssistedInject constructor(
             ownership = ownership,
             grace = grace,
             wasPreviouslyPro = wasEverPro && !current.isPro,
+            hasPendingPurchase = current.toPendingFlag(),
             // This ViewModel's own action wins; otherwise a launch started elsewhere (previous VM
             // instance, e.g. across a rotation — the launch lives on AppScope) or the repo's
             // invisible already-owned auto-restore still pauses the entitlement actions here.
@@ -293,44 +297,78 @@ class UpgradeViewModel @AssistedInject constructor(
         return true
     }
 
+    // Outcome of the pre-purchase check with Play. Both purchase paths share it: they buy
+    // alternatives of the same entitlement from the same account, so a check only one of them runs
+    // is exactly how a double charge slips through. [Blocked] means the user was already told why.
+    private sealed interface PurchaseGate {
+        data class Clear(val info: UpgradeRepoGplay.Info) : PurchaseGate
+        data object Blocked : PurchaseGate
+    }
+
+    // Fails closed: no fresh, complete answer from Play (error, timeout) means no purchase. Bounded,
+    // because the repo waits for a healthy connection indefinitely and a tap must not park the
+    // single-flight guard through an outage.
+    private suspend fun runPurchaseGate(): PurchaseGate {
+        val info = try {
+            withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.verifyPurchaseStateNow() }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            log(tag, WARN) { "Purchase verification errored: ${e.asLog()}" }
+            errorEvents.tryEmit(e)
+            return PurchaseGate.Blocked
+        }
+        if (info == null) {
+            log(tag, WARN) { "Purchase verification timed out" }
+            events.tryEmit(UpgradeEvents.PurchaseCheckFailed)
+            return PurchaseGate.Blocked
+        }
+        if (info.pendingSkus.isNotEmpty()) {
+            // Play rejects a purchase while it is still processing a payment for this account, and
+            // the alternative product would charge twice for the same features.
+            log(tag, INFO) { "Purchase blocked: a payment is still pending" }
+            events.tryEmit(UpgradeEvents.PurchasePending)
+            return PurchaseGate.Blocked
+        }
+        return PurchaseGate.Clear(info)
+    }
+
+    // A launch that failed on a pending payment is not an error the user can act on: it gets the
+    // informational dialog instead of the already-owned copy and its restore tips.
+    private fun onLaunchError(error: Throwable) {
+        if (error is PendingPurchaseBillingException) {
+            events.tryEmit(UpgradeEvents.PurchasePending)
+        } else {
+            errorEvents.tryEmit(error)
+        }
+    }
+
     fun onGoIap(activity: Activity) {
         log(tag) { "onGoIap($activity)" }
         launch {
             // Single-flight: repeated taps must not stack verifications or billing launches.
             if (!acquireOp(BusyOp.IAP)) return@launch
             try {
-                // Hard gate against double-billing: verify against a FRESH SUBS-only query — the
-                // replayed upgradeInfo can be stale or built from partial results. Fails closed:
-                // no verified "not set to renew" (or no sub at all), no one-time purchase.
-                val subscriptions = try {
-                    withTimeoutOrNull(VERIFY_TIMEOUT_MS) { upgradeRepo.queryCurrentSubscriptions() }
-                } catch (e: CancellationException) {
-                    throw e
-                } catch (e: Exception) {
-                    log(tag, WARN) { "Subscription verification errored: ${e.asLog()}" }
-                    errorEvents.tryEmit(e)
+                val gate = runPurchaseGate()
+                if (gate !is PurchaseGate.Clear) return@launch
+                // Hard gate against double-billing, against the FRESH result — the replayed
+                // upgradeInfo can be stale or built from partial results. Asked of the RAW
+                // purchases (see Info.hasAutoRenewingSubscription), never of the mapped upgrades:
+                // a renewing subscription with an unknown or legacy product ID must block the
+                // one-time purchase too, or the user pays for Pro twice.
+                if (gate.info.hasAutoRenewingSubscription) {
+                    log(tag, INFO) { "IAP purchase blocked: subscription is still set to renew" }
+                    events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
                     return@launch
                 }
-                when {
-                    subscriptions == null -> {
-                        log(tag, WARN) { "Subscription verification timed out" }
-                        events.tryEmit(UpgradeEvents.SubscriptionCheckFailed)
-                    }
-
-                    subscriptions.any { it.isAutoRenewing } -> {
-                        log(tag, INFO) { "IAP purchase blocked: subscription is still set to renew" }
-                        events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
-                    }
-
-                    // Suspends until the Play sheet launch resolved, so the single-flight guard
-                    // covers the whole tap-to-sheet window, not just the verification.
-                    else -> upgradeRepo.launchBillingFlowNow(
-                        activity,
-                        OurSku.Iap.PRO_UPGRADE,
-                        null,
-                        onError = errorEvents::tryEmit,
-                    )
-                }
+                // Suspends until the Play sheet launch resolved, so the single-flight guard covers
+                // the whole tap-to-sheet window, not just the verification.
+                upgradeRepo.launchBillingFlowNow(
+                    activity,
+                    OurSku.Iap.PRO_UPGRADE,
+                    null,
+                    onError = ::onLaunchError,
+                )
             } finally {
                 activeOp.value = null
             }
@@ -351,6 +389,9 @@ class UpgradeViewModel @AssistedInject constructor(
         launch {
             if (!acquireOp(BusyOp.SUBSCRIPTION)) return@launch
             try {
+                // Same fresh check as the one-time path: a pending payment (for either product)
+                // must block this launch too — Play would reject it, or bill it on top.
+                if (runPurchaseGate() !is PurchaseGate.Clear) return@launch
                 // launchBillingFlowNow suspends until the launch resolved, so the guard covers the
                 // whole tap-to-sheet window. The flow itself still runs on AppScope, so closing the
                 // screen mid-launch doesn't abort the purchase.
@@ -358,7 +399,7 @@ class UpgradeViewModel @AssistedInject constructor(
                     activity,
                     OurSku.Sub.PRO_UPGRADE,
                     offer,
-                    onError = errorEvents::tryEmit,
+                    onError = ::onLaunchError,
                 )
             } finally {
                 activeOp.value = null
@@ -418,6 +459,14 @@ class UpgradeViewModel @AssistedInject constructor(
                     // Explicit feedback: on the ownership screen a successful restore changes
                     // nothing visible (the user already is Pro), so silence reads as "broken".
                     events.tryEmit(UpgradeEvents.RestoreSucceeded)
+                }
+
+                restored.info.pendingSkus.isNotEmpty() -> {
+                    // Play answered and found the purchase — it just hasn't been paid for yet.
+                    // RestoreFailed would send this user chasing account and support advice for
+                    // something that resolves itself.
+                    log(tag, INFO) { "Restore found a purchase with a pending payment" }
+                    events.tryEmit(UpgradeEvents.PurchasePending)
                 }
 
                 else -> {

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeViewModel.kt
@@ -391,7 +391,30 @@ class UpgradeViewModel @AssistedInject constructor(
             try {
                 // Same fresh check as the one-time path: a pending payment (for either product)
                 // must block this launch too — Play would reject it, or bill it on top.
-                if (runPurchaseGate() !is PurchaseGate.Clear) return@launch
+                val gate = runPurchaseGate()
+                if (gate !is PurchaseGate.Clear) return@launch
+                // The reactive UI can be stale (the purchase was made on another device), and Play
+                // happily sells the subscription alongside an owned one-time purchase — the user
+                // would pay for Pro twice. The strict refresh already committed into the shared
+                // billing data, so the screen re-renders to the ownership state, and the
+                // restore-success toast explains why nothing launched. Deliberately the MAPPED
+                // upgrades, not isPro: grace users (mapped upgrades empty) may legitimately
+                // re-purchase.
+                if (gate.info.upgrades.isNotEmpty()) {
+                    log(tag, INFO) { "Subscription purchase blocked: fresh check found an owned upgrade" }
+                    events.tryEmit(UpgradeEvents.RestoreSucceeded)
+                    return@launch
+                }
+                // Same breadth as the one-time path's renewal guard: an auto-renewing subscription
+                // with an unknown or legacy product ID (which maps to zero upgrades, so the block
+                // above passed) must still block a new subscription — two renewing subscriptions
+                // for the same features is the same double-billing. Reuses the existing
+                // manage-subscription dialog.
+                if (gate.info.hasAutoRenewingSubscription) {
+                    log(tag, INFO) { "Subscription purchase blocked: another subscription is still set to renew" }
+                    events.tryEmit(UpgradeEvents.SubscriptionStillRenewing)
+                    return@launch
+                }
                 // launchBillingFlowNow suspends until the launch resolved, so the guard covers the
                 // whole tap-to-sheet window. The flow itself still runs on AppScope, so closing the
                 // screen mid-launch doesn't abort the purchase.

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Subskripsie steeds aktief</string>
     <string name="upgrade_screen_sub_still_renewing_message">Jou subskripsie is steeds gestel om te hernu. Kanselleer dit eers in Google Play, kom dan terug om die eenmalige aankoop te koop — so word jy nie twee keer gehef nie.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Ons kon nie jou subskripsiestatus bevestig nie. Kyk asseblief jou verbinding en probeer weer.</string>
     <string name="upgrades_gplay_already_owned_error_title">Reeds gekoop</string>
     <string name="upgrades_gplay_already_owned_error_description">Gebruik die \"Herstel aankoop\"-opsie om jou aankoop te herstel. As die probleem voortduur, probeer om die Google Play-kas skoon te maak en jou toestel te herbegin.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-fout</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">ምዝገባ ገና ንቁ ነው</string>
     <string name="upgrade_screen_sub_still_renewing_message">ምዝገባዎ ገና እንደገና ለማደስ ተዘጋጅቶ ነው። በመጀመሪያ በGoogle Play ውስጥ ሰርዙት፣ ከዚያም ወደዚህ ተመለሱ አንድ ጊዜ ግዢ ለመግዛት - በዚህ መንገድ ሁለት ጊዜ ክፍያ አይወስዱም።</string>
-    <string name="upgrade_screen_sub_check_failed_message">ምዝገባዎን ሁኔታ ማረጋገጥ አልቻልንም። እባክዎ ግንኙነትዎን ይፈትሹ እና ድጋሚ ሞክሩ።</string>
     <string name="upgrades_gplay_already_owned_error_title">ተገዛ ነው</string>
     <string name="upgrades_gplay_already_owned_error_description">\'ግዢ ወደ ኋላ መመለስ\' አማራጭ ተጠቀም ግዢዎን ለመመለስ። ችግሩ ካልተፈታ፣ Google Play ካሽ ይጽደ እና መሳሪያዎን ድጋሚ ያስጀምሩ።</string>
     <string name="upgrades_gplay_internal_error_title">Google Play ስህተት</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">الاشتراك ما زال نشطًا</string>
     <string name="upgrade_screen_sub_still_renewing_message">اشتراكك لا يزال مُعدًا للتجديد. ألغه في Google Play أولاً، ثم عد لشراء الشراء لمرة واحدة — بهذه الطريقة لن تُخصم منك رسوم مرتين.</string>
-    <string name="upgrade_screen_sub_check_failed_message">لم نتمكن من التحقق من حالة اشتراكك. يُرجى التحقق من اتصالك والمحاولة مرة أخرى.</string>
     <string name="upgrades_gplay_already_owned_error_title">تم الشراء بالفعل</string>
     <string name="upgrades_gplay_already_owned_error_description">استخدم خيار \"استعادة الشراء\" لاستعادة عملية الشراء الخاصة بك. إذا استمرت المشكلة، حاول مسح ذاكرة التخزين المؤقتة لـ Google Play وإعادة تشغيل جهازك.</string>
     <string name="upgrades_gplay_internal_error_title">خطأ في Google Play</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abunəlik hələ də aktivdir</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abunəliyiniz hələ də yenilənməyə təyin edilib. Əvvəlcə onu Google Play-də ləğv edin, sonra birdəfəlik alışı almaq üçün geri qayıdın — bu şəkildə iki dəfə ödəniş almayacaqsınız.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Abunəlik statusunuzu yoxlaya bilmədik. Zəhmət olmasa bağlantınızı yoxlayın və yenidən cəhd edin.</string>
     <string name="upgrades_gplay_already_owned_error_title">Artıq alınıb</string>
     <string name="upgrades_gplay_already_owned_error_description">Alışınızı bərpa etmək üçün \"Alışı bərpa et\" seçimindən istifadə edin. Problem davam edərsə, Google Play keşini təmizləməyə və cihazınızı yenidən başlatmağa çalışın.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play xətası</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Падпіска ўсё яшчэ актыўная</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша падпіска ўсё яшчэ будзе аднаўляцца. Скасуйце яе ў Google Play спачатку, потым вярніцеся, каб купіць аднаразовую пакупку — такім чынам з вас не спагоняць плату двайчы.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Мы не змаглі праверыць статус вашай падпіскі. Праверце злучэнне і паспрабуйце зноў.</string>
     <string name="upgrades_gplay_already_owned_error_title">Ужо куплена</string>
     <string name="upgrades_gplay_already_owned_error_description">Скарыстайцеся апцыяй «Аднавіць пакупку», каб аднавіць вашу пакупку. Калі праблема застаецца, паспрабуйце ачысціць кэш Google Play і перазапусціць прыладу.</string>
     <string name="upgrades_gplay_internal_error_title">Памылка Google Play</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Абонаментът все още е активен</string>
     <string name="upgrade_screen_sub_still_renewing_message">Абонаментът ви все още е зададен за подновяване. Първо го отменете в Google Play, а след това се върнете, за да купите еднократната покупка — така няма да бъдете таксувани два пъти.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не успяхме да проверим статуса на абонамента ви. Моля, проверете връзката си и опитайте отново.</string>
     <string name="upgrades_gplay_already_owned_error_title">Вече закупено</string>
     <string name="upgrades_gplay_already_owned_error_description">Използвайте опцията „Възстановяване на покупка“, за да възстановите покупката си. Ако проблемът продължи, опитайте да изчистите кеша на Google Play и да рестартирате устройството си.</string>
     <string name="upgrades_gplay_internal_error_title">Грешка в Google Play</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">সাবস্ক্রিপশন এখনও সক্রিয়</string>
     <string name="upgrade_screen_sub_still_renewing_message">আপনার সাবস্ক্রিপশন এখনও নবায়নের জন্য সেট করা আছে। প্রথমে Google Play-তে এটি বাতিল করুন, তারপর একবারের ক্রয় কিনতে ফিরে আসুন — এভাবে আপনার কাছ থেকে দুইবার চার্জ নেওয়া হবে না।</string>
-    <string name="upgrade_screen_sub_check_failed_message">আমরা আপনার সাবস্ক্রিপশন স্ট্যাটাস যাচাই করতে পারিনি। অনুগ্রহ করে আপনার সংযোগ যাচাই করে আবার চেষ্টা করুন।</string>
     <string name="upgrades_gplay_already_owned_error_title">ইতিমধ্যে কেনা হয়েছে</string>
     <string name="upgrades_gplay_already_owned_error_description">আপনার ক্রয় পুনরুদ্ধার করতে \"ক্রয় পুনরুদ্ধার করুন\" অপশনটি ব্যবহার করুন। সমস্যা থেকেই গেলে, Google Play ক্যাশে সাফ করে আপনার ডিভাইস পুনরায় চালু করার চেষ্টা করুন।</string>
     <string name="upgrades_gplay_internal_error_title">Google Play ত্রুটি</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">La subscripció encara està activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">La vostra subscripció encara està configurada per renovar-se. Cancel·leu-la primer a Google Play i després torneu per comprar la compra única; així no us cobraran dues vegades.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No hem pogut comprovar l’estat de la vostra subscripció. Comproveu la vostra connexió i torneu-ho a provar.</string>
     <string name="upgrades_gplay_already_owned_error_title">Ja comprat</string>
     <string name="upgrades_gplay_already_owned_error_description">Feu servir l\'opció «Restaura la compra» per restaurar la compra. Si el problema persisteix, proveu d\'esborrar la memòria cau del Google Play i reinicieu el dispositiu.</string>
     <string name="upgrades_gplay_internal_error_title">Error del Google Play</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Předplatné je stále aktivní</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaše předplatné je stále nastaveno na obnovení. Nejprve ho zrušte v Google Play a pak se vraťte a kupte jednorázový nákup — takto vám nebude účtováno dvakrát.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nepodařilo se nám zkontrolovat stav vašeho předplatného. Zkontrolujte prosím připojení a zkuste to znovu.</string>
     <string name="upgrades_gplay_already_owned_error_title">Již zakoupeno</string>
     <string name="upgrades_gplay_already_owned_error_description">Použijte možnost \"Obnovit nákup\" k obnovení nákupu. Pokud problém přetrvává, zkuste vyčistit mezipaměť Google Play a restartovat zařízení.</string>
     <string name="upgrades_gplay_internal_error_title">Chyba Google Play</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement stadig aktivt</string>
     <string name="upgrade_screen_sub_still_renewing_message">Dit abonnement er stadig indstillet til at blive fornyet. Annuller det i Google Play først, og kom derefter tilbage for at købe engangskøbet — på den måde bliver du ikke opkrævet to gange.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Vi kunne ikke tjekke din abonnementsstatus. Tjek din forbindelse, og prøv igen.</string>
     <string name="upgrades_gplay_already_owned_error_title">Allerede købt</string>
     <string name="upgrades_gplay_already_owned_error_description">Brug indstillingen \"Gendan køb\" for at gendanne dit køb. Hvis problemet fortsætter, så prøv at rydde Google Play-cachen og genstarte din enhed.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-fejl</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abo noch aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Dein Abo wird noch verlängert. Kündige es zuerst in Google Play und komm dann zurück, um den einmaligen Kauf zu tätigen — so wirst du nicht doppelt belastet.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Wir konnten deinen Abostatus nicht überprüfen. Bitte prüfe deine Verbindung und versuche es erneut.</string>
     <string name="upgrades_gplay_already_owned_error_title">Bereits gekauft</string>
     <string name="upgrades_gplay_already_owned_error_description">Verwende die Option \"Auswahl wiederherstellen\", um Deinen Kauf wiederherzustellen. Falls das Problem weiterhin besteht, versuche den Google Play Cache zu leeren und Dein Gerät neu zu starten.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play Fehler</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Η συνδρομή είναι ακόμα ενεργή</string>
     <string name="upgrade_screen_sub_still_renewing_message">Η συνδρομή σου εξακολουθεί να είναι ρυθμισμένη να ανανεωθεί. Ακύρωσέ την πρώτα στο Google Play και μετά επέστρεψε για να αγοράσεις την εφάπαξ αγορά — έτσι δεν θα χρεωθείς δύο φορές.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Δεν μπορέσαμε να ελέγξουμε την κατάσταση της συνδρομής σου. Έλεγξε τη σύνδεσή σου και δοκίμασε ξανά.</string>
     <string name="upgrades_gplay_already_owned_error_title">Ήδη αγορασμένο</string>
     <string name="upgrades_gplay_already_owned_error_description">Χρησιμοποιήστε την επιλογή \"Επαναφορά αγοράς\" για να επαναφέρετε την αγορά σας. Εάν το πρόβλημα παραμένει, δοκιμάστε να καθαρίσετε την προσωρινή μνήμη του Google Play και να επανεκκινήσετε τη συσκευή σας.</string>
     <string name="upgrades_gplay_internal_error_title">Σφάλμα Google Play</string>

--- a/app/src/gplay/res/values-eo-rUY/strings.xml
+++ b/app/src/gplay/res/values-eo-rUY/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abonado daŭre aktiva</string>
     <string name="upgrade_screen_sub_still_renewing_message">Via abonado estas daŭre agordita por renovi. Nuligu ĝin en Google Play unue, poste revenu por aĉeti unufojan aĉeton — tiele vi ne estos ŝarĝita dufoje.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Ni ne povis kontroli vian abonadan staton. Bonvolu kontroli vian konekton kaj provu denove.</string>
     <string name="upgrades_gplay_already_owned_error_title">Jam aĉetita</string>
     <string name="upgrades_gplay_already_owned_error_description">Uzu la \"Rekuperi aĉeton\" eblecon por rekuperi vian aĉeton. Se la problemo daŭras, provu forviŝi la kaŝmemoron de Google Play Store kaj restartigi vian aparaton.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play eraro</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Suscripción todavía activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción todavía está configurada para renovarse. Cancelala primero en Google Play y después volvé para comprar la compra única — así no te cobran dos veces.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No pudimos verificar el estado de tu suscripción. Revisá tu conexión y probá de nuevo.</string>
     <string name="upgrades_gplay_already_owned_error_title">Ya comprado</string>
     <string name="upgrades_gplay_already_owned_error_description">Usá la opción \"Restaurar compra\" para restaurar tu compra. Si el problema persiste, probá borrar la caché de Google Play y reiniciar tu dispositivo.</string>
     <string name="upgrades_gplay_internal_error_title">Error de Google Play</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Suscripción todavía activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción todavía está configurada para renovarse. Cancélala primero en Google Play y luego regresa a comprar la compra única; así no se te cobrará dos veces.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No pudimos verificar el estado de tu suscripción. Revisa tu conexión e intenta de nuevo.</string>
     <string name="upgrades_gplay_already_owned_error_title">Ya comprado</string>
     <string name="upgrades_gplay_already_owned_error_description">Usa la opción \"Restaurar compra\" para restaurar tu compra. Si el problema persiste, intenta borrar la caché de Google Play y reiniciar tu dispositivo.</string>
     <string name="upgrades_gplay_internal_error_title">Error de Google Play</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Suscripción todavía activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tu suscripción todavía está configurada para renovarse. Cancélala primero en Google Play y luego vuelve para comprar la compra única — así no se te cobrará dos veces.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No pudimos comprobar el estado de tu suscripción. Comprueba tu conexión e inténtalo de nuevo.</string>
     <string name="upgrades_gplay_already_owned_error_title">Ya comprado</string>
     <string name="upgrades_gplay_already_owned_error_description">Usa la opción «Restaurar compra» para restaurar tu compra. Si el problema persiste, intenta borrar la caché de Google Play y reiniciar tu dispositivo.</string>
     <string name="upgrades_gplay_internal_error_title">Error de Google Play</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Tellimus on endiselt kasutusel</string>
     <string name="upgrade_screen_sub_still_renewing_message">Sinu tellimus uueneb endiselt. Tühista see kõigepealt rakenduses Google Play ja tule siis tagasi, et osta ühekordne ost — nii ei arveldata sind kaks korda.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Me ei saanud sinu tellimuse olekut kontrollida. Palun kontrolli oma internetiühendust ja proovi uuesti.</string>
     <string name="upgrades_gplay_already_owned_error_title">Juba ostetud</string>
     <string name="upgrades_gplay_already_owned_error_description">Ostu taastamiseks kasuta „Taasta ost“ valikut. Mure püsimisel ürita tühjendada Google Play vahemälu ja taaskäivitada seadet.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play viga</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Harpidetza oraindik aktibo</string>
     <string name="upgrade_screen_sub_still_renewing_message">Zure harpidetza oraindik berritzeko ezarrita dago. Utzi lehenbizi Google Play-n, eta gero itzuli ordainketa bakarreko erosketa egitera — horrela ez zaituzte bi aldiz kobratuko.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Ezin izan dugu zure harpidetzaren egoera egiaztatu. Egiaztatu zure konexioa eta saiatu berriro.</string>
     <string name="upgrades_gplay_already_owned_error_title">Jada erosita</string>
     <string name="upgrades_gplay_already_owned_error_description">Erabili \"Berreskuratu erosketa\" aukera zure erosketa berreskuratzeko. Arazoak jarraitzen badu, saiatu Google Play-ren cachea garbitzen eta gailua berrabiarazten.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play errorea</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">اشتراک هنوز فعال است</string>
     <string name="upgrade_screen_sub_still_renewing_message">اشتراک شما هنوز برای تمدید تنظیم شده است. ابتدا آن را در Google Play لغو کنید، سپس برای خرید یک‌باره برگردید — این‌طور دو بار از شما هزینه دریافت نمی‌شود.</string>
-    <string name="upgrade_screen_sub_check_failed_message">نتوانستیم وضعیت اشتراک شما را بررسی کنیم. لطفاً اتصال خود را بررسی کرده و دوباره تلاش کنید.</string>
     <string name="upgrades_gplay_already_owned_error_title">قبلاً خریداری شده</string>
     <string name="upgrades_gplay_already_owned_error_description">برای بازیابی خرید خود از گزینه «بازیابی خرید» استفاده کنید. اگر مشکل ادامه داشت، سعی کنید کش Google Play را پاک کرده و دستگاه خود را دوباره راه‌اندازی کنید.</string>
     <string name="upgrades_gplay_internal_error_title">خطای Google Play</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Tilaus on yhä aktiivinen</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tilauksesi uusiutuu yhä automaattisesti. Peruuta se ensin Google Playssa ja palaa sitten ostamaan kertaosto — näin sinulta ei veloiteta kahdesti.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Emme pystyneet tarkistamaan tilauksesi tilaa. Tarkista yhteytesi ja yritä uudelleen.</string>
     <string name="upgrades_gplay_already_owned_error_title">Jo ostettu</string>
     <string name="upgrades_gplay_already_owned_error_description">Käytä \"Palauta ostos\" -toimintoa palauttaaksesi ostoksesi. Jos ongelma jatkuu, tyhjennä Google Play -välimuisti ja käynnistä laite uudelleen.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play -virhe</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Aktibo pa rin ang subscription</string>
     <string name="upgrade_screen_sub_still_renewing_message">Naka-set pa rin mag-renew ang iyong subscription. I-cancel muna ito sa Google Play, tapos bumalik para bilhin ang one-time purchase — sa ganoong paraan hindi ka masisingil nang dalawang beses.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Hindi namin nasuri ang status ng iyong subscription. Pakisuri ang iyong koneksyon at subukan ulit.</string>
     <string name="upgrades_gplay_already_owned_error_title">Nabili na</string>
     <string name="upgrades_gplay_already_owned_error_description">Gamitin ang opsyong \"I-restore ang purchase\" para i-restore ang iyong purchase. Kung nagpapatuloy ang isyu, subukang i-clear ang Google Play cache at i-restart ang iyong device.</string>
     <string name="upgrades_gplay_internal_error_title">Error sa Google Play</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement toujours actif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Votre abonnement est toujours configuré pour se renouveler. Annulez-le d’abord dans Google Play, puis revenez acheter l’achat unique — ainsi vous ne serez pas facturé deux fois.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nous n’avons pas pu vérifier le statut de votre abonnement. Veuillez vérifier votre connexion et réessayer.</string>
     <string name="upgrades_gplay_already_owned_error_title">Déjà acheté</string>
     <string name="upgrades_gplay_already_owned_error_description">Utilisez l\'option « Rétablir l’achat ». Si le problème persiste, essayez de vider le cache de Google Play et de redémarrer votre appareil.</string>
     <string name="upgrades_gplay_internal_error_title">Erreur Google Play</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Subscrición aínda activa</string>
     <string name="upgrade_screen_sub_still_renewing_message">A túa subscrición aínda está configurada para renovarse. Cancélaa primeiro en Google Play e despois volve para mercar a compra única — así non se che cobrará dúas veces.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Non puidemos comprobar o estado da túa subscrición. Comproba a túa conexión e téntao de novo.</string>
     <string name="upgrades_gplay_already_owned_error_title">Xa mercado</string>
     <string name="upgrades_gplay_already_owned_error_description">Usa a opción \"Restaurar compra\" para restaurar a túa compra. Se o problema persiste, tenta limpar a caché de Google Play e reiniciar o teu dispositivo.</string>
     <string name="upgrades_gplay_internal_error_title">Erro de Google Play</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">सदस्यता अभी भी सक्रिय है</string>
     <string name="upgrade_screen_sub_still_renewing_message">आपकी सदस्यता अभी भी नवीनीकृत होने के लिए सेट है। पहले इसे Google Play में रद्द करें, फिर एकमुश्त खरीदारी करने के लिए वापस आएं — इस तरह आपसे दो बार शुल्क नहीं लिया जाएगा।</string>
-    <string name="upgrade_screen_sub_check_failed_message">हम आपकी सदस्यता की स्थिति जांच नहीं सके। कृपया अपना कनेक्शन जांचें और फिर से प्रयास करें।</string>
     <string name="upgrades_gplay_already_owned_error_title">पहले ही खरीदा जा चुका है</string>
     <string name="upgrades_gplay_already_owned_error_description">अपनी खरीदारी को पुनर्स्थापित करने के लिए \"खरीदारी पुनर्स्थापित करें\" विकल्प का उपयोग करें। अगर समस्या बनी रहती है, तो Google Play कैश साफ़ करके अपना डिवाइस पुनः प्रारंभ करके देखें।</string>
     <string name="upgrades_gplay_internal_error_title">Google Play त्रुटि</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Pretplata je i dalje aktivna</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaša pretplata je i dalje postavljena za obnavljanje. Prvo je otkažite u Google Playu, a zatim se vratite kako biste kupili jednokratnu kupnju — tako vam neće biti naplaćeno dvaput.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nismo mogli provjeriti status vaše pretplate. Provjerite svoju vezu i pokušajte ponovno.</string>
     <string name="upgrades_gplay_already_owned_error_title">Već kupljeno</string>
     <string name="upgrades_gplay_already_owned_error_description">Upotrijebite opciju \"Vrati kupnju\" kako biste vratili svoju kupnju. Ako se problem nastavi, pokušajte očistiti predmemoriju Google Playa i ponovno pokrenuti uređaj.</string>
     <string name="upgrades_gplay_internal_error_title">Greška Google Playa</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Az előfizetés még aktív</string>
     <string name="upgrade_screen_sub_still_renewing_message">Az előfizetésed még megújulásra van állítva. Először mondd le a Google Playben, majd gyere vissza, hogy megvedd az egyszeri vásárlást — így nem terhelnek meg kétszer.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nem sikerült ellenőrizni az előfizetésed állapotát. Ellenőrizd a kapcsolatod, és próbáld újra.</string>
     <string name="upgrades_gplay_already_owned_error_title">Már megvásárolva</string>
     <string name="upgrades_gplay_already_owned_error_description">Használd a „Vásárlás visszaállítása” opciót a vásárlásod visszaállításához. Ha a probléma továbbra is fennáll, próbáld törölni a Google Play gyorsítótárát, és indítsd újra a készüléked.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play hiba</string>

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Բաժանորդագրությունը դեռ ակտիվ է</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ձեր բաժանորդագրությունը դեռ նախատեսված է երկարաձգվել։ Նախ չեղարկեք այն Google Play-ում, ապա վերադարձեք՝ միանվագ գնումը կատարելու համար — այդպես ձեզանից գումար կրկնակի չի գանձվի։</string>
-    <string name="upgrade_screen_sub_check_failed_message">Մենք չկարողացանք ստուգել ձեր բաժանորդագրության կարգավիճակը։ Ստուգեք ձեր կապը և կրկին փորձեք։</string>
     <string name="upgrades_gplay_already_owned_error_title">Արդեն գնված է</string>
     <string name="upgrades_gplay_already_owned_error_description">Օգտագործեք «Վերականգնել գնումը» տարբերակը՝ ձեր գնումը վերականգնելու համար։ Եթե խնդիրը շարունակվում է, փորձեք մաքրել Google Play-ի քեշը և վերագործարկել ձեր սարքը։</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-ի սխալ</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Langganan masih aktif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Langganan Anda masih diatur untuk diperpanjang. Batalkan terlebih dahulu di Google Play, lalu kembali untuk membeli pembelian satu kali — dengan begitu Anda tidak akan dikenai biaya dua kali.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kami tidak dapat memeriksa status langganan Anda. Silakan periksa koneksi Anda dan coba lagi.</string>
     <string name="upgrades_gplay_already_owned_error_title">Sudah dibeli</string>
     <string name="upgrades_gplay_already_owned_error_description">Gunakan opsi \"Pulihkan pembelian\" untuk memulihkan pembelian Anda. Jika masalah berlanjut, coba hapus cache Google Play dan mulai ulang perangkat Anda.</string>
     <string name="upgrades_gplay_internal_error_title">Kesalahan Google Play</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Áskrift enn virk</string>
     <string name="upgrade_screen_sub_still_renewing_message">Áskriftin þín er enn stillt á að endurnýjast. Segðu henni upp í Google Play fyrst og komdu svo aftur til að kaupa eingreiðslukaupin — þannig verðurðu ekki rukuð(ur) tvisvar.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Við gátum ekki athugað áskriftarstöðu þína. Athugaðu nettenginguna og reyndu aftur.</string>
     <string name="upgrades_gplay_already_owned_error_title">Þegar keypt</string>
     <string name="upgrades_gplay_already_owned_error_description">Notaðu valkostinn „Endurheimta kaup“ til að endurheimta kaupin þín. Ef vandamálið er viðvarandi skaltu reyna að hreinsa skyndiminni Google Play og endurræsa tækið.</string>
     <string name="upgrades_gplay_internal_error_title">Villa í Google Play</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abbonamento ancora attivo</string>
     <string name="upgrade_screen_sub_still_renewing_message">Il tuo abbonamento è ancora impostato per il rinnovo. Annullalo prima in Google Play, poi torna qui per acquistare l’acquisto una tantum — in questo modo non ti verrà addebitato due volte.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Non siamo riusciti a verificare lo stato del tuo abbonamento. Controlla la tua connessione e riprova.</string>
     <string name="upgrades_gplay_already_owned_error_title">Già acquistato</string>
     <string name="upgrades_gplay_already_owned_error_description">Usa l’opzione \"Ripristina acquisto\" per ripristinare il tuo acquisto. Se il problema persiste, prova a cancellare la cache di Google Play e a riavviare il dispositivo.</string>
     <string name="upgrades_gplay_internal_error_title">Errore di Google Play</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">המנוי עדיין פעיל</string>
     <string name="upgrade_screen_sub_still_renewing_message">המנוי שלכם עדיין מוגדר להתחדש. בטלו אותו קודם ב-Google Play, ואז חזרו לקנות את הרכישה החד-פעמית — כך לא תחויבו פעמיים.</string>
-    <string name="upgrade_screen_sub_check_failed_message">לא הצלחנו לבדוק את סטטוס המנוי שלכם. בדקו את החיבור שלכם ונסו שוב.</string>
     <string name="upgrades_gplay_already_owned_error_title">כבר נרכש</string>
     <string name="upgrades_gplay_already_owned_error_description">השתמשו באפשרות \"שחזור רכישה\" כדי לשחזר את הרכישה שלכם. אם הבעיה נמשכת, נסו לנקות את מטמון Google Play ולהפעיל מחדש את המכשיר שלכם.</string>
     <string name="upgrades_gplay_internal_error_title">שגיאת Google Play</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">サブスクリプションはまだ有効です</string>
     <string name="upgrade_screen_sub_still_renewing_message">サブスクリプションはまだ更新される設定になっています。まずGoogle Playで解約してから、買い切り購入に戻ってください。そうすれば二重に請求されません。</string>
-    <string name="upgrade_screen_sub_check_failed_message">サブスクリプションの状態を確認できませんでした。接続を確認してもう一度お試しください。</string>
     <string name="upgrades_gplay_already_owned_error_title">購入済みです</string>
     <string name="upgrades_gplay_already_owned_error_description">「購入を復元」オプションを使用して購入を復元してください。問題が解決しない場合は、Google Playのキャッシュを消去してデバイスを再起動してください。</string>
     <string name="upgrades_gplay_internal_error_title">Google Playエラー</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">გამოწერა ჯერ კიდევ აქტიურია</string>
     <string name="upgrade_screen_sub_still_renewing_message">თქვენი გამოწერა ჯერ კიდევ ავტომატურად განახლდება. ჯერ გააუქმეთ ის Google Play-ში, შემდეგ დაბრუნდით ერთჯერადი შენაძენის შესაძენად — ასე ორჯერ არ გადაგახდევინებენ.</string>
-    <string name="upgrade_screen_sub_check_failed_message">ვერ შევძელით თქვენი გამოწერის სტატუსის შემოწმება. გთხოვთ, შეამოწმოთ თქვენი კავშირი და ხელახლა სცადოთ.</string>
     <string name="upgrades_gplay_already_owned_error_title">უკვე შეძენილია</string>
     <string name="upgrades_gplay_already_owned_error_description">გამოიყენეთ „შენაძენის აღდგენა\" ოფცია თქვენი შენაძენის აღსადგენად. თუ პრობლემა გრძელდება, სცადეთ Google Play-ის ქეშის გასუფთავება და მოწყობილობის გადატვირთვა.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-ის შეცდომა</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">ការជាវនៅតែសកម្ម</string>
     <string name="upgrade_screen_sub_still_renewing_message">ការជាវរបស់អ្នកនៅតែត្រូវបានកំណត់ឱ្យបន្តជាថ្មី។ សូមលុបចោលវានៅក្នុង Google Play ជាមុនសិន បន្ទាប់មកត្រឡប់មកទិញការទិញតែម្តងវិញ — ដោយវិធីនេះអ្នកនឹងមិនត្រូវបានគិតប្រាក់ពីរដងទេ។</string>
-    <string name="upgrade_screen_sub_check_failed_message">យើងមិនអាចពិនិត្យស្ថានភាពការជាវរបស់អ្នកបានទេ។ សូមពិនិត្យការតភ្ជាប់របស់អ្នក ហើយព្យាយាមម្តងទៀត។</string>
     <string name="upgrades_gplay_already_owned_error_title">បានទិញរួចហើយ</string>
     <string name="upgrades_gplay_already_owned_error_description">សូមប្រើជម្រើស \"ស្តារការទិញ\" ដើម្បីស្តារការទិញរបស់អ្នក។ ប្រសិនបើបញ្ហានៅតែកើតមាន សូមព្យាយាមសម្អាតឃ្លាំងសម្ងាត់ Google Play ហើយចាប់ផ្តើមឧបករណ៍របស់អ្នកឡើងវិញ។</string>
     <string name="upgrades_gplay_internal_error_title">កំហុស Google Play</string>

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Bendavî hîn jî çalak e</string>
     <string name="upgrade_screen_sub_still_renewing_message">Bendavî xwe hîn jî bo nûkirinê mîhenk kiriye. Ew di Google Play de bê yekemîn betal bikin, paşê vegerin û kire xweze bikin — bi vî awayî du caran lê vatin nabe.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Em nikarî rewşa bendavî xwe kontrol bikin. Girêdanê xwe kontrol bikin û dîsa biceribînin.</string>
     <string name="upgrades_gplay_already_owned_error_title">Jixwe kirî ye</string>
     <string name="upgrades_gplay_already_owned_error_description">Vebijarka Kirina Vegerandin bikar bînin da ku kirina xwe vegerandin. Eger pirsgêrk berdewam be, derbasbûna Google Play paqij bikin û amûra xwe dîsa destpê bikin.</string>
     <string name="upgrades_gplay_internal_error_title">Xebata Google Play</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">ಸದಸ್ಯತ್ವ ಇನ್ನೂ ಸಕ್ರಿಯವಾಗಿದೆ</string>
     <string name="upgrade_screen_sub_still_renewing_message">ನಿಮ್ಮ ಸದಸ್ಯತ್ವ ನವೀಕರಣ ಮಾಡಲು ಇನ್ನೂ ಹೊಂದಿಸಲಾಗಿದೆ. ಇದನ್ನು ಮೊದಲು Google Play ನಲ್ಲಿ ರದ್ದುಗೊಳಿಸಿ, ನಂತರ ಏಕಕಾಲೀನ ಖರೀದಿಗಾಗಿ ಹಿಂತಿರುಗಿ — ಆ ರೀತಿಯಲ್ಲಿ ನಿಮಗೆ ಎರಡು ಬಾರಿ ಚಾರ್ಜ್ ಆಗುವುದಿಲ್ಲ.</string>
-    <string name="upgrade_screen_sub_check_failed_message">ನಾವು ನಿಮ್ಮ ಸದಸ್ಯತ್ವ ಸ್ಥಿತಿ ಪರಿಶೀಲಿಸಲು ಸಾಧ್ಯವಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ನಿಮ್ಮ ಸಂಪರ್ಕ ಪರಿಶೀಲಿಸಿ ಮತ್ತು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
     <string name="upgrades_gplay_already_owned_error_title">ಈಗಾಗಲೇ ಖರೀದಿಸಲಾಗಿದೆ</string>
     <string name="upgrades_gplay_already_owned_error_description">ನಿಮ್ಮ ಖರೀದಿ ಮರುಸ್ಥಾಪಿಸಲು \"ಖರೀದಿ ಮರುಸ್ಥಾಪಿಸಿ\" ಆಯ್ಕೆ ಬಳಸಿ. ಸಮಸ್ಯೆ ಪುನರಾವರ್ತಿತವಾಗುತ್ತಲೇ ಇದ್ದರೆ, Google Play ಕ್ಯಾಶೆ ಸ್ವಚ್ಛ ಮಾಡಲು ಪ್ರಯತ್ನಿಸಿ ಮತ್ತು ನಿಮ್ಮ ಸಾಧನವನ್ನು ಮತ್ತೆ ಪ್ರಾರಂಭಿಸಿ.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play ದೋಷ</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">구독이 아직 활성 상태입니다</string>
     <string name="upgrade_screen_sub_still_renewing_message">구독이 아직 자동 갱신으로 설정되어 있습니다. 먼저 Google Play에서 구독을 취소한 다음 돌아와서 일회성 구매를 진행하세요 — 그러면 두 번 청구되지 않습니다.</string>
-    <string name="upgrade_screen_sub_check_failed_message">구독 상태를 확인할 수 없습니다. 연결 상태를 확인하고 다시 시도해 주세요.</string>
     <string name="upgrades_gplay_already_owned_error_title">이미 구매함</string>
     <string name="upgrades_gplay_already_owned_error_description">\"구매 복원\" 옵션을 사용하여 구매 내역을 복원하세요. 문제가 계속되면 Google Play 캐시를 삭제하고 기기를 재시작해 보세요.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play 오류</string>

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Жазылуу дагы эле активдүү</string>
     <string name="upgrade_screen_sub_still_renewing_message">Сиздин жазылуу дагы эле кайталанууга коюлган. Адегенде аны Google Play\'де жокко чыгарыңыз, андан кийин бир жолу сатып алуу үчүн кайра келиңиз — ошентип эки жолу төлөбойсуңуз.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Биз сиздин жазылуу статусун текшей албадык. Байланышыңызды текшеңиз жана кайра аракет кылыңыз.</string>
     <string name="upgrades_gplay_already_owned_error_title">Мурда сатылып алынган</string>
     <string name="upgrades_gplay_already_owned_error_description">\"Сатып алууну калыбына келтирүү\" опциясын колдонуп, сатып алууңузду калыбына келтириңиз. Эгер проблема сакталса, Google Play кэшин тазалап жана түзмөгүңүздү кайра жүктөп көрүңүз.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play катасы</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">ການສະໝັກສະມາຊິກຍັງເປີດໃຊ້ງານຢູ່</string>
     <string name="upgrade_screen_sub_still_renewing_message">ການສະໝັກສະມາຊິກຂອງທ່ານຍັງຕັ້ງໄວ້ໃຫ້ຕໍ່ອາຍຸຢູ່. ໃຫ້ຍົກເລີກມັນໃນ Google Play ກ່ອນ, ແລ້ວກັບມາຊື້ແບບຄັ້ງດຽວ — ວິທີນີ້ຈະບໍ່ໃຫ້ທ່ານຖືກຮຽກເກັບເງິນສອງເທື່ອ.</string>
-    <string name="upgrade_screen_sub_check_failed_message">ພວກເຮາບໍ່ສາມາດກວດສອບສະຖານະການສະໝັກສະມາຊິກຂອງທ່ານໄດ້. ກະລຸນາກວດເບິ່ງການເຊື່ອມຕໍ່ຂອງທ່ານແລ້ວລອງໃໝ່.</string>
     <string name="upgrades_gplay_already_owned_error_title">ຊື້ແລ້ວ</string>
     <string name="upgrades_gplay_already_owned_error_description">ໃຊ້ຕຽວເລືອກ \"ກູ້ຄືນການຊື້\" ເພື່ອກູ້ຄືນການຊື້ຂອງທ່ານ. ຖ້າບັນໝາຍັງເກີດຂຶ້ນຢູ່, ລອງລ້າງແຄດຊ Google Play ແລ້ວເປີດອຸປະກອນຂອງທ່ານໃໝ່.</string>
     <string name="upgrades_gplay_internal_error_title">ຂໍ້ຜິດພາດ Google Play</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Prenumerata vis dar aktyvi</string>
     <string name="upgrade_screen_sub_still_renewing_message">Jūsų prenumerata vis dar bus atnaujinama. Pirmiausia atšaukite ją „Google Play“, tada grįžkite ir įsigykite vienkartinį pirkinį — taip nebūsite apmokestinti du kartus.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nepavyko patikrinti jūsų prenumeratos būsenos. Patikrinkite ryšį ir bandykite dar kartą.</string>
     <string name="upgrades_gplay_already_owned_error_title">Jau įsigyta</string>
     <string name="upgrades_gplay_already_owned_error_description">Naudokite parinktį „Atkurti pirkinį“, kad atkurtumėte savo pirkinį. Jei problema kartojasi, pabandykite išvalyti „Google Play“ talpyklą ir iš naujo paleisti įrenginį.</string>
     <string name="upgrades_gplay_internal_error_title">„Google Play“ klaida</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abonements joprojām aktīvs</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tavs abonements joprojām ir iestatīts atjaunoties. Vispirms atcel to Google Play, pēc tam atgriezies, lai iegādātos vienreizējo pirkumu — tā tev netiks ieturēta maksa divreiz.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Mēs nevarējām pārbaudīt tava abonementa statusu. Lūdzu, pārbaudi savienojumu un mēģini vēlreiz.</string>
     <string name="upgrades_gplay_already_owned_error_title">Jau iegādāts</string>
     <string name="upgrades_gplay_already_owned_error_description">Izmanto opciju \"Atjaunot pirkumu\", lai atjaunotu savu pirkumu. Ja problēma joprojām pastāv, mēģini notīrīt Google Play kešatmiņu un restartēt ierīci.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play kļūda</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Претплатата е сè уште активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Вашата претплата е сè уште поставена да се обнови. Прво откажете ја во Google Play, потоа вратете се да ја купите еднократната куповина — на тој начин нема да бидете наплатени двапати.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не можевме да го провериме вашиот статус на претплата. Ве молиме проверете ја вашата врска и обидете се повторно.</string>
     <string name="upgrades_gplay_already_owned_error_title">Веќе купено</string>
     <string name="upgrades_gplay_already_owned_error_description">Користете ја опцијата „Обнови куповина\" за да ја обновите вашата куповина. Ако проблемот продолжува, обидете се да го исчистите кешот на Google Play Store и да го рестартирате уредот.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play грешка</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">സബ്സ്ക്രിപ്ഷൻ ഇപ്പോഴും സജീവമാണ്</string>
     <string name="upgrade_screen_sub_still_renewing_message">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ പുതുക്കാൻ സജ്ജമായിരിക്കുന്നു. Google Play-ൽ ആദ്യം അത് റദ്ദ് ചെയ്യുക, പിന്നെ ഒറിക്കലുളള വാങ്ങലിനായി തിരികെ വരിക — ഈ വിധത്തിൽ നിങ്ങൾക്ക് രണ്ടുതവണ ചാർജ് ചെയ്യപ്പെടുകയില്ല.</string>
-    <string name="upgrade_screen_sub_check_failed_message">നിങ്ങളുടെ സബ്സ്ക്രിപ്ഷൻ അവസ്ഥ പരിശോധിക്കാൻ ഞങ്ങൾക്ക് കഴിഞ്ഞില്ല. ദയവായി നിങ്ങളുടെ കണക്ഷൻ പരിശോധിച്ച് വീണ്ടും ശ്രമിക്കുക.</string>
     <string name="upgrades_gplay_already_owned_error_title">ഇതിനകം വാങ്ങിയിരിക്കുന്നു</string>
     <string name="upgrades_gplay_already_owned_error_description">നിങ്ങളുടെ വാങ്ങൽ പുനരുദ്ധരിക്കാൻ \"വാങ്ങൽ പുനരുദ്ധരിക്കുക\" ഓപ്ഷൻ ഉപയോഗിക്കുക. പ്രശ്നം തുടരുന്നുണ്ടെങ്കിൽ, Google Play കാഷെ നീക്കം ചെയ്യുകയോ നിങ്ങളുടെ ഡിവൈസ് പുനരാരംഭിക്കുകയോ ചെയ്തു നോക്കുക.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play പിശക്</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Захиалга идэвхтэй байна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Таны захиалга сэргээгдэхээр тохируулагдсан байна. Эхлээд Google Play-д цуцлана уу, дараа нь нэг удаагийн худалдан авалт хийхээр буцаж ирнэ үү — ингэснээр та хоёр удаа суллагдахгүй.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Бид таны захиалгын статусыг шалгаж чадаагүй. Интернэт холболт шалгаж дахин оролдоно уу.</string>
     <string name="upgrades_gplay_already_owned_error_title">Аль хэдийн худалдан авсан</string>
     <string name="upgrades_gplay_already_owned_error_description">\"Худалдан авалтыг сэргэх\" сонголтыг ашиглан таны худалдан авалтыг сэргээнэ үү. Хэрвээ асуудал үргэлжвэл Google Play-ийн кеш цэвэрлэж, төхөөрөмжөө дахин эхлүүлэхийг оролдоно уу.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play алдаа</string>

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">सदस्यता अजूनही सक्रिय आहे</string>
     <string name="upgrade_screen_sub_still_renewing_message">आपली सदस्यता अजूनही नवीन करण्यासाठी सेट आहे. प्रथम ते Google Play मध्ये रद्द करा, नंतर एकवेळी खरेदी खरेदी करण्यासाठी परत या — अशा प्रकारे आपल्याला दोनदा शुल्क लागणार नाही.</string>
-    <string name="upgrade_screen_sub_check_failed_message">आम्ही आपल्या सदस्यता स्थिती तपासू शकत नाही. कृपया आपले कनेक्शन तपासा आणि पुन्हा प्रयत्न करा.</string>
     <string name="upgrades_gplay_already_owned_error_title">आधीच खरेदी केली</string>
     <string name="upgrades_gplay_already_owned_error_description">आपली खरेदी पुनर्संचयित करण्यासाठी \"खरेदी पुनर्संचयित करा\" पर्याय वापरा. समस्या कायम राहिल्यास, Google Play कॅश साफ करण्याचा प्रयत्न करा आणि आपले डिव्हाइस पुनरारंभ करा.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play त्रुटी</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Langganan masih aktif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Langganan anda masih ditetapkan untuk diperbaharui. Batalkan ia di Google Play terlebih dahulu, kemudian kembali untuk membeli pembelian satu kali — dengan cara itu anda tidak akan dikenakan bayaran dua kali.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Kami tidak dapat memeriksa status langganan anda. Sila periksa sambungan anda dan cuba lagi.</string>
     <string name="upgrades_gplay_already_owned_error_title">Sudah dibeli</string>
     <string name="upgrades_gplay_already_owned_error_description">Gunakan pilihan \"Pulih pembelian\" untuk memulihkan pembelian anda. Jika masalah berterusan, cuba hapuskan cache Google Play dan mulai semula peranti anda.</string>
     <string name="upgrades_gplay_internal_error_title">Ralat Google Play</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">စာရင်းသွင်းမှု ပြဲး အလုပ်ဆောင်နေသည်</string>
     <string name="upgrade_screen_sub_still_renewing_message">သင်၏ စာရင်းသွင်းမှုစိ ယခုအခါ အလိုအလျောက်အသစ်ဖြစ်စေရန် သတ်မှတ်ထားသည်။ Google Play တွင် ပထမဆုံ ပယ်ဖျက်ပါ။ ထို့နောက် တစ်ကြိမ်တည်းသည့် ဝယ်ယူမှုကို ဝယ်ယူပါ — သို့မှ သင်သည် အကြိမ်နှစ်ကြိမ် အခြေခြံရီမည်မဟုတ်ပါ။</string>
-    <string name="upgrade_screen_sub_check_failed_message">ကျွန်ုပ်တို့သည် သင်၏ စာရင်းသွင်းမှု အခြေအနေကို မစိစစနိုင်ခဲပါ။ သင်၏ အင်တာနက်ချိတ်ဆက်မှုကို ကျေးဇူးပြီး စစ်ဆပါ၊ ထို့နောက် ထပ်မံကြိုးစားပါ။</string>
     <string name="upgrades_gplay_already_owned_error_title">ယခင်က ဝယ်ယူပြီးပြီ</string>
     <string name="upgrades_gplay_already_owned_error_description">သင်၏ဝယ်ယူမှုကိုပြန်လည်ရယူရန် \"ဝယ်ယူမှုပြန်လည်ရယူ\" ရွေးချယ်မှုကိုအသုံးပြုပါ။ အကယ်၏ပြဲဆနာအဆက်အလက်ရှိပါက Google Play ကက်ရှ်ကိုရှင်လင်းပြီးသင်၏ကိရိယာကိုပြန်စတင်ကြည့်ပါ။</string>
     <string name="upgrades_gplay_internal_error_title">Google Play အမှားအယွင်း</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">सदस्यता अझै सक्रिय छ</string>
     <string name="upgrade_screen_sub_still_renewing_message">तपाईंको सदस्यता अझै नवीकरण गर्न सेट गरिएको छ। यसलाई पहिले Google Play मा रद्द गर्नुहोस्, त्यसपछि एकबार खरिद गर्न फिर्ता आउनुहोस् — त्यसरी तपाईंलाई दुबै पटक शुल्क लिइने छैन।</string>
-    <string name="upgrade_screen_sub_check_failed_message">हामी तपाईंको सदस्यता स्थिति जाँच गर्न सकेनौँ। कृपया तपाईंको जडान जाँच गर्नुहोस् र फेरी प्रयास गर्नुहोस्।</string>
     <string name="upgrades_gplay_already_owned_error_title">पहिले नै खरिद गरिएको</string>
     <string name="upgrades_gplay_already_owned_error_description">तपाईंको खरिद पुनर्स्थापन गर्न \"खरिद पुनर्स्थापन गर्नुहोस्\" विकल्पको प्रयोग गर्नुहोस्। यदि समस्या कायम रहन्छ भने, Google Play क्यास साफ गर्ने र आफ्नो डिभाइस पुनः सुरु गर्ने प्रयास गर्नुहोस्।</string>
     <string name="upgrades_gplay_internal_error_title">Google Play त्रुटि</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement nog steeds actief</string>
     <string name="upgrade_screen_sub_still_renewing_message">Je abonnement is nog steeds ingesteld om te vernieuwen. Annuleer dit eerst in Google Play, kom dan terug om de eenmalige aankoop te doen — zo word je niet twee keer in rekening gebracht.</string>
-    <string name="upgrade_screen_sub_check_failed_message">We konden je abonnementsstatus niet controleren. Controleer je verbinding en probeer het opnieuw.</string>
     <string name="upgrades_gplay_already_owned_error_title">Reeds gekocht</string>
     <string name="upgrades_gplay_already_owned_error_description">Gebruik de optie \'Aankoop herstellen\' om uw aankoop te herstellen. Als het probleem aanhoudt, probeer dan de cache van Google Play te wissen en uw apparaat opnieuw op te starten.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-fout</string>

--- a/app/src/gplay/res/values-no/strings.xml
+++ b/app/src/gplay/res/values-no/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abonnement fortsatt aktivt</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonnementet ditt er fortsatt satt til å fornyes. Avbryt det i Google Play først, så kom tilbake for å kjøpe engangskjøp — på den måten blir du ikke belastet to ganger.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Vi kunne ikke sjekke abonnementstatusen din. Vennligst sjekk tilkoblingen din og prøv igjen.</string>
     <string name="upgrades_gplay_already_owned_error_title">Allerede kjøpt</string>
     <string name="upgrades_gplay_already_owned_error_description">Bruk alternativet «Gjenopprette kjøp» for å gjenopprette kjøpet ditt. Hvis problemet vedvarer, prøv å fjerne Google Play-hurtiglagre og start enheten på nytt.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-feil</string>

--- a/app/src/gplay/res/values-pcm-rNG/strings.xml
+++ b/app/src/gplay/res/values-pcm-rNG/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Subscription still active</string>
     <string name="upgrade_screen_sub_still_renewing_message">Your subscription still dey set to renew. Cancel am for Google Play first, then come back buy the one-time purchase — that way dem no go charge you twice.</string>
-    <string name="upgrade_screen_sub_check_failed_message">We no fit check your subscription status. Check your connection and try again.</string>
     <string name="upgrades_gplay_already_owned_error_title">Already purchased</string>
     <string name="upgrades_gplay_already_owned_error_description">Use the \"Restore purchase\" option to restore your purchase. If the problem still dey, try clear Google Play cache and restart your device.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play error</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Subskrypcja nadal aktywna</string>
     <string name="upgrade_screen_sub_still_renewing_message">Twoja subskrypcja nadal jest ustawiona na odnawianie. Najpierw anuluj ją w Google Play, a potem wróć, aby kupić wersję jednorazową — dzięki temu unikniesz podwójnej opłaty.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nie udało się sprawdzić statusu Twojej subskrypcji. Sprawdź połączenie internetowe i spróbuj ponownie.</string>
     <string name="upgrades_gplay_already_owned_error_title">Już zakupiono</string>
     <string name="upgrades_gplay_already_owned_error_description">Użyj opcji \"Przywróć zakup\", aby przywrócić zakup. Jeśli problem będzie się powtarzał, spróbuj wyczyścić pamięć podręczną Google Play i ponownie uruchomić urządzenie.</string>
     <string name="upgrades_gplay_internal_error_title">Błąd Google Play</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Assinatura ainda ativa</string>
     <string name="upgrade_screen_sub_still_renewing_message">Sua assinatura ainda está configurada para renovar. Cancele-a no Google Play primeiro, depois volte para comprar a licença única — assim você não será cobrado duas vezes.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Não conseguimos verificar o status de sua assinatura. Verifique sua conexão e tente novamente.</string>
     <string name="upgrades_gplay_already_owned_error_title">Já comprado</string>
     <string name="upgrades_gplay_already_owned_error_description">Use a opção \"Restaurar compra\" para restaurar sua compra. Se o problema persistir, tente limpar o cache do Google Play e reiniciar seu dispositivo.</string>
     <string name="upgrades_gplay_internal_error_title">Erro do Google Play</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Subscrição ainda ativa</string>
     <string name="upgrade_screen_sub_still_renewing_message">A tua subscrição ainda está configurada para renovar. Cancela-a primeiro no Google Play e depois volta para comprar a compra única — assim não serás cobrado duas vezes.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Não foi possível verificar o estado da tua subscrição. Verifica a tua ligação e tenta novamente.</string>
     <string name="upgrades_gplay_already_owned_error_title">Já comprado</string>
     <string name="upgrades_gplay_already_owned_error_description">Utilize a opção \"Restaurar compra\" para restaurar a sua compra. Se o problema persistir, tente limpar a cache do Google Play e reiniciar o dispositivo.</string>
     <string name="upgrades_gplay_internal_error_title">Erro no Google Play</string>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">L\'abunament è anc activ</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tia abunament è anc sa da renovar. Annulla la avant-maun en Google Play, lura vegn uss a cumprar la commanda unica - uschia na vegn ti na chargiau duas vias.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nus n\'empruvain a controlleschar il status da tia abunament. Controllescha per plaschair tia connexiun e prouva uss.</string>
     <string name="upgrades_gplay_already_owned_error_title">Gia cumpra</string>
     <string name="upgrades_gplay_already_owned_error_description">Utilisescha l\'opziun \"Restituir la commanda\" per restituir tia commanda. Sche il problem persista, emprouva a stritgar il cache da Google Play e da restartar tia apparat.</string>
     <string name="upgrades_gplay_internal_error_title">Errur da Google Play</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abonament încă activ</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonamentul tău este încă setat să se reînnoiască. Anulează-l mai întâi în Google Play, apoi revino să cumperi achiziția unică — așa nu vei fi taxat de două ori.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nu am putut verifica statusul abonamentului tău. Te rog, verifică conexiunea și încearcă din nou.</string>
     <string name="upgrades_gplay_already_owned_error_title">Deja cumpărat</string>
     <string name="upgrades_gplay_already_owned_error_description">Folosește opțiunea \"Restaurează achiziția\" pentru a restaura achiziția ta. Dacă problema persistă, încearcă să ștergi cache-ul Google Play și să restartezi dispozitivul.</string>
     <string name="upgrades_gplay_internal_error_title">Eroare Google Play</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Подписка всё ещё активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша подписка всё ещё продлевается. Сначала отмените её в Google Play, а потом вернитесь, чтобы купить разовую покупку — так вы не заплатите дважды.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не удалось проверить статус вашей подписки. Проверьте подключение и попробуйте снова.</string>
     <string name="upgrades_gplay_already_owned_error_title">Уже приобретено</string>
     <string name="upgrades_gplay_already_owned_error_description">Используйте опцию \"Восстановить покупку\" для восстановления. Если проблема не устранена, попробуйте очистить кэш Google Play и перезагрузить устройство.</string>
     <string name="upgrades_gplay_internal_error_title">Ошибка Google Play</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">S\'iscritzione est sempre attiva</string>
     <string name="upgrade_screen_sub_still_renewing_message">Sa subscriptione tua est sempre impostada a isrenoare. Cancellàla in Google Play prima, dessos conpora sa compra de unu cunta — asa manera no ti carregant duas bilas.</string>
-    <string name="upgrade_screen_sub_check_failed_message">No podimus cuntullare s\'istadu de sa subscriptione tua. Cuntulla sa connessione tua e tenta anzis.</string>
     <string name="upgrades_gplay_already_owned_error_title">Già conporada</string>
     <string name="upgrades_gplay_already_owned_error_description">Imprea s\'optzione \'Isculà sa compra\' a isculàla. Si su problema perdurat, tenta de scancellare sa cache de Google Play e de ristartare s\'apparatu.</string>
     <string name="upgrades_gplay_internal_error_title">Errore de Google Play</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">දායකත්ව තවමත් ක්‍රියාකාරී</string>
     <string name="upgrade_screen_sub_still_renewing_message">ඔබේ දායකත්ව තවමත් නැවුම් කිරීමට සකසා ඉන්න. එය ප්‍රථමයෙන් Google Play වලින් අවලංගු කරන්න, ඉන්පසු එක් වතාවක මිලදී ගැනීමට ආපසු එන්න — එසේ ඔබ දෙවරක් අයකර නොමැතිවනු ඇත.</string>
-    <string name="upgrade_screen_sub_check_failed_message">අපි ඔබේ දායකත්ව තත්වය පරීක්ෂා කිරීමට නොහැකි විය. කරුණාකර ඔබේ සම්බන්ධතාවය පරීක්ෂා කරන්න සහ නැවත උත්සාහ කරන්න.</string>
     <string name="upgrades_gplay_already_owned_error_title">දැනටමත් මිලදී ගන්නා ඇත</string>
     <string name="upgrades_gplay_already_owned_error_description">ඔබේ මිලදී ගැනීම පුනෳ ස්ථාපනය කිරීමට \"මිලදී ගැනීම පුනෳ ස්ථාපනය\" විකල්පය භාවිතා කරන්න. ගටළුව නොතීරුවෙන් තිබේ නම්, Google Play කැෂ් ඉවත් කිරීමට සහ ඔබේ ගිණුමිය නැවත ආරම්භ කිරීමට උත්සාහ කරන්න.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play දොෂයක්</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Predplatné je stále aktívne</string>
     <string name="upgrade_screen_sub_still_renewing_message">Vaše predplatné je stále nastavené na obnovenie. Najprv ho zrušte v službe Google Play, potom sa vráťte a kúpte si jednorazový nákup – tak vás nebudeme účtovať dvakrát.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nemohli sme skontrolovať stav vášho predplatného. Skontrolujte vaše pripojenie a skúste znova.</string>
     <string name="upgrades_gplay_already_owned_error_title">Už zakúpené</string>
     <string name="upgrades_gplay_already_owned_error_description">Použite možnosť „Obnoviť nákup“ na obnovenie vašej kúpy. Ak problém pretrváva, skúste vyčistiť vyrovnávaciu pamäť služby Google Play a reštartujte zariadenie.</string>
     <string name="upgrades_gplay_internal_error_title">Chyba Google Play</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Naročnina je še vedno aktivna</string>
     <string name="upgrade_screen_sub_still_renewing_message">Tvoja naročnina je še vedno nastavljena za obnovitev. Najprej jo prekliči v Google Play, nato se vrni in kupi enkratni nakup — na ta način ne boš zaračunan dvakrat.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nismo mogli preveriti stanja tvoje naročnine. Prosimo, preveri svojo povezavo in poskusi ponovno.</string>
     <string name="upgrades_gplay_already_owned_error_title">Že kupljeno</string>
     <string name="upgrades_gplay_already_owned_error_description">Uporabi možnost »Obnovi nakup«, da obnoviš svoj nakup. Če se težava nadaljuje, poskusi počistiti predpomnilnik Google Play in ponovno zagnati napravo.</string>
     <string name="upgrades_gplay_internal_error_title">Napaka Google Play</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abonimi ende aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Abonimi juaj është ende i caktuar për t\'u rinovuar. Anulojeni atë në Google Play fillimisht, pastaj kthehuni për të blerë blerjen njëherë — kështu nuk do të ngarkoheni dy herë.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Nuk mundëm të kontrollojmë statusin e abonimit tuaj. Ju lutemi kontrolloni lidhjen tuaj dhe provoni përsëri.</string>
     <string name="upgrades_gplay_already_owned_error_title">Tashmë i blerë</string>
     <string name="upgrades_gplay_already_owned_error_description">Përdorni opsionin \"Rikthe blerjen\" për të rikthyer blerjen tuaj. Nëse problemi vazhdon, provoni të fshini memorjen cache të Google Play dhe të ristartoni pajisjen tuaj.</string>
     <string name="upgrades_gplay_internal_error_title">Gabim i Google Play</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Претплата је још увек активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша претплата је још увек подешена да се обнови. Прво је откажите у Google Play, а затим се вратите да купите једнократну куповину — на тај начин вам неће бити наплаћено два пута.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Нисмо могли проверити статус ваше претплате. Молимо проверите везу и покушајте поново.</string>
     <string name="upgrades_gplay_already_owned_error_title">Већ купљено</string>
     <string name="upgrades_gplay_already_owned_error_description">Користите опцију „Врати куповину” да вратите вашу куповину. Ако проблем настави, покушајте да очистите кеш Google Play-а и поново покренете уређај.</string>
     <string name="upgrades_gplay_internal_error_title">Грешка Google Play</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Prenumeration fortfarande aktiv</string>
     <string name="upgrade_screen_sub_still_renewing_message">Din prenumeration är fortfarande inställd på att förnya. Avbryt den i Google Play först, kom sedan tillbaka för att köpa engångsköpet — så blir du inte debiterad två gånger.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Vi kunde inte kontrollera din prenumerationsstatus. Kontrollera din anslutning och försök igen.</string>
     <string name="upgrades_gplay_already_owned_error_title">Redan köpt</string>
     <string name="upgrades_gplay_already_owned_error_description">Använd alternativet ”Återställ köp” för att återställa ditt köp. Om problemet kvarstår, försök att rensa Google Play-cacheminnet och starta om enheten.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play-fel</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Usajili bado ni hai</string>
     <string name="upgrade_screen_sub_still_renewing_message">Usajili wako bado umewekwa kurejea. Ghairi katika Google Play kwanza, kisha rudi kununua kwa mara moja — kwa hiyo hutatozwa mara mbili.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Hatukuweza kuangalia hali ya usajili wako. Tafadhali angalia muunganisho wako na jaribu tena.</string>
     <string name="upgrades_gplay_already_owned_error_title">Tayari umeshanunua</string>
     <string name="upgrades_gplay_already_owned_error_description">Tumia chaguo la \"Rejesha ununuzi\" kurejesha ununuzi wako. Ikiwa tatizo linaendelea, jaribu kuondoa akache ya Google Play na kuanzisha upya kifaa chako.</string>
     <string name="upgrades_gplay_internal_error_title">Hitilafu ya Google Play</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">சந்தா இன்னும் செயலில் உள்ளது</string>
     <string name="upgrade_screen_sub_still_renewing_message">உங்கள் சந்தா இன்னும் புதுப்பிக்க வைக்கப்பட்டுள்ளது. முதலில் Google Play இல் அதை ரத்து செய்யவும், பிறகு திரும்பி வந்து ஒரு முறை வாங்குவனை வாங்கவும் — அப்படி செய்தால் உங்களிடம் இரண்டு முறை பணம் வசூல் செய்யப்பட மாட்டாது.</string>
-    <string name="upgrade_screen_sub_check_failed_message">உங்கள் சந்தா நிலைமையை நாங்கள் சரிபார்க்க முடியவில்லை. தயவுசெய்து உங்கள் இணைப்பைச் சரிபார்த்து மீண்டும் முயற்சி செய்யவும்.</string>
     <string name="upgrades_gplay_already_owned_error_title">ஏற்கனவே வாங்கப்பட்டது</string>
     <string name="upgrades_gplay_already_owned_error_description">உங்கள் வாங்குதலை மீட்டெடுக்க \"வாங்குதலை மீட்டெடு\" விருப்பத்தைப் பயன்படுத்தவும். சிக்கல் தொடர்ந்திருந்தால், Google Play சேமிப்பை அழிக்க முயற்சி செய்து உங்கள் சாதனத்தை மீண்டும் தொடங்கவும்.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play பிழை</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">సబ్‌స్క్రిప్షన్ ఇప్పటికీ క్రియాశీలంగా ఉంది</string>
     <string name="upgrade_screen_sub_still_renewing_message">మీ సబ్‌స్క్రిప్షన్ ఇప్పటికీ పునరావృత్తికి సెట్ చేయబడి ఉంది. Google Play లో దీన్ని ముందుగా రద్దు చేసి, తర్వాత ఒక్కసారి కొనుగోలు కొరకు తిరిగి రండి — ఆ విధంగా మీరు రెండుసార్లు ఛార్జ్ చేయబడరు.</string>
-    <string name="upgrade_screen_sub_check_failed_message">మీ సబ్‌స్క్రిప్షన్ స్థితిని తనిఖీ చేయలేకపోయాము. దయచేసి మీ కనెక్షన్‌ను తనిఖీ చేసి, మళ్లీ ప్రయత్నించండి.</string>
     <string name="upgrades_gplay_already_owned_error_title">ఇప్పటికే కొనుగోలు చేయబడింది</string>
     <string name="upgrades_gplay_already_owned_error_description">మీ కొనుగోలును పునరుద్ధరించడానికి \"కొనుగోలును పునరుద్ధరించండి\" ఎంపికను ఉపయోగించండి. సమస్య కొనసాగితే, Google Play క్యాష్‌ను క్లిఅర్ చేసి మీ పరికరాన్ని పునరారంభించడానికి ప్రయత్నించండి.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play లోపం</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">การสมัครสมาชิกยังใช้งานอยู่</string>
     <string name="upgrade_screen_sub_still_renewing_message">การสมัครสมาชิกของคุณยังตั้งค่าให้ต่ออายุ ยกเลิกการสมัครใน Google Play ก่อน จากนั้นกลับมาซื้อแบบครั้งเดียว — ด้วยวิธีนี้คุณจะไม่ถูกเรียกเก็บเงินสองครั้ง</string>
-    <string name="upgrade_screen_sub_check_failed_message">เราไม่สามารถตรวจสอบสถานะการสมัครสมาชิกของคุณได้ โปรดตรวจสอบการเชื่อมต่อและลองใหม่</string>
     <string name="upgrades_gplay_already_owned_error_title">ซื้อไปแล้ว</string>
     <string name="upgrades_gplay_already_owned_error_description">ใช้ตัวเลือก \"กู้คืนการซื้อ\" เพื่อกู้คืนการซื้อของคุณ หากปัญหายังคงเกิดขึ้น ให้ลองล้างแคชของ Google Play และรีสตาร์ตอุปกรณ์ของคุณ</string>
     <string name="upgrades_gplay_internal_error_title">ข้อผิดพลาด Google Play</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Abonelik hâlâ aktif</string>
     <string name="upgrade_screen_sub_still_renewing_message">Aboneliğiniz hâlâ yenilenecek şekilde ayarlı. Önce Google Play\'de iptal edin, ardından tek seferlik satın almayı yapmak için geri dönün — böylece iki kez ücretlendirilmezsiniz.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Abonelik durumunuzu kontrol edemedik. Lütfen bağlantınızı kontrol edin ve tekrar deneyin.</string>
     <string name="upgrades_gplay_already_owned_error_title">Zaten satın alındı</string>
     <string name="upgrades_gplay_already_owned_error_description">\"Satın almayı geri yükle\" seçeneğini kullanarak satın alımınızı geri yükleyin. Sorun devam ederse, Google Play Store önbelleğini temizleyin ve cihazınızı yeniden başlatın.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play hatası</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Підписка все ще активна</string>
     <string name="upgrade_screen_sub_still_renewing_message">Ваша підписка все ще налаштована на автоматичне поновлення. Спочатку скасуйте її в Google Play, а потім поверніться, щоб придбати одноразову покупку — так з вас не стягнуть плату двічі.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Не вдалося перевірити статус вашої підписки. Перевірте з\'єднання і спробуйте ще раз.</string>
     <string name="upgrades_gplay_already_owned_error_title">Вже придбано</string>
     <string name="upgrades_gplay_already_owned_error_description">Скористайтеся опцією «Відновити покупку», щоб відновити свою покупку. Якщо проблема не зникає, спробуйте очистити кеш Google Play і перезавантажити пристрій.</string>
     <string name="upgrades_gplay_internal_error_title">Помилка Google Play</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">رکنیت ابھی فعال ہے</string>
     <string name="upgrade_screen_sub_still_renewing_message">آپ کی رکنیت ابھی بھی تجدید کے لیے سیٹ ہے۔ پہلے اسے Google Play میں منسوخ کریں، پھر واپس آئیں اور ایک بار کی خریداری کریں — اس طریقے آپ سے دوہری رقم نہیں لی جائے گی۔</string>
-    <string name="upgrade_screen_sub_check_failed_message">ہم آپ کی رکنیت کی حالت کو چیک نہیں کر سکے۔ براہ کرم اپنا کنکشن چیک کریں اور دوبارہ کوشش کریں۔</string>
     <string name="upgrades_gplay_already_owned_error_title">پہلے سے خریدا گیا</string>
     <string name="upgrades_gplay_already_owned_error_description">اپنی خریداری کو بحال کرنے کے لیے \"خریداری بحال کریں\" آپشن استعمال کریں۔ اگر مسئلہ برقرار ہے، تو Google Play کیش صاف کرنے اور اپنے ڈیوائس کو دوبارہ شروع کرنے کی کوشش کریں۔</string>
     <string name="upgrades_gplay_internal_error_title">Google Play خرابی</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Obuna hali ham faol</string>
     <string name="upgrade_screen_sub_still_renewing_message">Sizning obunangiz hali ham yangilashga o\'rnatilib boradi. Avval Google Play-da uni bekor qiling, so\'ng bir marta xaridni sotib olish uchun qaytib keling — shu tarzda sizdan ikki marta to\'lov qilinmaydi.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Biz sizning obunaning holatini tekshire olmadik. Iltimos, ulanishni tekshiring va qayta harakat qiling.</string>
     <string name="upgrades_gplay_already_owned_error_title">Allaqachon sotib olingan</string>
     <string name="upgrades_gplay_already_owned_error_description">Xaridingizni tiklash uchun \"Xaridni tiklash\" variantidan foydalaning. Agar muammo davom etsa, Google Play keshini o\'chirib, qurilmangizni qayta ishga tushiring.</string>
     <string name="upgrades_gplay_internal_error_title">Google Play xatosi</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Gói đăng ký vẫn đang hoạt động</string>
     <string name="upgrade_screen_sub_still_renewing_message">Gói đăng ký của bạn vẫn được đặt để gia hạn. Hãy hủy gói đó trong Google Play trước, sau đó quay lại mua giao dịch một lần — như vậy bạn sẽ không bị tính phí hai lần.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Chúng tôi không thể kiểm tra trạng thái gói đăng ký của bạn. Vui lòng kiểm tra kết nối và thử lại.</string>
     <string name="upgrades_gplay_already_owned_error_title">Đã mua</string>
     <string name="upgrades_gplay_already_owned_error_description">Sử dụng tùy chọn \"Khôi phục giao dịch mua\" để khôi phục giao dịch mua của bạn. Nếu vấn đề vẫn tiếp diễn, hãy thử xóa bộ nhớ đệm Google Play và khởi động lại thiết bị của bạn.</string>
     <string name="upgrades_gplay_internal_error_title">Lỗi Google Play</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">订阅仍然有效</string>
     <string name="upgrade_screen_sub_still_renewing_message">您的订阅仍设置为续订。请先在 Google Play 中取消订阅,然后返回购买一次性购买项目 — 这样您就不会被收费两次。</string>
-    <string name="upgrade_screen_sub_check_failed_message">我们无法检查您的订阅状态。请检查您的连接并重试。</string>
     <string name="upgrades_gplay_already_owned_error_title">已购买</string>
     <string name="upgrades_gplay_already_owned_error_description">使用“恢复购买”选项来恢复您的购买。如果问题仍然存在,请尝试清除 Google Play 缓存并重启您的设备。</string>
     <string name="upgrades_gplay_internal_error_title">Google Play 错误</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">訂閱仍然有效</string>
     <string name="upgrade_screen_sub_still_renewing_message">您的訂閱仍設定為續約。請先在 Google Play 中取消，然後回來購買一次性購買 — 這樣就不會被收費兩次。</string>
-    <string name="upgrade_screen_sub_check_failed_message">我們無法檢查您的訂閱狀態。請檢查您的連線並重試。</string>
     <string name="upgrades_gplay_already_owned_error_title">已購買</string>
     <string name="upgrades_gplay_already_owned_error_description">使用「還原購買」選項來還原您的購買。如果問題仍然存在，請嘗試清除 Google Play 快取並重新啟動您的裝置。</string>
     <string name="upgrades_gplay_internal_error_title">Google Play 錯誤</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">訂閱仍然有效</string>
     <string name="upgrade_screen_sub_still_renewing_message">您的訂閱仍設定為自動續約。請先在 Google Play 中取消訂閱，然後回來購買一次性版本 — 這樣您就不會被重複收費。</string>
-    <string name="upgrade_screen_sub_check_failed_message">我們無法檢查您的訂閱狀態。請檢查您的網路連線並再試一次。</string>
     <string name="upgrades_gplay_already_owned_error_title">已購買</string>
     <string name="upgrades_gplay_already_owned_error_description">使用「還原購買」選項來還原您的購買。如果問題仍未解決，請嘗試清除 Google Play 商店快取並重新啟動您的裝置。</string>
     <string name="upgrades_gplay_internal_error_title">Google Play 錯誤</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -41,7 +41,6 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">I-subscription isaphila</string>
     <string name="upgrade_screen_sub_still_renewing_message">I-subscription yakho isashintshile ngokwazisela iyabuya. Isikisele ku-Google Play kuqala, khona-ke buya ukuthenga okuthengwa kanye — ngale ndlela ngeke ubhalwe kabili.</string>
-    <string name="upgrade_screen_sub_check_failed_message">Asikwazi ukukhexuza isimo se-subscription yakho. Sicela ukhone ukuxhumana kwakho zama futhi.</string>
     <string name="upgrades_gplay_already_owned_error_title">Sekuthengile</string>
     <string name="upgrades_gplay_already_owned_error_description">Sebenzisa inketho \"Lusulula ukuthenga\" ukubuya kwazisela ukuthenga kwakho. Uma inkinga ihlala ikhona, zama okusula i-cache ye-Google Play nokuwutshela isishintshi sakho.</string>
     <string name="upgrades_gplay_internal_error_title">Iphutha le-Google Play</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -51,7 +51,12 @@
     <!-- Fail-closed switch gate dialogs -->
     <string name="upgrade_screen_sub_still_renewing_title">Subscription still active</string>
     <string name="upgrade_screen_sub_still_renewing_message">Your subscription is still set to renew. Cancel it in Google Play first, then come back to buy the one-time purchase — that way you won\'t be charged twice.</string>
-    <string name="upgrade_screen_sub_check_failed_message">We couldn\'t check your subscription status. Please check your connection and try again.</string>
+    <string name="upgrade_screen_purchase_check_failed_message">We couldn\'t check your purchases with Google Play. Please check your connection and try again.</string>
+
+    <!-- Google Play is still processing a payment (cash, carrier billing, bank transfer) -->
+    <string name="upgrade_screen_pending_card_title">Payment pending</string>
+    <string name="upgrade_screen_pending_card_body">Google Play is still processing your payment. Pro unlocks by itself once the payment goes through. Some payment methods take a while, there\'s nothing else you need to do.</string>
+    <string name="upgrade_screen_pending_dialog_message">Google Play found a purchase whose payment is still being processed. Pro unlocks by itself once the payment goes through.</string>
 
     <string name="upgrades_gplay_already_owned_error_title">Already purchased</string>
     <string name="upgrades_gplay_already_owned_error_description">Use the \"Restore purchase\" option to restore your purchase. If the issue persists, try clearing Google Play cache and restarting your device.</string>

--- a/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeContent.kt
@@ -82,6 +82,7 @@ internal object UpgradeScreenTags {
     const val GPLAY_OWNED_IAP = "upgrade_gplay_owned_iap"
     const val GPLAY_OWNED_SUB = "upgrade_gplay_owned_sub"
     const val GPLAY_MANAGE_SUB = "upgrade_gplay_manage_sub"
+    const val GPLAY_PENDING = "upgrade_gplay_pending"
     const val GPLAY_GRACE = "upgrade_gplay_grace"
     const val GPLAY_GRACE_SPINNER = "upgrade_gplay_grace_spinner"
     const val GPLAY_GRACE_RESTORE = "upgrade_gplay_grace_restore"

--- a/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeViewModelTest.kt
+++ b/app/src/testFoss/java/eu/darken/bluemusic/upgrade/ui/FossUpgradeViewModelTest.kt
@@ -212,6 +212,31 @@ class FossUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `the non-manage route shows the upgraded status when the sponsor flow completes`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The view mapping used to gate STATUS_UPGRADED on the manage route, so every other entry
+        // stayed on the sales pitch with a live sponsor button — which reads as "sponsoring didn't
+        // work" to someone who just donated. The auto-close follows, but the status view is what
+        // acknowledges the upgrade.
+        val info = MutableStateFlow(UpgradeRepoFoss.Info())
+        val vm = buildVm(repo = mockRepo(info))
+
+        val pitchView = async { vm.state.first { it.view != null } }
+        vm.bindRoute(Nav.Main.Upgrade())
+        advanceUntilIdle()
+        pitchView.await().view shouldBe FossUpgradeView.PITCH
+
+        val upgradedView = async { vm.state.first { it.view == FossUpgradeView.STATUS_UPGRADED } }
+        info.value = upgradedInfo()
+        advanceUntilIdle()
+
+        upgradedView.await().view shouldBe FossUpgradeView.STATUS_UPGRADED
+        // Auto-close semantics are unchanged: a non-manage entry still leaves once Pro lands.
+        verify(exactly = 1) { navCtrl.up() }
+    }
+
+    @Test
     fun `default route bounces an upgraded user out of the screen`() = runTest2(context = testDispatcher) {
         val vm = buildVm(repo = mockRepo(MutableStateFlow(upgradedInfo())))
 

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/UpgradeRepoGplayTest.kt
@@ -10,6 +10,7 @@ import eu.darken.bluemusic.upgrade.core.billing.BillingData
 import eu.darken.bluemusic.upgrade.core.billing.BillingManager
 import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.bluemusic.upgrade.core.billing.ItemAlreadyOwnedBillingException
+import eu.darken.bluemusic.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.bluemusic.upgrade.core.billing.PurchasedSku
 import eu.darken.bluemusic.upgrade.core.billing.UserCanceledBillingException
 import eu.darken.bluemusic.main.core.CurriculumVitae
@@ -118,6 +119,13 @@ class UpgradeRepoGplayTest : BaseTest() {
         every { purchaseTime } returns Instant.parse("2024-01-01T00:00:00Z").toEpochMilli()
     }
 
+    // A payment Play is still processing. Lands in BillingData.pendingPurchases, never in
+    // purchases — the split happens at the billing layer, this is what the repo receives.
+    private fun pendingPurchase(productId: String = OurSku.Iap.PRO_UPGRADE.id) = mockk<Purchase>().apply {
+        every { products } returns listOf(productId)
+        every { purchaseTime } returns 1_000L
+    }
+
     @Test fun `test upgrade info pro status mapping`() {
         UpgradeRepoGplay.Info(
             gracePeriod = false,
@@ -163,6 +171,108 @@ class UpgradeRepoGplayTest : BaseTest() {
             )
         ).isPro shouldBe true
     }
+
+    // region pending payments
+
+    @Test fun `a pending payment is mapped but grants nothing`() {
+        val info = UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = BillingData(purchases = emptySet(), pendingPurchases = setOf(pendingPurchase())),
+        )
+
+        info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+        // The whole point of the split: visible, never an entitlement.
+        info.upgrades shouldBe emptyList()
+        info.isPro shouldBe false
+        info.upgradedAt shouldBe null
+    }
+
+    @Test fun `a pending payment for an unknown product is dropped`() {
+        UpgradeRepoGplay.Info(
+            gracePeriod = false,
+            billingData = BillingData(
+                purchases = emptySet(),
+                pendingPurchases = setOf(pendingPurchase("some.unknown.product")),
+            ),
+        ).pendingSkus shouldBe emptyList()
+    }
+
+    @Test fun `the grace-substituted info keeps the pending payment visible`() = runTest2 {
+        // The audience that needs the explanation most: Pro is running on grace while Play is still
+        // processing the payment that will renew it. Dropping the data here (as the grace branch
+        // used to) left them with a silent screen.
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val outcome = repo(lastProAt = System.currentTimeMillis() - 1_000).restorePurchaseNow()
+
+        outcome.info.isPro shouldBe true
+        outcome.info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+    }
+
+    @Test fun `a restore that only finds a pending payment reports it without pro`() = runTest2 {
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val outcome = repo(lastProAt = 0L).restorePurchaseNow()
+
+        outcome.shouldBeInstanceOf<UpgradeRepoGplay.RestoreOutcome.Checked>()
+        outcome.info.isPro shouldBe false
+        outcome.info.pendingSkus shouldBe listOf(OurSku.Iap.PRO_UPGRADE)
+    }
+
+    @Test fun `a manual restore over a partial refresh still advances the unconfirmed episode`() = runTest2 {
+        // The restore itself succeeds (a pending payment IS an answer), so nothing on this path
+        // throws — the episode clock is fed by the manager's reconciliation signal instead, which
+        // carries the refresh's commit time.
+        val failures = MutableSharedFlow<Long>(extraBufferCapacity = 1)
+        val confirmedAt = System.currentTimeMillis() - 1_000
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+        val repo = repo(lastProAt = confirmedAt, connectionFailures = failures)
+
+        repo.restorePurchaseNow().info.isPro shouldBe true
+        failures.emit(confirmedAt + 500)
+        advanceUntilIdle()
+
+        coVerify { proUnconfirmedMock.update(any()) }
+    }
+
+    @Test fun `verifyPurchaseStateNow fails closed instead of substituting grace`() = runTest2 {
+        val boom = GplayServiceUnavailableException(RuntimeException("one product type failed"))
+        coEvery { billingManager.refreshStrict() } throws boom
+
+        // Even a recent owner gets the error: a gate that can't verify must not let a purchase
+        // through on the strength of a grace window.
+        shouldThrow<GplayServiceUnavailableException> {
+            repo(lastProAt = System.currentTimeMillis() - 1_000).verifyPurchaseStateNow()
+        }
+    }
+
+    @Test fun `verifyPurchaseStateNow reports the fresh split state`() = runTest2 {
+        coEvery { billingManager.refreshStrict() } returns BillingData(
+            purchases = setOf(proPurchase()),
+            pendingPurchases = setOf(pendingPurchase(OurSku.Sub.PRO_UPGRADE.id)),
+        )
+
+        val info = repo(lastProAt = 0L).verifyPurchaseStateNow()
+
+        info.upgrades.map { it.sku } shouldBe OurSku.PRO_SKUS.toList()
+        info.pendingSkus shouldBe listOf(OurSku.Sub.PRO_UPGRADE)
+        info.isSettled shouldBe true
+    }
+
+    @Test fun `already-owned recovery reports a pending payment instead of restore tips`() = runTest2 {
+        // Play refuses to re-sell a product whose payment it is still processing. The already-owned
+        // dialog would tell the user to restore, which cannot help.
+        coEvery { billingManager.startIapFlow(any(), any(), null) } throws
+            ItemAlreadyOwnedBillingException(RuntimeException("launch result"))
+        coEvery { billingManager.refresh() } returns BillingData(emptySet(), setOf(pendingPurchase()))
+
+        val errors = mutableListOf<Throwable>()
+        repo(lastProAt = 0L).startLaunch { errors.add(it) }
+
+        errors.single().shouldBeInstanceOf<PendingPurchaseBillingException>()
+    }
+
+    // endregion
 
     @Test fun `grace period is 7 days`() {
         // Guards against the unit error where 7 * 24 * 60 * 1000 (2.8h) was used instead of 7 days,

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
@@ -14,6 +14,7 @@ import eu.darken.bluemusic.upgrade.core.billing.client.BillingClientException
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnection
 import eu.darken.bluemusic.upgrade.core.billing.client.BillingConnectionProvider
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldNotContain
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -728,6 +729,54 @@ class BillingManagerTest : BaseTest() {
         runCurrent()
 
         failures shouldBe emptyList()
+    }
+
+    @Test fun `a strict gate failure on a dead connection still tears the connection down`() = runTest2 {
+        // The gate's throw happens after useConnection already returned, so its dead-binder
+        // detection can't fire — without the explicit invalidation connection 1 stays installed and
+        // every later purchase check runs against the corpse. Feeding the episode clock still stays
+        // off this path.
+        val owned = purchase()
+        val dead = connection(
+            refreshes = listOf(
+                completeRefresh(),
+                partialRefresh(
+                    occurredAt = 4242L,
+                    error = GplayServiceUnavailableException(
+                        BillingClientException(result(BillingResponseCode.SERVICE_DISCONNECTED))
+                    ),
+                ),
+            ),
+        )
+        val good = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(if (attempts == 1) dead else good)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+        val failures = collectFailures(manager)
+        runCurrent() // connection 1 established
+
+        shouldThrow<Exception> { manager.refreshStrict() }
+        // Teardown takes several dispatches and runs on backgroundScope — runCurrent, never
+        // advanceUntilIdle, which would leave the connect loop untouched.
+        runCurrent()
+
+        // The next action is fresh demand: it skips the reconnect backoff and lands on connection 2.
+        val refreshed = async { manager.refresh() }
+        advanceUntilIdle()
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
+
+        runCurrent()
+        // The torn-down connection is a failed loop iteration (wall-clock stamped), but the gate's
+        // own partial refresh must never reach the feed with its commit time.
+        failures.isNotEmpty() shouldBe true
+        failures shouldNotContain 4242L
     }
 
     @Test fun `a partial reconciliation without a confirmed pro purchase signals its commit time`() = runTest2 {

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/BillingManagerTest.kt
@@ -71,6 +71,15 @@ class BillingManagerTest : BaseTest() {
         every { isAcknowledged } returns true
     }
 
+    // A payment Play is still processing: carried by the state, but never owned and never ackable.
+    private fun pendingPurchase(token: String = "pending-token") = mockk<Purchase>().apply {
+        every { purchaseState } returns PurchaseState.PENDING
+        every { purchaseTime } returns 2_000L
+        every { purchaseToken } returns token
+        every { isAcknowledged } returns false
+        every { products } returns listOf(OurSku.Iap.PRO_UPGRADE.id)
+    }
+
     // An unacknowledged purchase with its own token: the ack bookkeeping (log level, permanent
     // failure reports) is keyed per token, so tests need distinguishable ones.
     private fun unackedPurchase(
@@ -89,16 +98,53 @@ class BillingManagerTest : BaseTest() {
     private fun connection(
         refreshResults: List<Collection<Purchase>> = listOf(emptyList()),
         refreshComplete: Boolean = true,
+        // Full refresh outcomes for the tests that care about provenance (confirmed set, commit
+        // time, partial error); overrides the plain refreshResults shorthand.
+        refreshes: List<BillingConnection.PurchaseRefresh>? = null,
         purchasesFlow: Flow<Collection<Purchase>> = flowOf(emptyList()),
         freshUpdatesFlow: Flow<BillingConnection.FreshUpdate> = emptyFlow(),
         failures: Flow<BillingResult> = emptyFlow(),
     ) = mockk<BillingConnection>().apply {
-        coEvery { refreshPurchases() } returnsMany
-            refreshResults.map { BillingConnection.PurchaseRefresh(it, isComplete = refreshComplete) }
+        coEvery { refreshPurchases() } returnsMany (
+            refreshes ?: refreshResults.map {
+                BillingConnection.PurchaseRefresh(
+                    purchases = it,
+                    confirmed = it,
+                    hasConfirmedProPurchase = it.isNotEmpty(),
+                    isComplete = refreshComplete,
+                )
+            }
+            )
         every { purchases } returns purchasesFlow
         every { freshUpdates } returns freshUpdatesFlow
         every { purchaseFailures } returns failures
     }
+
+    // An incomplete reconciliation: it committed what it found, but one product type couldn't be
+    // checked. The default cause is NON-invalidating — the dead-binder codes are opted into.
+    private fun partialRefresh(
+        purchases: Collection<Purchase> = emptyList(),
+        confirmed: Collection<Purchase> = emptyList(),
+        hasConfirmedPro: Boolean = false,
+        occurredAt: Long = 4242L,
+        error: Throwable = GplayServiceUnavailableException(
+            BillingClientException(result(BillingResponseCode.ERROR))
+        ),
+    ) = BillingConnection.PurchaseRefresh(
+        purchases = purchases,
+        confirmed = confirmed,
+        hasConfirmedProPurchase = hasConfirmedPro,
+        isComplete = false,
+        occurredAt = occurredAt,
+        partialError = error,
+    )
+
+    private fun completeRefresh(purchases: Collection<Purchase> = emptyList()) = BillingConnection.PurchaseRefresh(
+        purchases = purchases,
+        confirmed = purchases,
+        hasConfirmedProPurchase = purchases.isNotEmpty(),
+        isComplete = true,
+    )
 
     // The real provider flow emits one connection and stays open for its lifetime -- flowOf() would
     // complete immediately, which the connect loop rightly treats as a connection failure.
@@ -540,6 +586,10 @@ class BillingManagerTest : BaseTest() {
 
     // Drains the manager's connectionFailures (occurrence timestamps) into a list. Launched on
     // backgroundScope so it lives for the whole test.
+    //
+    // Drive it with runCurrent() (or a suspension of the test body), NEVER with advanceUntilIdle():
+    // that one stops as soon as no FOREGROUND event is left and never runs backgroundScope work, so
+    // a signal sent from the test body would sit unconsumed and the list would read empty.
     private fun TestScope.collectFailures(manager: BillingManager): List<Long> = mutableListOf<Long>().also { out ->
         backgroundScope.launch { manager.connectionFailures.collect { out.add(it) } }
     }
@@ -665,20 +715,199 @@ class BillingManagerTest : BaseTest() {
         failures.isNotEmpty() shouldBe true
     }
 
-    @Test fun `a non-invalidating action error does not emit`() = runTest2 {
-        // A strict querySubscriptions failure whose code is NOT invalidating leaves the connection
-        // installed, so no connect-loop iteration fails and nothing feeds the episode clock.
-        val conn = connection().apply {
-            coEvery { querySubscriptions() } throws BillingClientException(result(BillingResponseCode.ERROR))
-        }
+    @Test fun `a strict gate failure does not feed the episode clock`() = runTest2 {
+        // The gate surfaces its own failure to the user (fail-closed) and leaves the connection
+        // installed. The episode clock is fed by the connect loop and by refresh() — a gate that
+        // the user aborted mid-purchase is not a reconciliation outcome.
+        val conn = connection(refreshes = listOf(completeRefresh(), partialRefresh()))
         val manager = manager(conn)
         val failures = collectFailures(manager)
         runCurrent() // connection established
 
-        shouldThrow<Exception> { manager.querySubscriptions() }
-        advanceUntilIdle()
+        shouldThrow<Exception> { manager.refreshStrict() }
+        runCurrent()
 
         failures shouldBe emptyList()
+    }
+
+    @Test fun `a partial reconciliation without a confirmed pro purchase signals its commit time`() = runTest2 {
+        // The pending-only cold start: Play answered for one type with a payment in progress, the
+        // other failed. Nothing confirms Pro, so the grace episode clock must advance — stamped
+        // with the refresh's COMMIT time, so a confirmation landing in between stays newer.
+        val pending = pendingPurchase()
+        val conn = connection(
+            refreshes = listOf(partialRefresh(purchases = listOf(pending), occurredAt = 4242L)),
+            purchasesFlow = flowOf(listOf(pending)),
+        )
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+
+        runCurrent()
+
+        // Still published: a partial refresh is a usable connection, and starving billingData would
+        // leave the screen at Loading forever.
+        manager.billingData.first() shouldBe BillingData(
+            purchases = emptyList(),
+            pendingPurchases = listOf(pending),
+        )
+        failures shouldBe listOf(4242L)
+    }
+
+    @Test fun `a partial manual refresh signals too`() = runTest2 {
+        // Manual Restore runs the same reconciliation as the connect loop — before this it was the
+        // only path whose partial outcome silently vanished.
+        val conn = connection(refreshes = listOf(completeRefresh(), partialRefresh(occurredAt = 7_777L)))
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+        runCurrent()
+
+        manager.refresh()
+        runCurrent() // the collector lives on backgroundScope, which advanceUntilIdle would skip
+
+        failures shouldBe listOf(7_777L)
+    }
+
+    @Test fun `a partial refresh that confirmed pro does not signal`() = runTest2 {
+        val owned = purchase()
+        val conn = connection(
+            refreshes = listOf(
+                completeRefresh(),
+                partialRefresh(purchases = listOf(owned), confirmed = listOf(owned), hasConfirmedPro = true),
+            ),
+        )
+        val manager = manager(conn)
+        val failures = collectFailures(manager)
+        runCurrent()
+
+        manager.refresh()
+        runCurrent()
+
+        // Pro WAS confirmed by this round-trip; the failed sibling type proves nothing against it.
+        failures shouldBe emptyList()
+    }
+
+    @Test fun `an invalidating partial refresh tears the connection down`() = runTest2 {
+        // The dead-binder teardown used to ride refreshPurchases' throw path through useConnection.
+        // A partial refresh returns instead of throwing, so without the explicit invalidation the
+        // dead connection would stay installed for every later caller.
+        val owned = purchase()
+        val dead = connection(
+            refreshes = listOf(
+                partialRefresh(
+                    purchases = listOf(owned),
+                    confirmed = listOf(owned),
+                    hasConfirmedPro = true,
+                    error = GplayServiceUnavailableException(
+                        BillingClientException(result(BillingResponseCode.SERVICE_DISCONNECTED))
+                    ),
+                ),
+            ),
+        )
+        val good = connection(refreshResults = listOf(emptyList(), listOf(owned)))
+        var attempts = 0
+        val provider = mockk<BillingConnectionProvider>().apply {
+            every { this@apply.connection } returns flow {
+                attempts++
+                emit(if (attempts == 1) dead else good)
+                awaitCancellation()
+            }
+        }
+        val manager = manager(provider)
+        runCurrent() // connection 1 established; its partial refresh signals the invalidation
+
+        // The next action is fresh demand: it skips the reconnect backoff and lands on connection 2.
+        // await() is what drives the connect loop here — it runs on backgroundScope, which
+        // advanceUntilIdle() alone would never touch.
+        val refreshed = async { manager.refresh() }
+        advanceUntilIdle()
+
+        refreshed.await() shouldBe BillingData(listOf(owned))
+        attempts shouldBe 2
+    }
+
+    // endregion
+
+    // region pending purchases
+
+    @Test fun `billing data splits owned purchases from pending payments`() = runTest2 {
+        val owned = purchase()
+        val pending = pendingPurchase()
+        val manager = manager(connection(purchasesFlow = flowOf(listOf(owned, pending))))
+
+        // The split is what keeps a payment in progress out of every entitlement decision while
+        // still letting the UI show it.
+        manager.billingData.first() shouldBe BillingData(
+            purchases = listOf(owned),
+            pendingPurchases = listOf(pending),
+        )
+    }
+
+    @Test fun `a pending purchase is never acknowledged`() = runTest2 {
+        val pending = pendingPurchase()
+        val purchases = purchasesFlow()
+        val conn = connection(purchasesFlow = purchases)
+        val acks = conn.scriptAck { _, _ -> result(BillingResponseCode.OK) }
+        manager(conn)
+        runCurrent()
+
+        purchases.tryEmit(listOf(pending))
+        advanceTimeBy(400_000)
+        runCurrent()
+
+        // Play rejects acking a pending purchase permanently: an unfiltered pass would fire a bug
+        // report on every pass, forever, for a purchase that has nothing to acknowledge yet.
+        acks shouldBe emptyList()
+        verify(exactly = 0) { Bugs.report(any()) }
+    }
+
+    @Test fun `a follow-up refresh after a partial publish recovers the full state`() = runTest2 {
+        val pending = pendingPurchase()
+        val owned = purchase()
+        val purchases = purchasesFlow()
+        val conn = connection(
+            refreshes = listOf(
+                partialRefresh(purchases = listOf(pending)),
+                completeRefresh(listOf(owned)),
+            ),
+            purchasesFlow = purchases,
+        )
+        val manager = manager(conn)
+        runCurrent()
+
+        purchases.tryEmit(listOf(pending))
+        manager.billingData.first().pendingPurchases shouldBe listOf(pending)
+
+        // The payment completed: the next reconciliation returns the owned purchase, no reconnect
+        // needed (the partial one left a working connection installed).
+        manager.refresh() shouldBe BillingData(listOf(owned))
+    }
+
+    @Test fun `refreshStrict fails closed on an incomplete refresh`() = runTest2 {
+        val conn = connection(
+            refreshes = listOf(
+                completeRefresh(),
+                partialRefresh(purchases = listOf(purchase()), confirmed = listOf(purchase())),
+            ),
+        )
+        val manager = manager(conn)
+        runCurrent()
+
+        // A gate must not treat "one product type couldn't be checked" as "nothing else is owned":
+        // that is exactly how a double purchase gets through.
+        shouldThrow<GplayServiceUnavailableException> { manager.refreshStrict() }
+    }
+
+    @Test fun `refreshStrict returns the split data on a complete refresh`() = runTest2 {
+        val owned = purchase()
+        val pending = pendingPurchase()
+        val conn = connection(refreshes = listOf(completeRefresh(), completeRefresh(listOf(owned, pending))))
+        val manager = manager(conn)
+        runCurrent()
+
+        manager.refreshStrict() shouldBe BillingData(
+            purchases = listOf(owned),
+            pendingPurchases = listOf(pending),
+        )
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/core/billing/client/BillingConnectionTest.kt
@@ -25,7 +25,6 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
-import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -69,13 +68,20 @@ class BillingConnectionTest : BaseTest() {
         token: String = "token-$time",
         products: List<String> = listOf(OurSku.Iap.PRO_UPGRADE.id),
         acknowledged: Boolean = false,
+        state: Int = PurchaseState.PURCHASED,
     ) = mockk<Purchase>().apply {
         every { purchaseTime } returns time
         every { purchaseToken } returns token
         every { this@apply.products } returns products
-        every { purchaseState } returns PurchaseState.PURCHASED
+        every { purchaseState } returns state
         every { isAcknowledged } returns acknowledged
     }
+
+    private fun pendingPurchase(
+        time: Long,
+        token: String = "pending-$time",
+        products: List<String> = listOf(OurSku.Iap.PRO_UPGRADE.id),
+    ) = purchase(time = time, token = token, products = products, state = PurchaseState.PENDING)
 
     private fun result(code: Int): BillingResult = BillingResult.newBuilder().setResponseCode(code).build()
 
@@ -121,6 +127,42 @@ class BillingConnectionTest : BaseTest() {
                 sub = Result.failure(RuntimeException("SUBS query failed")),
             )
         }
+    }
+
+    @Test fun `a known pending purchase suppresses the couldn't-verify error`() {
+        // The user's payment is being processed: that IS a usable answer about this account, so a
+        // failing sibling query must not turn the screen into "can't reach Play".
+        val pending = pendingPurchase(1_000)
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(pending)),
+            sub = Result.failure(RuntimeException("SUBS query failed")),
+            typeOf = typeOf,
+        ) shouldBe listOf(pending)
+    }
+
+    @Test fun `an unknown pending purchase does not suppress the couldn't-verify error`() {
+        // A pending payment for a product this app doesn't sell says nothing about the type whose
+        // query failed — counting it as a find would swallow a real "couldn't verify".
+        shouldThrow<RuntimeException> {
+            BillingConnection.combinePurchaseResults(
+                iap = Result.success(listOf(pendingPurchase(1_000, products = listOf("some.unknown.product")))),
+                sub = Result.failure(RuntimeException("SUBS query failed")),
+                typeOf = typeOf,
+            )
+        }
+    }
+
+    @Test fun `an unknown PURCHASED product still suppresses the error`() {
+        // Ownership of anything is authoritative: every product this app sells is a Pro SKU, so an
+        // unrecognized owned product means our own SKU list is stale, not that Play failed.
+        val owned = purchase(1_000, products = listOf("some.unknown.product"))
+
+        BillingConnection.combinePurchaseResults(
+            iap = Result.success(listOf(owned)),
+            sub = Result.failure(RuntimeException("SUBS query failed")),
+            typeOf = typeOf,
+        ) shouldBe listOf(owned)
     }
 
     // endregion
@@ -423,13 +465,8 @@ class BillingConnectionTest : BaseTest() {
         connection.purchaseFailures.first().responseCode shouldBe BillingResponseCode.USER_CANCELED
     }
 
-    @Test fun `a pending purchase never surfaces as owned or as fresh data`() = runTest2 {
-        val pending = mockk<Purchase>().apply {
-            every { purchaseState } returns PurchaseState.PENDING
-            every { purchaseTime } returns 1_000L
-            every { purchaseToken } returns "pending"
-            every { this@apply.products } returns listOf(OurSku.Iap.PRO_UPGRADE.id)
-        }
+    @Test fun `a pending purchase event enters the state but never the fresh stream`() = runTest2 {
+        val pending = pendingPurchase(1_000, token = "pending")
         val connection = BillingConnection(
             client = clientReturning(
                 result(BillingResponseCode.OK) to emptyList(),
@@ -437,14 +474,169 @@ class BillingConnectionTest : BaseTest() {
             ),
         )
 
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
-        connection.refreshPurchases()
+        val freshUpdates = mutableListOf<BillingConnection.FreshUpdate>()
+        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            connection.freshUpdates.collect { freshUpdates.add(it) }
+        }
+        connection.refreshPurchases() // settles the state; predates the event
 
-        connection.purchases.first() shouldBe emptyList()
-        // Only the refresh's own emission — the PENDING event never produced one.
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
+        runCurrent()
+
+        // Visible as state (the UI must be able to show a payment in progress)...
+        connection.purchases.first().map { it.purchaseToken } shouldBe listOf("pending")
+        // ...but the fresh stream feeds the entitlement and grace bookkeeping, so only the
+        // refresh's own emission is on it — a pending payment confirms nothing.
+        freshUpdates.size shouldBe 1
+        freshUpdates.single().purchases shouldBe emptyList()
+    }
+
+    @Test fun `a pending query result enters the state but never the fresh stream`() = runTest2 {
+        val pending = pendingPurchase(1_000, token = "pending")
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(pending),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+
+        refresh.purchases.map { it.purchaseToken } shouldBe listOf("pending")
+        refresh.confirmed shouldBe emptyList()
+        refresh.hasConfirmedProPurchase shouldBe false
+        connection.purchases.first().map { it.purchaseToken } shouldBe listOf("pending")
         val update = connection.freshUpdates.first()
         update.purchases shouldBe emptyList()
         update.isFullSnapshot shouldBe true
+    }
+
+    @Test fun `a completing payment supersedes its own pending entry`() = runTest2 {
+        // Play delivers the same purchaseToken again once the payment cleared: the dedup must let
+        // the PURCHASED instance win instead of leaving the user with two records.
+        val pending = pendingPurchase(1_000, token = "same")
+        val purchased = purchase(1_000, token = "same")
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        connection.refreshPurchases() // settles the state; predates both events
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pending))
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(purchased))
+
+        val merged = connection.purchases.first()
+        merged.size shouldBe 1
+        merged.single().purchaseState shouldBe PurchaseState.PURCHASED
+        // The completion is fresh Play data: it must reach the grace bookkeeping, unlike the
+        // pending event before it.
+        val updates = connection.freshUpdates.take(2).toList()
+        updates[0].purchases shouldBe emptyList()
+        updates[1].purchases shouldBe listOf(purchased)
+    }
+
+    @Test fun `an unspecified-state purchase is dropped everywhere`() = runTest2 {
+        val unspecified = purchase(1_000, token = "unspecified", state = PurchaseState.UNSPECIFIED_STATE)
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(unspecified),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(unspecified))
+
+        val refresh = connection.refreshPurchases()
+
+        // Neither owned nor a payment in progress: it must not reach state, refresh or UI.
+        refresh.purchases shouldBe emptyList()
+        connection.purchases.first() shouldBe emptyList()
+    }
+
+    @Test fun `a pending-only overlay survivor does not suppress absence bookkeeping`() = runTest2 {
+        // A pending payment arrives while a refresh is in flight: the queries verified empty, and
+        // the surviving PENDING overlay proves no ownership — the snapshot still proves absence,
+        // unlike the PURCHASED case (which must not start a false unconfirmed-grace episode).
+        val pendingListeners = mutableListOf<PurchasesResponseListener>()
+        val client = mockk<BillingClient>().apply {
+            every { queryPurchasesAsync(any<QueryPurchasesParams>(), any()) } answers {
+                pendingListeners.add(secondArg())
+            }
+        }
+        val connection = BillingConnection(client = client)
+
+        val refresh = async(start = CoroutineStart.UNDISPATCHED) { connection.refreshPurchases() }
+        runCurrent()
+        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(pendingPurchase(1_000)))
+        pendingListeners.forEach { it.onQueryPurchasesResponse(result(BillingResponseCode.OK), mutableListOf()) }
+        runCurrent()
+        refresh.await()
+
+        val update = connection.freshUpdates.first()
+        update.purchases shouldBe emptyList()
+        update.isFullSnapshot shouldBe true
+    }
+
+    @Test fun `a refresh reports only what its own queries confirmed`() = runTest2 {
+        val iapOwned = purchase(1_000, token = "iap")
+        val connection = BillingConnection(
+            client = clientReturning(
+                // Refresh 1: both succeed, IAP owned.
+                result(BillingResponseCode.OK) to listOf(iapOwned),
+                result(BillingResponseCode.OK) to emptyList(),
+                // Refresh 2: IAP fails (stale snapshot retained), SUB confirms a pending payment.
+                result(BillingResponseCode.ERROR) to emptyList(),
+                result(BillingResponseCode.OK) to listOf(
+                    pendingPurchase(2_000, token = "pending-sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
+                ),
+            ),
+        )
+        connection.refreshPurchases()
+
+        val second = connection.refreshPurchases()
+
+        // The retained IAP purchase is in the committed view, but it is NOT something these
+        // queries confirmed — reporting it as confirmed Pro would keep the grace clock frozen
+        // through an indefinite outage.
+        second.purchases.map { it.purchaseToken } shouldContainExactly listOf("pending-sub", "iap")
+        second.confirmed shouldBe emptyList()
+        second.hasConfirmedProPurchase shouldBe false
+        second.isComplete shouldBe false
+        second.partialError.shouldNotBeNull()
+    }
+
+    @Test fun `a confirmed known purchase is reported as confirmed pro`() = runTest2 {
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to listOf(purchase(1_000, token = "iap")),
+                result(BillingResponseCode.ERROR) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+
+        refresh.confirmed.map { it.purchaseToken } shouldBe listOf("iap")
+        refresh.hasConfirmedProPurchase shouldBe true
+        refresh.isComplete shouldBe false
+    }
+
+    @Test fun `a refresh is stamped with its commit time`() = runTest2 {
+        val before = System.currentTimeMillis()
+        val connection = BillingConnection(
+            client = clientReturning(
+                result(BillingResponseCode.OK) to emptyList(),
+                result(BillingResponseCode.OK) to emptyList(),
+            ),
+        )
+
+        val refresh = connection.refreshPurchases()
+        val after = System.currentTimeMillis()
+
+        (refresh.occurredAt in before..after) shouldBe true
+        // The same instant travels on the fresh update, so a confirmation and a later failure
+        // signal can be ordered against each other.
+        refresh.occurredAt shouldBe connection.freshUpdates.first().occurredAt
     }
 
     @Test fun `fresh updates arrive in commit order`() = runTest2 {
@@ -803,146 +995,6 @@ class BillingConnectionTest : BaseTest() {
         shouldThrow<BillingClientException> {
             connection.launchBillingFlow(mockk(), OurSku.Iap.PRO_UPGRADE, null)
         }
-    }
-
-    // endregion
-
-    // region querySubscriptions (pre-purchase gate)
-
-    @Test fun `querySubscriptions returns fresh subs and keeps the iap snapshot intact`() = runTest2 {
-        val iapOwned = purchase(1_000, token = "iap")
-        val subOwned = purchase(2_000, token = "sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val client = clientReturning(
-            // Refresh: IAP owned, no subs yet.
-            result(BillingResponseCode.OK) to listOf(iapOwned),
-            result(BillingResponseCode.OK) to emptyList(),
-            // SUBS-only gate query: sub found.
-            result(BillingResponseCode.OK) to listOf(subOwned),
-        )
-        val connection = BillingConnection(client = client)
-        connection.refreshPurchases()
-
-        val gateView = connection.querySubscriptions()
-
-        gateView shouldBe listOf(subOwned)
-        // The gate must have queried SUBS, not INAPP (clientReturning ignores the params, so this
-        // would otherwise go unnoticed). zza() is the params' only product-type accessor — a
-        // billing library upgrade renaming it breaks this line loudly at compile time.
-        verify(exactly = 2) {
-            client.queryPurchasesAsync(match<QueryPurchasesParams> { it.zza() == BillingClient.ProductType.SUBS }, any())
-        }
-        // The SUBS-only commit updates the reactive view WITHOUT disturbing the IAP snapshot —
-        // wiping it would briefly un-Pro a one-time-purchase owner.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
-        val updates = connection.freshUpdates.take(2).toList()
-        // Partial by definition: it proves what the SUBS query found, never absence of the rest.
-        updates[1].purchases shouldBe listOf(subOwned)
-        updates[1].isFullSnapshot shouldBe false
-    }
-
-    @Test fun `a failed querySubscriptions propagates and commits nothing`() = runTest2 {
-        val iapOwned = purchase(1_000, token = "iap")
-        val subOwned = purchase(2_000, token = "sub", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val connection = BillingConnection(
-            client = clientReturning(
-                result(BillingResponseCode.OK) to listOf(iapOwned),
-                result(BillingResponseCode.OK) to listOf(subOwned),
-                result(BillingResponseCode.ERROR) to emptyList(),
-            ),
-        )
-        val freshUpdates = mutableListOf<BillingConnection.FreshUpdate>()
-        backgroundScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            connection.freshUpdates.collect { freshUpdates.add(it) }
-        }
-        connection.refreshPurchases()
-
-        // Fail-closed contract: the gate must see the error, not an empty "no subscriptions".
-        shouldThrow<BillingClientException> { connection.querySubscriptions() }
-        runCurrent()
-
-        // No commit and no fresh emission from the failed query — only the refresh's own. Both
-        // snapshots survive, including the SUB one the failed query was about.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("sub", "iap")
-        freshUpdates.size shouldBe 1
-    }
-
-    @Test fun `querySubscriptions clears an older sub overlay it could have seen`() = runTest2 {
-        // The sub arrived via purchase event, then the user refunded/cancelled it away: the gate
-        // query verifies empty and must supersede the stale event — otherwise the ghost sub keeps
-        // blocking the one-time purchase.
-        val subEvent = purchase(1_000, token = "sub-event", products = listOf(OurSku.Sub.PRO_UPGRADE.id))
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to emptyList()),
-        )
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(subEvent))
-
-        connection.querySubscriptions() shouldBe emptyList()
-        connection.purchases.first() shouldBe emptyList()
-    }
-
-    @Test fun `querySubscriptions prefers a racing event's renewal state for the same token`() = runTest2 {
-        // The stale query result says the sub no longer renews, but a purchase event that landed
-        // while the query was in flight says it does (user just re-subscribed): the gate must see
-        // the overlay version, or the fail-closed double-billing check lets the buy through.
-        val queried = purchase(1_000, token = "same", products = listOf(OurSku.Sub.PRO_UPGRADE.id)).apply {
-            every { isAutoRenewing } returns false
-        }
-        val raced = purchase(1_000, token = "same", products = listOf(OurSku.Sub.PRO_UPGRADE.id)).apply {
-            every { isAutoRenewing } returns true
-        }
-        val pendingListeners = mutableListOf<PurchasesResponseListener>()
-        val client = mockk<BillingClient>().apply {
-            every { queryPurchasesAsync(any<QueryPurchasesParams>(), any()) } answers {
-                pendingListeners.add(secondArg())
-            }
-        }
-        val connection = BillingConnection(client = client)
-
-        val gate = async(start = CoroutineStart.UNDISPATCHED) { connection.querySubscriptions() }
-        runCurrent()
-        pendingListeners.size shouldBe 1
-
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(raced))
-        pendingListeners.single().onQueryPurchasesResponse(result(BillingResponseCode.OK), mutableListOf(queried))
-        runCurrent()
-
-        val gateView = gate.await()
-        gateView.single().isAutoRenewing shouldBe true
-    }
-
-    @Test fun `querySubscriptions excludes iap overlay entries but keeps untyped ones`() = runTest2 {
-        val iapEvent = purchase(1_000, token = "iap-event")
-        val unknownEvent = purchase(2_000, token = "unknown", products = listOf("some.unknown.product"))
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to emptyList()),
-        )
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(iapEvent))
-        connection.onPurchasesUpdated(result(BillingResponseCode.OK), listOf(unknownEvent))
-
-        val gateView = connection.querySubscriptions()
-
-        // An IAP can't be the blocking subscription; an unknown product might be, so it stays in
-        // on the safe side.
-        gateView.map { it.purchaseToken } shouldBe listOf("unknown")
-        // Excluded from the gate view only — the reducer still owns both entries.
-        connection.purchases.first().map { it.purchaseToken } shouldContainExactly listOf("unknown", "iap-event")
-    }
-
-    @Test fun `querySubscriptions filters pending subscription results`() = runTest2 {
-        val pendingSub = mockk<Purchase>().apply {
-            every { purchaseState } returns PurchaseState.PENDING
-            every { purchaseTime } returns 1_000L
-            every { purchaseToken } returns "pending-sub"
-            every { this@apply.products } returns listOf(OurSku.Sub.PRO_UPGRADE.id)
-        }
-        val connection = BillingConnection(
-            client = clientReturning(result(BillingResponseCode.OK) to listOf(pendingSub)),
-        )
-
-        // A PENDING subscription is not an active one — it must neither block the gate nor
-        // surface as owned.
-        connection.querySubscriptions() shouldBe emptyList()
-        connection.purchases.first() shouldBe emptyList()
     }
 
     // endregion

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeOwnershipTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeOwnershipTest.kt
@@ -101,4 +101,38 @@ class GplayUpgradeOwnershipTest : BaseTest() {
 
         ownership.ownsAnything shouldBe false
     }
+
+    private fun pendingInfo(vararg pending: Purchase) = UpgradeRepoGplay.Info(
+        false,
+        BillingData(purchases = emptyList(), pendingPurchases = pending.toList()),
+        null,
+    )
+
+    @Test
+    fun `a pending payment sets the pending flag`() {
+        pendingInfo(mockPurchase("upgrade.premium.rewrite.v3")).toPendingFlag().shouldBeTrue()
+        pendingInfo(mockPurchase("upgrade.pro")).toPendingFlag().shouldBeTrue()
+    }
+
+    @Test
+    fun `no pending payment leaves the flag off`() {
+        info(mockPurchase("upgrade.premium.rewrite.v3")).toPendingFlag().shouldBeFalse()
+        pendingInfo().toPendingFlag().shouldBeFalse()
+    }
+
+    @Test
+    fun `an unknown pending product does not set the flag`() {
+        // Nothing to explain and nothing to lock: a product this app doesn't sell isn't the Pro
+        // upgrade the user is waiting for.
+        pendingInfo(mockPurchase("some.unknown.sku")).toPendingFlag().shouldBeFalse()
+    }
+
+    @Test
+    fun `a pending payment is not ownership`() {
+        val ownership = pendingInfo(mockPurchase("upgrade.premium.rewrite.v3")).toOwnership()
+
+        ownership.hasIap.shouldBeFalse()
+        ownership.subscription.shouldBeNull()
+        ownership.ownsAnything.shouldBeFalse()
+    }
 }

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeScreenHostTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeScreenHostTest.kt
@@ -2,7 +2,9 @@ package eu.darken.bluemusic.upgrade.ui
 
 import androidx.activity.ComponentActivity
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.lifecycle.Lifecycle
+import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.PreviewWrapper
 import eu.darken.bluemusic.upgrade.core.UpgradeRepoGplay
 import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
@@ -38,6 +40,35 @@ class GplayUpgradeScreenHostTest : BaseTest() {
         every { proUnconfirmedSince } returns MutableStateFlow(0L)
         every { autoRestoreBusy } returns MutableStateFlow(false)
         every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+    }
+
+    @Test
+    fun `a pending-purchase event puts the informational dialog on screen`() {
+        // Host-level wiring: the ViewModel tests prove the event is emitted, only a real
+        // composition proves it reaches a dialog (and survives as a rememberSaveable flag).
+        val repo = mockRepo()
+        coEvery { repo.querySkus(any()) } returns emptyList()
+        val vm = UpgradeViewModel(
+            manage = false,
+            dispatcherProvider = TestDispatcherProvider(),
+            navCtrl = mockk(relaxed = true),
+            upgradeRepo = repo,
+            webpageTool = mockk(relaxed = true),
+        )
+
+        composeRule.setContent {
+            PreviewWrapper {
+                UpgradeScreenHost(manage = false, vm = vm)
+            }
+        }
+        composeRule.waitForIdle()
+
+        vm.events.tryEmit(UpgradeEvents.PurchasePending)
+
+        val message = composeRule.activity.getString(R.string.upgrade_screen_pending_dialog_message)
+        composeRule.waitUntil {
+            composeRule.onAllNodesWithText(message, substring = true).fetchSemanticsNodes().isNotEmpty()
+        }
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeScreenTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeScreenTest.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
@@ -365,6 +366,88 @@ class GplayUpgradeScreenTest : BaseComposeRobolectricTest() {
         )
         check(idle.iapEnabled) { "IAP buy should be enabled when idle" }
         check(idle.subscriptionEnabled) { "Subscription buy should be enabled when idle" }
+
+        // A pending payment locks BOTH, whichever product it belongs to: Play rejects a second
+        // purchase of the pending product, and the alternative would charge twice for Pro.
+        val pending = toLoadedState(
+            iap = SkuDetails(OurSku.Iap.PRO_UPGRADE, iapDetails),
+            sub = SkuDetails(OurSku.Sub.PRO_UPGRADE, subDetails),
+            ownership = Ownership(),
+            hasPendingPurchase = true,
+        )
+        check(!pending.iapEnabled) { "IAP buy must be disabled while a payment is pending" }
+        check(!pending.subscriptionEnabled) { "Subscription buy must be disabled while a payment is pending" }
+    }
+
+    @Test
+    fun `a pending payment shows the card and locks the offers for acquisition`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = GplayUpgradeUiState.Loaded(
+                    subscriptionAction = SubscriptionAction.STANDARD,
+                    subscriptionEnabled = false,
+                    subscriptionPrice = "$12.99",
+                    iapEnabled = false,
+                    iapPrice = "$24.99",
+                    hasPendingPurchase = true,
+                ),
+            )
+        }
+
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_pending_card_body))
+            .assertCountEquals(1)
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_SUBSCRIPTION).assertIsNotEnabled()
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_IAP).assertIsNotEnabled()
+        // Restore stays available: re-checking with Play is exactly the right move for someone who
+        // believes the payment already went through.
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_RESTORE).assertIsEnabled()
+    }
+
+    @Test
+    fun `a pending payment shows the card on the ownership screen and locks the switch`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(
+                uiState = ownedState(Ownership(subscription = SubscriptionOwnership(isAutoRenewing = false)))
+                    .copy(hasPendingPurchase = true),
+            )
+        }
+
+        // The subscriber switching to the one-time purchase: the switch offer is unlocked by the
+        // non-renewing subscription, but a payment in progress must still hold it.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onNodeWithTag(UpgradeScreenTags.GPLAY_IAP).assertIsNotEnabled()
+    }
+
+    @Test
+    fun `a pending payment shows the card during a young grace episode`() {
+        composeRule.setUpgradeContent {
+            UpgradeScreen(uiState = graceState(showDiagnostics = false).copy(hasPendingPurchase = true))
+        }
+
+        // The young grace stage hides the offers box entirely, so a card rendered inside it would
+        // never reach this audience — which is precisely the one waiting for a renewal payment.
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_PENDING).assertCountEquals(1)
+        composeRule.onAllNodesWithTag(UpgradeScreenTags.GPLAY_GRACE).assertCountEquals(1)
+    }
+
+    @Test
+    fun `the pending dialog is informational only`() {
+        var dismissals = 0
+        composeRule.setUpgradeContent { PurchasePendingDialog(onDismiss = { dismissals++ }) }
+
+        composeRule.onNodeWithText(
+            context.getString(R.string.upgrade_screen_pending_dialog_message),
+            substring = true,
+        ).assertExists()
+        // No support escalation and no restore tips: there is nothing for the user to do.
+        composeRule.onAllNodesWithText(context.getString(R.string.settings_support_contact_label))
+            .assertCountEquals(0)
+        composeRule.onAllNodesWithText(context.getString(R.string.upgrade_screen_restore_multiaccount_hint))
+            .assertCountEquals(0)
+
+        composeRule.onNodeWithText(context.getString(R.string.general_dismiss_action)).performClick()
+        composeRule.runOnIdle { dismissals shouldBe 1 }
     }
 
     @Test

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -694,6 +694,45 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
+    fun `a subscription purchase is blocked when the fresh check finds an owned upgrade`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The screen can be stale (the one-time purchase was made on another device) and Play sells
+        // the subscription right next to an owned IAP — launching here charges the user for Pro a
+        // second time.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns proInfo(mockPurchase(OurSku.Iap.PRO_UPGRADE.id))
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscription(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.RestoreSucceeded
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a subscription purchase is blocked when an unknown renewing subscription exists`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Unknown product ID => zero mapped upgrades, so the ownership block above lets it through.
+        // It still renews and still bills, and a second subscription for the same features is the
+        // same double charge.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase("some.unknown.subscription", autoRenewing = true))
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscription(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.SubscriptionStillRenewing
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
     fun `a pending-payment launch failure surfaces as the pending dialog`() = runTest2(context = testDispatcher) {
         // Play can only report this at launch time (the gate saw a clean state moments earlier):
         // the already-owned error dialog with its restore tips would be the wrong advice.

--- a/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeViewModelTest.kt
+++ b/app/src/testGplay/java/eu/darken/bluemusic/upgrade/ui/GplayUpgradeViewModelTest.kt
@@ -10,6 +10,7 @@ import eu.darken.bluemusic.upgrade.core.UpgradeRepoGplay
 import eu.darken.bluemusic.upgrade.core.billing.BillingData
 import eu.darken.bluemusic.upgrade.core.billing.GplayServiceUnavailableException
 import eu.darken.bluemusic.upgrade.core.billing.OfferUnavailableBillingException
+import eu.darken.bluemusic.upgrade.core.billing.PendingPurchaseBillingException
 import eu.darken.bluemusic.upgrade.core.billing.Sku
 import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
@@ -21,6 +22,7 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -295,6 +297,9 @@ class GplayUpgradeViewModelTest : BaseTest() {
         // Relaxed mocks return a no-op Flow that never emits -- the state combine would starve.
         every { autoRestoreBusy } returns MutableStateFlow(false)
         every { purchaseLaunchSku } returns MutableStateFlow<Sku?>(null)
+        // Both purchase paths run the pre-purchase gate: the default is a clean account (nothing
+        // owned, nothing pending), so tests only stub it when the gate IS the subject.
+        coEvery { verifyPurchaseStateNow() } returns UpgradeRepoGplay.Info(false, null, null, isSettled = true)
     }
 
     private fun buildVm(
@@ -321,6 +326,15 @@ class GplayUpgradeViewModelTest : BaseTest() {
         BillingData(purchases = purchases.toList()),
         null,
         // Ownership data implies a committed reconciliation -> always settled.
+        isSettled = true,
+    )
+
+    // Play is still processing a payment: nothing owned, nothing granted, but the purchase paths
+    // must treat it as a blocking answer.
+    private fun pendingInfo(skuId: String = OurSku.Iap.PRO_UPGRADE.id) = UpgradeRepoGplay.Info(
+        false,
+        BillingData(purchases = emptyList(), pendingPurchases = listOf(mockPurchase(skuId))),
+        null,
         isSettled = true,
     )
 
@@ -373,6 +387,22 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test
+    fun `restore that finds a pending payment emits PurchasePending`() = runTest2(context = testDispatcher) {
+        // Play answered and DID find the purchase — it just isn't paid for yet. RestoreFailed would
+        // send this user through account troubleshooting and support for something that resolves
+        // itself.
+        val repo = mockRepo()
+        coEvery { repo.restorePurchaseNow() } returns checked(pendingInfo())
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.restorePurchase()
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
     }
 
     @Test
@@ -521,7 +551,28 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase is blocked while the subscription is still set to renew`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns listOf(mockPurchase("upgrade.pro", autoRenewing = true))
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = true))
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.SubscriptionStillRenewing
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `iap purchase is blocked by a renewing subscription with an unknown product`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // The gate reads the RAW purchases, never the mapped upgrades: a subscription whose product
+        // ID this build doesn't know (legacy SKU, renamed product) still renews and still bills, so
+        // letting the one-time purchase through here charges the user for Pro twice.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase("some.unknown.subscription", autoRenewing = true))
         val vm = buildVm(repo)
 
         val event = async { vm.events.first() }
@@ -535,7 +586,8 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase proceeds when the subscription is not set to renew`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns listOf(mockPurchase("upgrade.pro", autoRenewing = false))
+        coEvery { repo.verifyPurchaseStateNow() } returns
+            proInfo(mockPurchase(OurSku.Sub.PRO_UPGRADE.id, autoRenewing = false))
         val vm = buildVm(repo)
 
         vm.onGoIap(mockk<Activity>(relaxed = true))
@@ -547,7 +599,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
     @Test
     fun `iap purchase proceeds without any subscription`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } returns emptyList()
+        coEvery { repo.verifyPurchaseStateNow() } returns UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         val vm = buildVm(repo)
 
         vm.onGoIap(mockk<Activity>(relaxed = true))
@@ -557,12 +609,12 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `failing subscription verification blocks the purchase and forwards the error`() = runTest2(
+    fun `failing purchase verification blocks the purchase and forwards the error`() = runTest2(
         context = testDispatcher,
     ) {
         val repo = mockRepo()
         val boom = IllegalStateException("Play unavailable")
-        coEvery { repo.queryCurrentSubscriptions() } throws boom
+        coEvery { repo.verifyPurchaseStateNow() } throws boom
         val vm = buildVm(repo)
 
         val forwardedError = async { vm.errorEvents.first() }
@@ -574,13 +626,13 @@ class GplayUpgradeViewModelTest : BaseTest() {
     }
 
     @Test
-    fun `subscription verification timeout blocks the purchase with a check-failed event`() = runTest2(
+    fun `purchase verification timeout blocks the purchase with a check-failed event`() = runTest2(
         context = testDispatcher,
     ) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
             delay(30_000) // longer than the 10s verification timeout
-            emptyList()
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         }
         val vm = buildVm(repo)
 
@@ -588,16 +640,87 @@ class GplayUpgradeViewModelTest : BaseTest() {
         vm.onGoIap(mockk<Activity>(relaxed = true))
         advanceUntilIdle()
 
-        event.await() shouldBe UpgradeEvents.SubscriptionCheckFailed
+        event.await() shouldBe UpgradeEvents.PurchaseCheckFailed
         coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a subscription gate timeout blocks that purchase too`() = runTest2(context = testDispatcher) {
+        // The subscription path used to launch unverified: a slow Play means we don't know whether
+        // a payment is already pending, so it must fail closed like the one-time path.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
+            delay(30_000)
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
+        }
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscription(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchaseCheckFailed
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending payment blocks the one-time purchase`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns pendingInfo()
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending payment blocks the subscription purchase`() = runTest2(context = testDispatcher) {
+        // SKU-agnostic on purpose: the two products are alternatives, so a pending payment for
+        // either one must block both — completing both charges the user twice.
+        val repo = mockRepo()
+        coEvery { repo.verifyPurchaseStateNow() } returns pendingInfo()
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoSubscriptionTrial(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
+        coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `a pending-payment launch failure surfaces as the pending dialog`() = runTest2(context = testDispatcher) {
+        // Play can only report this at launch time (the gate saw a clean state moments earlier):
+        // the already-owned error dialog with its restore tips would be the wrong advice.
+        // The callback is captured and invoked from the test body rather than from inside the
+        // answer: on a suspend function the argument list carries the continuation, so grabbing the
+        // callback positionally there is a coin flip — and a wrong cast would surface as a hang.
+        val repo = mockRepo()
+        val onError = slot<(Throwable) -> Unit>()
+        coEvery { repo.launchBillingFlowNow(any(), any(), any(), capture(onError)) } returns Unit
+        val vm = buildVm(repo)
+
+        val event = async { vm.events.first() }
+        vm.onGoIap(mockk<Activity>(relaxed = true))
+        advanceUntilIdle()
+
+        onError.captured(PendingPurchaseBillingException())
+        advanceUntilIdle()
+
+        event.await() shouldBe UpgradeEvents.PurchasePending
     }
 
     @Test
     fun `iap taps are single-flight while a verification is running`() = runTest2(context = testDispatcher) {
         val repo = mockRepo()
-        coEvery { repo.queryCurrentSubscriptions() } coAnswers {
+        coEvery { repo.verifyPurchaseStateNow() } coAnswers {
             delay(5_000)
-            emptyList()
+            UpgradeRepoGplay.Info(false, null, null, isSettled = true)
         }
         val vm = buildVm(repo)
 
@@ -606,7 +729,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
         vm.onGoIap(mockk<Activity>(relaxed = true))
         advanceUntilIdle()
 
-        coVerify(exactly = 1) { repo.queryCurrentSubscriptions() }
+        coVerify(exactly = 1) { repo.verifyPurchaseStateNow() }
         coVerify(exactly = 1) { repo.launchBillingFlowNow(any(), eq(OurSku.Iap.PRO_UPGRADE), isNull(), any()) }
     }
 
@@ -643,8 +766,9 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         // One arbiter for all three: the purchase and the restore would otherwise run concurrent
-        // Play operations against the same account state.
-        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+        // Play operations against the same account state. Exactly one gate ran — the subscription's
+        // own; the blocked IAP tap never got to verify anything.
+        coVerify(exactly = 1) { repo.verifyPurchaseStateNow() }
         coVerify(exactly = 0) { repo.restorePurchaseNow() }
         coVerify(exactly = 1) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
     }
@@ -667,7 +791,7 @@ class GplayUpgradeViewModelTest : BaseTest() {
 
         coVerify(exactly = 1) { repo.restorePurchaseNow() }
         coVerify(exactly = 0) { repo.launchBillingFlowNow(any(), any(), any(), any()) }
-        coVerify(exactly = 0) { repo.queryCurrentSubscriptions() }
+        coVerify(exactly = 0) { repo.verifyPurchaseStateNow() }
     }
 
     @Test
@@ -960,6 +1084,43 @@ class GplayUpgradeViewModelTest : BaseTest() {
         advanceUntilIdle()
 
         event.await() shouldBe UpgradeEvents.RestoreFailed
+    }
+
+    @Test
+    fun `a pending payment renders while the price queries are still running`() = runTest2(
+        context = testDispatcher,
+    ) {
+        // Price-independent like owners and grace users: the pending card is this user's answer and
+        // both offers are locked anyway, so waiting on prices would hide it behind Loading.
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns MutableStateFlow(pendingInfo())
+        coEvery { repo.querySkus(any()) } coAnswers {
+            delay(60_000) // effectively never within this test
+            emptyList()
+        }
+        val vm = buildVm(repo)
+
+        val collector = launch(start = CoroutineStart.UNDISPATCHED) { vm.state.collect { } }
+        testScheduler.advanceTimeBy(1_000)
+
+        val loaded = vm.state.value.shouldBeInstanceOf<GplayUpgradeUiState.Loaded>()
+        loaded.hasPendingPurchase shouldBe true
+        collector.cancel()
+    }
+
+    @Test
+    fun `a pending payment keeps its card when both price queries fail`() = runTest2(context = testDispatcher) {
+        val repo = mockRepo()
+        every { repo.upgradeInfo } returns MutableStateFlow(pendingInfo())
+        coEvery { repo.querySkus(any()) } throws IllegalStateException("Play unavailable")
+        val vm = buildVm(repo)
+
+        val loaded = async { awaitLoaded(vm) }
+        advanceUntilIdle()
+
+        // Not the acquisition-style Unavailable card: the pending explanation must survive a price
+        // outage, exactly like the grace card does.
+        loaded.await().hasPendingPurchase shouldBe true
     }
 
     @Test


### PR DESCRIPTION
## What changed

When Google Play is still processing a payment (cash, carrier billing, bank transfer), the app previously had no idea the user had bought anything: the upgrade screen kept selling, and a retry was rejected by Play as "already owned". Pending payments now travel through the billing stack: a "Payment pending" card explains the wait, both purchase buttons lock (buying the alternative product would double-charge), a restore that finds the unpaid purchase says so instead of suggesting account troubleshooting, and retrying the pending product gets the same explanation instead of a misleading "already owned" error.

Both purchase buttons also verify the account state with Play at tap time before opening the checkout: a pending payment, an existing Pro purchase made on another device, or a subscription still set to renew stops the launch instead of charging twice. If the check cannot complete, the purchase does not start.

## Technical Context

- Port of the canonical sdmaid-se implementation (d4rken-org/sdmaid-se#2653 plus its two follow-up gate corrections, sdmaid-se PR #2662); billing-core files are byte-parity with the donor modulo package rename, verified by a normalized diff in review.
- Pending purchases never touch entitlement: `BillingData` splits PURCHASED-only `purchases` from `pendingPurchases` at every exit, so granting Pro, stamping the grace cache, and the acknowledgement pass (which Play rejects permanently for pending purchases) stay PURCHASED-only by construction.
- The pre-purchase gate fails closed on anything short of a complete Play round-trip (`refreshStrict`), and invalidates a connection that died mid-check so later checks reconnect instead of reusing it.
- The renewal guard reads RAW purchases, not mapped SKUs, so a renewing subscription with a legacy or unknown product ID still blocks a double purchase.
