### PR TITLE
Fix hard-to-read text and invisible icons on colored cards

### DIFF
--- a/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
+++ b/app/src/foss/java/eu/darken/bluemusic/upgrade/ui/UpgradeScreen.kt
@@ -178,6 +178,7 @@ private fun UpgradePitchContent(
         ) {
             Button(
                 onClick = onGithubSponsors,
+                colors = tertiaryCardButtonColors(),
                 modifier = Modifier
                     .fillMaxWidth()
                     .testTag(UpgradeScreenTags.FOSS_SPONSOR),
@@ -185,7 +186,10 @@ private fun UpgradePitchContent(
                 Text(stringResource(R.string.upgrade_screen_sponsor_action))
             }
 
-            UpgradeHintText(text = stringResource(R.string.upgrade_screen_sponsor_action_hint))
+            UpgradeHintText(
+                text = stringResource(R.string.upgrade_screen_sponsor_action_hint),
+                color = MaterialTheme.colorScheme.onTertiaryContainer,
+            )
         }
     }
 }

--- a/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeRestore.kt
+++ b/app/src/gplay/java/eu/darken/bluemusic/upgrade/ui/UpgradeRestore.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
@@ -49,6 +50,9 @@ internal fun UpgradeRestoreSection(
         } else {
             null
         },
+        // The header icon defaults to the primary accent, which is near-invisible on the tinted
+        // container.
+        iconTint = if (emphasized) MaterialTheme.colorScheme.onTertiaryContainer else Color.Unspecified,
     ) {
         if (emphasized) {
             // Plain Text: the tinted container brings its own content color, the muted
@@ -64,6 +68,7 @@ internal fun UpgradeRestoreSection(
             Button(
                 onClick = onRestore,
                 enabled = busy == null,
+                colors = tertiaryCardButtonColors(),
                 modifier = Modifier
                     .fillMaxWidth()
                     .testTag(restoreTag),

--- a/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/ui/settings/backup/BackupRestoreScreen.kt
@@ -389,7 +389,9 @@ private fun WarningCard(text: String) {
             Icon(
                 imageVector = Icons.TwoTone.Warning,
                 contentDescription = null,
-                tint = MaterialTheme.colorScheme.tertiary,
+                // Not `tertiary`: it sits at nearly the same luminance as the tertiaryContainer
+                // fill behind it, so the icon disappears.
+                tint = MaterialTheme.colorScheme.onTertiaryContainer,
             )
             Spacer(modifier = Modifier.padding(horizontal = 6.dp))
             Text(
@@ -414,7 +416,9 @@ private fun ResultSection(result: BackupRestoreViewModel.OperationResult) {
                 Icon(
                     imageVector = Icons.TwoTone.CheckCircle,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary,
+                    // Not `primary`: it is nearly the same color as the primaryContainer fill
+                    // behind it, so the icon disappears.
+                    tint = MaterialTheme.colorScheme.onPrimaryContainer,
                 )
                 Spacer(modifier = Modifier.padding(horizontal = 8.dp))
                 Text(

--- a/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeContent.kt
+++ b/app/src/main/java/eu/darken/bluemusic/upgrade/ui/UpgradeContent.kt
@@ -22,6 +22,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.twotone.ArrowBack
 import androidx.compose.material.icons.twotone.CheckCircle
 import androidx.compose.material.icons.twotone.WarningAmber
+import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CardColors
 import androidx.compose.material3.CardDefaults
@@ -624,15 +625,35 @@ private fun UpgradeFeatureRow(
 internal fun UpgradeHintText(
     text: String,
     modifier: Modifier = Modifier,
+    // Muted against a neutral surface by default. A tinted card must pass its own "on" color:
+    // onSurfaceVariant is a surface role and washes out badly on a filled container.
+    color: Color = MaterialTheme.colorScheme.onSurfaceVariant,
 ) {
     Text(
         text = text,
         style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant,
+        color = color,
         textAlign = TextAlign.Center,
         modifier = modifier.fillMaxWidth(),
     )
 }
+
+// Buttons on a tertiaryContainer card. The default primary fill has almost the same luminance as
+// the container in the dark theme, so it separates by hue alone. Swapping the container/content
+// pair borrows whatever contrast the theme's own tertiary pair has, which is the best a role
+// swap can do — it cannot improve on an under-contrast palette.
+// The disabled pair is spelled out too. Material3's default disabled fill is onSurface at 12%,
+// which on a tinted card is almost entirely the card showing through — the button stops being a
+// shape and anything drawn on it (the busy spinner) loses its background. These buttons are
+// disabled only while their operation runs, so the disabled state has to stay readable: an opaque
+// fill and a lightly dimmed label, rather than the usual near-invisible treatment.
+@Composable
+internal fun tertiaryCardButtonColors(): ButtonColors = ButtonDefaults.buttonColors(
+    containerColor = MaterialTheme.colorScheme.onTertiaryContainer,
+    contentColor = MaterialTheme.colorScheme.tertiaryContainer,
+    disabledContainerColor = MaterialTheme.colorScheme.onTertiaryContainer,
+    disabledContentColor = MaterialTheme.colorScheme.tertiaryContainer.copy(alpha = 0.8f),
+)
 
 @Composable
 internal fun UpgradeActionCard(


### PR DESCRIPTION
## What changed

Text and icons sitting on the app's colored highlight cards were close to unreadable. On the upgrade screen, the note under the sponsor button was washed out against the orange card. On the Google Play restore card, the icon in the card header was effectively invisible, and the backup and restore screen had the same problem with its warning and success icons.

The buttons on those colored cards also blended into the card behind them, and the spinner that shows while a purchase or restore is running had no visible background. Both are now legible.

## Technical Context

- Root cause: several shared helpers hardcoded surface-role colors (`onSurfaceVariant` for hint text, `primary` and `tertiary` for icons) that only work on a neutral card. In the dark theme `tertiaryContainer` is a light orange, so those colors landed at 1.36:1 for the hint text and roughly 1.0:1 for the icons. The palette itself is fine: the `tertiaryContainer` / `onTertiaryContainer` pair sits at 6.2:1.
- `UpgradeHintText` gains a `color` parameter instead of deriving from `LocalContentColor`. It has two callers and the other one is on a neutral card where the existing muted tone is correct, so a content-derived default would have shifted that one for no reason. Icon tints stay per-callsite on the same grounds: deriving them would turn the blue accent icons gray on the ten or so neutral cards.
- `tertiaryCardButtonColors()` spells out the disabled pair as well as the enabled one. Material3's default disabled fill is `onSurface` at 12%, which on a tinted card is almost entirely the card showing through, so the button stops being a shape and anything drawn on it loses its background. These buttons are disabled only while their operation is running, so that state has to stay readable rather than get the usual near-invisible treatment.
- Worth a close look: the in-button spinner colors are deliberately left alone. An earlier revision changed them to track the button's content color, which was wrong. Each of those spinners renders only while its button is disabled (`enabled = busy == null`, spinner on `busy != null`), so that change resolved to `disabledContentColor` and made contrast worse, around 5.65:1 down to 1.76:1 on a neutral card. The opaque disabled fill above is what makes the spinner visible.
- Not fixed here: the Sunset theme's dark `tertiaryContainer` / `onTertiaryContainer` pair is only 4.03:1, below the 4.5:1 needed for small text. Using the correct roles preserves whatever contrast a theme defines but cannot improve on an under-contrast palette; that needs a palette change.
