### PR TITLE
Update production lane rollout to 100%

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -83,7 +83,7 @@ platform :android do
     supply(
         track: 'beta',
         package_name: 'eu.darken.bluemusic',
-        rollout: '0.10',
+        rollout: '1.0',
         mapping: 'app/build/outputs/mapping/gplayRelease/mapping.txt',
         metadata_path: play_metadata_path,
         skip_upload_changelogs: 'false',


### PR DESCRIPTION
## What changed

No user-facing behavior change. The `production` fastlane lane now uploads at a full 100% rollout instead of a 10% staged fraction.

## Technical Context

- The `beta` lane is untouched and still stages at `rollout: '0.10'`.
- The `production` lane uploads to `track: 'beta'`, which is deliberate: the release build soaks on the beta track and gets promoted to production from the Play Console.