### PR TITLE
Tell the user when Android blocks a connect action

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
@@ -32,6 +32,7 @@ import eu.darken.bluemusic.eq.ui.EqAppResolver
 import eu.darken.bluemusic.eq.ui.EqStatus
 import eu.darken.bluemusic.eq.ui.deriveEqStatus
 import eu.darken.bluemusic.main.core.GeneralSettings
+import eu.darken.bluemusic.monitor.core.BackgroundActivityGuard
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeModeTool
@@ -66,6 +67,7 @@ class DashboardViewModel @Inject constructor(
     private val speakerProvider: SpeakerDeviceProvider,
     private val reviewTool: ReviewTool,
     private val eqAppResolver: EqAppResolver,
+    private val backgroundActivityGuard: BackgroundActivityGuard,
     eqCoordinator: EqCoordinator,
     eqEligibility: EqEligibility,
     dispatcherProvider: DispatcherProvider,
@@ -100,6 +102,10 @@ class DashboardViewModel @Inject constructor(
         generalSettings.isAndroid10AppLaunchHintDismissed.flow,
         devicesFlow
     ) { _, isDismissed, devices ->
+        // Piggyback on this poll to retire the blocked-action notification: granting the permission
+        // from the system settings or the hint card below doesn't otherwise reach the monitor until
+        // the next connect event, which can be hours away.
+        backgroundActivityGuard.syncNotificationState()
         val hasDevicesNeedingOverlay = devices.any { it.launchPkgs.isNotEmpty() || it.showHomeScreen || it.keepAwake }
         val hint = permissionHelper.getOverlayPermissionHint(isDismissed, hasDevicesNeedingOverlay)
         hint

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/BackgroundActivityGuard.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/BackgroundActivityGuard.kt
@@ -1,0 +1,91 @@
+package eu.darken.bluemusic.monitor.core
+
+import android.app.ActivityManager
+import android.app.ActivityManager.RunningAppProcessInfo
+import android.content.Context
+import android.os.Process
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
+import eu.darken.bluemusic.common.debug.logging.asLog
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.common.permissions.PermissionHelper
+import eu.darken.bluemusic.monitor.ui.BlockedActionNotifications
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Gate for the connect actions that start an activity from the background.
+ *
+ * Android 10+ (API 29) blocks background activity starts unless the app has an exemption, and it
+ * blocks them *silently*: `startActivity` returns normally and throws nothing, the system just
+ * drops the start on its own side. Without this gate a debug log reads
+ * "Launching app: com.example.player" with no error after it, which looks exactly like success and
+ * has repeatedly sent support down the wrong path.
+ *
+ * Two exemptions are reachable here: holding SYSTEM_ALERT_WINDOW ("Display over other apps"), which
+ * is the only durable one for an autonomous start out of the monitor pipeline, and having a visible
+ * activity, which applies while the user is in BlueMusic testing a reconnect. A foreground service
+ * on its own is explicitly not an exemption.
+ */
+@Singleton
+class BackgroundActivityGuard @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val permissionHelper: PermissionHelper,
+    private val notifications: BlockedActionNotifications,
+) {
+
+    private val activityManager by lazy {
+        context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    }
+
+    /**
+     * Returns true when a background activity start will actually reach the system.
+     *
+     * When it will not, logs [what] as blocked and raises the permission notification so the user
+     * learns why their configured action did nothing. [what] is a log-only description and is never
+     * shown to the user.
+     */
+    fun canStartActivityOrNotify(what: String): Boolean {
+        if (!permissionHelper.needsOverlayPermission()) {
+            notifications.clearOverlayPermissionMissing()
+            return true
+        }
+
+        // A visible activity is an independent BAL exemption, so a connect that happens while the
+        // user sits in BlueMusic testing their setup would succeed even without the permission.
+        // Reporting it as blocked there would be a false alarm on the one screen that can fix it.
+        if (hasVisibleActivity()) {
+            log(TAG, VERBOSE) { "Allowing $what: no overlay permission, but our UI is visible." }
+            return true
+        }
+
+        log(TAG, WARN) { "Skipping $what: Android 10+ blocks this without the overlay permission." }
+        notifications.showOverlayPermissionMissing()
+        return false
+    }
+
+    /**
+     * Drops the notification once the permission is in place, for the case where it was granted
+     * somewhere other than the notification's own tap-through (dashboard hint, system settings).
+     * Otherwise it would linger until the next connect event, which may be hours away.
+     */
+    fun syncNotificationState() {
+        if (permissionHelper.needsOverlayPermission()) return
+        notifications.clearOverlayPermissionMissing()
+    }
+
+    private fun hasVisibleActivity(): Boolean = try {
+        // Since API 21 this only ever reports our own processes, which is all we need.
+        val own = activityManager.runningAppProcesses?.firstOrNull { it.pid == Process.myPid() }
+        own != null && own.importance <= RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+    } catch (e: Exception) {
+        log(TAG, WARN) { "Failed to determine process importance: ${e.asLog()}" }
+        false
+    }
+
+    companion object {
+        private val TAG = logTag("Monitor", "BackgroundActivityGuard")
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/WakeLockManager.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/WakeLockManager.kt
@@ -12,7 +12,6 @@ import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
 import eu.darken.bluemusic.common.debug.logging.asLog
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
-import eu.darken.bluemusic.common.permissions.PermissionHelper
 import eu.darken.bluemusic.monitor.core.screenwake.ScreenWakeActivity
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -23,7 +22,7 @@ import javax.inject.Singleton
 @Singleton
 class WakeLockManager @Inject constructor(
     @ApplicationContext private val context: Context,
-    private val permissionHelper: PermissionHelper,
+    private val backgroundActivityGuard: BackgroundActivityGuard,
 ) {
     private val powerManager by lazy { context.getSystemService(Context.POWER_SERVICE) as PowerManager }
     private val keyguardManager by lazy { context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager }
@@ -69,22 +68,23 @@ class WakeLockManager @Inject constructor(
     fun releaseBlocking() = runBlocking { setWakeLock(false) }
 
     fun wakeScreenNow() {
-        // Background activity launch (BAL) restrictions only apply on API 29+ (Android 10+).
-        // On API 23-28 a transparent activity launch from a foreground service is permitted
-        // without SYSTEM_ALERT_WINDOW. Skipping only when the OS would actually reject the
-        // launch avoids silently no-oping on Android 6-9 where the dashboard hint is also
-        // gated off.
-        if (permissionHelper.needsOverlayPermission()) {
-            log(TAG, WARN) { "Skipping screen wake: overlay permission not granted (Android 10+)." }
-            return
-        }
         // Skip the wake-and-hold round-trip when the device is already in active use
         // (interactive AND not behind the keyguard). On the lockscreen we still wake
         // so the launched app can surface above the keyguard.
+        //
+        // This has to come before the BAL guard: no activity start was going to happen here, so
+        // running the guard first would raise a "your action was blocked" notification for a wake
+        // that was never needed in the first place.
         if (powerManager.isInteractive && !keyguardManager.isKeyguardLocked) {
             log(TAG, VERBOSE) { "Screen on and unlocked; skipping wake." }
             return
         }
+        // Background activity launch (BAL) restrictions only apply on API 29+ (Android 10+).
+        // On API 23-28 a transparent activity launch from a foreground service is permitted
+        // without SYSTEM_ALERT_WINDOW. The guard skips only when the OS would actually reject
+        // the launch, so this doesn't silently no-op on Android 6-9 where the dashboard hint is
+        // also gated off.
+        if (!backgroundActivityGuard.canStartActivityOrNotify("screen wake")) return
         try {
             val intent = Intent(context, ScreenWakeActivity::class.java).apply {
                 addFlags(

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/action/ShowHomeScreenModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/action/ShowHomeScreenModule.kt
@@ -8,6 +8,7 @@ import dagger.multibindings.IntoSet
 import eu.darken.bluemusic.common.apps.AppRepo
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.monitor.core.BackgroundActivityGuard
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
 import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
 import javax.inject.Inject
@@ -16,6 +17,7 @@ import javax.inject.Singleton
 @Singleton
 class ShowHomeScreenModule @Inject internal constructor(
     private val appRepo: AppRepo,
+    private val backgroundActivityGuard: BackgroundActivityGuard,
 ) : ConnectionModule {
 
     override val tag: String
@@ -31,6 +33,8 @@ class ShowHomeScreenModule @Inject internal constructor(
     override suspend fun handle(event: DeviceEvent) {
         if (!isApplicable(event)) return
         val device = event.device
+
+        if (!backgroundActivityGuard.canStartActivityOrNotify("show home screen (${device.label})")) return
 
         log(TAG) { "Showing home screen for device: ${device.label}" }
         appRepo.goToHomeScreen()

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/AppLaunchModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/connection/AppLaunchModule.kt
@@ -8,6 +8,7 @@ import dagger.multibindings.IntoSet
 import eu.darken.bluemusic.common.apps.AppRepo
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.monitor.core.BackgroundActivityGuard
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
 import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
 import kotlinx.coroutines.delay
@@ -16,7 +17,8 @@ import javax.inject.Singleton
 
 @Singleton
 class AppLaunchModule @Inject constructor(
-    private val appRepo: AppRepo
+    private val appRepo: AppRepo,
+    private val backgroundActivityGuard: BackgroundActivityGuard,
 ) : ConnectionModule {
 
     override val tag: String
@@ -33,6 +35,8 @@ class AppLaunchModule @Inject constructor(
         if (!isApplicable(event)) return
         val device = event.device
         val appsToLaunch = device.launchPkgs
+
+        if (!backgroundActivityGuard.canStartActivityOrNotify("app launch ($appsToLaunch)")) return
 
         log(TAG) { "Launching ${appsToLaunch.size} apps: $appsToLaunch" }
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/ui/BlockedActionNotifications.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/ui/BlockedActionNotifications.kt
@@ -1,0 +1,106 @@
+package eu.darken.bluemusic.monitor.ui
+
+import android.annotation.SuppressLint
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.provider.Settings
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import dagger.hilt.android.qualifiers.ApplicationContext
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.common.PendingIntentCompat
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
+import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
+import eu.darken.bluemusic.common.debug.logging.log
+import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.common.hasApiLevel
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Tells the user why a connect action (launch app, show home screen, wake screen) did nothing.
+ *
+ * Android 10+ drops background activity starts without SYSTEM_ALERT_WINDOW, and it drops them
+ * silently: [Context.startActivity] does not throw, so the failure is invisible both to the app
+ * and to the user. The dashboard hint card that asks for the permission is dismissible, so a user
+ * who dismissed it once gets no further signal that their configured actions never run.
+ */
+@Singleton
+class BlockedActionNotifications @Inject constructor(
+    @param:ApplicationContext private val context: Context,
+    private val notificationManager: NotificationManager,
+) {
+
+    /**
+     * Posts the "grant Display over other apps" notification, or updates it in place when it is
+     * already showing. [NotificationCompat.Builder.setOnlyAlertOnce] keeps repeat connects from
+     * buzzing the user again, so no extra throttling state is needed.
+     */
+    fun showOverlayPermissionMissing() {
+        ensureNotificationChannel()
+
+        val settingsIntent = Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        val settingsPi = PendingIntent.getActivity(
+            context,
+            PI_REQUEST_CODE,
+            settingsIntent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntentCompat.FLAG_IMMUTABLE,
+        )
+
+        val message = context.getString(R.string.android10_applaunch_hint_message)
+        val notification = NotificationCompat.Builder(context, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_notification_small)
+            .setContentTitle(context.getString(R.string.android10_applaunch_hint_title))
+            .setContentText(message)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+            .setContentIntent(settingsPi)
+            .setAutoCancel(true)
+            .setOnlyAlertOnce(true)
+            .setCategory(NotificationCompat.CATEGORY_ERROR)
+            .build()
+
+        // notify() is a silent no-op when notifications are off (POST_NOTIFICATIONS denied on
+        // API 33+, or the user disabled them). Record that, otherwise a support log shows us
+        // raising the notification and the user insisting they never saw anything.
+        if (!NotificationManagerCompat.from(context).areNotificationsEnabled()) {
+            log(TAG, WARN) { "Overlay permission is missing, but notifications are disabled." }
+            return
+        }
+
+        log(TAG, WARN) { "Notifying about missing overlay permission" }
+        notificationManager.notify(NOTIFICATION_ID, notification)
+    }
+
+    /** Called once a background activity start succeeds again, i.e. the permission was granted. */
+    fun clearOverlayPermissionMissing() {
+        log(TAG, VERBOSE) { "Clearing overlay permission notification" }
+        notificationManager.cancel(NOTIFICATION_ID)
+    }
+
+    @SuppressLint("NewApi")
+    private fun ensureNotificationChannel() {
+        if (!hasApiLevel(Build.VERSION_CODES.O)) return
+        notificationManager.createNotificationChannel(
+            NotificationChannel(
+                CHANNEL_ID,
+                context.getString(R.string.label_notification_channel_setup),
+                NotificationManager.IMPORTANCE_DEFAULT,
+            )
+        )
+    }
+
+    companion object {
+        private val TAG = logTag("Monitor", "BlockedAction", "Notifications")
+        private const val CHANNEL_ID = "notification.channel.setup"
+
+        // 1 is the monitor foreground service notification, see MonitorNotifications.
+        private const val NOTIFICATION_ID = 2
+        private const val PI_REQUEST_CODE = 2
+    }
+}

--- a/app/src/main/java/eu/darken/bluemusic/monitor/ui/BlockedActionNotifications.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/ui/BlockedActionNotifications.kt
@@ -54,11 +54,18 @@ class BlockedActionNotifications @Inject constructor(
         )
 
         val message = context.getString(R.string.android10_applaunch_hint_message)
+
+        // Several OEM skins gate background launches behind a second toggle of their own (MIUI's
+        // "Display pop-up windows while running in background" is the common one) and keep
+        // reporting canDrawOverlays()=true regardless, so the app cannot detect that state. Once
+        // the user grants the Android permission this notification stops firing while the launch
+        // still fails, so the caveat has to be here, before they grant it, rather than after.
+        val oemHint = context.getString(R.string.android10_applaunch_oem_hint)
         val notification = NotificationCompat.Builder(context, CHANNEL_ID)
             .setSmallIcon(R.drawable.ic_notification_small)
             .setContentTitle(context.getString(R.string.android10_applaunch_hint_title))
             .setContentText(message)
-            .setStyle(NotificationCompat.BigTextStyle().bigText(message))
+            .setStyle(NotificationCompat.BigTextStyle().bigText("$message\n\n$oemHint"))
             .setContentIntent(settingsPi)
             .setAutoCancel(true)
             .setOnlyAlertOnce(true)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -355,6 +355,7 @@
     <string name="label_add_device">Add device</string>
     <string name="label_just_a_moment_please">Just a moment, please.</string>
     <string name="label_notification_channel_status">Status</string>
+    <string name="label_notification_channel_setup">Setup required</string>
     <string name="monitor_notification_starting">Starting up…</string>
     <string name="action_set">Set</string>
     <string name="action_cancel">Cancel</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -441,6 +441,7 @@
     <string name="battery_optimization_fix_action">Disable optimizations</string>
     <string name="android10_applaunch_hint_title">Display over apps permission</string>
     <string name="android10_applaunch_hint_message">Android 10+ needs a special permission to launch apps, show the home screen, or wake the screen from the background on connect. Grant "Display over other apps" permission.</string>
+    <string name="android10_applaunch_oem_hint">Some manufacturers need a second permission on top of this one. If it still doesn\'t work after granting, look for a background pop-up or background launch setting in your phone\'s app permissions.</string>
     <string name="notification_permission_hint_title">Notification permission</string>
     <string name="notification_permission_hint_message">Grant notification permission to see status updates when adjusting volumes.</string>
     <string name="dnd_access_hint_title">Do Not Disturb access</string>

--- a/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModelTest.kt
@@ -178,6 +178,7 @@ class DashboardViewModelTest : BaseTest() {
         eqAppResolver = mockk<EqAppResolver>().apply {
             coEvery { resolved(any()) } answers { firstArg() }
         },
+        backgroundActivityGuard = mockk(relaxed = true),
         eqCoordinator = eqCoordinator,
         eqEligibility = eqEligibility,
         dispatcherProvider = TestDispatcherProvider(UnconfinedTestDispatcher(testScheduler)),

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/BackgroundActivityGuardTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/BackgroundActivityGuardTest.kt
@@ -1,0 +1,115 @@
+package eu.darken.bluemusic.monitor.core
+
+import android.app.ActivityManager
+import android.app.ActivityManager.RunningAppProcessInfo
+import android.content.Context
+import android.os.Process
+import eu.darken.bluemusic.common.permissions.PermissionHelper
+import eu.darken.bluemusic.monitor.ui.BlockedActionNotifications
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class BackgroundActivityGuardTest : BaseTest() {
+
+    private lateinit var context: Context
+    private lateinit var activityManager: ActivityManager
+    private lateinit var permissionHelper: PermissionHelper
+    private lateinit var notifications: BlockedActionNotifications
+
+    @BeforeEach
+    fun setup() {
+        mockkStatic(Process::class)
+        every { Process.myPid() } returns OUR_PID
+
+        activityManager = mockk(relaxed = true)
+        every { activityManager.runningAppProcesses } returns emptyList()
+
+        context = mockk(relaxed = true)
+        every { context.getSystemService(Context.ACTIVITY_SERVICE) } returns activityManager
+
+        permissionHelper = mockk(relaxed = true)
+        notifications = mockk(relaxed = true)
+    }
+
+    private fun createGuard() = BackgroundActivityGuard(context, permissionHelper, notifications)
+
+    private fun setOwnImportance(importance: Int) {
+        every { activityManager.runningAppProcesses } returns listOf(
+            RunningAppProcessInfo().apply {
+                pid = OUR_PID
+                this.importance = importance
+            }
+        )
+    }
+
+    @Test
+    fun `blocks and notifies when the overlay permission is missing`() {
+        every { permissionHelper.needsOverlayPermission() } returns true
+
+        createGuard().canStartActivityOrNotify("app launch") shouldBe false
+
+        verify { notifications.showOverlayPermissionMissing() }
+        verify(exactly = 0) { notifications.clearOverlayPermissionMissing() }
+    }
+
+    @Test
+    fun `allows and clears the notification when the permission is granted`() {
+        every { permissionHelper.needsOverlayPermission() } returns false
+
+        createGuard().canStartActivityOrNotify("app launch") shouldBe true
+
+        verify { notifications.clearOverlayPermissionMissing() }
+        verify(exactly = 0) { notifications.showOverlayPermissionMissing() }
+    }
+
+    @Test
+    fun `a visible activity is its own exemption, so no permission and no false alarm`() {
+        every { permissionHelper.needsOverlayPermission() } returns true
+        setOwnImportance(RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
+
+        createGuard().canStartActivityOrNotify("app launch") shouldBe true
+
+        verify(exactly = 0) { notifications.showOverlayPermissionMissing() }
+    }
+
+    @Test
+    fun `a foreground service alone is not an exemption`() {
+        every { permissionHelper.needsOverlayPermission() } returns true
+        setOwnImportance(RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE)
+
+        createGuard().canStartActivityOrNotify("app launch") shouldBe false
+
+        verify { notifications.showOverlayPermissionMissing() }
+    }
+
+    @Test
+    fun `every blocked attempt notifies, deduplication is the notification layer's job`() {
+        every { permissionHelper.needsOverlayPermission() } returns true
+        val guard = createGuard()
+
+        repeat(3) { guard.canStartActivityOrNotify("app launch") shouldBe false }
+
+        verify(exactly = 3) { notifications.showOverlayPermissionMissing() }
+    }
+
+    @Test
+    fun `syncNotificationState only clears once the permission is actually granted`() {
+        every { permissionHelper.needsOverlayPermission() } returns true
+        createGuard().syncNotificationState()
+        verify(exactly = 0) { notifications.clearOverlayPermissionMissing() }
+
+        every { permissionHelper.needsOverlayPermission() } returns false
+        createGuard().syncNotificationState()
+        verify { notifications.clearOverlayPermissionMissing() }
+    }
+
+    companion object {
+        private const val OUR_PID = 1234
+    }
+}


### PR DESCRIPTION
## What changed

When a Bluetooth device connects, BlueMusic can launch apps, show the home screen and wake the screen. On Android 10 and newer these need the "Display over other apps" permission, and without it Android blocks them without any error: the app appeared to do nothing at all, with no explanation anywhere.

Now a notification explains why the action didn't run and links straight to the permission screen. It disappears once the permission is granted.

The notification also warns that some manufacturers require a second, separate background-launch permission, because on those ROMs granting the Android one is not enough.

The dashboard already had a hint card for this, but it can be dismissed, after which nothing ever mentioned it again.

## Technical Context

- Root cause: `startActivity()` from a background context does not throw when the OS drops it for BAL (background activity launch) restrictions. `AppLaunchModule` and `ShowHomeScreenModule` had no permission check, so their `try/catch` never fired and the debug log printed `Launching app: <pkg>` with nothing after it. Support logs from affected users looked like successful launches.
- `WakeLockManager.wakeScreenNow()` already had the correct check inline. Behaviour there is unchanged, it now shares `BackgroundActivityGuard` instead of duplicating the logic.
- The guard checks process importance before reporting a block, because a visible activity is an independent BAL exemption. Skipping that check would raise a false "blocked" notification when a device connects while the user is in BlueMusic testing their setup, which is the likeliest moment for a connect to coincide with the app being open.
- The OEM caveat sits in the message shown *before* the permission is granted, not in a follow-up. MIUI-style skins keep reporting `canDrawOverlays()=true` while still dropping the launch, so once the Android permission is granted the guard stops blocking and this notification stops firing, even though nothing actually works yet. It stays vendor-neutral rather than sniffing `Build.MANUFACTURER`, since the menu wording differs per skin and version.
- Worth a close look: the guard call in `wakeScreenNow()` sits deliberately **after** the "screen already interactive and unlocked" early return. Ordering it before would notify about a wake that was never going to happen.
- Reuses the existing `android10_applaunch_hint_title` / `_message` strings, already translated across all locales. Two strings are new: `label_notification_channel_setup` (channel name only, never shown on the notification) and `android10_applaunch_oem_hint`.
- Known limit, not addressed here: on API 33+ with notifications denied the alert cannot be shown, which is the default state on a fresh install until the user grants notifications. The guard logs a `WARN` in that case so support logs distinguish "never raised" from "raised but invisible".
- Manual verification on an Android 14 emulator covered what CI cannot: all four permission/visibility combinations against the real `AppLaunchModule` path, the notification's rendered content, its auto-cancel, and the tap-through landing on the overlay permission screen.
