### PR TITLE
Stop Bluetooth volume dropping to zero on connect

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/RouteOwnerAgreement.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/RouteOwnerAgreement.kt
@@ -1,0 +1,36 @@
+package eu.darken.bluemusic.monitor.core.audio
+
+enum class RouteVerdict {
+    AGREE,
+    DISAGREE,
+    UNKNOWN,
+    ;
+}
+
+/**
+ * Does the media route agree that [ownerAddresses] (or the phone speaker) owns what is playing?
+ *
+ * Route says BT_A2DP 'AA:BB' while the owner group is ["AA:BB"] -> AGREE.
+ * Route says SPEAKER while the owner group is ["AA:BB"] -> DISAGREE.
+ * Route says BT_A2DP 'CC:DD' while the owner group is ["AA:BB"] -> DISAGREE.
+ *
+ * UNKNOWN whenever the route can't classify itself, so an uninformative query never blocks.
+ */
+fun routeVerdict(
+    route: VolumeTool.MediaRoute?,
+    isPhoneSpeaker: Boolean,
+    ownerAddresses: Set<String>,
+): RouteVerdict {
+    if (route == null) return RouteVerdict.UNKNOWN
+    val routedToBluetooth = route.isBluetooth ?: return RouteVerdict.UNKNOWN
+
+    if (isPhoneSpeaker) return if (routedToBluetooth) RouteVerdict.DISAGREE else RouteVerdict.AGREE
+
+    if (!routedToBluetooth) return RouteVerdict.DISAGREE
+
+    val routed = route.addresses.filter { it.isNotBlank() }.map { it.lowercase() }.toSet()
+    if (routed.isEmpty()) return RouteVerdict.AGREE
+
+    val owners = ownerAddresses.map { it.lowercase() }.toSet()
+    return if (routed.any { it in owners }) RouteVerdict.AGREE else RouteVerdict.DISAGREE
+}

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/RouteOwnerAgreement.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/RouteOwnerAgreement.kt
@@ -10,9 +10,12 @@ enum class RouteVerdict {
 /**
  * Does the media route agree that [ownerAddresses] (or the phone speaker) owns what is playing?
  *
- * Route says BT_A2DP 'AA:BB' while the owner group is ["AA:BB"] -> AGREE.
- * Route says SPEAKER while the owner group is ["AA:BB"] -> DISAGREE.
- * Route says BT_A2DP 'CC:DD' while the owner group is ["AA:BB"] -> DISAGREE.
+ * [knownAddresses] are all addresses BVM manages, owners included.
+ *
+ * Route BT_A2DP 'AA:BB', owners ["AA:BB"] -> AGREE.
+ * Route SPEAKER, owners ["AA:BB"] -> DISAGREE.
+ * Route BT_A2DP 'CC:DD', owners ["AA:BB"], known ["AA:BB", "CC:DD"] -> DISAGREE.
+ * Route BT_A2DP 'CC:DD', owners ["AA:BB"], known ["AA:BB"] -> AGREE.
  *
  * UNKNOWN whenever the route can't classify itself, so an uninformative query never blocks.
  */
@@ -20,6 +23,7 @@ fun routeVerdict(
     route: VolumeTool.MediaRoute?,
     isPhoneSpeaker: Boolean,
     ownerAddresses: Set<String>,
+    knownAddresses: Set<String>,
 ): RouteVerdict {
     if (route == null) return RouteVerdict.UNKNOWN
     val routedToBluetooth = route.isBluetooth ?: return RouteVerdict.UNKNOWN
@@ -32,5 +36,11 @@ fun routeVerdict(
     if (routed.isEmpty()) return RouteVerdict.AGREE
 
     val owners = ownerAddresses.map { it.lowercase() }.toSet()
-    return if (routed.any { it in owners }) RouteVerdict.AGREE else RouteVerdict.DISAGREE
+    if (routed.any { it in owners }) return RouteVerdict.AGREE
+
+    // Owner addresses come from ACL broadcasts, the route address comes from the audio
+    // framework: an LE Audio set member or a hearing aid can report a third address that
+    // belongs to no device BVM knows. That says nothing, so it counts as agreement.
+    val others = knownAddresses.map { it.lowercase() }.toSet() - owners
+    return if (routed.any { it in others }) RouteVerdict.DISAGREE else RouteVerdict.AGREE
 }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeEvent.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeEvent.kt
@@ -5,4 +5,5 @@ data class VolumeEvent(
     val oldVolume: Int,
     val newVolume: Int,
     val self: Boolean,
+    val route: VolumeTool.MediaRoute? = null,
 )

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeObserver.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeObserver.kt
@@ -48,9 +48,9 @@ class VolumeObserver @Inject constructor(
 
     internal fun dispatchVolumeChanges(selfChange: Boolean, emit: (VolumeEvent) -> Unit) {
         log(TAG, VERBOSE) { "Change detected (selfChange=$selfChange)" }
-        // Diagnostic (issue #232): query the active media route once per dispatch,
-        // only when something actually changed, to correlate 15->0 drops with routing.
-        var routeLogged = false
+        // The route is sampled once per dispatch, at the instant the new volume is read,
+        // so the classification matches the moment the change was observed.
+        var route: VolumeTool.MediaRoute? = null
         AudioStream.Id.entries.forEach { id ->
             val newVolume = volumeTool.getCurrentVolume(id)
             val oldVolume = volumesCache[id] ?: -1
@@ -58,9 +58,10 @@ class VolumeObserver @Inject constructor(
                 // Classify self-ness first: wasUs() is TTL-sensitive, so the route
                 // query (a binder call) must not delay it and skew the window.
                 val isSelf = volumeTool.wasUs(id, newVolume)
-                if (!routeLogged) {
-                    log(TAG) { "Media route on change: ${volumeTool.describeActiveMediaRoute()}" }
-                    routeLogged = true
+                if (route == null) {
+                    val queried = volumeTool.queryActiveMediaRoute()
+                    route = queried
+                    log(TAG) { "Media route on change: ${queried.description}" }
                 }
                 log(TAG) { "Volume changed (type=$id, old=$oldVolume, new=$newVolume, self=$isSelf)" }
                 volumesCache[id] = newVolume
@@ -69,7 +70,8 @@ class VolumeObserver @Inject constructor(
                         streamId = id,
                         oldVolume = oldVolume,
                         newVolume = newVolume,
-                        self = isSelf
+                        self = isSelf,
+                        route = route,
                     )
                 )
             }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
@@ -5,6 +5,7 @@ import android.media.AudioDeviceInfo
 import android.media.AudioManager
 import android.os.Build
 import android.os.SystemClock
+import androidx.annotation.RequiresApi
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.DEBUG
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
@@ -101,17 +102,25 @@ class VolumeTool @Inject constructor(
     }
 
     /**
-     * Diagnostic only (issue #232): describes the active media output route.
-     * On some Android 16 builds the audio route tears down ~2s before
-     * ACL_DISCONNECTED, so the phone speaker's volume gets attributed to the
-     * disconnecting BT device. Logging this alongside volume changes lets a
-     * debug log reveal whether media is still routed to Bluetooth at that moment.
+     * Where media (USAGE_MEDIA/CONTENT_TYPE_MUSIC) would play right now.
      *
+     * [isBluetooth] is null when the query can't answer: below API 33 there is no
+     * active-route API, and an empty device list carries no information.
+     * [addresses] is empty when the platform withholds identities (BLUETOOTH_CONNECT
+     * not granted returns blank addresses).
+     */
+    data class MediaRoute(
+        val isBluetooth: Boolean?,
+        val addresses: Set<String>,
+        val description: String,
+    )
+
+    /**
      * API 33+ returns the predicted active route; below that only the connected
      * output list is available (labelled accordingly, not the active route).
      */
     @Suppress("DEPRECATION") // isBluetoothA2dpOn/ScoOn are deprecated but still the routing signal we want to log
-    fun describeActiveMediaRoute(): String {
+    fun queryActiveMediaRoute(): MediaRoute {
         val start = clock()
         return try {
             val a2dp = audioManager.isBluetoothA2dpOn
@@ -122,15 +131,40 @@ class VolumeTool @Inject constructor(
                     .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
                     .build()
                 val devices = audioManager.getAudioDevicesForAttributes(attrs)
-                formatMediaRoute(active = true, devices = devices, a2dp = a2dp, sco = sco, queryMs = clock() - start)
+                MediaRoute(
+                    isBluetooth = bluetoothRouteFrom(active = true, devices = devices),
+                    addresses = addressesFrom(devices),
+                    description = formatMediaRoute(active = true, devices = devices, a2dp = a2dp, sco = sco, queryMs = clock() - start),
+                )
             } else {
                 val outputs = audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS).toList()
-                formatMediaRoute(active = false, devices = outputs, a2dp = a2dp, sco = sco, queryMs = clock() - start)
+                MediaRoute(
+                    isBluetooth = bluetoothRouteFrom(active = false, devices = outputs),
+                    addresses = emptySet(),
+                    description = formatMediaRoute(active = false, devices = outputs, a2dp = a2dp, sco = sco, queryMs = clock() - start),
+                )
             }
         } catch (e: Exception) {
-            "route-query-failed: ${e.javaClass.simpleName}: ${e.message}"
+            MediaRoute(
+                isBluetooth = null,
+                addresses = emptySet(),
+                description = "route-query-failed: ${e.javaClass.simpleName}: ${e.message}",
+            )
         }
     }
+
+    fun describeActiveMediaRoute(): String = queryActiveMediaRoute().description
+
+    internal fun bluetoothRouteFrom(active: Boolean, devices: List<AudioDeviceInfo>): Boolean? {
+        if (!active) return null
+        if (devices.isEmpty()) return null
+        return devices.any { it.type in BLUETOOTH_OUTPUT_TYPES }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.P)
+    internal fun addressesFrom(devices: List<AudioDeviceInfo>): Set<String> = devices
+        .mapNotNull { it.address?.trim()?.takeIf { addr -> addr.isNotEmpty() } }
+        .toSet()
 
     // Separated from the platform query so the formatting can be unit-tested in
     // plain JVM without Robolectric. `active` = predicted route (API 33+),
@@ -265,5 +299,16 @@ class VolumeTool @Inject constructor(
 
     companion object {
         private val TAG = logTag("Audio", "StreamHelper")
+
+        // ASHA hearing aids and LE Audio outputs are Bluetooth devices too, an omission here
+        // would permanently block volume management for those device classes.
+        private val BLUETOOTH_OUTPUT_TYPES = setOf(
+            AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+            AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+            AudioDeviceInfo.TYPE_HEARING_AID,
+            AudioDeviceInfo.TYPE_BLE_HEADSET,
+            AudioDeviceInfo.TYPE_BLE_SPEAKER,
+            AudioDeviceInfo.TYPE_BLE_BROADCAST,
+        )
     }
 }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
@@ -153,8 +153,6 @@ class VolumeTool @Inject constructor(
         }
     }
 
-    fun describeActiveMediaRoute(): String = queryActiveMediaRoute().description
-
     internal fun bluetoothRouteFrom(active: Boolean, devices: List<AudioDeviceInfo>): Boolean? {
         if (!active) return null
         if (devices.isEmpty()) return null

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/audio/VolumeTool.kt
@@ -133,7 +133,7 @@ class VolumeTool @Inject constructor(
                 val devices = audioManager.getAudioDevicesForAttributes(attrs)
                 MediaRoute(
                     isBluetooth = bluetoothRouteFrom(active = true, devices = devices),
-                    addresses = addressesFrom(devices),
+                    addresses = bluetoothAddressesFrom(devices),
                     description = formatMediaRoute(active = true, devices = devices, a2dp = a2dp, sco = sco, queryMs = clock() - start),
                 )
             } else {
@@ -163,6 +163,13 @@ class VolumeTool @Inject constructor(
     internal fun addressesFrom(devices: List<AudioDeviceInfo>): Set<String> = devices
         .mapNotNull { it.address?.trim()?.takeIf { addr -> addr.isNotEmpty() } }
         .toSet()
+
+    // Only Bluetooth outputs can match an owner address. A USB output on the same route
+    // reports `card=1;device=0`, which would make the set non-empty even when every
+    // Bluetooth output on it came back with a blank address (BLUETOOTH_CONNECT denied).
+    @RequiresApi(Build.VERSION_CODES.P)
+    internal fun bluetoothAddressesFrom(devices: List<AudioDeviceInfo>): Set<String> =
+        addressesFrom(devices.filter { it.type in BLUETOOTH_OUTPUT_TYPES })
 
     // Separated from the platform query so the formatting can be unit-tested in
     // plain JVM without Robolectric. `active` = predicted route (API 33+),

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
@@ -16,10 +17,12 @@ import eu.darken.bluemusic.devices.core.updateVolume
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.RingerMode
 import eu.darken.bluemusic.monitor.core.audio.RingerTool
+import eu.darken.bluemusic.monitor.core.audio.RouteVerdict
 import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.audio.levelToPercentage
 import eu.darken.bluemusic.monitor.core.audio.percentageToLevel
+import eu.darken.bluemusic.monitor.core.audio.routeVerdict
 import eu.darken.bluemusic.monitor.core.modules.ConnectionModule
 import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
 import eu.darken.bluemusic.monitor.core.modules.SettlePolicy
@@ -63,8 +66,16 @@ class VolumeDisconnectModule @Inject constructor(
         }
 
         log(TAG, INFO) { "Saving volumes on disconnect for device ${device.label}" }
-        // Diagnostic (issue #232): live route now, to compare against the pre-reroute snapshot.
-        log(TAG, INFO) { "Media route at disconnect-save for ${device.label}: ${volumeTool.describeActiveMediaRoute()}" }
+        val route = event.volumeSnapshot?.route
+        log(TAG, INFO) { "Media route at disconnect for ${device.label}: ${route?.description}" }
+        // Media is the only stream the route query can speak for (it asks
+        // USAGE_MEDIA/CONTENT_TYPE_MUSIC), so a disagreeing route drops MUSIC alone and the
+        // remaining streams still save as usual.
+        val musicVerdict = routeVerdict(
+            route = route,
+            isPhoneSpeaker = device.type == SourceDevice.Type.PHONE_SPEAKER,
+            ownerAddresses = setOf(device.address),
+        )
 
         // TODO: RingerTool.getCurrentRingerMode() falls back to NORMAL on unknown
         // Android modes. If Android ever adds a new ringer mode, this module will
@@ -78,6 +89,14 @@ class VolumeDisconnectModule @Inject constructor(
         // (e.g. events from FakeSpeakerEventDebouncer or test harnesses).
         val snapshots = AudioStream.Type.entries.mapNotNull { type ->
             if (device.getVolume(type) == null) return@mapNotNull null
+
+            if (type == AudioStream.Type.MUSIC && musicVerdict == RouteVerdict.DISAGREE) {
+                log(TAG, INFO) {
+                    "Route disagrees with ${device.address}/${device.label}, skipping $type " +
+                        "(route=${route?.description}, routedTo=${route?.addresses})"
+                }
+                return@mapNotNull null
+            }
 
             val streamId = device.getStreamId(type)
             val snapshotLevel = event.volumeSnapshot?.levels?.get(streamId)

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
@@ -12,6 +12,7 @@ import eu.darken.bluemusic.common.debug.logging.Logging.Priority.WARN
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.devices.core.DeviceRepo
+import eu.darken.bluemusic.devices.core.currentDevices
 import eu.darken.bluemusic.devices.core.getVolume
 import eu.darken.bluemusic.devices.core.updateVolume
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
@@ -79,6 +80,7 @@ class VolumeDisconnectModule @Inject constructor(
             route = route,
             isPhoneSpeaker = device.type == SourceDevice.Type.PHONE_SPEAKER,
             ownerAddresses = ownerAddresses,
+            knownAddresses = deviceRepo.currentDevices().map { it.address }.toSet(),
         )
 
         // TODO: RingerTool.getCurrentRingerMode() falls back to NORMAL on unknown

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModule.kt
@@ -68,13 +68,17 @@ class VolumeDisconnectModule @Inject constructor(
         log(TAG, INFO) { "Saving volumes on disconnect for device ${device.label}" }
         val route = event.volumeSnapshot?.route
         log(TAG, INFO) { "Media route at disconnect for ${device.label}: ${route?.description}" }
+        // The whole owner group counts as agreement: when grouped bud A disconnects, the route
+        // may already name its still-connected sibling B, and B's level is A's level too.
+        val ownerAddresses = disconnectResult?.ownerGroupBefore?.toSet()?.takeIf { it.isNotEmpty() }
+            ?: setOf(device.address)
         // Media is the only stream the route query can speak for (it asks
         // USAGE_MEDIA/CONTENT_TYPE_MUSIC), so a disagreeing route drops MUSIC alone and the
         // remaining streams still save as usual.
         val musicVerdict = routeVerdict(
             route = route,
             isPhoneSpeaker = device.type == SourceDevice.Type.PHONE_SPEAKER,
-            ownerAddresses = setOf(device.address),
+            ownerAddresses = ownerAddresses,
         )
 
         // TODO: RingerTool.getCurrentRingerMode() falls back to NORMAL on unknown

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
@@ -65,7 +65,8 @@ class VolumeUpdateModule @Inject constructor(
             return
         }
 
-        val allActive = deviceRepo.currentDevices().filter { it.isActive }
+        val allDevices = deviceRepo.currentDevices()
+        val allActive = allDevices.filter { it.isActive }
 
         val candidates = allActive.filter { dev ->
             if (dev.address !in ownerAddresses) return@filter false
@@ -95,11 +96,13 @@ class VolumeUpdateModule @Inject constructor(
         // MUSIC is gated: the route query asks USAGE_MEDIA/CONTENT_TYPE_MUSIC, which says nothing
         // about who owns call, ringtone, notification or alarm audio.
         val agreeing = if (id == AudioStream.Id.STREAM_MUSIC) {
+            val knownAddresses = allDevices.map { it.address }.toSet()
             stable.filter { dev ->
                 val verdict = routeVerdict(
                     route = event.route,
                     isPhoneSpeaker = dev.type == SourceDevice.Type.PHONE_SPEAKER,
                     ownerAddresses = ownerAddresses,
+                    knownAddresses = knownAddresses,
                 )
                 when (verdict) {
                     RouteVerdict.DISAGREE -> {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModule.kt
@@ -5,6 +5,7 @@ import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import dagger.multibindings.IntoSet
+import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.DEBUG
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.VERBOSE
@@ -16,11 +17,13 @@ import eu.darken.bluemusic.devices.core.updateVolume
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
 import eu.darken.bluemusic.monitor.core.audio.RingerMode
 import eu.darken.bluemusic.monitor.core.audio.RingerTool
+import eu.darken.bluemusic.monitor.core.audio.RouteVerdict
 import eu.darken.bluemusic.monitor.core.audio.VolumeEvent
 import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.audio.levelToPercentage
 import eu.darken.bluemusic.monitor.core.audio.percentageToLevel
+import eu.darken.bluemusic.monitor.core.audio.routeVerdict
 import eu.darken.bluemusic.monitor.core.modules.VolumeModule
 import eu.darken.bluemusic.monitor.core.ownership.AudioStreamOwnerRegistry
 import java.time.Duration
@@ -54,8 +57,7 @@ class VolumeUpdateModule @Inject constructor(
         }
 
         log(TAG, DEBUG) { "Volume change $event" }
-        // Diagnostic (issue #232): route at the moment we decide to persist.
-        log(TAG, DEBUG) { "Media route for $id: ${volumeTool.describeActiveMediaRoute()}" }
+        log(TAG, DEBUG) { "Media route for $id: ${event.route?.description}" }
 
         val ownerAddresses = ownerRegistry.ownerAddressesFor(id).toSet()
         if (ownerAddresses.isEmpty()) {
@@ -88,6 +90,42 @@ class VolumeUpdateModule @Inject constructor(
             return
         }
 
+        // The owner registry is driven by ACL broadcasts alone; on some devices the media route
+        // leaves the Bluetooth device over a second before ACL_DISCONNECTED (issue #232). Only
+        // MUSIC is gated: the route query asks USAGE_MEDIA/CONTENT_TYPE_MUSIC, which says nothing
+        // about who owns call, ringtone, notification or alarm audio.
+        val agreeing = if (id == AudioStream.Id.STREAM_MUSIC) {
+            stable.filter { dev ->
+                val verdict = routeVerdict(
+                    route = event.route,
+                    isPhoneSpeaker = dev.type == SourceDevice.Type.PHONE_SPEAKER,
+                    ownerAddresses = ownerAddresses,
+                )
+                when (verdict) {
+                    RouteVerdict.DISAGREE -> {
+                        log(TAG, INFO) {
+                            "Route disagrees with owner, skipping $id=${event.newVolume} for " +
+                                "${dev.address}/${dev.label} (route=${event.route?.description}, " +
+                                "routedTo=${event.route?.addresses}, owners=$ownerAddresses)"
+                        }
+                        false
+                    }
+
+                    RouteVerdict.UNKNOWN -> {
+                        log(TAG, INFO) {
+                            "No usable route classification for $id, persisting for " +
+                                "${dev.address}/${dev.label} (route=${event.route?.description})"
+                        }
+                        true
+                    }
+
+                    RouteVerdict.AGREE -> true
+                }
+            }
+        } else {
+            stable
+        }
+
         val ringerMode = ringerTool.getCurrentRingerMode()
         val min = volumeTool.getMinVolume(id)
         val max = volumeTool.getMaxVolume(id)
@@ -106,7 +144,7 @@ class VolumeUpdateModule @Inject constructor(
         }
         val percentage = levelToPercentage(effectiveVolume, min, max)
 
-        stable.forEach { dev ->
+        agreeing.forEach { dev ->
             val streamType = dev.getStreamType(id)!!
 
             val mode: VolumeMode? = when (streamType) {

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
@@ -62,26 +62,24 @@ class MonitorEventReceiver : BroadcastReceiver() {
             return
         }
 
-        // Capture volume snapshot synchronously before any async processing.
-        // At this point (~2ms after broadcast), audio routing hasn't changed
-        // yet. By the time the coroutine runs (~80ms+), Android will have
-        // rerouted and getStreamVolume() returns the new device's values.
+        // Capture volumes and the media route synchronously, as early after the broadcast as
+        // possible (~2ms), before the coroutine below runs (~80ms+) and getStreamVolume() reports
+        // the next device's values. Routing may already have moved by then: on some devices
+        // ACL_DISCONNECTED arrives after media has left the Bluetooth device, so the route is
+        // recorded alongside the levels instead of assumed.
         // Needed for both DISCONNECTED (real device save-on-disconnect) and
         // CONNECTED (the synthetic FakeSpeaker DISCONNECTED side effect).
-        val volumeSnapshot = BluetoothEventQueue.VolumeSnapshot(
-            levels = AudioStream.Id.entries.associateWith { id ->
-                BluetoothEventQueue.VolumeSnapshot.Level(
-                    current = volumeTool.getCurrentVolume(id),
-                    min = volumeTool.getMinVolume(id),
-                    max = volumeTool.getMaxVolume(id),
-                )
-            }
-        )
+        val levels = AudioStream.Id.entries.associateWith { id ->
+            BluetoothEventQueue.VolumeSnapshot.Level(
+                current = volumeTool.getCurrentVolume(id),
+                min = volumeTool.getMinVolume(id),
+                max = volumeTool.getMaxVolume(id),
+            )
+        }
+        val route = volumeTool.queryActiveMediaRoute()
+        val volumeSnapshot = BluetoothEventQueue.VolumeSnapshot(levels = levels, route = route)
 
-        // Diagnostic (issue #232): capture the active media route at broadcast time,
-        // synchronously, to reveal whether it already reports the phone speaker
-        // during the pre-disconnect window.
-        log(TAG, DEBUG) { "Route at broadcast (action=${intent.action}): ${volumeTool.describeActiveMediaRoute()}" }
+        log(TAG, DEBUG) { "Route at broadcast (action=${intent.action}): ${route.description}" }
 
         val pendingResult = goAsync()
 

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/receiver/MonitorEventReceiver.kt
@@ -69,14 +69,17 @@ class MonitorEventReceiver : BroadcastReceiver() {
         // recorded alongside the levels instead of assumed.
         // Needed for both DISCONNECTED (real device save-on-disconnect) and
         // CONNECTED (the synthetic FakeSpeaker DISCONNECTED side effect).
+        // The route only judges MUSIC, so it is queried right after that level: the other streams
+        // cost ~15 AudioManager calls, enough of a window for a reroute to slip in between.
+        val musicLevel = volumeTool.getCurrentVolume(AudioStream.Id.STREAM_MUSIC)
+        val route = volumeTool.queryActiveMediaRoute()
         val levels = AudioStream.Id.entries.associateWith { id ->
             BluetoothEventQueue.VolumeSnapshot.Level(
-                current = volumeTool.getCurrentVolume(id),
+                current = if (id == AudioStream.Id.STREAM_MUSIC) musicLevel else volumeTool.getCurrentVolume(id),
                 min = volumeTool.getMinVolume(id),
                 max = volumeTool.getMaxVolume(id),
             )
         }
-        val route = volumeTool.queryActiveMediaRoute()
         val volumeSnapshot = BluetoothEventQueue.VolumeSnapshot(levels = levels, route = route)
 
         log(TAG, DEBUG) { "Route at broadcast (action=${intent.action}): ${route.description}" }

--- a/app/src/main/java/eu/darken/bluemusic/monitor/core/service/BluetoothEventQueue.kt
+++ b/app/src/main/java/eu/darken/bluemusic/monitor/core/service/BluetoothEventQueue.kt
@@ -5,6 +5,7 @@ import eu.darken.bluemusic.bluetooth.core.SourceDevice
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.flow.receiveAsFlow
 import java.util.concurrent.atomic.AtomicLong
@@ -62,7 +63,10 @@ class BluetoothEventQueue @Inject constructor() {
         }
     }
 
-    data class VolumeSnapshot(val levels: Map<AudioStream.Id, Level>) {
+    data class VolumeSnapshot(
+        val levels: Map<AudioStream.Id, Level>,
+        val route: VolumeTool.MediaRoute? = null,
+    ) {
         data class Level(val current: Int, val min: Int, val max: Int)
     }
 

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/RouteOwnerAgreementTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/RouteOwnerAgreementTest.kt
@@ -16,39 +16,93 @@ class RouteOwnerAgreementTest : BaseTest() {
 
     @Test
     fun `an unclassifiable route is unknown for both device kinds`() {
-        routeVerdict(route(null), isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.UNKNOWN
-        routeVerdict(route(null), isPhoneSpeaker = true, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.UNKNOWN
+        routeVerdict(
+            route(null),
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner),
+        ) shouldBe RouteVerdict.UNKNOWN
+        routeVerdict(
+            route(null),
+            isPhoneSpeaker = true,
+            ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner),
+        ) shouldBe RouteVerdict.UNKNOWN
     }
 
     @Test
     fun `a missing route is unknown for both device kinds`() {
-        routeVerdict(null, isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.UNKNOWN
-        routeVerdict(null, isPhoneSpeaker = true, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.UNKNOWN
+        routeVerdict(
+            null,
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner),
+        ) shouldBe RouteVerdict.UNKNOWN
+        routeVerdict(
+            null,
+            isPhoneSpeaker = true,
+            ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner),
+        ) shouldBe RouteVerdict.UNKNOWN
     }
 
     @Test
     fun `bluetooth device disagrees with a non-bluetooth route`() {
-        routeVerdict(route(false), isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.DISAGREE
+        routeVerdict(
+            route(false),
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner),
+        ) shouldBe RouteVerdict.DISAGREE
     }
 
     @Test
     fun `bluetooth device agrees when the route names it`() {
-        routeVerdict(route(true, owner), isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.AGREE
+        routeVerdict(
+            route(true, owner),
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner),
+        ) shouldBe RouteVerdict.AGREE
     }
 
     @Test
     fun `bluetooth device agrees when the route has no usable addresses`() {
-        routeVerdict(route(true), isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.AGREE
-        routeVerdict(route(true, "", "   "), isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.AGREE
+        routeVerdict(
+            route(true),
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner),
+        ) shouldBe RouteVerdict.AGREE
+        routeVerdict(
+            route(true, "", "   "),
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner),
+        ) shouldBe RouteVerdict.AGREE
     }
 
     @Test
-    fun `bluetooth device disagrees when the route names a different device`() {
+    fun `bluetooth device disagrees when the route names a different managed device`() {
         routeVerdict(
             route(true, "11:22:33:44:55:66"),
             isPhoneSpeaker = false,
             ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner, "11:22:33:44:55:66"),
         ) shouldBe RouteVerdict.DISAGREE
+    }
+
+    @Test
+    fun `bluetooth device agrees when the route names nothing BVM manages`() {
+        // LE Audio set members and hearing aids can report an address the ACL
+        // broadcasts never carried; it identifies no other device, so it can't
+        // contradict the owner.
+        routeVerdict(
+            route(true, "11:22:33:44:55:66"),
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner),
+        ) shouldBe RouteVerdict.AGREE
     }
 
     @Test
@@ -58,6 +112,7 @@ class RouteOwnerAgreementTest : BaseTest() {
             route(true, "11:22:33:44:55:66"),
             isPhoneSpeaker = false,
             ownerAddresses = setOf(owner, "11:22:33:44:55:66"),
+            knownAddresses = setOf(owner, "11:22:33:44:55:66"),
         ) shouldBe RouteVerdict.AGREE
     }
 
@@ -67,16 +122,43 @@ class RouteOwnerAgreementTest : BaseTest() {
             route(true, "aa:bb:cc:dd:ee:ff"),
             isPhoneSpeaker = false,
             ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner),
         ) shouldBe RouteVerdict.AGREE
     }
 
     @Test
+    fun `known address comparison ignores case`() {
+        routeVerdict(
+            route(true, "11:22:33:44:55:66"),
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner, "11:22:33:44:55:AA"),
+        ) shouldBe RouteVerdict.AGREE
+        routeVerdict(
+            route(true, "11:22:33:44:55:aa"),
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner),
+            knownAddresses = setOf(owner, "11:22:33:44:55:AA"),
+        ) shouldBe RouteVerdict.DISAGREE
+    }
+
+    @Test
     fun `phone speaker disagrees with a bluetooth route`() {
-        routeVerdict(route(true, owner), isPhoneSpeaker = true, ownerAddresses = setOf("speaker")) shouldBe RouteVerdict.DISAGREE
+        routeVerdict(
+            route(true, owner),
+            isPhoneSpeaker = true,
+            ownerAddresses = setOf("speaker"),
+            knownAddresses = setOf("speaker", owner),
+        ) shouldBe RouteVerdict.DISAGREE
     }
 
     @Test
     fun `phone speaker agrees with a non-bluetooth route`() {
-        routeVerdict(route(false), isPhoneSpeaker = true, ownerAddresses = setOf("speaker")) shouldBe RouteVerdict.AGREE
+        routeVerdict(
+            route(false),
+            isPhoneSpeaker = true,
+            ownerAddresses = setOf("speaker"),
+            knownAddresses = setOf("speaker"),
+        ) shouldBe RouteVerdict.AGREE
     }
 }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/RouteOwnerAgreementTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/RouteOwnerAgreementTest.kt
@@ -1,0 +1,82 @@
+package eu.darken.bluemusic.monitor.core.audio
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import testhelpers.BaseTest
+
+class RouteOwnerAgreementTest : BaseTest() {
+
+    private val owner = "AA:BB:CC:DD:EE:FF"
+
+    private fun route(isBluetooth: Boolean?, vararg addresses: String) = VolumeTool.MediaRoute(
+        isBluetooth = isBluetooth,
+        addresses = addresses.toSet(),
+        description = "test-route",
+    )
+
+    @Test
+    fun `an unclassifiable route is unknown for both device kinds`() {
+        routeVerdict(route(null), isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.UNKNOWN
+        routeVerdict(route(null), isPhoneSpeaker = true, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.UNKNOWN
+    }
+
+    @Test
+    fun `a missing route is unknown for both device kinds`() {
+        routeVerdict(null, isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.UNKNOWN
+        routeVerdict(null, isPhoneSpeaker = true, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.UNKNOWN
+    }
+
+    @Test
+    fun `bluetooth device disagrees with a non-bluetooth route`() {
+        routeVerdict(route(false), isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.DISAGREE
+    }
+
+    @Test
+    fun `bluetooth device agrees when the route names it`() {
+        routeVerdict(route(true, owner), isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.AGREE
+    }
+
+    @Test
+    fun `bluetooth device agrees when the route has no usable addresses`() {
+        routeVerdict(route(true), isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.AGREE
+        routeVerdict(route(true, "", "   "), isPhoneSpeaker = false, ownerAddresses = setOf(owner)) shouldBe RouteVerdict.AGREE
+    }
+
+    @Test
+    fun `bluetooth device disagrees when the route names a different device`() {
+        routeVerdict(
+            route(true, "11:22:33:44:55:66"),
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner),
+        ) shouldBe RouteVerdict.DISAGREE
+    }
+
+    @Test
+    fun `route naming another member of the owner group agrees`() {
+        // Grouped earbuds: the left bud is routed, the right bud reports the change.
+        routeVerdict(
+            route(true, "11:22:33:44:55:66"),
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner, "11:22:33:44:55:66"),
+        ) shouldBe RouteVerdict.AGREE
+    }
+
+    @Test
+    fun `address comparison ignores case`() {
+        routeVerdict(
+            route(true, "aa:bb:cc:dd:ee:ff"),
+            isPhoneSpeaker = false,
+            ownerAddresses = setOf(owner),
+        ) shouldBe RouteVerdict.AGREE
+    }
+
+    @Test
+    fun `phone speaker disagrees with a bluetooth route`() {
+        routeVerdict(route(true, owner), isPhoneSpeaker = true, ownerAddresses = setOf("speaker")) shouldBe RouteVerdict.DISAGREE
+    }
+
+    @Test
+    fun `phone speaker agrees with a non-bluetooth route`() {
+        routeVerdict(route(false), isPhoneSpeaker = true, ownerAddresses = setOf("speaker")) shouldBe RouteVerdict.AGREE
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeObserverTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeObserverTest.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
@@ -15,6 +16,7 @@ import testhelpers.BaseTest
 class VolumeObserverTest : BaseTest() {
 
     private lateinit var context: Context
+    private lateinit var audioManager: android.media.AudioManager
     private lateinit var audioLevels: MutableMap<AudioStream.Id, Int>
     private lateinit var volumeTool: VolumeTool
 
@@ -26,7 +28,7 @@ class VolumeObserverTest : BaseTest() {
         val contentResolver = mockk<ContentResolver>(relaxed = true)
         fakeTime = 1000L
 
-        val audioManager = mockk<android.media.AudioManager>(relaxed = true)
+        audioManager = mockk(relaxed = true)
         audioLevels = AudioStream.Id.entries.associateWith { 0 }.toMutableMap().apply {
             this[AudioStream.Id.STREAM_MUSIC] = 2
         }
@@ -62,7 +64,7 @@ class VolumeObserverTest : BaseTest() {
         val events = mutableListOf<VolumeEvent>()
         observer.dispatchVolumeChanges(false) { events += it }
 
-        events.single() shouldBe VolumeEvent(
+        events.single().copy(route = null) shouldBe VolumeEvent(
             streamId = AudioStream.Id.STREAM_MUSIC,
             oldVolume = 2,
             newVolume = 11,
@@ -85,12 +87,62 @@ class VolumeObserverTest : BaseTest() {
         val events = mutableListOf<VolumeEvent>()
         observer.dispatchVolumeChanges(true) { events += it }
 
-        events.single() shouldBe VolumeEvent(
+        events.single().copy(route = null) shouldBe VolumeEvent(
             streamId = AudioStream.Id.STREAM_MUSIC,
             oldVolume = 2,
             newVolume = 11,
             self = false,
         )
+    }
+
+    @Test
+    fun `the route is queried once per dispatch and attached to every event`() = runTest {
+        val mockedTool = mockk<VolumeTool>(relaxed = true)
+        val route = VolumeTool.MediaRoute(
+            isBluetooth = true,
+            addresses = setOf("AA:BB:CC:DD:EE:FF"),
+            description = "predicted=[BT_A2DP#8]",
+        )
+        every { mockedTool.wasUs(any(), any()) } returns false
+        every { mockedTool.queryActiveMediaRoute() } returns route
+        every { mockedTool.getCurrentVolume(any()) } returns 3
+
+        val observer = VolumeObserver(
+            context = context,
+            appScope = backgroundScope,
+            volumeTool = mockedTool,
+        )
+        observer.primeCache()
+
+        every { mockedTool.getCurrentVolume(any()) } returns 7
+
+        val events = mutableListOf<VolumeEvent>()
+        observer.dispatchVolumeChanges(false) { events += it }
+
+        events.size shouldBe AudioStream.Id.entries.size
+        events.map { it.route }.toSet() shouldBe setOf(route)
+        verify(exactly = 1) { mockedTool.queryActiveMediaRoute() }
+    }
+
+    @Test
+    fun `a failed route query still emits the volume change`() = runTest {
+        every { audioManager.getDevices(any()) } throws SecurityException("nope")
+
+        val observer = VolumeObserver(
+            context = context,
+            appScope = backgroundScope,
+            volumeTool = volumeTool,
+        )
+        observer.primeCache()
+
+        audioLevels[AudioStream.Id.STREAM_MUSIC] = 11
+
+        val events = mutableListOf<VolumeEvent>()
+        observer.dispatchVolumeChanges(false) { events += it }
+
+        val event = events.single()
+        event.newVolume shouldBe 11
+        event.route?.isBluetooth shouldBe null
     }
 
     private fun toStreamId(id: Int): AudioStream.Id {

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
@@ -358,6 +358,26 @@ class VolumeToolTest : BaseTest() {
         volumeTool.addressesFrom(devices) shouldBe setOf("AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
     }
 
+    @Test
+    fun `bluetoothAddressesFrom keeps bluetooth output addresses only`() {
+        val devices = listOf(
+            audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP, null, "AA:BB:CC:DD:EE:FF"),
+            audioDevice(AudioDeviceInfo.TYPE_USB_HEADSET, null, "card=1;device=0"),
+        )
+
+        volumeTool.bluetoothAddressesFrom(devices) shouldBe setOf("AA:BB:CC:DD:EE:FF")
+    }
+
+    @Test
+    fun `bluetoothAddressesFrom is empty when the bluetooth output has no address`() {
+        val devices = listOf(
+            audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP, null, ""),
+            audioDevice(AudioDeviceInfo.TYPE_USB_HEADSET, null, "card=1;device=0"),
+        )
+
+        volumeTool.bluetoothAddressesFrom(devices) shouldBe emptySet<String>()
+    }
+
     private fun toStreamId(id: Int): AudioStream.Id {
         return AudioStream.Id.entries.first { it.id == id }
     }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
@@ -237,15 +237,15 @@ class VolumeToolTest : BaseTest() {
         )
     }
 
-    // In a pure-JVM test Build.VERSION.SDK_INT is 0, so describeActiveMediaRoute
+    // In a pure-JVM test Build.VERSION.SDK_INT is 0, so queryActiveMediaRoute
     // takes the < API33 fallback branch (getDevices + a2dp/sco booleans).
     @Test
-    fun `describeActiveMediaRoute falls back to available outputs below API33`() = runTest {
+    fun `queryActiveMediaRoute falls back to available outputs below API33`() = runTest {
         every { audioManager.getDevices(AudioManager.GET_DEVICES_OUTPUTS) } returns emptyArray()
         every { audioManager.isBluetoothA2dpOn } returns false
         every { audioManager.isBluetoothScoOn } returns false
 
-        val result = volumeTool.describeActiveMediaRoute()
+        val result = volumeTool.queryActiveMediaRoute().description
 
         result shouldContain "availableOnly=[none]"
         result shouldContain "a2dpOn=false"
@@ -253,10 +253,10 @@ class VolumeToolTest : BaseTest() {
     }
 
     @Test
-    fun `describeActiveMediaRoute swallows route-query failures`() = runTest {
+    fun `queryActiveMediaRoute swallows route-query failures`() = runTest {
         every { audioManager.getDevices(any()) } throws SecurityException("nope")
 
-        volumeTool.describeActiveMediaRoute() shouldBe "route-query-failed: SecurityException: nope"
+        volumeTool.queryActiveMediaRoute().description shouldBe "route-query-failed: SecurityException: nope"
     }
 
     // The API 33+ predicted branch can't run in plain JVM (AudioAttributes.Builder

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/audio/VolumeToolTest.kt
@@ -261,9 +261,10 @@ class VolumeToolTest : BaseTest() {
 
     // The API 33+ predicted branch can't run in plain JVM (AudioAttributes.Builder
     // is a stub), so the formatting is verified directly via the extracted helper.
-    private fun audioDevice(type: Int, product: CharSequence?): AudioDeviceInfo = mockk {
+    private fun audioDevice(type: Int, product: CharSequence?, addr: String = ""): AudioDeviceInfo = mockk {
         every { getType() } returns type
         every { productName } returns product
+        every { getAddress() } returns addr
     }
 
     @Test
@@ -293,6 +294,68 @@ class VolumeToolTest : BaseTest() {
     fun `formatMediaRoute reports none and availableOnly suffix`() {
         volumeTool.formatMediaRoute(active = false, devices = emptyList(), a2dp = false, sco = false, queryMs = 0) shouldBe
             "availableOnly=[none] a2dpOn=false scoOn=false queryMs=0 (no active-route API < API33)"
+    }
+
+    @Test
+    fun `bluetoothRouteFrom is true for every bluetooth output type`() {
+        listOf(
+            AudioDeviceInfo.TYPE_BLUETOOTH_A2DP,
+            AudioDeviceInfo.TYPE_BLUETOOTH_SCO,
+            AudioDeviceInfo.TYPE_HEARING_AID,
+            AudioDeviceInfo.TYPE_BLE_HEADSET,
+            AudioDeviceInfo.TYPE_BLE_SPEAKER,
+            AudioDeviceInfo.TYPE_BLE_BROADCAST,
+        ).forEach { type ->
+            volumeTool.bluetoothRouteFrom(active = true, devices = listOf(audioDevice(type, null))) shouldBe true
+        }
+    }
+
+    @Test
+    fun `bluetoothRouteFrom is true when any routed device is bluetooth`() {
+        val devices = listOf(
+            audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, null),
+            audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP, null),
+        )
+
+        volumeTool.bluetoothRouteFrom(active = true, devices = devices) shouldBe true
+    }
+
+    @Test
+    fun `bluetoothRouteFrom is false for speaker and wired outputs`() {
+        volumeTool.bluetoothRouteFrom(
+            active = true,
+            devices = listOf(audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, null)),
+        ) shouldBe false
+
+        volumeTool.bluetoothRouteFrom(
+            active = true,
+            devices = listOf(audioDevice(AudioDeviceInfo.TYPE_WIRED_HEADPHONES, null)),
+        ) shouldBe false
+    }
+
+    @Test
+    fun `bluetoothRouteFrom is unknown for an empty device list`() {
+        volumeTool.bluetoothRouteFrom(active = true, devices = emptyList()) shouldBe null
+    }
+
+    @Test
+    fun `bluetoothRouteFrom is unknown below API33`() {
+        volumeTool.bluetoothRouteFrom(
+            active = false,
+            devices = listOf(audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP, null)),
+        ) shouldBe null
+    }
+
+    @Test
+    fun `addressesFrom keeps non-blank addresses only`() {
+        val devices = listOf(
+            audioDevice(AudioDeviceInfo.TYPE_BLUETOOTH_A2DP, null, "AA:BB:CC:DD:EE:FF"),
+            audioDevice(AudioDeviceInfo.TYPE_BUILTIN_SPEAKER, null, "   "),
+            audioDevice(AudioDeviceInfo.TYPE_BLE_HEADSET, null, ""),
+            audioDevice(AudioDeviceInfo.TYPE_BLE_SPEAKER, null, "11:22:33:44:55:66"),
+        )
+
+        volumeTool.addressesFrom(devices) shouldBe setOf("AA:BB:CC:DD:EE:FF", "11:22:33:44:55:66")
     }
 
     private fun toStreamId(id: Int): AudioStream.Id {

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
@@ -10,6 +10,7 @@ import eu.darken.bluemusic.monitor.core.audio.RingerTool
 import eu.darken.bluemusic.monitor.core.audio.VolumeMode
 import eu.darken.bluemusic.monitor.core.audio.VolumeTool
 import eu.darken.bluemusic.monitor.core.modules.DeviceEvent
+import eu.darken.bluemusic.monitor.core.service.BluetoothEventQueue
 import io.kotest.matchers.shouldBe
 import io.mockk.Runs
 import io.mockk.coEvery
@@ -20,6 +21,7 @@ import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import testhelpers.BaseTest
 
@@ -83,6 +85,17 @@ class VolumeDisconnectModuleTest : BaseTest() {
     private fun mockStream(id: AudioStream.Id, current: Int, max: Int) {
         every { volumeTool.getCurrentVolume(id) } returns current
         every { volumeTool.getMaxVolume(id) } returns max
+    }
+
+    private fun speakerSourceDevice(): SourceDevice = mockk {
+        every { this@mockk.address } returns this@VolumeDisconnectModuleTest.address
+        every { label } returns "Phone speaker"
+        every { deviceType } returns SourceDevice.Type.PHONE_SPEAKER
+        every { getStreamId(AudioStream.Type.MUSIC) } returns AudioStream.Id.STREAM_MUSIC
+        every { getStreamId(AudioStream.Type.CALL) } returns AudioStream.Id.STREAM_VOICE_CALL
+        every { getStreamId(AudioStream.Type.RINGTONE) } returns AudioStream.Id.STREAM_RINGTONE
+        every { getStreamId(AudioStream.Type.NOTIFICATION) } returns AudioStream.Id.STREAM_NOTIFICATION
+        every { getStreamId(AudioStream.Type.ALARM) } returns AudioStream.Id.STREAM_ALARM
     }
 
     /**
@@ -572,5 +585,111 @@ class VolumeDisconnectModuleTest : BaseTest() {
         // Should not throw. 0.5 * 25 = 12.5 → round → 13. Drift-suppressed.
         val result = runTransform(module, DeviceEvent.Disconnected(device), cfg)
         result.musicVolume shouldBe 0.5f
+    }
+
+    // ------------------------------------------------------------------------
+    // Route/owner agreement — on some devices ACL_DISCONNECTED arrives after the
+    // media route has already left the device, so the snapshot carries the route
+    // classification taken at broadcast time.
+    // ------------------------------------------------------------------------
+    @Nested
+    inner class RouteAgreement {
+
+        private fun route(isBluetooth: Boolean?, vararg addresses: String) = VolumeTool.MediaRoute(
+            isBluetooth = isBluetooth,
+            addresses = addresses.toSet(),
+            description = "test-route",
+        )
+
+        private fun disconnectEvent(route: VolumeTool.MediaRoute?, device: ManagedDevice) = DeviceEvent.Disconnected(
+            device = device,
+            volumeSnapshot = BluetoothEventQueue.VolumeSnapshot(levels = emptyMap(), route = route),
+        )
+
+        private fun allStreamsConfig() = config(
+            musicVolume = 0.5f,
+            callVolume = 0.5f,
+            ringVolume = 0.5f,
+            notificationVolume = 0.5f,
+            alarmVolume = 0.5f,
+        )
+
+        private fun mockAllStreams() {
+            AudioStream.Id.entries.forEach { mockStream(it, current = 11, max = 25) }
+        }
+
+        @Test
+        fun `disagreeing route drops music but keeps the other streams`() = runTest {
+            val module = createModule()
+            val cfg = allStreamsConfig()
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+            mockAllStreams()
+
+            val result = runTransform(module, disconnectEvent(route(false), managedDevice(cfg)), cfg)
+
+            result.musicVolume shouldBe 0.5f
+            result.callVolume shouldBe (11f / 25f)
+            result.ringVolume shouldBe (11f / 25f)
+            result.notificationVolume shouldBe (11f / 25f)
+            result.alarmVolume shouldBe (11f / 25f)
+        }
+
+        @Test
+        fun `route naming the device saves every stream`() = runTest {
+            val module = createModule()
+            val cfg = allStreamsConfig()
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+            mockAllStreams()
+
+            val result = runTransform(module, disconnectEvent(route(true, address), managedDevice(cfg)), cfg)
+
+            result.musicVolume shouldBe (11f / 25f)
+            result.callVolume shouldBe (11f / 25f)
+        }
+
+        @Test
+        fun `unknown route saves every stream`() = runTest {
+            val module = createModule()
+            val cfg = allStreamsConfig()
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+            mockAllStreams()
+
+            val result = runTransform(module, disconnectEvent(route(null), managedDevice(cfg)), cfg)
+
+            result.musicVolume shouldBe (11f / 25f)
+            result.callVolume shouldBe (11f / 25f)
+        }
+
+        @Test
+        fun `bluetooth route drops music for the phone speaker`() = runTest {
+            val module = createModule()
+            val cfg = allStreamsConfig()
+            val speaker = ManagedDevice(isConnected = true, device = speakerSourceDevice(), config = cfg)
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+            mockAllStreams()
+
+            val result = runTransform(
+                module,
+                disconnectEvent(route(true, "AA:BB:CC:DD:EE:01"), speaker),
+                cfg,
+            )
+
+            result.musicVolume shouldBe 0.5f
+            result.callVolume shouldBe (11f / 25f)
+        }
+
+        @Test
+        fun `speaker route saves every stream for the phone speaker`() = runTest {
+            val module = createModule()
+            val cfg = allStreamsConfig()
+            val speaker = ManagedDevice(isConnected = true, device = speakerSourceDevice(), config = cfg)
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+            mockAllStreams()
+
+            val result = runTransform(module, disconnectEvent(route(false), speaker), cfg)
+
+            result.musicVolume shouldBe (11f / 25f)
+            result.callVolume shouldBe (11f / 25f)
+        }
     }
 }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
@@ -19,6 +19,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.slot
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
@@ -33,12 +34,15 @@ class VolumeDisconnectModuleTest : BaseTest() {
     private lateinit var ringerTool: RingerTool
     private lateinit var deviceRepo: DeviceRepo
     private lateinit var sourceDevice: SourceDevice
+    private lateinit var devicesFlow: MutableStateFlow<List<ManagedDevice>>
 
     @BeforeEach
     fun setup() {
         volumeTool = mockk(relaxed = true)
         ringerTool = mockk(relaxed = true)
         deviceRepo = mockk(relaxed = true)
+        devicesFlow = MutableStateFlow(emptyList())
+        every { deviceRepo.devices } returns devicesFlow
         coEvery { deviceRepo.updateDevice(any(), any()) } just Runs
 
         sourceDevice = mockk {
@@ -694,6 +698,46 @@ class VolumeDisconnectModuleTest : BaseTest() {
                 ),
             )
             val result = runTransform(module, event, cfg)
+
+            result.musicVolume shouldBe (11f / 25f)
+            result.callVolume shouldBe (11f / 25f)
+        }
+
+        @Test
+        fun `route naming a different managed device drops music`() = runTest {
+            val module = createModule()
+            val cfg = allStreamsConfig()
+            val otherAddress = "AA:BB:CC:DD:EE:03"
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+            mockAllStreams()
+            devicesFlow.value = listOf(
+                managedDevice(cfg),
+                ManagedDevice(
+                    isConnected = true,
+                    device = mockk(relaxed = true),
+                    config = DeviceConfigEntity(address = otherAddress),
+                ),
+            )
+
+            val result = runTransform(module, disconnectEvent(route(true, otherAddress), managedDevice(cfg)), cfg)
+
+            result.musicVolume shouldBe 0.5f
+            result.callVolume shouldBe (11f / 25f)
+        }
+
+        @Test
+        fun `route naming no managed device saves every stream`() = runTest {
+            val module = createModule()
+            val cfg = allStreamsConfig()
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+            mockAllStreams()
+            devicesFlow.value = listOf(managedDevice(cfg))
+
+            val result = runTransform(
+                module,
+                disconnectEvent(route(true, "AA:BB:CC:DD:EE:03"), managedDevice(cfg)),
+                cfg,
+            )
 
             result.musicVolume shouldBe (11f / 25f)
             result.callVolume shouldBe (11f / 25f)

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeDisconnectModuleTest.kt
@@ -679,6 +679,27 @@ class VolumeDisconnectModuleTest : BaseTest() {
         }
 
         @Test
+        fun `route naming a sibling of the owner group saves every stream`() = runTest {
+            val module = createModule()
+            val cfg = allStreamsConfig()
+            val sibling = "AA:BB:CC:DD:EE:02"
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+            mockAllStreams()
+
+            val event = disconnectEvent(route(true, sibling), managedDevice(cfg)).copy(
+                disconnectResult = eu.darken.bluemusic.monitor.core.ownership.DisconnectResult(
+                    wasInOwnerGroup = true,
+                    ownerGroupBefore = listOf(address, sibling),
+                    ownerGroupAfter = listOf(sibling),
+                ),
+            )
+            val result = runTransform(module, event, cfg)
+
+            result.musicVolume shouldBe (11f / 25f)
+            result.callVolume shouldBe (11f / 25f)
+        }
+
+        @Test
         fun `speaker route saves every stream for the phone speaker`() = runTest {
             val module = createModule()
             val cfg = allStreamsConfig()

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModuleTest.kt
@@ -38,6 +38,23 @@ class VolumeUpdateModuleTest : BaseTest() {
     private lateinit var sourceDevice: SourceDevice
     private lateinit var devicesFlow: MutableStateFlow<List<ManagedDevice>>
 
+    private val unknownRoute = VolumeTool.MediaRoute(
+        isBluetooth = null,
+        addresses = emptySet(),
+        description = "availableOnly=[none]",
+    )
+    private val speakerRoute = VolumeTool.MediaRoute(
+        isBluetooth = false,
+        addresses = emptySet(),
+        description = "predicted=[SPEAKER#2]",
+    )
+
+    private fun btRoute(vararg addresses: String) = VolumeTool.MediaRoute(
+        isBluetooth = true,
+        addresses = addresses.toSet(),
+        description = "predicted=[BT_A2DP#8]",
+    )
+
     @BeforeEach
     fun setup() {
         volumeTool = mockk(relaxed = true)
@@ -50,6 +67,7 @@ class VolumeUpdateModuleTest : BaseTest() {
         coEvery { deviceRepo.updateDevice(any(), any()) } just Runs
         every { volumeTool.getMinVolume(any()) } returns 0
         every { volumeTool.getMaxVolume(any()) } returns 15
+        every { volumeTool.queryActiveMediaRoute() } returns unknownRoute
 
         sourceDevice = mockk {
             every { this@mockk.address } returns this@VolumeUpdateModuleTest.address
@@ -443,10 +461,14 @@ class VolumeUpdateModuleTest : BaseTest() {
     // Multi-device characterization: documents current fan-out behavior
     // ------------------------------------------------------------------------
 
-    private fun makeSourceDevice(addr: String, name: String): SourceDevice = mockk {
+    private fun makeSourceDevice(
+        addr: String,
+        name: String,
+        type: SourceDevice.Type = SourceDevice.Type.HEADPHONES,
+    ): SourceDevice = mockk {
         every { this@mockk.address } returns addr
         every { label } returns name
-        every { deviceType } returns SourceDevice.Type.HEADPHONES
+        every { deviceType } returns type
         every { getStreamId(AudioStream.Type.MUSIC) } returns AudioStream.Id.STREAM_MUSIC
         every { getStreamId(AudioStream.Type.CALL) } returns AudioStream.Id.STREAM_VOICE_CALL
         every { getStreamId(AudioStream.Type.RINGTONE) } returns AudioStream.Id.STREAM_RINGTONE
@@ -727,6 +749,147 @@ class VolumeUpdateModuleTest : BaseTest() {
             )
 
             result.musicVolume shouldBe levelToPercentage(11, 0, 15)
+        }
+    }
+
+    // ------------------------------------------------------------------------
+    // Route/owner agreement — the owner registry only sees ACL broadcasts, the
+    // media route is the second opinion on who is actually playing.
+    // ------------------------------------------------------------------------
+    @Nested
+    inner class RouteAgreement {
+
+        private val speakerAddress = "00:00:00:00:00:00"
+
+        @Test
+        fun `music change is dropped when media no longer routes to the bluetooth owner`() = runTest {
+            val module = createModule()
+            val cfg = config(musicVolume = 0.1f)
+            seedActive(managedDevice(cfg))
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+            handleObserved(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false, route = speakerRoute),
+            )
+
+            coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+        }
+
+        @Test
+        fun `music change persists when the route names the owner`() = runTest {
+            val module = createModule()
+            val cfg = config(musicVolume = 0.1f)
+            seedActive(managedDevice(cfg))
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+            val result = runTransform(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false, route = btRoute(address)),
+                cfg,
+            )
+
+            result.musicVolume shouldBe levelToPercentage(11, 0, 15)
+        }
+
+        @Test
+        fun `music change persists when the route can not classify itself`() = runTest {
+            val module = createModule()
+            val cfg = config(musicVolume = 0.1f)
+            seedActive(managedDevice(cfg))
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+            handleObserved(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false, route = unknownRoute),
+            )
+
+            coVerify(exactly = 1) { deviceRepo.updateDevice(address, any()) }
+        }
+
+        @Test
+        fun `call change persists while media routes to the speaker`() = runTest {
+            // HFP car kit with media audio disabled: it owns the call volume even
+            // though music plays through the phone.
+            val module = createModule()
+            val cfg = config(callVolume = 0.1f)
+            seedActive(managedDevice(cfg))
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+            handleObserved(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_VOICE_CALL, 5, 11, self = false, route = speakerRoute),
+            )
+
+            coVerify(exactly = 1) { deviceRepo.updateDevice(address, any()) }
+        }
+
+        @Test
+        fun `music change is dropped for the phone speaker while media routes to bluetooth`() = runTest {
+            val module = createModule()
+            seedSpeaker()
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+            handleObserved(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false, route = btRoute("AA:BB:CC:DD:EE:01")),
+            )
+
+            coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+        }
+
+        @Test
+        fun `music change persists for the phone speaker while media routes to the speaker`() = runTest {
+            val module = createModule()
+            seedSpeaker()
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+            handleObserved(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false, route = speakerRoute),
+            )
+
+            coVerify(exactly = 1) { deviceRepo.updateDevice(speakerAddress, any()) }
+        }
+
+        @Test
+        fun `music change is dropped when the route still names the previous device`() = runTest {
+            val module = createModule()
+            val cfg = config(musicVolume = 0.1f)
+            seedActive(managedDevice(cfg))
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+            handleObserved(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false, route = btRoute("AA:BB:CC:DD:EE:01")),
+            )
+
+            coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+        }
+
+        private suspend fun seedSpeaker() {
+            val speaker = makeSourceDevice(speakerAddress, "Phone speaker", SourceDevice.Type.PHONE_SPEAKER)
+            val cfg = DeviceConfigEntity(
+                address = speakerAddress,
+                musicVolume = 0.1f,
+                volumeObserving = true,
+                lastConnected = 0L,
+            )
+            devicesFlow.value = listOf(ManagedDevice(isConnected = true, device = speaker, config = cfg))
+            ownerRegistry.onDeviceConnected(
+                address = speakerAddress,
+                label = "Phone speaker",
+                deviceType = SourceDevice.Type.PHONE_SPEAKER,
+                receivedAtElapsedMs = 1000L,
+                sequence = 0L,
+            )
         }
     }
 }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModuleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/modules/volume/VolumeUpdateModuleTest.kt
@@ -863,6 +863,30 @@ class VolumeUpdateModuleTest : BaseTest() {
             val module = createModule()
             val cfg = config(musicVolume = 0.1f)
             seedActive(managedDevice(cfg))
+            // Handoff between two BVM-managed devices: the previous one is already
+            // disconnected but the route still names it.
+            val previousAddress = "AA:BB:CC:DD:EE:01"
+            devicesFlow.value = devicesFlow.value + ManagedDevice(
+                isConnected = false,
+                device = makeSourceDevice(previousAddress, "Previous Device"),
+                config = DeviceConfigEntity(address = previousAddress, musicVolume = 0.1f),
+            )
+
+            every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
+
+            handleObserved(
+                module,
+                VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false, route = btRoute(previousAddress)),
+            )
+
+            coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+        }
+
+        @Test
+        fun `music change persists when the route names no device BVM manages`() = runTest {
+            val module = createModule()
+            val cfg = config(musicVolume = 0.1f)
+            seedActive(managedDevice(cfg))
 
             every { ringerTool.getCurrentRingerMode() } returns RingerMode.NORMAL
 
@@ -871,7 +895,7 @@ class VolumeUpdateModuleTest : BaseTest() {
                 VolumeEvent(AudioStream.Id.STREAM_MUSIC, 5, 11, self = false, route = btRoute("AA:BB:CC:DD:EE:01")),
             )
 
-            coVerify(exactly = 0) { deviceRepo.updateDevice(any(), any()) }
+            coVerify(exactly = 1) { deviceRepo.updateDevice(address, any()) }
         }
 
         private suspend fun seedSpeaker() {


### PR DESCRIPTION
## What changed

Bluetooth devices could end up stuck at silent. On some Android builds the system switches audio away from a Bluetooth device a second or more before it tells apps that the device disconnected. In that window BVM saw the phone speaker's volume arrive as an ordinary volume change and saved it as the Bluetooth device's volume. For anyone whose phone speaker sits at zero, the stored volume became zero and every later connect forced the device silent.

BVM now checks where audio is actually routed before saving a music volume, and only saves when the route and the device agree. Everything else is unchanged: call, ringtone, notification and alarm volumes are untouched, and when the system cannot say where audio is routed BVM saves exactly as it did before.

Refs #232

## Technical Context

- Root cause: stream ownership is driven solely by ACL connect/disconnect broadcasts, so during the pre-disconnect reroute window the disconnecting device is still the recorded owner while the system has already moved audio to the phone speaker. Diagnosed from two user debug logs; the route diagnostic added earlier for #232 is what made the ordering visible.
- The route is sampled where the value it explains is read: in `VolumeObserver` at the instant the new volume is read, and in `MonitorEventReceiver` alongside the synchronous pre-reroute snapshot. Sampling it later at the persist decision reintroduces the stale-read hazard the existing comment there already warned about. Both sites sample once, so the number of platform calls is unchanged.
- Only the music stream is gated. The query asks `USAGE_MEDIA`/`CONTENT_TYPE_MUSIC`, so it answers only where media would play, and an HFP car kit with media audio disabled legitimately owns a call-volume change while media plays through the speaker. On the disconnect path music is dropped alone, so save-on-disconnect keeps working for the other streams.
- Every ambiguity fails open. Below API 33 there is no active-route API, an empty device list carries no information, and without `BLUETOOTH_CONNECT` the platform returns blank addresses; all of these proceed with the save. Address agreement is checked against the whole owner group so grouped earbuds agree with each other, and an address matching no managed device is treated as no information rather than as a mismatch. The failure mode is therefore "the fix does not fire", never "a legitimate save is blocked".
- Worth close review: `RouteOwnerAgreement.routeVerdict` is the single statement of the rule and every branch of it is covered; the two call sites differ only in how they build the owner set. Runtime validation on a device did not complete — the behaviour needs hardware that exhibits the reroute ordering, and the device available for testing blocks programmatic volume control — so the gate was never exercised against a live Bluetooth route and coverage rests on the unit tests.
