### PR TITLE
Mention the equalizer in the Play Store description

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -2,6 +2,7 @@
 
 **Features:**
 * Set music, call, ringtone, and notification volumes per device  
+* Per-device equalizer with presets and a volume boost  
 * Auto-send media commands like Play or Next  
 * Launch apps on connect  
 * Keep screen awake  
@@ -10,8 +11,6 @@
 
 No ads, no tracking. Open-source.  
 Some extras require a paid upgrade to support development.
-
-**Note:** This app can't boost volume or override system volume limits.
 
 **Permissions:**
 * **Internet** – for optional bug reports  


### PR DESCRIPTION
## What changed

The Play Store feature list now names the per-device equalizer and its volume boost. The store page already shipped an equalizer screenshot, but no text on the listing mentioned the feature, so nobody browsing would learn the app has one without scrolling to the third screenshot.

This also removes the closing note that claimed the app "can't boost volume or override system volume limits". The equalizer screen has a volume boost slider that goes up to 10 dB, so that line read as false directly next to a screenshot showing it set to +3.0 dB.

## Technical Context

- Only `en-US` is edited. `crowdin.yaml` maps `full_description.txt` as a Crowdin source, so the other 78 locales pick the change up from there instead of being hand-edited.
- The removed note's still-accurate half (the app can't push the system volume slider past its maximum) was dropped rather than reworded. The equalizer screen already carries the app-support caveat in-app, where it reaches people who can act on it.
