### PR TITLE
Remove unused string resources

### DIFF
--- a/app/src/foss/res/values-af-rZA/strings.xml
+++ b/app/src/foss/res/values-af-rZA/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Vereis BVM FOSS</string>
     <string name="upgrade_prompt_title">Opgradeer na BVM FOSS</string>
     <string name="upgrade_prompt_body">Ontsluit addisionele funksies en word \'n beskermheer om voortgesette ontwikkeling te ondersteun!</string>
-    <string name="upgrade_prompt_upgrade_action">Gradeer Op</string>
     <string name="upgrade_screen_title">Opgradeer na BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager het geen advertensies nie en verkoop nie gebruikersdata nie. Voortgesette ontwikkeling word slegs deur jou moontlik gemaak.</string>
     <string name="upgrade_screen_how_title">Hoe om te help</string>

--- a/app/src/foss/res/values-am/strings.xml
+++ b/app/src/foss/res/values-am/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS ያስፈሉ።</string>
     <string name="upgrade_prompt_title">ወደ BVM FOSS ክበቱ</string>
     <string name="upgrade_prompt_body">ተጨማሪ ባህሪያትን ይክፈቱ እና ቀጣይ ልማትን ለመደገፍ ደጋፊ ይሁኑ!</string>
-    <string name="upgrade_prompt_upgrade_action">አሻሽል</string>
     <string name="upgrade_screen_title">ወደ BVM FOSS ክበቱ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ምንም እዋዀት ይረጋል፣ የተገባይ ውሂብንነም አይሸጥም። የተቆተቀወ ቅብት በእርስዎን ብቼድ ይተቀጥላል።</string>
     <string name="upgrade_screen_how_title">እንዴት መርዳት እንደሚችሉ</string>

--- a/app/src/foss/res/values-ar/strings.xml
+++ b/app/src/foss/res/values-ar/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">يتطلب BVM FOSS</string>
     <string name="upgrade_prompt_title">الترقية إلى BVM FOSS</string>
     <string name="upgrade_prompt_body">افتح ميزات إضافية وكن راعياً لدعم التطوير المستمر!</string>
-    <string name="upgrade_prompt_upgrade_action">تحديث</string>
     <string name="upgrade_screen_title">الترقية إلى BVM FOSS</string>
     <string name="upgrade_screen_preamble">لا يعرض Bluetooth Volume Manager أية إعلانات ولا يبيع بيانات المستخدم. التطوير المستمر ممكن فقط بدعمكم.</string>
     <string name="upgrade_screen_how_title">كيف أساعدك</string>

--- a/app/src/foss/res/values-az/strings.xml
+++ b/app/src/foss/res/values-az/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS tələb olunur</string>
     <string name="upgrade_prompt_title">BVM FOSS-a yüksəldin</string>
     <string name="upgrade_prompt_body">Əlavə xüsusiyyətləri açın və davamlı inkişafı dəstəkləmək üçün himayədar olun!</string>
-    <string name="upgrade_prompt_upgrade_action">Yüksəlt</string>
     <string name="upgrade_screen_title">BVM FOSS-a yüksəldin</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-də reklam yoxdur və istifadəçi məlumatlarını satmır. Davamlı inkışaf yalnız sizin sayənizdə mümkündür.</string>
     <string name="upgrade_screen_how_title">Necə kömək etmək</string>

--- a/app/src/foss/res/values-be/strings.xml
+++ b/app/src/foss/res/values-be/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Патрабуе BVM FOSS</string>
     <string name="upgrade_prompt_title">Перайсці на BVM FOSS</string>
     <string name="upgrade_prompt_body">Адкрыйце дадатковыя функцыі і станьце спонсарам, каб падтрымаць далейшую распрацоўку!</string>
-    <string name="upgrade_prompt_upgrade_action">Абнавіць</string>
     <string name="upgrade_screen_title">Перайсці на BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не мае рэкламы і не прадае дадзеныя карыстальнікаў. Працягнення разработкі магчыма толькі дзякуючы вам.</string>
     <string name="upgrade_screen_how_title">Як дапамагчы</string>

--- a/app/src/foss/res/values-bg/strings.xml
+++ b/app/src/foss/res/values-bg/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Изисква BVM FOSS</string>
     <string name="upgrade_prompt_title">Надграждане до BVM FOSS</string>
     <string name="upgrade_prompt_body">Отключете допълнителни функции и станете покровител, за да подкрепите непрекъснатото развитие!</string>
-    <string name="upgrade_prompt_upgrade_action">Ъпгрейд</string>
     <string name="upgrade_screen_title">Надграждане до BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager няма реклами и не продава потребителски данни. Непрекъснатото развитие е възможно само благодарение на вас.</string>
     <string name="upgrade_screen_how_title">Как да помогнете</string>

--- a/app/src/foss/res/values-bn-rBD/strings.xml
+++ b/app/src/foss/res/values-bn-rBD/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS প্রয়োজন</string>
     <string name="upgrade_prompt_title">BVM FOSS-এ আপগ্রেড করুন</string>
     <string name="upgrade_prompt_body">অতিরিক্ত ফিচার আনলক করুন এবং ক্রমাগত বিকাশকে সমর্থন করার জন্য একজন পৃষ্ঠপোষক হন!</string>
-    <string name="upgrade_prompt_upgrade_action">আপগ্রেড করুন</string>
     <string name="upgrade_screen_title">BVM FOSS-এ আপগ্রেড করুন</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-এ কোনো বিজ্ঞাপন নেই এবং ব্যবহারকারীর তথ্য বিক্রি করে না। চলমান উন্নয়ন শুধুমাত্র আপনার দ্বারা সম্ভব।</string>
     <string name="upgrade_screen_how_title">কিভাবে সাহায্য করতে পারি</string>

--- a/app/src/foss/res/values-ca/strings.xml
+++ b/app/src/foss/res/values-ca/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Requereix BVM FOSS</string>
     <string name="upgrade_prompt_title">Millora a BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloquegeu funcions addicionals i convertiu-vos en mecenes per donar suport al continuïtat del suport!</string>
-    <string name="upgrade_prompt_upgrade_action">Actualitza</string>
     <string name="upgrade_screen_title">Millora a BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no té anuncis i no ven dades d’usuari. El desenvolupament continuat només és possible gràcies a vosaltres.</string>
     <string name="upgrade_screen_how_title">Com ajudar</string>

--- a/app/src/foss/res/values-cs/strings.xml
+++ b/app/src/foss/res/values-cs/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Vyžaduje BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgradovat na BVM FOSS</string>
     <string name="upgrade_prompt_body">Odemkněte další funkce a staňte se patronem, který podpoří další vývoj!</string>
-    <string name="upgrade_prompt_upgrade_action">Upgradovat</string>
     <string name="upgrade_screen_title">Upgradovat na BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neobsahuje žádné reklamy a neprodává data uživatelů. Další vývoj je možný pouze díky vám.</string>
     <string name="upgrade_screen_how_title">Jak pomoci</string>

--- a/app/src/foss/res/values-da/strings.xml
+++ b/app/src/foss/res/values-da/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Kræver BVM FOSS</string>
     <string name="upgrade_prompt_title">Opgrader til BVM FOSS</string>
     <string name="upgrade_prompt_body">Lås op for flere funktioner, og bliv patron for at støtte den fortsatte udvikling!</string>
-    <string name="upgrade_prompt_upgrade_action">Opgrader</string>
     <string name="upgrade_screen_title">Opgrader til BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen reklamer og sælger ikke brugerdata. Fortsat udvikling er kun muliggjort af dig.</string>
     <string name="upgrade_screen_how_title">Sådan hjælper du</string>

--- a/app/src/foss/res/values-de/strings.xml
+++ b/app/src/foss/res/values-de/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Erfordert BVM FOSS</string>
     <string name="upgrade_prompt_title">Auf BVM FOSS upgraden</string>
     <string name="upgrade_prompt_body">Schalte zusätzliche Funktionen frei und werde Patron, um die Weiterentwicklung zu unterstützen!</string>
-    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
     <string name="upgrade_screen_title">Auf BVM FOSS upgraden</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager enthält keine Werbung und verkauft keine Nutzerdaten. Die Weiterentwicklung wird nur durch dich ermöglicht.</string>
     <string name="upgrade_screen_how_title">Wie kann ich helfen?</string>

--- a/app/src/foss/res/values-el/strings.xml
+++ b/app/src/foss/res/values-el/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Απαιτεί το BVM FOSS</string>
     <string name="upgrade_prompt_title">Αναβαθμίστε στο BVM FOSS</string>
     <string name="upgrade_prompt_body">Ξεκλειδώστε πρόσθετες δυνατότητες και γίνετε patron για να υποστηρίξετε τη συνεχή ανάπτυξη!</string>
-    <string name="upgrade_prompt_upgrade_action">Αναβάθμιση</string>
     <string name="upgrade_screen_title">Αναβαθμίστε στο BVM FOSS</string>
     <string name="upgrade_screen_preamble">Το Bluetooth Volume Manager δεν έχει διαφημίσεις και δεν πωλεί δεδομένα χρηστών. Η συνεχής ανάπτυξη είναι δυνατή μόνο χάρη σε εσάς.</string>
     <string name="upgrade_screen_how_title">Πώς να βοηθήσετε</string>

--- a/app/src/foss/res/values-eo-rUY/strings.xml
+++ b/app/src/foss/res/values-eo-rUY/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Postulas BVM FOSS</string>
     <string name="upgrade_prompt_title">Plibonigi al BVM FOSS</string>
     <string name="upgrade_prompt_body">Malŝlosi pliajn funkciojn kaj fiĝiĝi patrono por subteni daŭran disvolvadon!</string>
-    <string name="upgrade_prompt_upgrade_action">Plibonigi</string>
     <string name="upgrade_screen_title">Plibonigi al BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ne havas reklamojn kaj ne vendas uzantoajn datumojn. Daŭra disvolvado estas ebligita nur de vi.</string>
     <string name="upgrade_screen_how_title">Kiel helpi</string>

--- a/app/src/foss/res/values-es-rAR/strings.xml
+++ b/app/src/foss/res/values-es-rAR/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Requiere BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">¡Desbloqueá funciones adicionales y hacete patreon para ayudar a continuar el desarrollo!</string>
-    <string name="upgrade_prompt_upgrade_action">Mejorar</string>
     <string name="upgrade_screen_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende datos de usuario. El desarrollo continuo solo es posible gracias a vos.</string>
     <string name="upgrade_screen_how_title">Como ayudar</string>

--- a/app/src/foss/res/values-es-rMX/strings.xml
+++ b/app/src/foss/res/values-es-rMX/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Requiere BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">¡Desbloquea funciones adicionales y conviértete en pratrocinador para apoyar el desarrollo continuo!</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizar</string>
     <string name="upgrade_screen_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene publicidad y no vende datos de usuarios. El desarrollo continuo solo es posible gracias a ti.</string>
     <string name="upgrade_screen_how_title">Cómo ayudar</string>

--- a/app/src/foss/res/values-es/strings.xml
+++ b/app/src/foss/res/values-es/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Requiere BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">¡Desbloquea las funciones adicionales y conviértete en patrocinador para apoyar el desarrollo continuo!</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizar</string>
     <string name="upgrade_screen_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende los datos de los usuarios. El desarrollo continuo solo es posible gracias a ti.</string>
     <string name="upgrade_screen_how_title">Como ayudar</string>

--- a/app/src/foss/res/values-et-rEE/strings.xml
+++ b/app/src/foss/res/values-et-rEE/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Vajab BVM FOSS versiooni</string>
     <string name="upgrade_prompt_title">Uuenda BVM FOSS-iks</string>
     <string name="upgrade_prompt_body">Lubage lisavõimalused ja hakake toetajaks, et edendada arendamist.</string>
-    <string name="upgrade_prompt_upgrade_action">Täienda</string>
     <string name="upgrade_screen_title">Uuenda BVM FOSS-iks</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manageris pole reklaame ja see ei müü kasutajaandmeid. Jätkuv arendamine on võimalik vaid teie abil.</string>
     <string name="upgrade_screen_how_title">Kuidas aidata?</string>

--- a/app/src/foss/res/values-eu-rES/strings.xml
+++ b/app/src/foss/res/values-eu-rES/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS beharrezkoa da</string>
     <string name="upgrade_prompt_title">Berritu BVM FOSS-era</string>
     <string name="upgrade_prompt_body">Eginbide gehigarriak desblokeatu eta babesle izan etengabeko garapena laguntzeko!</string>
-    <string name="upgrade_prompt_upgrade_action">Eguneratu</string>
     <string name="upgrade_screen_title">Berritu BVM FOSS-era</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ek ez du iragarkirik eta ez du erabiltzailearen daturik saltzen. Garapenarekin jarraitzea zuk soilik egiten da posible.</string>
     <string name="upgrade_screen_how_title">Nola lagundu</string>

--- a/app/src/foss/res/values-fa/strings.xml
+++ b/app/src/foss/res/values-fa/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">نیاز به BVM FOSS دارد</string>
     <string name="upgrade_prompt_title">ارتقاء به BVM FOSS</string>
     <string name="upgrade_prompt_body">قفل ویژگی های اضافی را باز کنید و برای حمایت از توسعه مداوم، حامی شوید!</string>
-    <string name="upgrade_prompt_upgrade_action">ارتقاء</string>
     <string name="upgrade_screen_title">ارتقاء به BVM FOSS</string>
     <string name="upgrade_screen_preamble">مدیر صدای بلوتوث تبلیغات ندارد و داده‌های کاربر را نمی‌فروشد. توسعه مداوم تنها با کمک شما ممکن می‌شود.</string>
     <string name="upgrade_screen_how_title">چگونه کمک کنیم</string>

--- a/app/src/foss/res/values-fi/strings.xml
+++ b/app/src/foss/res/values-fi/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Vaatii BVM FOSS:in</string>
     <string name="upgrade_prompt_title">Päivitä BVM FOSS:iin</string>
     <string name="upgrade_prompt_body">Avaa lisäominaisuuksia ja ryhdy tukijaksi tukeaksesi jatkuvaa kehitystä!</string>
-    <string name="upgrade_prompt_upgrade_action">Päivitä</string>
     <string name="upgrade_screen_title">Päivitä BVM FOSS:iin</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerissa ei ole mainoksia eikä se myy käyttäjätietoja. Jatkuva kehitys on mahdollista vain sinun avullasi.</string>
     <string name="upgrade_screen_how_title">Kuinka auttaa</string>

--- a/app/src/foss/res/values-fil/strings.xml
+++ b/app/src/foss/res/values-fil/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Nangangailangan ng BVM FOSS</string>
     <string name="upgrade_prompt_title">I-upgrade sa BVM FOSS</string>
     <string name="upgrade_prompt_body">I-unlock ang mga karagdagang feature at maging patron para suportahan ang patuloy na development!</string>
-    <string name="upgrade_prompt_upgrade_action">I-upgrade</string>
     <string name="upgrade_screen_title">I-upgrade sa BVM FOSS</string>
     <string name="upgrade_screen_preamble">Walang mga ads ang Bluetooth Volume Manager at hindi nagbebenta ng data ng user. Ang patuloy na development ay posible lamang dahil sa inyo.</string>
     <string name="upgrade_screen_how_title">Paano tumulong</string>

--- a/app/src/foss/res/values-fr/strings.xml
+++ b/app/src/foss/res/values-fr/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Nécessite BVM FOSS</string>
     <string name="upgrade_prompt_title">Passer à BVM FOSS</string>
     <string name="upgrade_prompt_body">Débloquez des fonctions supplémentaires et devenez mécène pour soutenir le développement continu.</string>
-    <string name="upgrade_prompt_upgrade_action">Surclasser</string>
     <string name="upgrade_screen_title">Passer à BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n’affiche pas de publicités et ne vend pas les données des utilisateurs. La poursuite du développement n’est possible que grâce à vous.</string>
     <string name="upgrade_screen_how_title">Comment aider</string>

--- a/app/src/foss/res/values-gl-rES/strings.xml
+++ b/app/src/foss/res/values-gl-rES/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Require BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloquea características adicionais e convértete en mecenas para apoiar o desenvolvemento continuo!</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizar</string>
     <string name="upgrade_screen_title">Actualizar a BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non ten anuncios e non vende datos de usuario. O desenvolvemento continuo só é posible grazas a ti.</string>
     <string name="upgrade_screen_how_title">Como axudar</string>

--- a/app/src/foss/res/values-hi-rIN/strings.xml
+++ b/app/src/foss/res/values-hi-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS आवश्यक है</string>
     <string name="upgrade_prompt_title">BVM FOSS में अपग्रेड करें</string>
     <string name="upgrade_prompt_body">अतिरिक्त सुविधाओं को अनलॉक करें और निरंतर विकास का समर्थन करने के लिए संरक्षक बनें!</string>
-    <string name="upgrade_prompt_upgrade_action">अपग्रेड</string>
     <string name="upgrade_screen_title">BVM FOSS में अपग्रेड करें</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager में कोई विज्ञापन नहीं है और वह उपयोगकर्ता डेटा नहीं बेचता। निरंतर विकास केवल आपकी वजह से संभव है।</string>
     <string name="upgrade_screen_how_title">कैसे सहायता करें</string>

--- a/app/src/foss/res/values-hr/strings.xml
+++ b/app/src/foss/res/values-hr/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Zahtijeva BVM FOSS</string>
     <string name="upgrade_prompt_title">Nadogradite na BVM FOSS</string>
     <string name="upgrade_prompt_body">Otključajte dodatne značajke i postanite pokrovitelj kako biste podržali daljnji razvoj!</string>
-    <string name="upgrade_prompt_upgrade_action">Nadogradi</string>
     <string name="upgrade_screen_title">Nadogradite na BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nema oglasa i ne prodaje korisničke podatke. Kontinuirani razvoj omogućen je samo zbog vas.</string>
     <string name="upgrade_screen_how_title">Kako pomoći</string>

--- a/app/src/foss/res/values-hu/strings.xml
+++ b/app/src/foss/res/values-hu/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS szükséges</string>
     <string name="upgrade_prompt_title">Frissítés BVM FOSS-ra</string>
     <string name="upgrade_prompt_body">Fedezze fel a további funkciókat, és legyen patron támogató, hogy támogassa a folyamatos fejlesztést!</string>
-    <string name="upgrade_prompt_upgrade_action">Frissítés</string>
     <string name="upgrade_screen_title">Frissítés BVM FOSS-ra</string>
     <string name="upgrade_screen_preamble">A Bluetooth Volume Manager nem tartalmaz hirdetéseket, és nem értékesít felhasználói adatokat. A folyamatos fejlesztést csak te teszed lehetővé.</string>
     <string name="upgrade_screen_how_title">Hogyan lehet segíteni</string>

--- a/app/src/foss/res/values-hy-rAM/strings.xml
+++ b/app/src/foss/res/values-hy-rAM/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Պահանջվում է BVM FOSS</string>
     <string name="upgrade_prompt_title">Անցնել BVM FOSS-ին</string>
     <string name="upgrade_prompt_body">Բացեք լրացուցիչ գործառույթներ և դարձեք հովանավոր՝ շարունակական զարգացումը աջակցելու համար:</string>
-    <string name="upgrade_prompt_upgrade_action">Թարմացնել</string>
     <string name="upgrade_screen_title">Անցնել դևպի BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ում գովազդներ չկան և ուժղատության տվյալներ չի վարարկում։ Միայն դզեր կողմից ե հնարավոր շարունակ զարգացումն։</string>
     <string name="upgrade_screen_how_title">Ինչպես օգնել</string>

--- a/app/src/foss/res/values-in/strings.xml
+++ b/app/src/foss/res/values-in/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Membutuhkan BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgrade ke BVM FOSS</string>
     <string name="upgrade_prompt_body">Buka fitur-fitur tambahan dan jadilah penyokong yang mendukung pengembangan yang berkelanjutan!</string>
-    <string name="upgrade_prompt_upgrade_action">Tingkatkan</string>
     <string name="upgrade_screen_title">Upgrade ke BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tidak menampilkan iklan dan tidak menjual data pengguna. Pengembangan yang berkelanjutan hanya bisa dilakukan berkat Anda.</string>
     <string name="upgrade_screen_how_title">Cara membantu</string>

--- a/app/src/foss/res/values-is/strings.xml
+++ b/app/src/foss/res/values-is/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Krefst BVM FOSS</string>
     <string name="upgrade_prompt_title">Uppfæra í BVM FOSS</string>
     <string name="upgrade_prompt_body">Opnaðu viðbótareiginleika og vertu styrktaraðili til að styðja áframhaldandi þróun!</string>
-    <string name="upgrade_prompt_upgrade_action">Uppfæra</string>
     <string name="upgrade_screen_title">Uppfæra í BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager birtir engar auglýsingar og selur ekki notendagögn. Áframhaldandi þróun er eingungu möguleg þökk sé þér.</string>
     <string name="upgrade_screen_how_title">Hvernig á að hjálpa</string>

--- a/app/src/foss/res/values-it/strings.xml
+++ b/app/src/foss/res/values-it/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Richiede BVM FOSS</string>
     <string name="upgrade_prompt_title">Aggiorna a BVM FOSS</string>
     <string name="upgrade_prompt_body">Sblocca funzioni aggiuntive e diventa un sostenitore per supportare lo sviluppo continuo!</string>
-    <string name="upgrade_prompt_upgrade_action">Acquista</string>
     <string name="upgrade_screen_title">Aggiorna a BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non contiene pubblicità e non vende i dati degli utenti. Lo sviluppo continuo è possibile solo grazie a te.</string>
     <string name="upgrade_screen_how_title">Come aiutare</string>

--- a/app/src/foss/res/values-iw/strings.xml
+++ b/app/src/foss/res/values-iw/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">דורש BVM FOSS</string>
     <string name="upgrade_prompt_title">שדרג ל-BVM FOSS</string>
     <string name="upgrade_prompt_body">בטל נעילה של תכונות נוספות והפוך לפטרון לתמיכה בהמשך הפיתוח!</string>
-    <string name="upgrade_prompt_upgrade_action">שדרוג</string>
     <string name="upgrade_screen_title">שדרג ל-BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ללא מודעות ואינה מוכרת נתוני משתמשים. המשך הפיתוח מתאפשר רק על ידך.</string>
     <string name="upgrade_screen_how_title">איך לעזור</string>

--- a/app/src/foss/res/values-ja/strings.xml
+++ b/app/src/foss/res/values-ja/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS が必要です</string>
     <string name="upgrade_prompt_title">BVM FOSS にアップグレード</string>
     <string name="upgrade_prompt_body">開発を続けるためパトロンになって追加機能を解除してください</string>
-    <string name="upgrade_prompt_upgrade_action">アップグレード</string>
     <string name="upgrade_screen_title">BVM FOSS にアップグレード</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerは広告がなく、ユーザーデータを販売しません。継続的な開発は、あなたのおかげで成り立っています。</string>
     <string name="upgrade_screen_how_title">協力するには</string>

--- a/app/src/foss/res/values-ka-rGE/strings.xml
+++ b/app/src/foss/res/values-ka-rGE/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">საჭიროა BVM FOSS</string>
     <string name="upgrade_prompt_title">გადაიდგეს BVM FOSS-ზე</string>
     <string name="upgrade_prompt_body">განბლოკეთ დამატებითი ფუნქციები და გახდით მფარველი მუდმივი განვითარების მხარდასაჭერად!</string>
-    <string name="upgrade_prompt_upgrade_action">გარემონტება</string>
     <string name="upgrade_screen_title">გადაიდგეს BVM FOSS-ზე</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager რეკლამაგარეშია და მომხმარეთა მონაცემებს არ ყიდის. განვითარებად განვითარება მხოლოდ მხოლოდ შესაძლებელია ერთიადად თქვენით.</string>
     <string name="upgrade_screen_how_title">როგორ დაგეხმაროთ</string>

--- a/app/src/foss/res/values-km-rKH/strings.xml
+++ b/app/src/foss/res/values-km-rKH/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">ត្រូវការ BVM FOSS</string>
     <string name="upgrade_prompt_title">ធ្វើឱ្យប្រសើរទៅ BVM FOSS</string>
     <string name="upgrade_prompt_body">ដោះសោមុខងារបន្ថែម និងក្លាយជាអ្នកឧបត្ថម្ភដើម្បីគាំទ្រការអភិវឌ្ឍន៍បន្ត!</string>
-    <string name="upgrade_prompt_upgrade_action">វិសិដ្ឋកម្ម</string>
     <string name="upgrade_screen_title">ធ្វើឱ្យប្រសើរទៅ BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager មិនមានការផ្សាយពាណិជ្ជកម្ម ហើយមិនលក់ទិន្នន័យអ្នកប្រើប្រាស់ទេ។ ការអភិវឌ្ឍន៍ជាបន្ត​បន្ទាប់ត្រូវបានធ្វើឱ្យអាចធ្វើទៅបានតែដោយអ្នកប្រើ។</string>
     <string name="upgrade_screen_how_title">របៀបជួយ</string>

--- a/app/src/foss/res/values-kmr-rTR/strings.xml
+++ b/app/src/foss/res/values-kmr-rTR/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS hewce dike</string>
     <string name="upgrade_prompt_title">Biçe BVM FOSS</string>
     <string name="upgrade_prompt_body">Taybetmendîên zêde veke!</string>
-    <string name="upgrade_prompt_upgrade_action">Nûjen bike</string>
     <string name="upgrade_screen_title">Biçe BVM FOSS</string>
     <string name="upgrade_screen_preamble">BVM reklamê nake. Geşedana berdewam tenê bi we gengaz e.</string>
     <string name="upgrade_screen_how_title">Çawa bipşixe</string>

--- a/app/src/foss/res/values-kn-rIN/strings.xml
+++ b/app/src/foss/res/values-kn-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS ಅಗತ್ಯ</string>
     <string name="upgrade_prompt_title">BVM FOSS ಗೆ ದರ್ಜೆಯೇರಿ</string>
     <string name="upgrade_prompt_body">ಹೆಚ್ಚಿನ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಅನ್ಲಾಕ್ ಮಾಡಿ ಮತ್ತು ನಿರಂತರ ಅಭಿವರ್ಧನೆಗೆ ಬೆಂಬಲಿಸಲು ಪ್ರಾಯೋಜಕರಾಗಿ!</string>
-    <string name="upgrade_prompt_upgrade_action">ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ</string>
     <string name="upgrade_screen_title">BVM FOSS ಗೆ ದರ್ಜೆಯೇರಿ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ಜಾಹೀರಾತುಗಳಿಲ್ಲ ಮತ್ತು ಬಳಕೆದಾರರ ಡೇಟಾ ಮಾರಾಟುವುದಿಲ್ಲ. ನಿಮ್ಮಿಂದ ಮಾತ್ರ ನಿರಂತರ ಅಭಿವರ್ಧನೆ ಸಾಧ್ಯ.</string>
     <string name="upgrade_screen_how_title">ಸಹಾಯ ಮಾಡುವ ವಿಧಾನ</string>

--- a/app/src/foss/res/values-ko/strings.xml
+++ b/app/src/foss/res/values-ko/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS가 필요합니다</string>
     <string name="upgrade_prompt_title">BVM FOSS로 업그레이드</string>
     <string name="upgrade_prompt_body">후원자가 되어 앱 개발을 지원하고 추가 기능을 잠금해제 하세요!</string>
-    <string name="upgrade_prompt_upgrade_action">업그레이드</string>
     <string name="upgrade_screen_title">BVM FOSS로 업그레이드</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager는 광고가 없고 유저 데이터를 팔지 않습니다. 지속적인 개발은 여러분이 있기에 가능합니다.</string>
     <string name="upgrade_screen_how_title">도움 주기</string>

--- a/app/src/foss/res/values-ky-rKG/strings.xml
+++ b/app/src/foss/res/values-ky-rKG/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS талап кылат</string>
     <string name="upgrade_prompt_title">BVM FOSS га өтүү</string>
     <string name="upgrade_prompt_body">Кошумча функцияларды ачыңыз жана үзгөлтүрүлгөн ишкерленишти колдоо үчүн патрон болуңуз!</string>
-    <string name="upgrade_prompt_upgrade_action">Жаңыртуу</string>
     <string name="upgrade_screen_title">BVM FOSS га өтүү</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager жарнамаларсыз жана пайдалануучулардын мәлиматын сатпайт. Үзгөлтүрүлгөн ишкерлениш тек сиздин аркасында мүмкүн.</string>
     <string name="upgrade_screen_how_title">Калай жардам берүүгө</string>

--- a/app/src/foss/res/values-lo-rLA/strings.xml
+++ b/app/src/foss/res/values-lo-rLA/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">ຕ້ອງການ BVM FOSS</string>
     <string name="upgrade_prompt_title">ອັບເກຣດເປັນ BVM FOSS</string>
     <string name="upgrade_prompt_body">ປົດລັອກຄຸນສົມບັດເພີ່ມເຕີມ ແລະ ກາຍເປັນຜູ້ອຸປະຖໍາເພື່ອສະໜັບສະໜູນການພັດທະນາຢ່າງຕໍ່ເນື່ອງ!</string>
-    <string name="upgrade_prompt_upgrade_action">ອັບເກຣດ</string>
     <string name="upgrade_screen_title">ອັບເກຣດເປັນ BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ບ່ມີໂຆສນາແລະບ່ຂາຍຂ້ອມູນຜູ້ໃຊ້. ການພັດທນາຕ່ອເນື່ອງເປັນໄປໄດ້ໂດຍມີທ່ານເທ່ານັ້ນ.</string>
     <string name="upgrade_screen_how_title">ວິທີການຊ່ວຍເຫຼືອ</string>

--- a/app/src/foss/res/values-lt/strings.xml
+++ b/app/src/foss/res/values-lt/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Reikia BVM FOSS</string>
     <string name="upgrade_prompt_title">Atnaujinti į BVM FOSS</string>
     <string name="upgrade_prompt_body">Atrakinkite papildomas funkcijas ir tapkite globėju, kad palaikytumėte tolesnį plėtojimą!</string>
-    <string name="upgrade_prompt_upgrade_action">Atnaujinti</string>
     <string name="upgrade_screen_title">Atnaujinti į BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neturi reklamų ir neparduoda naudotojų duomenų. Tolesnė plėtra įmanoma tik dėka jūsų.</string>
     <string name="upgrade_screen_how_title">Kaip padėti</string>

--- a/app/src/foss/res/values-lv/strings.xml
+++ b/app/src/foss/res/values-lv/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Nepieciešams BSP FOSS</string>
     <string name="upgrade_prompt_title">Jaunināt uz BSP FOSS</string>
     <string name="upgrade_prompt_body">Atslēdz papildu iespējas un kļūsti par aizbildni, lai atbalstītu izstrādes nepārtrauktību!</string>
-    <string name="upgrade_prompt_upgrade_action">Jaunināt</string>
     <string name="upgrade_screen_title">Jaunināt uz BSP FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth skaļuma pārvaldniekā nav reklāmu, un tas nepārdod lietotāju datus. Izstrādes nepārtrauktība ir iespējama tikai pateicoties jums.</string>
     <string name="upgrade_screen_how_title">Kā palīdzēt</string>

--- a/app/src/foss/res/values-mk-rMK/strings.xml
+++ b/app/src/foss/res/values-mk-rMK/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Потребен е BVM FOSS</string>
     <string name="upgrade_prompt_title">Надгради на BVM FOSS</string>
     <string name="upgrade_prompt_body">Отклучете дополнителни функции и станете покровител за да го поддржите континуираниот развој!</string>
-    <string name="upgrade_prompt_upgrade_action">Надградба</string>
     <string name="upgrade_screen_title">Надгради на BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклами и не продава кориснички податоци. Континуираниот развој е можен само благодарение на вас.</string>
     <string name="upgrade_screen_how_title">Како да помогнете</string>

--- a/app/src/foss/res/values-ml-rIN/strings.xml
+++ b/app/src/foss/res/values-ml-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS ആവശ്യമാണ്</string>
     <string name="upgrade_prompt_title">BVM FOSS യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrade_prompt_body">കൂടുതൽ സവിശേഷതകൾ അൺലോക്കുചെയ്‌ത് തുടർ വികസനത്തെ പിന്തുണയ്ക്കുന്നതിന് ഒരു പാട്രോൺ ആകുക!</string>
-    <string name="upgrade_prompt_upgrade_action">അപ്ഗ്രേഡുചെയ്യുക</string>
     <string name="upgrade_screen_title">BVM FOSS യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager പ്രജ്ഞാപനങ്ങൾ ഇല്ല, ഉപയോക്തൃ ഡേറ്റ വിൽക്കുന്നില്ല. ഐക്കമാന വികസനം നിങ്ങൾ വഴി മാത്രം സാധ്യമാകുന്നു.</string>
     <string name="upgrade_screen_how_title">എങ്ങനെ സഹായിക്കാം</string>

--- a/app/src/foss/res/values-mn-rMN/strings.xml
+++ b/app/src/foss/res/values-mn-rMN/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS шаардлагана</string>
     <string name="upgrade_prompt_title">BVM FOSS рүү шилжээх</string>
     <string name="upgrade_prompt_body">Нэмэлт боломжуудыг нээж, тасралтгүй хөгжлийг дэмжихийн тулд ивээн тэтгэгч болоорой!</string>
-    <string name="upgrade_prompt_upgrade_action">Сайжруулах</string>
     <string name="upgrade_screen_title">BVM FOSS рүү шилжээх</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager сурталчилгаагүй бөгөөд хэрэглэгчийн өгөгдлийг зардаггүй. Цаашид хөгжлөлт зөвхөн тань боломжтой болгог.</string>
     <string name="upgrade_screen_how_title">Хэрхэн тусламж үзүүлэх</string>

--- a/app/src/foss/res/values-mr-rIN/strings.xml
+++ b/app/src/foss/res/values-mr-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS आवश्यक आहे</string>
     <string name="upgrade_prompt_title">BVM FOSS वर अपग्रेड करा</string>
     <string name="upgrade_prompt_body">अद्यावत वैशिष्ट्ये अनलॉक करा आणि सतत विकासास सहाय्य करण्यासाठी प्रायोजक व्हा!</string>
-    <string name="upgrade_prompt_upgrade_action">अपग्रेड करा</string>
     <string name="upgrade_screen_title">BVM FOSS वर अपग्रेड करा</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ला कोणतीही अॅड नाही आणि वापरकर्त्यांचा डेटा विकत नाही. सतत विकास केवळ तुमच्यामुळेही शक्य आहे.</string>
     <string name="upgrade_screen_how_title">कसे मदत करावी</string>

--- a/app/src/foss/res/values-ms/strings.xml
+++ b/app/src/foss/res/values-ms/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Memerlukan BVM FOSS</string>
     <string name="upgrade_prompt_title">Naik taraf ke BVM FOSS</string>
     <string name="upgrade_prompt_body">Buka kunci ciri tambahan dan menjadi penaung untuk menyokong pembangunan berterusan!</string>
-    <string name="upgrade_prompt_upgrade_action">Naik taraf</string>
     <string name="upgrade_screen_title">Naik taraf ke BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tiada iklan dan tidak menjual data pengguna. Pembangunan berterusan hanya boleh dilakukan dengan sokongan anda.</string>
     <string name="upgrade_screen_how_title">Bagaimana untuk membantu</string>

--- a/app/src/foss/res/values-my-rMM/strings.xml
+++ b/app/src/foss/res/values-my-rMM/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS လိုအပ်သည်</string>
     <string name="upgrade_prompt_title">BVM FOSS သို့ အဆင့်မြှင့်ပါ</string>
     <string name="upgrade_prompt_body">အပိုဝန်ဆောင်မှုများကို ဖွင့်ပြီး ဆက်လက်ဖွံ့ဖြိုးတိုးတက်မှုကို ပံ့ပိုးရန် ကူညီသူဖြစ်လာပါ!</string>
-    <string name="upgrade_prompt_upgrade_action">အဆင့်မြှင့်ပါ</string>
     <string name="upgrade_screen_title">BVM FOSS သို့ အဆင့်မြှင့်ပါ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager တွင် ကြော်ငြာများမရှိပြီး အသုံးပြုသူဒေတာများကိုလည်း မရောင်းချပါ။ ဆက်လက်ဖွံ့ဖြိုးတိုးတက်မှုသည် သင့ေကြောင့်သာသာ ဖြစ်နိုင်သည်။</string>
     <string name="upgrade_screen_how_title">ကူညီနည်းလမ်း</string>

--- a/app/src/foss/res/values-ne-rNP/strings.xml
+++ b/app/src/foss/res/values-ne-rNP/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS आवश्यक छ</string>
     <string name="upgrade_prompt_title">BVM FOSS मा अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_prompt_body">थप सुविधाहरू अनलक गर्नुहोस् र निरन्तर विकासलाई समर्थन गर्न संरक्षक बन्नुहोस्!</string>
-    <string name="upgrade_prompt_upgrade_action">अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_screen_title">BVM FOSS मा अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager मा कुनै विज्ञापन छैन र यसले प्रयोगकर्ताको डेटा बাंड्दैन। निरन्तर विकास केवल तपाईंले गर्नुभएको सहयोगबाट मात्र संभव भएको छ।</string>
     <string name="upgrade_screen_how_title">कसरी मद्दत गर्ने</string>

--- a/app/src/foss/res/values-nl/strings.xml
+++ b/app/src/foss/res/values-nl/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Vereist BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgrade naar BVM FOSS</string>
     <string name="upgrade_prompt_body">Ontgrendel extra functies en word een patroon om verdere ontwikkeling te ondersteunen!</string>
-    <string name="upgrade_prompt_upgrade_action">Upgraden</string>
     <string name="upgrade_screen_title">Upgrade naar BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager bevat geen advertenties en verkoopt geen gebruikersgegevens. Verdere ontwikkeling wordt alleen door jou mogelijk gemaakt.</string>
     <string name="upgrade_screen_how_title">Hoe kun je helpen</string>

--- a/app/src/foss/res/values-no/strings.xml
+++ b/app/src/foss/res/values-no/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Krever BVM FOSS</string>
     <string name="upgrade_prompt_title">Oppgrader til BVM FOSS</string>
     <string name="upgrade_prompt_body">Lås opp flere funksjoner og bli en patron for å støtte utviklingen videre!</string>
-    <string name="upgrade_prompt_upgrade_action">Oppgrader</string>
     <string name="upgrade_screen_title">Oppgrader til BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen annonser og selger ikke brukerdata. Fortsatt utvikling er bare mulig ved hjelp av deg.</string>
     <string name="upgrade_screen_how_title">Hvordan hjelpe</string>

--- a/app/src/foss/res/values-pcm-rNG/strings.xml
+++ b/app/src/foss/res/values-pcm-rNG/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Need BVM FOSS</string>
     <string name="upgrade_prompt_title">Upgrade to BVM FOSS</string>
     <string name="upgrade_prompt_body">Unlock additional features and become patron to support continued development!</string>
-    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
     <string name="upgrade_screen_title">Upgrade to BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no get ads and no dey sell user data. Continued development na only possible because of you.</string>
     <string name="upgrade_screen_how_title">How to help</string>

--- a/app/src/foss/res/values-pl/strings.xml
+++ b/app/src/foss/res/values-pl/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Wymaga BVM FOSS</string>
     <string name="upgrade_prompt_title">Uaktualnij do BVM FOSS</string>
     <string name="upgrade_prompt_body">Odblokuj dodatkowe funkcje i zostań patronem, aby wesprzeć dalszy rozwój!</string>
-    <string name="upgrade_prompt_upgrade_action">Ulepszenie</string>
     <string name="upgrade_screen_title">Uaktualnij do BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nie ma reklam i nie sprzedaje danych użytkowników. Dalszy rozwój jest możliwy tylko dzięki tobie.</string>
     <string name="upgrade_screen_how_title">Jak pomóc</string>

--- a/app/src/foss/res/values-pt-rBR/strings.xml
+++ b/app/src/foss/res/values-pt-rBR/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Requer BVM FOSS</string>
     <string name="upgrade_prompt_title">Atualizar para BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloqueie recursos adicionais e torne-se um patrão para apoiar o desenvolvimento contínuo!</string>
-    <string name="upgrade_prompt_upgrade_action">Atualizar</string>
     <string name="upgrade_screen_title">Atualizar para BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados do usuário. O desenvolvimento contínuo só é possível graças a você.</string>
     <string name="upgrade_screen_how_title">Como ajudar</string>

--- a/app/src/foss/res/values-pt/strings.xml
+++ b/app/src/foss/res/values-pt/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Requer BVM FOSS</string>
     <string name="upgrade_prompt_title">Atualizar para BVM FOSS</string>
     <string name="upgrade_prompt_body">Desbloqueie funcionalidades extra e torne-se um patrono para apoiar o desenvolvimento contínuo!</string>
-    <string name="upgrade_prompt_upgrade_action">Atualizar</string>
     <string name="upgrade_screen_title">Atualizar para BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados dos utilizadores. O desenvolvimento contínuo só é possível graças a si.</string>
     <string name="upgrade_screen_how_title">Como ajudar</string>

--- a/app/src/foss/res/values-rm/strings.xml
+++ b/app/src/foss/res/values-rm/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Basegna BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualisar a BVM FOSS</string>
     <string name="upgrade_prompt_body">Deblocha funcziuns supplementaras e daventescha in patronu per sustegnair il svilup ulterior!</string>
-    <string name="upgrade_prompt_upgrade_action">Actualisar</string>
     <string name="upgrade_screen_title">Actualisar a BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n\'ha naginas reclamas e na vend betg datas d\'utilisaders. Il svilup ulterior è mo pussaivel grazia a tai.</string>
     <string name="upgrade_screen_how_title">Tge che ti pos far</string>

--- a/app/src/foss/res/values-ro/strings.xml
+++ b/app/src/foss/res/values-ro/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Necesită BVM FOSS</string>
     <string name="upgrade_prompt_title">Actualizează la BVM FOSS</string>
     <string name="upgrade_prompt_body">Deblochează funcții suplimentare și devino un patron pentru a suporta dezvoltarea continuată!</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizează</string>
     <string name="upgrade_screen_title">Actualizează la BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nu are reclame şi nu vinde datele utilizatorilor. Continuarea dezvoltării este posibilă numai datorită ție.</string>
     <string name="upgrade_screen_how_title">Cum să ajuți</string>

--- a/app/src/foss/res/values-ru/strings.xml
+++ b/app/src/foss/res/values-ru/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Требуется BVM FOSS</string>
     <string name="upgrade_prompt_title">Обновить до BVM FOSS</string>
     <string name="upgrade_prompt_body">Разблокируйте дополнительные возможности и станьте спонсором, чтобы поддержать разработку приложения!</string>
-    <string name="upgrade_prompt_upgrade_action">Обновление</string>
     <string name="upgrade_screen_title">Обновить до BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не содержит рекламы и не продаёт данные пользователей. Дальнейшее развитие возможно только благодаря вам.</string>
     <string name="upgrade_screen_how_title">Как помочь</string>

--- a/app/src/foss/res/values-sc-rIT/strings.xml
+++ b/app/src/foss/res/values-sc-rIT/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Riquerit BVM FOSS</string>
     <string name="upgrade_prompt_title">Addobba a BVM FOSS</string>
     <string name="upgrade_prompt_body">Aberri funtzionalidades addizionales e diventa patronu pro sustènnere su isvilupu continuadu!</string>
-    <string name="upgrade_prompt_upgrade_action">Agiornare</string>
     <string name="upgrade_screen_title">Addobba a BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tenet pubblicidade e no vendet datos de s\'usuàriu. S\'isvilupu continuadu est possìbile solamente gràtzias a tene.</string>
     <string name="upgrade_screen_how_title">Comente agiudare</string>

--- a/app/src/foss/res/values-si-rLK/strings.xml
+++ b/app/src/foss/res/values-si-rLK/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS අවශ්‍යයි</string>
     <string name="upgrade_prompt_title">BVM FOSS වෙත උත්‍යෝජනය කරන්න</string>
     <string name="upgrade_prompt_body">අමතර විශේෂාංග අඟුල හරිමින් අඛණ්ඩ සංවර්ධනයට සහාය වීමට අනුග්‍රාහකයෙකු වන්න!</string>
-    <string name="upgrade_prompt_upgrade_action">වැඩිදියුණු කරන්න</string>
     <string name="upgrade_screen_title">BVM FOSS වෙත උත්‍යෝජනය කරන්න</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager හි දැන්වීම් නොමැති අතර පරිශීලක දත්ත අලේවි නොකරයි. අකට් සඹ්වර්ධනය ඔබ නිසා පමණක් හෙකියාවක්.</string>
     <string name="upgrade_screen_how_title">උදව් කරන්නේ කෙසේද</string>

--- a/app/src/foss/res/values-sk/strings.xml
+++ b/app/src/foss/res/values-sk/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Vyžaduje BVM FOSS</string>
     <string name="upgrade_prompt_title">Prejsť na BVM FOSS</string>
     <string name="upgrade_prompt_body">Odomknite ďalšie funkcie a staňte sa patrónom na podporu ďalšieho vývoja!</string>
-    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
     <string name="upgrade_screen_title">Prejsť na BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nemá žiadne reklamy a nepredáva údaje používateľov. Neustály vývoj umožňujete len vy.</string>
     <string name="upgrade_screen_how_title">Ako pomôcť</string>

--- a/app/src/foss/res/values-sl/strings.xml
+++ b/app/src/foss/res/values-sl/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Zahteva BVM FOSS</string>
     <string name="upgrade_prompt_title">Nadgradite na BVM FOSS</string>
     <string name="upgrade_prompt_body">Odklenite dodatne funkcije in postanite pokrovitelj, da podprete nadaljnji razvoj!</string>
-    <string name="upgrade_prompt_upgrade_action">Nadgradi</string>
     <string name="upgrade_screen_title">Nadgradite na BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nima oglasov in ne prodaja uporabniških podatkov. Nadaljnji razvoj je omogočen samo z vašo podporo.</string>
     <string name="upgrade_screen_how_title">Kako pomagati.</string>

--- a/app/src/foss/res/values-sq-rAL/strings.xml
+++ b/app/src/foss/res/values-sq-rAL/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Kërkon BVM FOSS</string>
     <string name="upgrade_prompt_title">Përmirëso në BVM FOSS</string>
     <string name="upgrade_prompt_body">Çelni veçori shtesë dhe bëhuni një mbrojtës për të mbështetur zhvillimin e vazhdueshëm!</string>
-    <string name="upgrade_prompt_upgrade_action">Përmirëso</string>
     <string name="upgrade_screen_title">Përmirëso në BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nuk ka reklama dhe nuk shet të dhënat e përdoruesit. Zhvillimi i vazhdueshëm bëhet i mundur vetëm nga ju.</string>
     <string name="upgrade_screen_how_title">Si të ndihmoj</string>

--- a/app/src/foss/res/values-sr/strings.xml
+++ b/app/src/foss/res/values-sr/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Захтева BVM FOSS</string>
     <string name="upgrade_prompt_title">Надогради на BVM FOSS</string>
     <string name="upgrade_prompt_body">Откључај додатне функције и постани покровитељ да подржиш континуирани развој!</string>
-    <string name="upgrade_prompt_upgrade_action">Надогради</string>
     <string name="upgrade_screen_title">Надогради на BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклама и не продаје корисничке податке. Наставак развоја могућ је само захваљујући теби.</string>
     <string name="upgrade_screen_how_title">Како помоћи</string>

--- a/app/src/foss/res/values-sv/strings.xml
+++ b/app/src/foss/res/values-sv/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Kräver BVM FOSS</string>
     <string name="upgrade_prompt_title">Uppgradera till BVM FOSS</string>
     <string name="upgrade_prompt_body">Lås upp ytterligare funktioner och bli en beskyddare för att stödja fortsatt utveckling!</string>
-    <string name="upgrade_prompt_upgrade_action">Uppgradera</string>
     <string name="upgrade_screen_title">Uppgradera till BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har inga annonser och säljer inte användardata. Fortsätt utveckling är endast möjlig tack vare dig.</string>
     <string name="upgrade_screen_how_title">Hur du kan hjälpa</string>

--- a/app/src/foss/res/values-sw/strings.xml
+++ b/app/src/foss/res/values-sw/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Inahitaji BVM FOSS</string>
     <string name="upgrade_prompt_title">Boresha hadi BVM FOSS</string>
     <string name="upgrade_prompt_body">Fungua vipengele vya ziada na uwe mfumo wa kuunga mkono maendeleo ya kuendelea!</string>
-    <string name="upgrade_prompt_upgrade_action">Boresha</string>
     <string name="upgrade_screen_title">Boresha hadi BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager haina matangazo na haiuzi data ya mtumiaji. Maendeleo yanayoendelea yanawezeshwa tu na wewe.</string>
     <string name="upgrade_screen_how_title">Jinsi ya kusaidia</string>

--- a/app/src/foss/res/values-ta-rIN/strings.xml
+++ b/app/src/foss/res/values-ta-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS தேவைப்படுகிறது</string>
     <string name="upgrade_prompt_title">BVM FOSSக்கு மேம்படுத்து</string>
     <string name="upgrade_prompt_body">கூடுதல் அம்சங்களைத் திறக்கவும் மற்றும் தொடர்ச்சியான மேம்பாட்டை ஆதரிக்க புரவலராக மாறவும்!</string>
-    <string name="upgrade_prompt_upgrade_action">மேம்படுத்து</string>
     <string name="upgrade_screen_title">BVM FOSSக்கு மேம்படுத்து</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager விளம்பரங்கள் இல்லாதது மற்றும் பயனர் தரவுகளை விற்கவிற்கை இல்லை. தொடர்ந்த மேம்பாடு உங்களால் மட்டுமே சாத்தியமாகிறது.</string>
     <string name="upgrade_screen_how_title">எப்படி உதவுவது</string>

--- a/app/src/foss/res/values-te-rIN/strings.xml
+++ b/app/src/foss/res/values-te-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS అవసరం</string>
     <string name="upgrade_prompt_title">BVM FOSS కి అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_prompt_body">అదనపు ఫీచర్లను అన్‌లాక్ చేసి, నిరంతర అభివృద్ధికి మద్దతు ఇవ్వడానికి పేట్రన్ అవ్వండి!</string>
-    <string name="upgrade_prompt_upgrade_action">అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_screen_title">BVM FOSS కి అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager కి ప్రకటనలు లేవు మరియు వినియోగదారు డేటాను అమ్మదు. నిరంతర అభివృద్ధి మీ వల్లనే సాధ్యం.</string>
     <string name="upgrade_screen_how_title">ఎలా సహాయం చేయాలి</string>

--- a/app/src/foss/res/values-th/strings.xml
+++ b/app/src/foss/res/values-th/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">ต้องใช้ BVM FOSS</string>
     <string name="upgrade_prompt_title">อัปเกรดเป็น BVM FOSS</string>
     <string name="upgrade_prompt_body">ปลดล็อกฟีเจอร์เพิ่มเติมและเป็นผู้อุปถัมภ์เพื่อสนับสนุนการพัฒนาอย่างต่อเนื่อง!</string>
-    <string name="upgrade_prompt_upgrade_action">อัปเกรด</string>
     <string name="upgrade_screen_title">อัปเกรดเป็น BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ไม่มีโฆษณาและไม่ขายข้อมูลผู้ใช้ การพัฒนาอย่างต่อเนื่องเป็นไปได้เพียงเพราะคุณเท่านั้น</string>
     <string name="upgrade_screen_how_title">วิธีการช่วยเหลือ</string>

--- a/app/src/foss/res/values-tr/strings.xml
+++ b/app/src/foss/res/values-tr/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS gereklidir</string>
     <string name="upgrade_prompt_title">BVM FOSS\'a Yükselt</string>
     <string name="upgrade_prompt_body">Ek özelliklerin kilidini açın ve sürekli gelişimi desteklemek için bir patron olun!</string>
-    <string name="upgrade_prompt_upgrade_action">Yükselt</string>
     <string name="upgrade_screen_title">BVM FOSS\'a Yükselt</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklam içermez ve kullanıcı verilerini satmaz. Sürekli gelişim yalnızca sizin sayenizde mümkündür.</string>
     <string name="upgrade_screen_how_title">Nasıl yardım edilir</string>

--- a/app/src/foss/res/values-uk/strings.xml
+++ b/app/src/foss/res/values-uk/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Потрібен BVM FOSS</string>
     <string name="upgrade_prompt_title">Оновити до BVM FOSS</string>
     <string name="upgrade_prompt_body">Розблокуйте додаткові функції та станьте спонсором, щоб підтримати подальший розвиток!</string>
-    <string name="upgrade_prompt_upgrade_action">Підвищити статус</string>
     <string name="upgrade_screen_title">Оновити до BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не має реклами й не продає дані користувачів. Подальший розвиток можливий лише завдяки вам.</string>
     <string name="upgrade_screen_how_title">Як допомогти</string>

--- a/app/src/foss/res/values-ur-rIN/strings.xml
+++ b/app/src/foss/res/values-ur-rIN/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS کی ضرورت ہے</string>
     <string name="upgrade_prompt_title">BVM FOSS میں اپ گریڈ کریں</string>
     <string name="upgrade_prompt_body">اضافی خصوصیات کو غیر مقفل کریں اور مسلسل ترقی کی حمایت کے لیے سرپرست بنیں!</string>
-    <string name="upgrade_prompt_upgrade_action">اپ گریڈ کریں</string>
     <string name="upgrade_screen_title">BVM FOSS میں اپ گریڈ کریں</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager میں کوئی اشتہار نہیں ہے اور یہ صارف کا ڈیٹا فروخت نہیں کرتا۔ جاری ترقی صرف آپ کی وجہ سے ممکن ہے۔</string>
     <string name="upgrade_screen_how_title">کیسے مدد کریں</string>

--- a/app/src/foss/res/values-uz/strings.xml
+++ b/app/src/foss/res/values-uz/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">BVM FOSS talab qilinadi</string>
     <string name="upgrade_prompt_title">BVM FOSS ga o\'tish</string>
     <string name="upgrade_prompt_body">Qo\'shimcha xususiyatlarni oching va doimiy rivojlanishni qo\'llab-quvvatlash uchun homiy bo\'ling!</string>
-    <string name="upgrade_prompt_upgrade_action">Yangilash</string>
     <string name="upgrade_screen_title">BVM FOSS ga o\'tish</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklamasiz va foydalanuvchi ma\'lumotlarini sotmaydi. Rivojlanishning davom etishi faqat siz tufayli mumkin.</string>
     <string name="upgrade_screen_how_title">Qanday yordam berish</string>

--- a/app/src/foss/res/values-vi/strings.xml
+++ b/app/src/foss/res/values-vi/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Yêu cầu BVM FOSS</string>
     <string name="upgrade_prompt_title">Nâng cấp lên BVM FOSS</string>
     <string name="upgrade_prompt_body">Mở khóa các tính năng bổ sung và trở thành người bảo trợ để hỗ trợ sự phát triển liên tục!</string>
-    <string name="upgrade_prompt_upgrade_action">Nâng cấp</string>
     <string name="upgrade_screen_title">Nâng cấp lên BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager không có quảng cáo và không bán dữ liệu người dùng. Việc tiếp tục phát triển chỉ có thể thực hiện được nhờ bạn.</string>
     <string name="upgrade_screen_how_title">Làm thế nào để giúp đỡ</string>

--- a/app/src/foss/res/values-zh-rCN/strings.xml
+++ b/app/src/foss/res/values-zh-rCN/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">需要 BVM FOSS</string>
     <string name="upgrade_prompt_title">升级至 BVM FOSS</string>
     <string name="upgrade_prompt_body">解锁附加功能，成为支持持续开发的赞助人！</string>
-    <string name="upgrade_prompt_upgrade_action">升级</string>
     <string name="upgrade_screen_title">升级至 BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 没有广告，也不出售用户数据。持续开发只因有您的支持。</string>
     <string name="upgrade_screen_how_title">如何帮助我们</string>

--- a/app/src/foss/res/values-zh-rHK/strings.xml
+++ b/app/src/foss/res/values-zh-rHK/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">需要 BVM FOSS</string>
     <string name="upgrade_prompt_title">升級到 BVM FOSS</string>
     <string name="upgrade_prompt_body">解鎖額外功能，並成為贊助者，以支持持續開發！</string>
-    <string name="upgrade_prompt_upgrade_action">升級</string>
     <string name="upgrade_screen_title">升級到 BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不出售用戶數據。持續開發只有靠你的支持才成為可能。</string>
     <string name="upgrade_screen_how_title">如何協助</string>

--- a/app/src/foss/res/values-zh-rTW/strings.xml
+++ b/app/src/foss/res/values-zh-rTW/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">需要 BVM FOSS</string>
     <string name="upgrade_prompt_title">升級至 BVM FOSS</string>
     <string name="upgrade_prompt_body">解鎖額外功能，並成為贊助者，以支持持續開發！</string>
-    <string name="upgrade_prompt_upgrade_action">升級</string>
     <string name="upgrade_screen_title">升級至 BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不會出售使用者資料。持續的開發由你們所支援。</string>
     <string name="upgrade_screen_how_title">如何協助</string>

--- a/app/src/foss/res/values-zu/strings.xml
+++ b/app/src/foss/res/values-zu/strings.xml
@@ -3,7 +3,6 @@
     <string name="upgrade_feature_requires_pro">Kudingeka i-BVM FOSS</string>
     <string name="upgrade_prompt_title">Buyekeza kuya ku-BVM FOSS</string>
     <string name="upgrade_prompt_body">Vula izici ezengeziwe futhi ube ngumnikazi ukuze usekele ukuthuthukiswa okuqhubekayo!</string>
-    <string name="upgrade_prompt_upgrade_action">Thuthukisa</string>
     <string name="upgrade_screen_title">Buyekeza kuya ku-BVM FOSS</string>
     <string name="upgrade_screen_preamble">I-Bluetooth Volume Manager ayinazo izikhangiso futhi ayithengisi idatha yabasebenzisi. Ukuthuthukiswa okuqhubekayo kwenziwa kuphela nguwe.</string>
     <string name="upgrade_screen_how_title">Indlela yokusiza</string>

--- a/app/src/foss/res/values/strings.xml
+++ b/app/src/foss/res/values/strings.xml
@@ -7,7 +7,6 @@
 
     <string name="upgrade_prompt_title">Upgrade to BVM FOSS</string>
     <string name="upgrade_prompt_body">Unlock additional features and become a patron to support continued development!</string>
-    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
 
     <string name="upgrade_screen_title">Upgrade to BVM FOSS</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager has no ads and doesn\'t sell user data. Continued development is only made possible by you.</string>

--- a/app/src/gplay/res/values-af-rZA/strings.xml
+++ b/app/src/gplay/res/values-af-rZA/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Vereis BVM Pro</string>
     <string name="upgrade_prompt_title">Opgradeer na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro bied beter resultate, meer funksies en opsies vir kraggebruikers.</string>
-    <string name="upgrade_prompt_upgrade_action">Gradeer Op</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Opgradeer na %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager het geen advertensies nie en verkoop nie gebruikersdata nie. My werk word deur jou gefinansier ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan nie aan Google Play koppel nie. Is Google Play geïnstalleer en opgedateer? Is jou Google-rekening aangemeld? Probeer om die kas van die Google Play-toepassing skoon te maak en jou toestel herlaai.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Kon Google Play nie oopmaak nie. Dit kan vermis, gedeaktiveer of beperkt wees op hierdie toestel.</string>
-    <string name="upgrades_no_purchases_found_check_account">Geen aankope gevind nie. Gebruik jy die regte rekening?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opgraadopsies</string>
     <string name="upgrade_screen_offers_body">Beide opsies ontsluit presies dieselfde Pro-funksies — kies watter een jou pas.</string>

--- a/app/src/gplay/res/values-am/strings.xml
+++ b/app/src/gplay/res/values-am/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro ያስፈሉ።</string>
     <string name="upgrade_prompt_title">ወደ BVM Pro ክበቱ</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ለተጨማሪ ተመርጸውዎች፣ ተጨማሪ ብካዾች፥ እና የፐወር ተጠቃሚዎችን ይደግጋል።</string>
-    <string name="upgrade_prompt_upgrade_action">አሻሽል</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">ወደ %1$s ሻመ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ምንም እዋዀት ይረጋል፣ የተገባይ ውሂብንነም አይሸጥም። የ።ቡቡ፡ በ።ቡቡ፠ ዘርድ የካዘለኂው ❤️።</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ወደ Google Play መገናኘት አይቻል። Google Play የተገጀተ እና ወደ ላይ የተዘመኘትነ? የGoogle አካወንት የነጩ ክ? Google Play አፕሊኬስንን በሜᇍ ካስቀጁ መሣሪያውን አስለስለስ ያስፈለግላ።</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play መክፈት አልተቻለም። በዚህ መሳሪያ ላይ ሊሆን ይችላል የሌለ፣ ተሰናክሎ ወይም ተገድቦ።</string>
-    <string name="upgrades_no_purchases_found_check_account">ምንም ግዢዎች አልተገኙም። ትክክለኛውን መለያ እየተጠቀሙ ነው?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">የሻመ ምርጫዎች</string>
     <string name="upgrade_screen_offers_body">ሁለቱም ምርጫዎች ተመሳሳይ Pro ሞያዎችን ይከፍታሉ — የሚስማሙ ይምረጡ።</string>

--- a/app/src/gplay/res/values-ar/strings.xml
+++ b/app/src/gplay/res/values-ar/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">يتطلب BVM Pro</string>
     <string name="upgrade_prompt_title">الترقية إلى BVM Pro</string>
     <string name="upgrade_prompt_body">BVM Pro يمنحك نتائج أفضل، ومزيداً من المميزات والخيارات للمستخدمين المحترفين.</string>
-    <string name="upgrade_prompt_upgrade_action">تحديث</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">الترقية إلى %1$s</string>
     <string name="upgrade_screen_preamble">لا يعرض Bluetooth Volume Manager أية إعلانات ولا يبيع بيانات المستخدم. يتم تمويل عملي من قِبَلكم ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">يتعذر على Bluetooth Volume Manager الاتصال بـ Google Play. هل تم تثبيت Google Play وتحديثه؟ هل تم تسجيل الدخول إلى حسابك في Google؟ حاول مسح ذاكرة التخزين المؤقت لتطبيق Google Play وإعادة تشغيل جهازك.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">لم يتمكن من فتح متجر Google Play. قد يكون مفقودًا أو معطلاً أو مقيدًا على هذا الجهاز.</string>
-    <string name="upgrades_no_purchases_found_check_account">لم يتم العثور على عملية الشراء. هل تستخدم حساب Google الصحيح؟</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">خيارات الترقية</string>
     <string name="upgrade_screen_offers_body">كلا الخيارين يفتحان نفس ميزات Pro بالضبط — اختر ما يناسبك.</string>

--- a/app/src/gplay/res/values-az/strings.xml
+++ b/app/src/gplay/res/values-az/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro tələb olunur</string>
     <string name="upgrade_prompt_title">BVM Pro-ya yüksəldin</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro daha yaxşı nəticələr, daha çox xüsusiyyətlər və güc istifadəçiləri üçün seçimlər təklif edir.</string>
-    <string name="upgrade_prompt_upgrade_action">Yüksəlt</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Yüksəlt %1$s-ə</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-də reklam yoxdur və istifadəçi məlumatlarını satmır. Mənim işim sizin tərəfindən maliyyələşdirilir ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play-ə qoşula bilmir. Google Play quraşdırılıb və yenilənib? Google Hesabınıza daxil olubsunuz? Google Play tətbiqinin keşini təmizləməyə və cihazınızı yenidən başlatmağa çalışın.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play açıla bilmədi. Cihazda olmaya bilər, deaktiv edilmiş və ya məhdudlaşdırılmış ola bilər.</string>
-    <string name="upgrades_no_purchases_found_check_account">Heç bir alış tapılmadı. Düzgün hesabdan istifadə edirsiniz?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Yüksəltmə seçimləri</string>
     <string name="upgrade_screen_offers_body">Hər iki seçim eyni Pro xüsusiyyətlərin kilidini açır — sizə ən uyğun olanını seçin.</string>

--- a/app/src/gplay/res/values-be/strings.xml
+++ b/app/src/gplay/res/values-be/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Патрабуе BVM Pro</string>
     <string name="upgrade_prompt_title">Перайсці на BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro прапануе лепшыя вынікі, больш функцый і настроек для прасунутых карыстальнікаў.</string>
-    <string name="upgrade_prompt_upgrade_action">Абнавіць</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Абнавіце на %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не мае рэкламы і не прадае дадзеныя карыстальнікаў. Мая праца фінансуецца вамі ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не можа падключыцца да Google Play. Ці устанаўлены і абнаўлены Google Play? Ці ўвойдзены ваш акаўнт Google? Спрабуйце ачысціць кэш Google Play і перазагрузіць прыладу.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Не удалося адкрыць Google Play. Гэта можа адсутнічаць, быць адключаным ці абмежаваным на гэтым прыладзе.</string>
-    <string name="upgrades_no_purchases_found_check_account">Пакупак не знойдзена. Вы выкарыстоўваеце правільны ўліковы запіс?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Параметры абнаўлення</string>
     <string name="upgrade_screen_offers_body">Абедзве опцыі разблокіруюць адзінакавыя функцыі Pro — выберыце адну, якая вам больш удоба.</string>

--- a/app/src/gplay/res/values-bg/strings.xml
+++ b/app/src/gplay/res/values-bg/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Изисква BVM Pro</string>
     <string name="upgrade_prompt_title">Надграждане до BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro предлага по-добри резултати, повече функции и опции за напреднали потребители.</string>
-    <string name="upgrade_prompt_upgrade_action">Ъпгрейд</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Надграждане до %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager няма реклами и не продава потребителски данни. Работата ми се финансира от вас ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може да се свърже с Google Play. Инсталиран ли е Google Play и актуален ли е? Влязъл ли е вашият Google акаунт? Опитайте да изчистите кеша на приложението Google Play и да рестартирате устройството си.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Не се отвори Google Play. Възможно е приложението да липсва, е деактивирано или ограничено на това устройство.</string>
-    <string name="upgrades_no_purchases_found_check_account">Не са намерени покупки. Използвате ли правилния акаунт?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Опции за надграждане</string>
     <string name="upgrade_screen_offers_body">И двете опции отключват същите Pro функции — изберете която ви устройва по-добре.</string>

--- a/app/src/gplay/res/values-bn-rBD/strings.xml
+++ b/app/src/gplay/res/values-bn-rBD/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro প্রয়োজন</string>
     <string name="upgrade_prompt_title">BVM Pro-তে আপগ্রেড করুন</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro পারভার ব্যবহারকারীদের জন্য ভালো ফলাফল, আরও ফিচার এবং বিকল্প দেয়।</string>
-    <string name="upgrade_prompt_upgrade_action">আপগ্রেড করুন</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s-এ আপগ্রেড করুন</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-এ কোনো বিজ্ঞাপন নেই এবং ব্যবহারকারীর তথ্য বিক্রি করে না। আমার কাজ আপনার দ্বারা পরিচালিত ❤️।</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play-এ সংযোগ করতে পারছে না। কি Google Play ইনস্টল এবং আপডেট আছে? আপনার Google অ্যাকাউন্ট লগইন করা আছে? Google Play অ্যাপের ক্যাশ পরিষ্কার করে ডিভাইস রিবুট করুন।</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play খোলা যাচ্ছে না। এটি এই ডিভাইসে অনুপস্থিত, নিষ্ক্রিয় বা সীমাবদ্ধ থাকতে পারে।</string>
-    <string name="upgrades_no_purchases_found_check_account">আপনার পার্সেস পাওয়া যায় নাই। আপনি সঠিক অ্যাকাউন্ট ব্যবহার করছেন?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">আপগ্রেড বিকল্পগুলি</string>
     <string name="upgrade_screen_offers_body">উভয় বিকল্পই একই Pro বৈশিষ্ট্য আনলক করে — যেটি আপনার জন্য উপযুক্ত তা বেছে নিন।</string>

--- a/app/src/gplay/res/values-ca/strings.xml
+++ b/app/src/gplay/res/values-ca/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Requereix BVM Pro</string>
     <string name="upgrade_prompt_title">Millora a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofereix millors resultats, més funcions i opcions per a usuaris avançats.</string>
-    <string name="upgrade_prompt_upgrade_action">Actualitza</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Millora a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no té anuncis i no ven les dades d’usuari. El meu treball està finiançat per vosaltres ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no es pot connectar a Google Play. Google Play està instal·lat i actualitzat? El vostre compte de Google ha iniciat sessió? Proveu d’esborrar la memòria cau de Google Play i reinicieu el dispositiu.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">No s\'ha pogut obrir Google Play. Pot que manque, estigui desactivat o restringit en aquest dispositiu.</string>
-    <string name="upgrades_no_purchases_found_check_account">No s\'han trobat compres. Esteu fent servir el compte correcte?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opcions d\'actualització</string>
     <string name="upgrade_screen_offers_body">Ambdues opcions desbloquejen exactament les mateixes funcions Pro — tria la que més s\'ajusti a tu.</string>

--- a/app/src/gplay/res/values-cs/strings.xml
+++ b/app/src/gplay/res/values-cs/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Vyžaduje BVM Pro</string>
     <string name="upgrade_prompt_title">Upgradovat na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro nabízí lepší výsledky, více funkcí a možností pro zkušené uživatele.</string>
-    <string name="upgrade_prompt_upgrade_action">Upgradovat</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Upgradovat na %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neobsahuje žádné reklamy a neprodává data uživatelů. Moje práce je financována vámi ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager se nemůže připojit ke Google Play. Je Google Play nainstalován a aktuální? Jste přihlášeni ke svému účtu Google? Zkuste vymazat mezipaměť aplikace Google Play a restartovat zařízení.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nebylo možné otevřít Google Play. Aplikace na tomto zařízení může být chybějící, zakázaná nebo omezená.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nebyly nalezeny žádné nákupy. Používáte správný účet?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Možnosti upgradu</string>
     <string name="upgrade_screen_offers_body">Obě možnosti odemykají stejné funkce Pro — vyberte si, která vám vyhovuje.</string>

--- a/app/src/gplay/res/values-da/strings.xml
+++ b/app/src/gplay/res/values-da/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Kræver BVM Pro</string>
     <string name="upgrade_prompt_title">Opgrader til BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro giver bedre resultater, flere funktioner og muligheder for superbrugere.</string>
-    <string name="upgrade_prompt_upgrade_action">Opgrader</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Opgrader til %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen reklamer og sælger ikke brugerdata. Mit arbejde er finansieret af dig ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan ikke oprette forbindelse til Google Play. Er Google Play installeret og opdateret? Er din Google-konto logget ind? Prov at rydde cachen i Google Play-appen og genstarte din enhed.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Kunne ikke åbne Google Play. Det kan være manglende, deaktiveret eller begrænset på denne enhed.</string>
-    <string name="upgrades_no_purchases_found_check_account">Ingen køb fundet. Bruger du den rigtige konto?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opgraderingsmuligheder</string>
     <string name="upgrade_screen_offers_body">Begge muligheder låser op for de samme Pro-funktioner — vælg den, der passer dig bedst.</string>

--- a/app/src/gplay/res/values-de/strings.xml
+++ b/app/src/gplay/res/values-de/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Erfordert BVM Pro</string>
     <string name="upgrade_prompt_title">Auf BVM Pro upgraden</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro bietet bessere Ergebnisse, mehr Funktionen und Optionen für Power-User.</string>
-    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Upgrade auf %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager enthält keine Werbung und verkauft keine Nutzerdaten. Meine Arbeit wird von dir finanziert ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kann keine Verbindung zu Google Play herstellen. Ist Google Play installiert und aktuell? Ist dein Google-Konto angemeldet? Versuche, den Cache der Google Play-App zu leeren und dein Gerät neu zu starten.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play konnte nicht geöffnet werden. Möglicherweise ist die App auf diesem Gerät nicht installiert, deaktiviert oder der Zugriff darauf wurde eingeschränkt.</string>
-    <string name="upgrades_no_purchases_found_check_account">Keine Käufe gefunden. Verwendest Du das richtige Konto?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Upgrade-Möglichkeiten</string>
     <string name="upgrade_screen_offers_body">Beide Optionen bieten die gleichen Pro-Funktionen – wählen die aus, die dir am besten passt.</string>

--- a/app/src/gplay/res/values-el/strings.xml
+++ b/app/src/gplay/res/values-el/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Απαιτεί το BVM Pro</string>
     <string name="upgrade_prompt_title">Αναβαθμίστε στο BVM Pro</string>
     <string name="upgrade_prompt_body">Το Bluetooth Volume Manager Pro προσφέρει καλύτερα αποτελέσματα, περισσότερες δυνατότητες και επιλογές για προχωρημένους χρήστες.</string>
-    <string name="upgrade_prompt_upgrade_action">Αναβάθμιση</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Αναβάθμιση σε %1$s</string>
     <string name="upgrade_screen_preamble">Το Bluetooth Volume Manager δεν έχει διαφημίσεις και δεν πωλεί δεδομένα χρηστών. Η δουλειά μου χρηματοδοτείται από εσάς ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Το Bluetooth Volume Manager δεν μπορεί να συνδεθεί με το Google Play. Είναι το Google Play εγκατεστημένο και ενημερωμένο; Έχετε συνδεθεί με τον λογαριασμό Google σας; Δοκιμάστε να διαγράψετε την προσωρινή μνήμη της εφαρμογής Google Play και να επανεκκινήσετε τη συσκευή σας.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Δεν μπόρεσε να ανοίξει το Google Play. Ενδέχεται να λείπει, να είναι απενεργοποιημένο ή περιορισμένο σε αυτήν τη συσκευή.</string>
-    <string name="upgrades_no_purchases_found_check_account">Δεν βρέθηκαν αγορές. Χρησιμοποιείτε τον σωστό λογαριασμό;</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Επιλογές αναβάθμισης</string>
     <string name="upgrade_screen_offers_body">Και οι δύο επιλογές ξεκλειδώνουν ακριβώς τα ίδια Pro χαρακτηριστικά — επιλέξτε ό,τι σας ταιριάζει.</string>

--- a/app/src/gplay/res/values-eo-rUY/strings.xml
+++ b/app/src/gplay/res/values-eo-rUY/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Postulas BVM Pro</string>
     <string name="upgrade_prompt_title">Plibonigi al BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofertas pli bonajn rezultojn, pli da funkcioj kaj opcioj por potencaj uzantoj.</string>
-    <string name="upgrade_prompt_upgrade_action">Plibonigi</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Ĝisdatigi al %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ne havas reklamojn kaj ne vendas uzantoajn datumojn. Mia laboro estas financata de vi ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ne povas konektiĝi al Google Play. Ču Google Play estas instalita kaj ĝisdatigita? Ču via Google-konto estas ensalutinta? Provu forigi la kaŝmemoron de la aplikaĵo Google Play kaj restartiĝi vian aparaton.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Ne povis malfermi Google Play. Ĝi eble ne ekzistas, estas malŝaltita aŭ limigita en ĉi tiu aparato.</string>
-    <string name="upgrades_no_purchases_found_check_account">Neniaj aĉetoj trovis. Ču vi uzas la ĝustan konton?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Ĝisdatigo-variantoj</string>
     <string name="upgrade_screen_offers_body">Ambaŭ variantoj malŝlosus la ekzakte samajn Pro-funkciojn — elektu iun, kiu konvenas al vi.</string>

--- a/app/src/gplay/res/values-es-rAR/strings.xml
+++ b/app/src/gplay/res/values-es-rAR/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Requiere BVM Pro</string>
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
-    <string name="upgrade_prompt_upgrade_action">Mejorar</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Actualizar a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende datos de usuario. Mi trabajo es financiado por vos ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no puede conectarse a Google Play. ¿Está instalado y actualizado Google Play? ¿Tu cuenta de Google está iniciada? Intentá limpiar el caché de la app de Google Play y reiniciar tu dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">No se pudo abrir Google Play. Podría estar ausente, deshabilitado o restringido en este dispositivo.</string>
-    <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opciones de actualización</string>
     <string name="upgrade_screen_offers_body">Ambas opciones desbloquean exactamente las mismas funciones Pro — elegí la que mejor te convenga.</string>

--- a/app/src/gplay/res/values-es-rMX/strings.xml
+++ b/app/src/gplay/res/values-es-rMX/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Requiere BVM Pro</string>
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mejores resultados, más funciones y opciones para usuarios avanzados.</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizar</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Actualizar a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene publicidad y no vende datos de usuarios. Mi trabajo es financiado por ti ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no puede conectarse a Google Play. ¿Está Google Play instalado y actualizado? ¿Está tu cuenta de Google conectada? Intenta limpiar la caché de la app Google Play y reiniciar tu dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">No se pudo abrir Google Play. Podría estar faltando, deshabilitado o restringido en este dispositivo.</string>
-    <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opciones de actualización</string>
     <string name="upgrade_screen_offers_body">Ambas opciones desbloquean exactamente las mismas características Pro — elige la que más te convenga.</string>

--- a/app/src/gplay/res/values-es/strings.xml
+++ b/app/src/gplay/res/values-es/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Requiere BVM Pro</string>
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mejores resultados, más características y opciones para los usuarios avanzados.</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizar</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Actualizar a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no tiene anuncios y no vende los datos de los usuarios. Mi trabajo está financiado por ti ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no puede conectarse a Google Play. ¿Está Google Play instalado y actualizado? ¿Has iniciado sesión con tu cuenta de Google? Prueba a borrar la caché de la aplicación Google Play y reinicia tu dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">No se pudo abrir Google Play. Puede estar ausente, deshabilitado o restringido en este dispositivo.</string>
-    <string name="upgrades_no_purchases_found_check_account">No se encontraron compras. ¿Estás usando la cuenta correcta?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opciones de actualización</string>
     <string name="upgrade_screen_offers_body">Ambas opciones desbloquean exactamente las mismas funciones Pro — elige la que te convenga mejor.</string>

--- a/app/src/gplay/res/values-et-rEE/strings.xml
+++ b/app/src/gplay/res/values-et-rEE/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Vajab BVM Pro versiooni</string>
     <string name="upgrade_prompt_title">Uuenda BVM Pro-ks</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro pakub paremaid tulemusi, rohkem funktsioone ja valikuid edasijõudnutele.</string>
-    <string name="upgrade_prompt_upgrade_action">Täienda</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Täienda %1$s-le</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manageris pole reklaame ja see ei müü kasutajaandmeid. Minu tööd toetate teie ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ei suuda ühenduda Google Playga. Kas Google Play on paigaldatud ja ajakohane? Kas olete Google\'i kontole sisse logitud? Proovige tühjendada Google Play rakenduse vahemälu ja taaskäivitada seade.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play avamine nurjus. See võib olla selles seadmes puudu, keelatud või piiratud.</string>
-    <string name="upgrades_no_purchases_found_check_account">Oste ei leitud. Kas kasutate õiget kontot?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Täiendamise valikud</string>
     <string name="upgrade_screen_offers_body">Mõlemad valikud avavad täpselt samad Pro funktsioonid — vali, milline sulle sobib.</string>

--- a/app/src/gplay/res/values-eu-rES/strings.xml
+++ b/app/src/gplay/res/values-eu-rES/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro beharrezkoa da</string>
     <string name="upgrade_prompt_title">Berritu BVM Pro-ra</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro-k emaitza hobeak, ezaugarri gehiago eta aukera gehiago eskaintzen ditu erabiltzaile aurreratuei.</string>
-    <string name="upgrade_prompt_upgrade_action">Eguneratu</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Igo %1$s-ra</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ek ez du iragarkirik eta ez du erabiltzailearen daturik saltzen. Nire lana zuk finantzatzen duzu ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager-ek ezin du Google Play-ra konektatu. Google Play instalatuta eta eguneratuta al dago? Zure Google kontua saioa hasi al du? Saiatu Google Play aplikazioaren cachea garbitzen eta gailua berrabiarazten.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play ireki ez da ahal izan. Agian falta dago, desgaituta dago edo mugatuta dago gailu honetan.</string>
-    <string name="upgrades_no_purchases_found_check_account">Ez dira erosketarik aurkitu. Kontu zuzena erabiltzen ari zara?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Hobekuntza aukerak</string>
     <string name="upgrade_screen_offers_body">Bi aukerek Pro ezaugarri berdinak desblokeatu dituzte — egin zure gogoan duena.</string>

--- a/app/src/gplay/res/values-fa/strings.xml
+++ b/app/src/gplay/res/values-fa/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">نیاز به BVM Pro دارد</string>
     <string name="upgrade_prompt_title">ارتقاء به BVM Pro</string>
     <string name="upgrade_prompt_body">مدیر صدای بلوتوث Pro نتایج بهتر، ویژگی‌ها و گزینه‌های بیشتری برای کاربران حرفه‌ای ارائه می‌دهد.</string>
-    <string name="upgrade_prompt_upgrade_action">ارتقاء</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">ارتقا به %1$s</string>
     <string name="upgrade_screen_preamble">مدیر صدای بلوتوث تبلیغات ندارد و داده‌های کاربر را نمی‌فروشد. کار من توسط شما تأمین می‌شود ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">مدیر صدای بلوتوث نمی‌تواند به Google Play وصل شود. آیا Google Play نصب و به‌روز است؟ آیا حساب گوگلتان وارد شده؟ حافظه‌پنهان برنامه Google Play را پاک کنید و دستگاه را راه‌اندازی مجدد کنید.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">نمی‌توان Google Play را باز کرد. ممکن است در این دستگاه نصب نشده، غیرفعال یا محدود باشد.</string>
-    <string name="upgrades_no_purchases_found_check_account">هیچ خریدی یافت نشد. آیا از حساب صحیح استفاده می‌کنید؟</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">گزینه‌های ارتقا</string>
     <string name="upgrade_screen_offers_body">هر دو گزینه دقیقا همان ویژگی‌های Pro را باز می‌کنند — هرکدام که برای شما مناسب است انتخاب کنید.</string>

--- a/app/src/gplay/res/values-fi/strings.xml
+++ b/app/src/gplay/res/values-fi/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Vaatii BVM Pro:n</string>
     <string name="upgrade_prompt_title">Päivitä BVM Pro:hon</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro tarjoaa parempia tuloksia, enemmän ominaisuuksia ja vaihtoehtoja tehokäyttäjille.</string>
-    <string name="upgrade_prompt_upgrade_action">Päivitä</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Päivitä versioon %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerissa ei ole mainoksia eikä se myy käyttäjätietoja. Työni rahoitetaan sinun toimestasi ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ei voi yhdistää Google Playhin. Onko Google Play asennettu ja ajan tasalla? Onko Google-tilisi kirjautunut sisään? Kokeile tyhjenntää Google Play -sovelluksen välimuisti ja käynnistä laite uudelleen.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Playta ei voitu avata. Se saattaa olla puuttuva, käytöstä poistettu tai rajoitettu tällä laitteella.</string>
-    <string name="upgrades_no_purchases_found_check_account">Ostoja ei löytynyt. Käytätkö oikeaa tiliä?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Päivitysvaihtoehdot</string>
     <string name="upgrade_screen_offers_body">Molemmat vaihtoehdot vapauttavat täsmälleen samat Pro-ominaisuudet – valitse se, joka sopii sinulle parhaiten.</string>

--- a/app/src/gplay/res/values-fil/strings.xml
+++ b/app/src/gplay/res/values-fil/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Nangangailangan ng BVM Pro</string>
     <string name="upgrade_prompt_title">I-upgrade sa BVM Pro</string>
     <string name="upgrade_prompt_body">Ang Bluetooth Volume Manager Pro ay nag-aalok ng mas mahusay na mga resulta, mas maraming mga feature at mga opsyon para sa mga power user.</string>
-    <string name="upgrade_prompt_upgrade_action">I-upgrade</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">I-upgrade sa %1$s</string>
     <string name="upgrade_screen_preamble">Ang Bluetooth Volume Manager ay walang mga ad at hindi nagbebenta ng data ng user. Ang aking trabaho ay pinopondohan mo ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Hindi makakonekta ang Bluetooth Volume Manager sa Google Play. Naka-install ba at updated ang Google Play? Naka-log in ba ang iyong Google Account? Subukang i-clear ang cache ng Google Play app at i-reboot ang iyong device.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Hindi mabuksan ang Google Play. Maaari itong wala, na-disable, o na-restrict sa device na ito.</string>
-    <string name="upgrades_no_purchases_found_check_account">Walang nahanap na mga binili. Ginagamit mo ba ang iyong tamang account?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Mga opsyon sa upgrade</string>
     <string name="upgrade_screen_offers_body">Ang parehong opsyon ay nag-unlock ng parehong Pro features — pumili ng swak sa iyo.</string>

--- a/app/src/gplay/res/values-fr/strings.xml
+++ b/app/src/gplay/res/values-fr/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Nécessite BVM Pro</string>
     <string name="upgrade_prompt_title">Passer à BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro offre de meilleurs résultats, plus de fonctions et d’options pour les utilisateurs expérimentés.</string>
-    <string name="upgrade_prompt_upgrade_action">Surclasser</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Passer à %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n’affiche pas de publicités et ne vend pas les données des utilisateurs. Mon travail est financé par vous ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ne peut pas se connecter à Google Play. Google Play est-il installé et à jour ? Votre compte Google est-il connecté ? Essayez de vider le cache de l’appli Google Play et de redémarrer votre appareil.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Impossible d\'ouvrir Google Play. Il peut être manquant, désactivé ou restreint sur cet appareil.</string>
-    <string name="upgrades_no_purchases_found_check_account">Aucun achat n’a été trouvé. Utilisez-vous le bon compte ?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Options de mise à niveau</string>
     <string name="upgrade_screen_offers_body">Les deux options déverrouillent exactement les mêmes fonctionnalités Pro — choisissez celle qui vous convient.</string>

--- a/app/src/gplay/res/values-gl-rES/strings.xml
+++ b/app/src/gplay/res/values-gl-rES/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Require BVM Pro</string>
     <string name="upgrade_prompt_title">Actualizar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofrece mellores resultados, máis funcionalidades e opcións para usuarios avanzados.</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizar</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Actualizar a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non ten anuncios e non vende datos de usuario. O meu traballo está financiado por ti ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager non pode conectarse a Google Play. ¿Está Google Play instalado e actualizado? ¿Iniciaches sesión na túa conta de Google? Proba a borrar a caché da app Google Play e reinicia o dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Non se puido abrir Google Play. Pode que non estea dispoñible, deshabilitada ou restrinxida neste dispositivo.</string>
-    <string name="upgrades_no_purchases_found_check_account">Non se atoparon compras. Estás usando a conta correcta?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opcións de actualización</string>
     <string name="upgrade_screen_offers_body">Ambas as opcións desbloquean exactamente as mesmas características Pro — escolle a que máis te convena.</string>

--- a/app/src/gplay/res/values-hi-rIN/strings.xml
+++ b/app/src/gplay/res/values-hi-rIN/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro आवश्यक है</string>
     <string name="upgrade_prompt_title">BVM Pro में अपग्रेड करें</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro पावर उपयोगकर्ताओं के लिए बेहतर परिणाम, अधिक सुविधाएं और विकल्प प्रदान करता है।</string>
-    <string name="upgrade_prompt_upgrade_action">अपग्रेड</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s में अपग्रेड करें</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager में कोई विज्ञापन नहीं है और वह उपयोगकर्ता डेटा नहीं बेचता। मेरा काम आपके द्वारा वित्तपोषित है ❤️।</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play से कनेक्ट नहीं हो सकता। क्या Google Play इंस्टॉल और अप-टू-डेट है? क्या आपका Google खाता लॉग इन है? Google Play ऐप का कैश साफ़ करने और अपने डिवाइस को रीबूट करने का प्रयास करें।</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play को नहीं खोला जा सका। यह इस डिवाइस पर गायब, अक्षम या प्रतिबंधित हो सकता है।</string>
-    <string name="upgrades_no_purchases_found_check_account">कोई खरीदारी जानकारी नहीं मिली। क्या आप सही खाते का उपयोग कर रहे हैं?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">अपग्रेड विकल्प</string>
     <string name="upgrade_screen_offers_body">दोनों विकल्प बिल्कुल समान Pro सुविधाओं को अनलॉक करते हैं — जो आपको सूट करे उसे चुनें।</string>

--- a/app/src/gplay/res/values-hr/strings.xml
+++ b/app/src/gplay/res/values-hr/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Zahtijeva BVM Pro</string>
     <string name="upgrade_prompt_title">Nadogradite na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro nudi bolje rezultate, više značajki i opcije za napredne korisnike.</string>
-    <string name="upgrade_prompt_upgrade_action">Nadogradi</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Nadogradnja na %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nema oglasa i ne prodaje korisničke podatke. Moj rad financirate vi ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager se ne može spojiti na Google Play. Je li Google Play instaliran i ažuriran? Je li vaš Google račun prijavljen? Pokušajte obrisati predmemoriju aplikacije Google Play i restartajte uređaj.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nije moguće otvoriti Google Play. Možda nedostaje, onemogućena je ili ograničena na ovom uređaju.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nema pronađenih kupnji. Koristite li pravi račun?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opcije nadogradnje</string>
     <string name="upgrade_screen_offers_body">Obje opcije otključavaju iste Pro značajke — odaberite onu koja vam više odgovara.</string>

--- a/app/src/gplay/res/values-hu/strings.xml
+++ b/app/src/gplay/res/values-hu/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro szükséges</string>
     <string name="upgrade_prompt_title">Frissítés BVM Pro-ra</string>
     <string name="upgrade_prompt_body">A Bluetooth Volume Manager Pro jobb eredményeket, több funkciót és lehetőséget kínál a haladó felhasználóknak.</string>
-    <string name="upgrade_prompt_upgrade_action">Frissítés</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Frissítés a %1$s-re</string>
     <string name="upgrade_screen_preamble">A Bluetooth Volume Manager nem tartalmaz hirdetéseket, és nem értékesít felhasználói adatokat. A munkámat te finanszírozód ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">A Bluetooth Volume Manager nem tud csatlakozni a Google Playhez. Telepítve és naprакész a Google Play? Be vagy jelentkezve a Google-fiókodba? Próbáld meg törölni a Google Play alkalmazás gyorsítótárát és indítsd újra az eszközt.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nem sikerült megnyitni a Google Play-t. Lehetséges, hogy az eszközön hiányzik, letiltott vagy korlátozott.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nem található vásárlás. A megfelelő fiókot használja?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Frissítési lehetőségek</string>
     <string name="upgrade_screen_offers_body">Mindkét lehetőség ugyanazokat a Pro funkciókat oldja fel – válaszd azt, amelyik jobban passzol hozzád.</string>

--- a/app/src/gplay/res/values-hy-rAM/strings.xml
+++ b/app/src/gplay/res/values-hy-rAM/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Պահանջվում է BVM Pro</string>
     <string name="upgrade_prompt_title">Անցնել BVM Pro-ին</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ավելի լավ արդյունքներ՝ գորունակություններ և հնարավորություններ հզոր ուժղատություն ունեցողների համար։</string>
-    <string name="upgrade_prompt_upgrade_action">Թարմացնել</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Արդիացեք %1$s-ին</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager-ում գովազդներ չկան և ուժղատության տվյալներ չի վարարկում։ Մեր աշխատանքե ժղարգարվում ե դզեր կողմից։</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager-ե հնարավորություն չունի կապուտվել Google Play-ին։ Google Play տեղադրված և արդիականացված ե՞ Կիրարնեք Google հաշվիե մուտքագրված ե՞ Պորդեք մաքրել Google Play տվյալե և վերագնել սարքե։</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Չհաջողվեց Google Play բացել: Հնարավոր է, որ այն բացակա, անջատված կամ սահմանափակված է այս սարքում:</string>
-    <string name="upgrades_no_purchases_found_check_account">Գնումներ չեն գտնվել: Օգտագործում եք ճիշտ հաշիվը:</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Արդիացման տարբերակներ</string>
     <string name="upgrade_screen_offers_body">Երկու տարբերակներն էլ մեկնում են Pro-ի նույն հատկանիշները — ընտրեք որը հարմար է ձեզ համար։</string>

--- a/app/src/gplay/res/values-in/strings.xml
+++ b/app/src/gplay/res/values-in/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Membutuhkan BVM Pro</string>
     <string name="upgrade_prompt_title">Upgrade ke BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro menawarkan hasil lebih baik, lebih banyak fitur dan opsi untuk pengguna mahir.</string>
-    <string name="upgrade_prompt_upgrade_action">Tingkatkan</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Tingkatkan ke %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tidak menampilkan iklan dan tidak menjual data pengguna. Pekerjaan saya dibiayai oleh Anda ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager tidak dapat terhubung ke Google Play. Apakah Google Play sudah terpasang dan diperbarui? Apakah Akun Google Anda sudah masuk? Coba hapus cache aplikasi Google Play dan mulai ulang perangkat Anda.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Tidak bisa membuka Google Play. Aplikasinya mungkin tidak tersedia, dinonaktifkan, atau dibatasi di perangkat ini.</string>
-    <string name="upgrades_no_purchases_found_check_account">Pembelian tidak ditemukan. Apakah Anda menggunakan akun yang benar?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opsi upgrade</string>
     <string name="upgrade_screen_offers_body">Kedua opsi membuka fitur Pro yang sama persis — pilih yang paling sesuai untuk Anda.</string>

--- a/app/src/gplay/res/values-is/strings.xml
+++ b/app/src/gplay/res/values-is/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Krefst BVM Pro</string>
     <string name="upgrade_prompt_title">Uppfæra í BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro býður upp á betri niðurstöður, fleiri eiginleika og valkosti fyrir öfluga notendur.</string>
-    <string name="upgrade_prompt_upgrade_action">Uppfæra</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Uppfæra í %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager birtir engar auglýsingar og selur ekki notendagögn. Verk mitt er fjármagnaö af þér ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager getur ekki tengst Google Play. Er Google Play uppsett og uppfært? Ertu skráður inn á Google reikninginn? Prófaðu að hreinsa skyndiminnni Google Play forritsins og endurræsa tækið þit.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Gat ekki opnað Google Play. Það gæti verið að vantast, óvirkjað eða takmarkað á þessu tæki.</string>
-    <string name="upgrades_no_purchases_found_check_account">Engin kaup fundust. Ertu að nota réttan reikning?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Uppfærslumöguleikar</string>
     <string name="upgrade_screen_offers_body">Báðir valkostir opna sömu Pro eiginleika — veldu þann sem hentar þér best.</string>

--- a/app/src/gplay/res/values-it/strings.xml
+++ b/app/src/gplay/res/values-it/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Richiede BVM Pro</string>
     <string name="upgrade_prompt_title">Aggiorna a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro offre risultati migliori, più funzioni e opzioni per gli utenti avanzati.</string>
-    <string name="upgrade_prompt_upgrade_action">Acquista</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Esegui l\'upgrade a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non contiene pubblicità e non vende i dati degli utenti. Il mio lavoro è finanziato da te ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager non riesce a connettersi a Google Play. Google Play è installato e aggiornato? Il tuo account Google è connesso? Prova a cancellare la cache dell’app Google Play e a riavviare il dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Impossibile aprire Google Play. Potrebbe essere mancante, disabilitato o limitato su questo dispositivo.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nessun acquisto trovato. Stai usando l\'account corretto?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opzioni di upgrade</string>
     <string name="upgrade_screen_offers_body">Entrambe le opzioni sbloccano le stesse identiche funzioni Pro — scegli quella che preferisci.</string>

--- a/app/src/gplay/res/values-iw/strings.xml
+++ b/app/src/gplay/res/values-iw/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">דורש BVM Pro</string>
     <string name="upgrade_prompt_title">שדרג ל-BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro מציע תוצאות טובות יותר, יותר תכונות ואפשרויות למשתמשים מתקדמים.</string>
-    <string name="upgrade_prompt_upgrade_action">שדרוג</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">שדרג ל-%1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ללא מודעות ואינה מוכרת נתוני משתמשים. העבודה שלי ממומנת על ידך ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager לא מצליחה להתחבר ל-Google Play. האם Google Play מותקן ומעודכן? האם חשבון Google שלך מחובר? נסה לנקות את המטמון של אפליקציית Google Play ולהפעיל מחדש את המכשיר.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">לא ניתן לפתוח את Google Play. ייתכן שהוא לא מותקן, מנוטרל או מוגבל במכשיר זה.</string>
-    <string name="upgrades_no_purchases_found_check_account">לא נמצאו רכישות. האם אתה משתמש בחשבון הנכון?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">אפשרויות שדרוג</string>
     <string name="upgrade_screen_offers_body">שתי האפשרויות משחררות את אותן תכונות Pro בדיוק - בחר באיזו שמתאימה לך.</string>

--- a/app/src/gplay/res/values-ja/strings.xml
+++ b/app/src/gplay/res/values-ja/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro が必要です</string>
     <string name="upgrade_prompt_title">BVM Pro にアップグレード</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Proは、パワーユーザーにより良い結果、より多くの機能とオプションを提供します。</string>
-    <string name="upgrade_prompt_upgrade_action">アップグレード</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s にアップグレード</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Managerは広告がなく、ユーザーデータを販売しません。私の作業はあなたによって支えられています ❤️。</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager は Google Play に接続できません。Google Play はインストールされており、最新の状態ですか？Google アカウントにログインしていますか？Google Play アプリのキャッシュをクリアしてデバイスを再起動してみてください。</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play を開けませんでした。このデバイスで見つからない、無効になっている、または制限されている可能性があります。</string>
-    <string name="upgrades_no_purchases_found_check_account">購入が確認できませんでした。正しいアカウントを使用していますでしょうか？</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">アップグレードオプション</string>
     <string name="upgrade_screen_offers_body">どちらのオプションでも全く同じ Pro 機能が利用できます。あなたに合った方をお選びください。</string>

--- a/app/src/gplay/res/values-ka-rGE/strings.xml
+++ b/app/src/gplay/res/values-ka-rGE/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">საჭიროა BVM Pro</string>
     <string name="upgrade_prompt_title">გადაიდგეს BVM Pro-ზე</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro გთავაზობს უკეთეს შედეგადებს, მეტ თვისებასა და პარამეტრებს გამოცდილი მომხმარებისთვის.</string>
-    <string name="upgrade_prompt_upgrade_action">გარემონტება</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">დაუგრეჩეთ %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager რეკლამაგარეშია და მომხმარეთა მონაცემებს არ ყიდის. ჩემს სამუშაოს დაფინანსება თქვენია გვიერ გენიათ ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager-ს არ შეუძლია Google Play-ზე დაკავშირება. დაყენებულია Google Play დაყენებულია და განახლებულია? ეში თქვენი Google ანგარიში შესულია? სცადეთ Google Play აპის ქეშის გასუფთავება და მოწყობილობის გადატვირთვა.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">ვერ გამოვხსნეთ Google Play. ის შეიძლება აკლია, გამორთული ან შეზღუდული იყოს ამ მოწყობილობაზე.</string>
-    <string name="upgrades_no_purchases_found_check_account">შესყიდვები ვერ მოიძებნა. სწორ ანგარიშს იყენებთ?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">განახლების ვარიანტები</string>
     <string name="upgrade_screen_offers_body">ორივე ვარიანტი გთავაზობთ იმავე Pro ფუნქციებს — აირჩიეთ ის, რომელიც თქვენთვის უფრო კარგია.</string>

--- a/app/src/gplay/res/values-km-rKH/strings.xml
+++ b/app/src/gplay/res/values-km-rKH/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">ត្រូវការ BVM Pro</string>
     <string name="upgrade_prompt_title">អ័ពគថ83 ត្រឹមត្រូវ BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ផ្តល់នួវផលលើសជាង្រើសមុខងារនិងជម្រើសប័កព្រមសម្រាប់សម្រាប់សធ្វី។</string>
-    <string name="upgrade_prompt_upgrade_action">វិសិដ្ឋកម្ម</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">លើកកម្ពស់ទៅ %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager មិនមានព្សនា ។។។ ហើយមិនលក់លាយត្រម្វន្តិយរបស់ប្រើបស័រី។ ការការរបស់សម្រាប់របស់ត្រងប្រើទីអ្នក ❤️។</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager មិនអាចភ្ជាប់ទៅ Google Play បានទេ។ តើ Google Play ត្រូវបានដំឡើងហើយទាន់សម័យទេ? តើគណនី Google របស់អ្នកបានចូលហើយទេ? សូមព្យាយាមមើលការសម្អាតឃ្លាំងសម្ងាត់នៃកម្មវិធី Google Play ហើយចាប់ផ្ដើមដំណើរការឧបករណ៍ឡើងវិញ។</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">មិនបានបើក Google Play ទេ។ វាប្រហែលជាបាត់ ឈប់ដំណើរការ ឬត្រូវបានដាក់ឆ្នោតលើឧបករណ៍នេះ។</string>
-    <string name="upgrades_no_purchases_found_check_account">រកមិនឃើញការទិញ។ តើអ្នកកំពុងប្រើគណនីត្រឹមត្រូវទេ?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">ជម្រើសលើកកម្ពស់</string>
     <string name="upgrade_screen_offers_body">ជម្រើសទាំងពីរដោះលែកលក្ខណៈពិសេស Pro ដូចគ្នាបេះបិទ — ជ្រើសរើសមួយដែលសមស្របលោកអ្នក។</string>

--- a/app/src/gplay/res/values-kmr-rTR/strings.xml
+++ b/app/src/gplay/res/values-kmr-rTR/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro hewce dike</string>
     <string name="upgrade_prompt_title">Biçe BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ji bo bikarhênerên pêşkeftî encamên baştir, taybetmendî û vebijarkên zêdetir pêşkêş dike.</string>
-    <string name="upgrade_prompt_upgrade_action">Nûjen bike</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Bihevkirin a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklamê nake û daneya bikarhêner nafroşe. Xebata min ji aliyê we ve tê fînanskirinê ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nikare bi Google Play re girêbide. Ma Google Play saz û nûkirî ye? Cache ya Google Play pak bike û cîhazê xwe ji nû ve bixebite.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play nehat vekirin. Dibe ku winda bûbe, nehatiye çalak kirin an tê sînordar kirin di vê cihazê de.</string>
-    <string name="upgrades_no_purchases_found_check_account">Kirîn nehatin dîtin. Hûn hesabê rast bikar tînin?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Vebijarkên bihevkirinê</string>
     <string name="upgrade_screen_offers_body">Her du vebijark taybetmendiyên Pro-yê yên xwe de vekirî dikin — ya ku tu dixwazî, hilbijêre.</string>

--- a/app/src/gplay/res/values-kn-rIN/strings.xml
+++ b/app/src/gplay/res/values-kn-rIN/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro ಅಗತ್ಯ</string>
     <string name="upgrade_prompt_title">BVM Pro ಗೆ ದರ್ಜೆಯೇರಿ</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ಉತ್ತಮ ಫಲಿತಾಂಶಗಳನ್ನು, ಹೆಚ್ಚಿನ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಮತ್ತು ಪವರ್ ಬಳಕೆದಾರರಿಗೆ ಆಯ್ಕೆಗಳನ್ನು ನೀಡುತ್ತದೆ.</string>
-    <string name="upgrade_prompt_upgrade_action">ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s ಗೆ ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ಜಾಹೀರಾತುಗಳಿಲ್ಲ ಮತ್ತು ಬಳಕೆದಾರರ ಡೇಟಾ ಮಾರಾಟುವುದಿಲ್ಲ. ನನ್ನ ಕೆಲಸ ನಿಮ್ಮಿಂದ ಹಗಲಾಗುತ್ತದೆ ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play ಗೆ ಸಂಪರ್ಕಿಸಲು ಸಾಧ್ಯವಾಗುತ್ತಿಲ್ಲ. Google Play ಇನ್ಸ್ಟಾಲ್ ಆಗಿ ನವೀಕರಿಸಲಾಗಿದೆಯೇ? ನಿಮ್ಮ Google ಖಾತೆ ಲಾಗಿನ್ ಆಗಿದೆಯೇ? Google Play ಅಪ್ ಕ್ಯಾಚೆ ತೆರವುಮಾಡಿ ಮರುಬುಟ್ ಮಾಡಿ.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play ಅನ್ನು ತೆರೆಯಲಾಗಲಿಲ್ಲ. ಇದು ಸ್ಥಾಪಿತವಾಗಿರದೆ, ನಿಷ್ಕ್ರಿಯವಾಗಿರುವ ಅಥವಾ ಈ ಸಾಧನದಲ್ಲಿ ನಿರ್ಬಂಧಿತವಾಗಿರುವ ಸಾಧ್ಯತೆ ಇದೆ.</string>
-    <string name="upgrades_no_purchases_found_check_account">ಯಾವುದೇ ಖರೀದಿಗಳು ಕಂಡುಬಂದಿಲ್ಲ. ನೀವು ಸರಿಯಾದ ಖಾತೆಯನ್ನು ಬಳಸುತ್ತಿದ್ದೀರಾ?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">ಅಪ್‌ಗ್ರೇಡ್ ಆಯ್ಕೆಗಳು</string>
     <string name="upgrade_screen_offers_body">ಎರಡೂ ಆಯ್ಕೆಗಳು ನಿಖಿಲವಾಗಿ ಅದೇ ಪ್ರೋ ವೈಶಿಷ್ಟ್ಯಗಳನ್ನು ಅನ್‌ಲಾಕ್ ಮಾಡುತ್ತವೆ — ನಿಮಗೆ ಸರಿಯಾದುದನ್ನು ಆರಿಸಿಕೊಳ್ಳಿ.</string>

--- a/app/src/gplay/res/values-ko/strings.xml
+++ b/app/src/gplay/res/values-ko/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro가 필요합니다</string>
     <string name="upgrade_prompt_title">BVM Pro로 업그레이드</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro는 파워유저들을 위해 더 나은 결과와 더 많은 기능 및 옵션을 제공합니다.</string>
-    <string name="upgrade_prompt_upgrade_action">업그레이드</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s로 업그레이드</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager는 광고가 없고 유저 데이터를 팔지 않습니다. 제 작업은 여러분의 지원으로 이루어집니다 ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager가 Google Play에 연결할 수 없습니다. Google Play가 설치되어 있고 최신 버전인가요? Google 계정이 로그인되어 있나요? Google Play 앱의 캐시를 지우고 기기를 재부팅해 보세요.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play를 열 수 없습니다. 이 기기에서 Google Play가 없거나 비활성화되었거나 제한되어 있을 수 있습니다.</string>
-    <string name="upgrades_no_purchases_found_check_account">구매 항목을 찾을 수 없습니다. 올바른 계정을 사용 중인가요?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">업그레이드 옵션</string>
     <string name="upgrade_screen_offers_body">두 옵션 모두 동일한 Pro 기능을 제공합니다 — 원하는 것을 선택하세요.</string>

--- a/app/src/gplay/res/values-ky-rKG/strings.xml
+++ b/app/src/gplay/res/values-ky-rKG/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro талап кылат</string>
     <string name="upgrade_prompt_title">BVM Pro га өтүү</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro күчтүү пайдалануучулар үчүн жакшыраак натыйжаларды, көбүрөк функцияларды жана мүмкүнчүлүктөрдү сунат.</string>
-    <string name="upgrade_prompt_upgrade_action">Жаңыртуу</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s сунуштуу жогорулоо</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager жарнамаларсыз жана пайдалануучулардын мәлиматын сатпайт. Менин жумушум сиздин қаржыланат ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play га байлана албайт. Google Play орнотулган жана жаңыртылганбы? Google аккаунтыңызга киргенбе? Google Play кэшин тазалап, түзмөгүңүздү кайра чүмүрлөө көрүңүз.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play ачуу мүмкүн болбоду. Бул түзмөктө жок, өчүк же чектелген болушу мүмкүн.</string>
-    <string name="upgrades_no_purchases_found_check_account">Эч кандай сатып алуулар табылган жок. Туура каттоо эсебин колдонуп жатасызбы?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Жогорулоо опциялары</string>
     <string name="upgrade_screen_offers_body">Эки опция тең бирдей Pro функцияларын ачат — сизге ылайык болгонду тандаңыз.</string>

--- a/app/src/gplay/res/values-lo-rLA/strings.xml
+++ b/app/src/gplay/res/values-lo-rLA/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">ຕ້ອງການ BVM Pro</string>
     <string name="upgrade_prompt_title">ອັບເກຣດເປັນ BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ໃຫ້ຜ໏ລໍບທີ່ດີກວ່າ, ມີຄຸນສົມແລະຕັວເລືອກເພິ່ມເຕີມສຳຫຣັບຜູ້ໃຊ້ທີ່ເພີບ.</string>
-    <string name="upgrade_prompt_upgrade_action">ອັບເກຣດ</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">ອັບເກຣດເປັນ %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ບ່ມີໂຆສນາເກ໭ນແລະບ່ຂາຍຂ້ອມູນຜູ້ໃຊ້. ງານຂອງຂ້ອນສະຫນັບສນຸນໂດຍທ່ານ ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ໂຊ່ມຕ່ອກັບ Google Play ໄດ້. ໂດຍຕິດຕັ້ງ Google Play ແລະອັດເດທໄດ້ບ່? ເຂົ້າລັອກ Google ໄດ້ບ່? ລອງລ້າງແຄຊແລະຊົກເລີ່ມອຸປກອນຂອງທ່ານໃຫມ່.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">ບໍ່ສາມາດເປີດ Google Play ໄດ້. ມັນອາດຈະຫາຍໄປ, ປິດໃຊ້ງານ, ຫຼື ຖືກຈໍາກັດໃນອຸປະກອນນີ້.</string>
-    <string name="upgrades_no_purchases_found_check_account">ບໍ່ພົບການຊື້. ທ່ານກຳລັງໃຊ້ບັນຊີທີ່ຖືກຕ້ອງບໍ?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">ຕົວເລືອກການອັບເກຣດ</string>
     <string name="upgrade_screen_offers_body">ທັງສອງຕົວເລືອກຈະປົ່ອຍໃຫ້ຟີເຈີ Pro ແບບດຽວກັນ — ເລືອກອັນໃດກໍ່ໄດ້ທີ່ເໝາະສົມກັບທ່ານ.</string>

--- a/app/src/gplay/res/values-lt/strings.xml
+++ b/app/src/gplay/res/values-lt/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Reikia BVM Pro</string>
     <string name="upgrade_prompt_title">Atnaujinti į BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro siūlo geresnius rezultatus, daugiau funkcijų ir galimybių pažengusiems naudotojams.</string>
-    <string name="upgrade_prompt_upgrade_action">Atnaujinti</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Atnaujinti į %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager neturi reklamų ir neparduoda naudotojų duomenų. Mano darbas finansuojamas jūsų ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager negali prisijungti prie Google Play. Ar įdiegta ir atnaujinta Google Play? Ar esate prisijungę prie Google paskyros? Pabandykite išvalyti Google Play programėlės talpyklą ir paleisti iš naujo įrenginį.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nepavyko atidaryti „Google Play“. Jis gali būti nesuinstaliuotas, išjungtas arba apribotas šiame įrenginyje.</string>
-    <string name="upgrades_no_purchases_found_check_account">Pirkimų nerasta. Ar naudojate tinkamą paskyrą?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Atnaujinimo parinktys</string>
     <string name="upgrade_screen_offers_body">Abi parinktys atrakina tuos pačius Pro pranašumus — pasirinkite, kurie jums tinka.</string>

--- a/app/src/gplay/res/values-lv/strings.xml
+++ b/app/src/gplay/res/values-lv/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Nepieciešams BSP Pro</string>
     <string name="upgrade_prompt_title">Jaunināt uz BSP Pro</string>
     <string name="upgrade_prompt_body">Bluetooth skaļuma pārvaldnieks Pro piedāvā labākus rezultātus, vairāk funkciju un opciju sapļrotājiem lietotājiem.</string>
-    <string name="upgrade_prompt_upgrade_action">Jaunināt</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Jaunināt uz %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth skaļuma pārvaldniekam nav reklāmu un tas nepardod lietotāju datus. Manu darbu finansiē jūs.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth skaļuma pārvaldnieks nevar izveidot savienojumu ar Google Play. Vai Google Play ir instalēts un atjaunināts? Vai Google konts ir piezēmošanās? Mēģiniet notīrīt Google Play lietotnes kešatmiņu un pārstārtout ierīci.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nevarēja atvērt Google Play. Tas var nebūt instalēts, atspējots vai ierobežots šajā ierīcē.</string>
-    <string name="upgrades_no_purchases_found_check_account">Pirkumi nav atrasti. Vai izmantojat pareizo kontu?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Jaunināšanas opcijas</string>
     <string name="upgrade_screen_offers_body">Abas opcijas atbloķē tieši tās pašas Pro funkcijas — izvēlieties to, kas jums der.</string>

--- a/app/src/gplay/res/values-mk-rMK/strings.xml
+++ b/app/src/gplay/res/values-mk-rMK/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Потребен е BVM Pro</string>
     <string name="upgrade_prompt_title">Надгради на BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro нуди подобри резултати, повеќе функции и опции за напредни корисници.</string>
-    <string name="upgrade_prompt_upgrade_action">Надградба</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Надградете на %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклами и не продава кориснички податоци. Мојата работа е финансирана од вас ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може да се поврзе со Google Play. Дали Google Play е инсталиран и ажуриран? Дали вашата Google сметка е најавена? Обидете се да ја исчистите кеш меморијата на апликацијата Google Play и рестартирајте го вашиот уред.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Не можеше да се отвори Google Play. Може да е отсутно, деактивирано или ограничено на овој уред.</string>
-    <string name="upgrades_no_purchases_found_check_account">Не се пронајдени купувања. Дали користите вистинска сметка?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Опции за надградба</string>
     <string name="upgrade_screen_offers_body">Обете опции ви даваат исти Pro функции — одберите онаа која вам одговара.</string>

--- a/app/src/gplay/res/values-ml-rIN/strings.xml
+++ b/app/src/gplay/res/values-ml-rIN/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro ആവശ്യമാണ്</string>
     <string name="upgrade_prompt_title">BVM Pro യിലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro മികക്കല് മിക്ക ഫലം, പവർ ഉപയോക്താക്കൾക്ക് കൂടുതൽ ഫീച്ചർം ഓപ്ഷനുകളും നൽകുന്നു.</string>
-    <string name="upgrade_prompt_upgrade_action">അപ്ഗ്രേഡുചെയ്യുക</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s-ലേക്ക് അപ്ഗ്രേഡ് ചെയ്യുക</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager പ്രജ്ഞാപനങ്ങൾ ഇല്ല, ഉപയോക്തൃ ഡേറ്റ വിൽക്കുന്നില്ല. എന്റെ ജോലി നിങ്ങൾ വഴി ധനസഹായം കിട്ടുന്നു ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ക്ക് Google Play യുമായ് ബന്ധപ്പെടാൻ കഴിയുന്നില്ല. Google Play ഇൻസ്റ്റൽ ചെയ്ത് അപ്ഡേറ്റ് ചെയ്തിട്ടുണ്ടോ? നിങ്ങളുടെ Google അക്കൗൺട് ലോഗിൻ ചെയ്തിട്ടുണ്ടോ? Google Play ആപ്പിന്റെ ക്യാഷ് മാർജിക്കുകയും ഉപകരണം രീബൂട്ട് ചെയ്യുകയും ശ്രമിക്കുക.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play തുറക്കാൻ കഴിഞ്ഞില്ല. ഈ ഉപകരണത്തിൽ ഇത് നഷ്ടപ്പെട്ടതോ നിഷ്ക്രിയമാക്കപ്പെട്ടതോ നിയന്ത്രിതമാക്കപ്പെട്ടതോ ആയിരിക്കാം.</string>
-    <string name="upgrades_no_purchases_found_check_account">വാങ്ങലുകളൊന്നും കണ്ടെത്തിയില്ല. നിങ്ങൾ ശരിയായ അക്കൗണ്ട് തന്നെയാണോ ഉപയോഗിക്കുന്നത്?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">അപ്ഗ്രേഡ് ഐച്ഛികതകൾ</string>
     <string name="upgrade_screen_offers_body">രണ്ട് ഐച്ഛികതകളും ഒരേപോലെ Pro സവിശേഷതകൾ അൺലോക്ക് ചെയ്യുന്നു — നിങ്ങൾക്ക് ഇഷ്ടപ്പെട്ടത് തിരഞ്ഞെടുക്കുക.</string>

--- a/app/src/gplay/res/values-mn-rMN/strings.xml
+++ b/app/src/gplay/res/values-mn-rMN/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro шаардлагана</string>
     <string name="upgrade_prompt_title">BVM Pro рүү шилжээх</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro илүү үр дүн, илүү онцлог ба шинжлэх хэрэглэгчиддүгээр илүү сонголтыг саналддаг.</string>
-    <string name="upgrade_prompt_upgrade_action">Сайжруулах</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s рүү шаруулах</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager сурталчилгаагүй бөгөөд хэрэглэгчийн өгөгдлийг зардаггүй. Миний ажиллыг та нараар санхүүжнэ ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play-тай холбогдож чадахгүй байна. Google Play суулгагдсан бөгөөд шинэчлэлтсэн уу? Google хаднаа нэвтрээсэн байна уу? Google Play аппын кэшийг арилгаад төхөөрөмжийгеэ дахин ньюцлаарай.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play-г нээх боломжгүй байна. Энэ төхөөрөмжид байхгүй, идэвхгүй эсвэл хязгаарлагдсан байж болно.</string>
-    <string name="upgrades_no_purchases_found_check_account">Худалдан авалт олдсонгүй. Та зөв бүртгэл ашиглаж байна уу?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Шаруулах сонголтууд</string>
     <string name="upgrade_screen_offers_body">Хоёр сонголт нь яг адилхан Pro функцүүдийг нээдэг — танд тохирохыг сонгоно уу.</string>

--- a/app/src/gplay/res/values-mr-rIN/strings.xml
+++ b/app/src/gplay/res/values-mr-rIN/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro आवश्यक आहे</string>
     <string name="upgrade_prompt_title">BVM Pro वर अपग्रेड करा</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro शक्तिशाली वापरकर्त्यांसाठी चांगले परिणाम, अधिक वैशिष्ट्ये आणि पर्याय देते.</string>
-    <string name="upgrade_prompt_upgrade_action">अपग्रेड करा</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s वर अपग्रेड करा</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ला कोणतीही अॅड नाही आणि वापरकर्त्यांचा डेटा विकत नाही. माझे काम तुम्ही उचलवून अर्थपुरवठा केलेली आहे ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play शी कनेक्ट करू शकत नाही. Google Play इन्स्टॉल आणि अपडेट आहे का? तुमचे Google खाते लॉग इन आहे का? Google Play अॅपचा कॅश साफ करण्याचा आणि डिव्हाइस रीबूट करण्याचा प्रयत्न करा.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">गूगल प्ले खोलू शकलो नाही. हे या डिव्हाइसवर गहाळ, अक्षम किंवा प्रतिबंधित असू शकते.</string>
-    <string name="upgrades_no_purchases_found_check_account">कोणतीही खरेदी आढळली नाही. तुम्ही योग्य खाते वापरत आहात का?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">अपग्रेड पर्याय</string>
     <string name="upgrade_screen_offers_body">दोन्ही पर्याय समान Pro वैशिष्ट्ये अनलॉक करतात — जो तुम्हाला योग्य वाटतो तो निवडा.</string>

--- a/app/src/gplay/res/values-ms/strings.xml
+++ b/app/src/gplay/res/values-ms/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Memerlukan BVM Pro</string>
     <string name="upgrade_prompt_title">Naik taraf ke BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro menawarkan hasil yang lebih baik, lebih banyak ciri dan pilihan untuk pengguna berkuasa.</string>
-    <string name="upgrade_prompt_upgrade_action">Naik taraf</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Tingkatkan kepada %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager tiada iklan dan tidak menjual data pengguna. Kerja saya dibiayai oleh anda ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager tidak dapat menyambung ke Google Play. Adakah Google Play dipasang dan dikemaskini? Adakah Akaun Google anda log masuk? Cuba kosongkan cache aplikasi Google Play dan but semula peranti anda.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Tidak dapat membuka Google Play. Ia mungkin tiada, dimatikan, atau dibatasi di peranti ini.</string>
-    <string name="upgrades_no_purchases_found_check_account">Tiada pembelian ditemui. Adakah anda menggunakan akaun yang betul?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Pilihan peningkatan</string>
     <string name="upgrade_screen_offers_body">Kedua-dua pilihan membuka fitur Pro yang sama — pilih yang paling sesuai untuk anda.</string>

--- a/app/src/gplay/res/values-my-rMM/strings.xml
+++ b/app/src/gplay/res/values-my-rMM/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro လိုအပ်သည်</string>
     <string name="upgrade_prompt_title">BVM Pro သို့ အဆင့်မြှင့်ပါ</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro သည် ပိုမိုကောင်းမွန်သော ရလဒ်များ၊ ပိုမိုများပြားသော လုပ်ဆောင်ချက်များနှင့် ကျွမ်းကျင်အသုံးပြုသူများအတွက် ရွေးချယ်စရာများကို ပေးပါသည်။</string>
-    <string name="upgrade_prompt_upgrade_action">အဆင့်မြှင့်ပါ</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s သို့ အဆင့်မြှင့်တင်ပါ</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager တွင် ကြော်ငြာများမရှိပါ၊ အသုံးပြုသူဒေတာများကိုလည်း မရောင်းချပါ။ ကျွန်ုပ်၏အလုပ်ကို သင်မှ ငွေကြေးထောက်ပံ့ထားပါသည် ❤️။</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager မှ Google Play သို့ ချိတ်ဆက်၍မရပါ။ Google Play ထည့်သွင်းပြီး နောက်ဆုံးဗားရှင်းဖြစ်ပါသလား? သင်၏ Google အကောင့် ဝင်ရောက်ထားပါသလား? Google Play အက်ပ်၏ cache ကိုရှင်းလင်းပြီး ကိရိယာကိုပြန်လည်စတင်ကြည့်ပါ။</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play ကို မဖွင့်နိုင်ခဲ့ပါ။ ယင်းသည် ဤကိရိယာ ပေါ်တွင် မရှိခြင်း၊ ပိတ်ထားခြင်း သို့မဟုတ် ကန့်သတ်ထားခြင်း ရှိနိုင်ပါသည်။</string>
-    <string name="upgrades_no_purchases_found_check_account">ဝယ်ယူမှုများ ရှာမတွေ့ပါ။ မှန်ကန်သော အကောင့်ကို အသုံးပြုနေပါသလား။</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">အဆင့်မြှင့်တင်ခြင်းရွေးချယ်မှုများ</string>
     <string name="upgrade_screen_offers_body">ရွေးချယ်မှုနှစ်ခုစလုံးသည် အတူတူ Pro သွင်သတ္တာများကို သုံးစွဲနိုင်စေသည် — သင့်လျှောက်တွင်ရှိသည့်အရာ ရွေးချယ်ပါ။</string>

--- a/app/src/gplay/res/values-ne-rNP/strings.xml
+++ b/app/src/gplay/res/values-ne-rNP/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro आवश्यक छ</string>
     <string name="upgrade_prompt_title">BVM Pro मा अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ले शक्तिशाली प्रयोगकर्ताहरूका लागि राम्रो परिणाम, थप फिचरहरू र विकल्पहरू प्रदान गर्दछ।</string>
-    <string name="upgrade_prompt_upgrade_action">अपग्रेड गर्नुहोस्</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s मा अपग्रेड गर्नुहोस्</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager मा कुनै विज्ञापन छैन र यसले प्रयोगकर्ताको डेटा बাंड्दैन। मेरो काम तपाईंले गर्नुभएको आर्थिक सहयोगबाट चलिरहेको छ ❤️।</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play मा जोडिन सक्दैन। क्षमा गर्नुहोस्, Google Play स्थापित र अद्यतन छ? तपाईंको Google खाता लग इन गरिएको छ? Google Play अ्यापको क्यास साफ गर्नुहोस् र आफ्नो यन्त्र पुनःसुरू गर्नुहोस्।</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">गूगल प्ले खोल्न सकिएन। यो यस डिभाइसमा हराएको, अक्षम गरिएको वा प्रतिबन्धित हो सक्छ।</string>
-    <string name="upgrades_no_purchases_found_check_account">कुनै खरिदहरू फेला परेनन्। के तपाईं सही खाता प्रयोग गर्दै हुनुहुन्छ?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">अपग्रेड विकल्पहरू</string>
     <string name="upgrade_screen_offers_body">दोनै विकल्पले एक जस्तै Pro सुविधाहरू अनलक गर्छन् — आफूलाई सहि जो कुनै छनोट गर्नुहोस्।</string>

--- a/app/src/gplay/res/values-nl/strings.xml
+++ b/app/src/gplay/res/values-nl/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Vereist BVM Pro</string>
     <string name="upgrade_prompt_title">Upgrade naar BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro biedt betere resultaten, meer functies en opties voor hoofdgebruikers.</string>
-    <string name="upgrade_prompt_upgrade_action">Upgraden</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Upgrade naar %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager bevat geen advertenties en verkoopt geen gebruikersgegevens. Mijn werk wordt door jou gefinancierd ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan geen verbinding maken met Google Play. Is Google Play geïnstalleerd en up-to-date? Is je Google-account ingelogd? Probeer de cache van de Google Play-app te wissen en je apparaat opnieuw op te starten.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Kon Google Play niet openen. Het kan zijn dat het ontbreekt, is uitgeschakeld of beperkt is op dit apparaat.</string>
-    <string name="upgrades_no_purchases_found_check_account">Geen aankopen gevonden. Gebruik je de juiste rekening?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Upgrade-opties</string>
     <string name="upgrade_screen_offers_body">Beide opties ontgrendelen exact dezelfde Pro-functies — kies wat het beste voor je past.</string>

--- a/app/src/gplay/res/values-no/strings.xml
+++ b/app/src/gplay/res/values-no/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Krever BVM Pro</string>
     <string name="upgrade_prompt_title">Oppgrader til BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro tilbyr bedre resultater, flere funksjoner og alternativer for avanserte brukere.</string>
-    <string name="upgrade_prompt_upgrade_action">Oppgrader</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Oppgrader til %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har ingen annonser og selger ikke brukerdata. Arbeidet mitt er finansiert av deg ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan ikke koble til Google Play. Er Google Play installert og oppdatert? Er Google-kontoen din logget inn? Prøv å tømme hurtigbufferen til Google Play-appen og starte enheten på nytt.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Kunne ikke åpne Google Play. Det kan være manglende, deaktivert eller begrenset på denne enheten.</string>
-    <string name="upgrades_no_purchases_found_check_account">Ingen kjøp funnet. Bruker du riktig konto?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Oppgraderingsalternativer</string>
     <string name="upgrade_screen_offers_body">Begge alternativene låser opp nøyaktig samme Pro-funksjoner — velg det som passer best for deg.</string>

--- a/app/src/gplay/res/values-pcm-rNG/strings.xml
+++ b/app/src/gplay/res/values-pcm-rNG/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Need BVM Pro</string>
     <string name="upgrade_prompt_title">Upgrade to BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro dey give better results, more features and options for power users.</string>
-    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Upgrade to %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager no get ads and no dey sell user data. My work dey financed by you.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager no fit connect to Google Play. Google Play don install and up to date? Your Google Account don log in? Try clear di cache of Google Play app and reboot your device.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">No fit open Google Play. E fit be say am don miss, disabled or e restricted on this device.</string>
-    <string name="upgrades_no_purchases_found_check_account">No purchases found. You dey use di right account?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Ways to upgrade</string>
     <string name="upgrade_screen_offers_body">Both options go unlock same Pro features — pick di one wey fit you best.</string>

--- a/app/src/gplay/res/values-pl/strings.xml
+++ b/app/src/gplay/res/values-pl/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Wymaga BVM Pro</string>
     <string name="upgrade_prompt_title">Uaktualnij do BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferuje lepsze wyniki, więcej funkcji i opcji dla zaawansowanych użytkowników.</string>
-    <string name="upgrade_prompt_upgrade_action">Ulepszenie</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Uaktualnij do %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nie zawiera reklam i nie sprzedaje danych użytkowników. Moja praca jest finansowana przez ciebie ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nie może połączyć się z Google Play. Czy Google Play jest zainstalowany i aktualny? Czy jesteś zalogowany na swoim koncie Google? Spróbuj wyczyścić pamięć podręczną aplikacji Google Play i zrestartować urządzenie.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nie udało się otworzyć Google Play. Może być brakujące, wyłączone lub ograniczone na tym urządzeniu.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nie znaleziono zakupów. Czy używasz właściwego konta?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opcje aktualizacji</string>
     <string name="upgrade_screen_offers_body">Obie opcje odblokowują dokładnie te same funkcje Pro — wybierz tę, która ci się bardziej podoba.</string>

--- a/app/src/gplay/res/values-pt-rBR/strings.xml
+++ b/app/src/gplay/res/values-pt-rBR/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Requer BVM Pro</string>
     <string name="upgrade_prompt_title">Atualizar para BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferece melhores resultados, mais recursos e opções para usuários avançados.</string>
-    <string name="upgrade_prompt_upgrade_action">Atualizar</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Atualizar para %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados do usuário. Meu trabalho é financiado por você ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager não consegue se conectar ao Google Play. O Google Play está instalado e atualizado? Sua Conta do Google está conectada? Tente limpar o cache do app Google Play e reiniciar o dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Não foi possível abrir o Google Play. Pode estar ausente, desabilitado ou restrito neste dispositivo.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Você está usando a conta certa?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opções de upgrade</string>
     <string name="upgrade_screen_offers_body">Ambas as opções desbloqueiam os mesmos recursos Pro — escolha a que melhor se adequa a você.</string>

--- a/app/src/gplay/res/values-pt/strings.xml
+++ b/app/src/gplay/res/values-pt/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Requer BVM Pro</string>
     <string name="upgrade_prompt_title">Atualizar para BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferece melhores resultados, mais funcionalidades e opções para utilizadores avançados.</string>
-    <string name="upgrade_prompt_upgrade_action">Atualizar</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Atualizar para %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager não tem anúncios e não vende dados dos utilizadores. O meu trabalho é financiado por si ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">O Bluetooth Volume Manager não se consegue conectar ao Google Play. O Google Play está instalado e atualizado? A sua conta Google está conectada? Tente limpar a cache da aplicação Google Play e reinicie o seu dispositivo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Não foi possível abrir o Google Play. Pode estar em falta, desativado ou restringido neste dispositivo.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nenhuma compra encontrada. Está a usar a conta certa?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opções de atualização</string>
     <string name="upgrade_screen_offers_body">Ambas as opções desbloqueiam as mesmas funcionalidades Pro — escolha a que melhor se adequa.</string>

--- a/app/src/gplay/res/values-rm/strings.xml
+++ b/app/src/gplay/res/values-rm/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Dastga BVM Pro</string>
     <string name="upgrade_prompt_title">Upgradar a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro offra megliers resultats, pli blers featura ed opziuns per utilisaders avanzads.</string>
-    <string name="upgrade_prompt_upgrade_action">Actualisar</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Promomn tar %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager n\'ha nagins annunzis e na venda betg las datas dals utilisaders. Mia lavur vegn finanziada da tai ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager na po betg sa connectar cun Google Play. Es Google Play installar ed actualisà? Es tiu conto Google s\'annunzià? Emprova da stgular il cache da l\'applicaziun Google Play e da ristar tiu apparat.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">N\'ha pudì avrir Google Play. Igl pudess èsser che manca, deactivà u restringscha sin quest apparat.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nagins acquists chattads. Utiliseschas ti il conto gist?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opziuns da promomn</string>
     <string name="upgrade_screen_offers_body">Entrambi las opziuns deblieran las identicas funcziuns Pro — tscherna quella che ti stat meglier.</string>

--- a/app/src/gplay/res/values-ro/strings.xml
+++ b/app/src/gplay/res/values-ro/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Necesită BVM Pro</string>
     <string name="upgrade_prompt_title">Actualizează la BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferă rezultate mai bune, mai multe funcții şi opțiuni pentru utilizatorii avanсați.</string>
-    <string name="upgrade_prompt_upgrade_action">Actualizează</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Upgrade la %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nu are reclame şi nu vinde datele utilizatorilor. Munca mea este finanțată de tine ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nu se poate conecta la Google Play. Este Google Play instalat şi actualizat? Eşti conectat cu contul Google? Încearcă să ștergă cache-ul aplicației Google Play şi reporneşte dispozitivul.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nu s-a putut deschide Google Play. Este posibil să lipsească, să fie dezactivat sau restricționat pe acest dispozitiv.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nu s-a găsit nicio achiziție. Ești sigur că folosești contul corect?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opțiuni de upgrade</string>
     <string name="upgrade_screen_offers_body">Ambele opțiuni deblochează exact aceleași funcții Pro — alege pe care ți se potrivește.</string>

--- a/app/src/gplay/res/values-ru/strings.xml
+++ b/app/src/gplay/res/values-ru/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Требуется BVM Pro</string>
     <string name="upgrade_prompt_title">Обновить до BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro предлагает лучшие результаты, больше функций и опций для опытных пользователей.</string>
-    <string name="upgrade_prompt_upgrade_action">Обновление</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Перейти на %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не содержит рекламы и не продаёт данные пользователей. Моя работа финансируется вами ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не может подключиться к Google Play. Проверьте, установлен ли Google Play и обновлён ли до последней версии? Выполнен ли вход с Вашей учётной записью Google? Попробуйте очистить кэш Google Play и перезагрузить устройство.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Не удалось открыть Google Play. Возможно, он отсутствует, отключен или недоступен на этом устройстве.</string>
-    <string name="upgrades_no_purchases_found_check_account">Покупки не найдены. Используете ли Вы правильный аккаунт?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Варианты обновления</string>
     <string name="upgrade_screen_offers_body">Оба варианта разблокируют одинаковые функции Pro — выберите тот, который вам подходит.</string>

--- a/app/src/gplay/res/values-sc-rIT/strings.xml
+++ b/app/src/gplay/res/values-sc-rIT/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Riquerit BVM Pro</string>
     <string name="upgrade_prompt_title">Addobba a BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro oferit risultados mègius, prus caraterìsticas e optziones pro utentes avantzados.</string>
-    <string name="upgrade_prompt_upgrade_action">Agiornare</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Umpadu a %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager non tenet publitzidade e non bendet datos de sos utentes. Su traballu meu est finantziadu dae bois ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager non podet si connètere a Google Play. Google Play est installadu e agiornadu? Su contu Google tuo est intradu? Proa a limpiare sa cache de s\'aplicatzione Google Play e a torrare a allùghere su dispositivu tuo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">No at po abri Google Play. At po esser mancu, disabilidu o restrintu in custu dispositivu.</string>
-    <string name="upgrades_no_purchases_found_check_account">Perunu cùmperu agatadu. Ses impreande su contu giustu?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Optziones de umpadu</string>
     <string name="upgrade_screen_offers_body">Ambas as optziones isbalumant sa mesma funtzionalidades Pro — iscolzi chini ti cumenti.</string>

--- a/app/src/gplay/res/values-si-rLK/strings.xml
+++ b/app/src/gplay/res/values-si-rLK/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro අවශ්‍යයි</string>
     <string name="upgrade_prompt_title">BVM Pro වෙත උත්‍යෝජනය කරන්න</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro වඩා හොඳ ප්‍රතිඵල, වැඩි විශේෂාංග සහ බලවත් පරිශීලකයින් සඳහා විකල්ප ලබා දෙයි.</string>
-    <string name="upgrade_prompt_upgrade_action">වැඩිදියුණු කරන්න</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s වෙත උත්තර කරන්න</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager හි දැන්වීම් නොමැති අතර පරිශීලක දත්ත විකුණන්නේ නැත. මගේ වැඩ ඔබ විසින් මූල්‍යාධාර සපයයි ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager හට Google Play වෙත සම්බන්ධ වීමට නොහැකිය. Google Play ස්ථාපිත කර යාවත්කාලීන ද? ඔබේ Google ගිණුම පිවිසී ද? Google Play යෙදුමේ හැඹිලිය ඉවත් කර ඔබේ උපාංගය නැවත ආරම්භ කිරීමට උත්සාහ කරන්න.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play විවෘත කිරීමට නොහැකි විය. එය මෙම උපාංගයේ අතුරුදහන්, අබල හෝ සීමා කර ඇත.</string>
-    <string name="upgrades_no_purchases_found_check_account">කිසිදු මිලදී ගැනීමක් හමු නොවිණි. ඔබ නිවැරදි ගිණුම භාවිතා කරන්නේද?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">උත්තරණ විකල්පයන්</string>
     <string name="upgrade_screen_offers_body">දෙවිධ විකල්පයන්ම එකම ප්‍රෝ ගුණාංගයන් අගුළු ඇරයි — ඔබට සුදුසු එකක් තෝරන්න.</string>

--- a/app/src/gplay/res/values-sk/strings.xml
+++ b/app/src/gplay/res/values-sk/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Vyžaduje BVM Pro</string>
     <string name="upgrade_prompt_title">Prejsť na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ponúka lepšie výsledky, viac funkcií a možností pre náročných používateľov.</string>
-    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Upgradujte na %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nemá žiadne reklamy a nepredáva používateľské údaje. Moja práca je financovaná vami ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager sa nemôže pripojiť k Google Play. Je Google Play nainštalovaný a aktuálny? Je vaše konto Google prihlásené? Skúste vymazalť vyrovnávaciu pamäť aplikácie Google Play a reštartovať zariadenie.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nepodarilo sa otvoriť Google Play. Môže chýbať, byť zakázaná alebo obmedzená na tomto zariadení.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nenašli sa žiadne nákupy. Používate správny účet?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Možnosti upgradu</string>
     <string name="upgrade_screen_offers_body">Obe možnosti odomknú presne rovnaké funkcie Pro — vyberte si tú, ktorá vám vyhovuje.</string>

--- a/app/src/gplay/res/values-sl/strings.xml
+++ b/app/src/gplay/res/values-sl/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Zahteva BVM Pro</string>
     <string name="upgrade_prompt_title">Nadgradite na BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ponuja boljše rezultate, več funkcij in možnosti za napredne uporabnike.</string>
-    <string name="upgrade_prompt_upgrade_action">Nadgradi</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Nadgradite na %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nima oglasov in ne prodaja uporabniških podatkov. Moje delo financirate vi ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager se ne more povezati z Google Play. Ali je Google Play nameščen in posodobljen? Ali ste prijavljeni v Google Račun? Poskusite počistiti predpomnilnik aplikacije Google Play in znova zagnati napravo.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Ni bilo mogoče odpreti Google Play. Morda je onemogočena, ni dostopna ali omejena na tej napravi.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nakup ni bil najden.  Ali uporabljate pravi račun?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Možnosti nadgradnje</string>
     <string name="upgrade_screen_offers_body">Obe možnosti odkleneta enake Pro funkcije — izberite tisto, ki vam najbolj ustreza.</string>

--- a/app/src/gplay/res/values-sq-rAL/strings.xml
+++ b/app/src/gplay/res/values-sq-rAL/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Kërkon BVM Pro</string>
     <string name="upgrade_prompt_title">Përmirëso në BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ofron rezultate më të mira, më shumë veçori dhe opsione për përdoruesit e fuqishëm.</string>
-    <string name="upgrade_prompt_upgrade_action">Përmirëso</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Përmirëso në %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager nuk ka reklama dhe nuk shet të dhënat e përdoruesit. Puna ime financohet nga ju ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager nuk mund të lidhet me Google Play. A është Google Play i instaluar dhe i përditësuar? A jeni kyçur me llogarinë tuaj Google? Provoni të pastroni memorien e Google Play dhe të rinisni pajisjen tuaj.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Nuk mund të hape Google Play. Mund të mungojë, të jetë çaktivizuar ose i kufizuar në këtë pajisje.</string>
-    <string name="upgrades_no_purchases_found_check_account">Nuk u gjet asnjë blerje. A po përdorni llogarinë e duhur?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Opsionet e përmirësimit</string>
     <string name="upgrade_screen_offers_body">Të dy opsionet zhbllokojnë saktësisht të njëjtat veçori Pro — zgjidhni atë që ju përshtatet.</string>

--- a/app/src/gplay/res/values-sr/strings.xml
+++ b/app/src/gplay/res/values-sr/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Захтева BVM Pro</string>
     <string name="upgrade_prompt_title">Надогради на BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro нуди боље резултате, више функција и опција за искусне кориснике.</string>
-    <string name="upgrade_prompt_upgrade_action">Надогради</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Надгради на %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager нема реклама и не продаје корисничке податке. Мој рад финансираш ти ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може да се повеже на Google Play. Да ли је Google Play инсталиран и ажуриран? Да ли си пријављен на свој Google налог? Покушај очистити кеш Google Play апликације и поново покрени уређај.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Није могуће отворити Google Play. Може бити да недостаје, онемогућено је или ограничено на овом уређају.</string>
-    <string name="upgrades_no_purchases_found_check_account">Нису пронађене куповине. Користите ли прави налог?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Опције надградње</string>
     <string name="upgrade_screen_offers_body">Обе опције омогућавају исте Pro функције — изабери ону која ти одговара.</string>

--- a/app/src/gplay/res/values-sv/strings.xml
+++ b/app/src/gplay/res/values-sv/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Kräver BVM Pro</string>
     <string name="upgrade_prompt_title">Uppgradera till BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro erbjuder bättre resultat, fler funktioner och alternativ för avancerade användare.</string>
-    <string name="upgrade_prompt_upgrade_action">Uppgradera</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Uppgradera till %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager har inga annonser och säljer inte användardata. Mitt arbete finansieras av dig ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager kan inte ansluta till Google Play. Är Google Play installerat och uppdaterat? Är ditt Google-konto inloggat? Försök rensa cachen för Google Play-appen och starta om enheten.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Kunde inte öppna Google Play. Det kan vara saknat, inaktiverat eller begränsat på den här enheten.</string>
-    <string name="upgrades_no_purchases_found_check_account">Inga köp hittades. Använder du rätt konto?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Uppgraderingsalternativ</string>
     <string name="upgrade_screen_offers_body">Båda alternativen låser upp exakt samma Pro-funktioner – välj det som passar dig bäst.</string>

--- a/app/src/gplay/res/values-sw/strings.xml
+++ b/app/src/gplay/res/values-sw/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Inahitaji BVM Pro</string>
     <string name="upgrade_prompt_title">Boresha hadi BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro inatoa matokeo bora zaidi, vipengele vingi zaidi na chaguzi kwa watumiaji wa hali ya juu.</string>
-    <string name="upgrade_prompt_upgrade_action">Boresha</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Boreshwa kwa %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager haina matangazo na haiuzi data ya mtumiaji. Kazi yangu inafadhiliwa na wewe ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager haiwezi kuunganika na Google Play. Je, Google Play imewekwa na iko ya kisasa? Je, akaunti yako ya Google imeingia? Jaribu kufuta kashe ya programu ya Google Play na kuanzisha upya kifaa chako.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Haiwezi kufungua Google Play. Inaweza kuwa imefutwa, iliyolemazwa au iliyozuiwa kwenye simu hii.</string>
-    <string name="upgrades_no_purchases_found_check_account">Hakuna ununuzi uliopatikana. Je, unatumia akaunti sahihi?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Chaguo za kuboreshwa</string>
     <string name="upgrade_screen_offers_body">Chaguo zote zimefungua uwezo sawa wa Pro — chagua yoyote inayokufaa.</string>

--- a/app/src/gplay/res/values-ta-rIN/strings.xml
+++ b/app/src/gplay/res/values-ta-rIN/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro தேவைப்படுகிறது</string>
     <string name="upgrade_prompt_title">BVM Proக்கு மேம்படுத்து</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro சிறந்த தர்வ்ூதல்கள், மேலும் அனுபவம், மேலும் அமைப்்புகள் மற்றும் சக்தியான பயனர்களுக்கான விருப்பங்களை வாயில் வளர்கிறது.</string>
-    <string name="upgrade_prompt_upgrade_action">மேம்படுத்து</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s க்கு மேம்படுத்தவும்</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager விளம்பரங்கள் இல்லாதது மற்றும் பயனர் தரவுகளை விற்கவிற்கை இல்லை. என் பணியின் நிதியம் உங்களால் வழங்கப்படுகிறது.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Playஆல் இணையமுடியவில்லை. Google Play நிறுவப்பட்டு புதுப்பிக்கப்பட்டதா? உங்கள் Google கணக்கு உள்நுழைகிறீர்களா? Google Play பயன்பாட்டுகள் தீளிப்பை அழித்து சாதனத்தை மறுதொடக்கம் செய்து முயற்சிக்கவும்.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play ஐ திறக்க முடியவில்லை. இது சாதனத்தில் இல்லாமல் இருக்கலாம், முடக்கப்பட்டிருக்கலாம் அல்லது கட்டுப்படுத்தப்பட்டிருக்கலாம்.</string>
-    <string name="upgrades_no_purchases_found_check_account">கொள்முதல்கள் எதுவும் இல்லை. நீங்கள் சரியான கணக்கைப் பயன்படுத்துகிறீர்களா?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">மேம்படுத்தல் விருப்பங்கள்</string>
     <string name="upgrade_screen_offers_body">இரண்டு விருப்பங்களும் ஒரே Pro அம்சங்களை திறக்கின்றன — உங்களுக்குப் பொருத்தமான ஒன்றைத் தேர்ந்தெடுக்கவும்.</string>

--- a/app/src/gplay/res/values-te-rIN/strings.xml
+++ b/app/src/gplay/res/values-te-rIN/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro అవసరం</string>
     <string name="upgrade_prompt_title">BVM Pro కి అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro మెరుగైన ఫలితాలు, మరిన్ని ఫీచర్లు మరియు పవర్ యూజర్ల కోసం ఆప్షన్లను అందిస్తుంది.</string>
-    <string name="upgrade_prompt_upgrade_action">అప్‌గ్రేడ్ చేయండి</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s కు అప్‌గ్రేడ్ చేయండి</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager కి ప్రకటనలు లేవు మరియు వినియోగదారు డేటాను విక్రయించదు. నా పని మీరు ఆర్థిక సహాయం చేస్తున్నారు ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play కి కనెక్ట్ కాలేకపోతోంది. Google Play ఇన్‌స్టాల్ చేయబడి అప్-టు-డేట్‌గా ఉందా? మీ Google అకౌంట్ లాగిన్ అయి ఉందా? Google Play యాప్ యొక్క కాష్‌ని క్లియర్ చేసి మీ పరికరాన్ని రీబూట్ చేయడానికి ప్రయత్నించండి.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Playని తెరవలేకపోయాము. ఇది ఈ పరికరంపై లేకపోవచ్చు, నిష్క్రియం చేయబడవచ్చు లేదా నిషేధించబడవచ్చు.</string>
-    <string name="upgrades_no_purchases_found_check_account">కొనుగోళ్లు కనుగొనబడలేదు. మీరు సరైన ఖాతాను ఉపయోగిస్తున్నారా?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">అప్‌గ్రేడ్ ఎంపికలు</string>
     <string name="upgrade_screen_offers_body">రెండు ఎంపికలు ఖచ్చితంగా ఒకే Pro ఫీచర్‌లను అన్‌లాక్ చేస్తాయి — మీకు సరిపోయే దానిని ఎంచుకోండి.</string>

--- a/app/src/gplay/res/values-th/strings.xml
+++ b/app/src/gplay/res/values-th/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">ต้องใช้ BVM Pro</string>
     <string name="upgrade_prompt_title">อัปเกรดเป็น BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro ให้ผลลัพธ์ที่ดีกว่า ฟีเจอร์เพิ่มเติม และตัวเลือกสำหรับผู้ใช้ขั้นสูง</string>
-    <string name="upgrade_prompt_upgrade_action">อัปเกรด</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">อัปเกรดเป็น %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager ไม่มีโฆษณาและไม่ขายข้อมูลผู้ใช้ งานของฉันได้รับการสนับสนุนทางการเงินจากคุณ ❤️</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager ไม่สามารถเชื่อมต่อกับ Google Play ได้ Google Play ได้รับการติดตั้งและอัปเดตแล้วหรือไม่? บัญชี Google ของคุณเข้าสู่ระบบแล้วหรือไม่? ลองล้างแคชของแอป Google Play และรีบูตอุปกรณ์ของคุณ</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">ไม่สามารถเปิด Google Play ได้ แอปอาจหายไป ปิดใช้งาน หรือถูกจำกัดบนอุปกรณ์นี้</string>
-    <string name="upgrades_no_purchases_found_check_account">ไม่พบการซื้อ คุณใช้บัญชีที่ถูกต้องหรือไม่?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">ตัวเลือกอัปเกรด</string>
     <string name="upgrade_screen_offers_body">ตัวเลือกทั้งสองปลดล็อกฟีเจอร์ Pro เดียวกัน — เลือกตัวเลือกใดก็ได้ที่เหมาะกับคุณ</string>

--- a/app/src/gplay/res/values-tr/strings.xml
+++ b/app/src/gplay/res/values-tr/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro gereklidir</string>
     <string name="upgrade_prompt_title">BVM Pro\'ya Yükselt</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro, uzman kullanıcılar için daha iyi sonuçlar, daha fazla özellik ve seçenek sunar.</string>
-    <string name="upgrade_prompt_upgrade_action">Yükselt</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s\'a yükseltin</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklam içermez ve kullanıcı verilerini satmaz. Çalışmalarım sizler tarafından finanse edilmektedir ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play\'e bağlanamıyor. Google Play yüklü ve güncel mi? Google Hesabınız ile oturum açtınız mı? Google Play uygulamasının önbelleğini temizlemeyi ve cihazınızı yeniden başlatmayı deneyin.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play açılamadı. Bu cihazda yüklü olmayabilir, devre dışı olabilir veya kısıtlanmış olabilir.</string>
-    <string name="upgrades_no_purchases_found_check_account">Satın alma bulunamadı. Doğru hesabı mı kullanıyorsunuz?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Yükseltme seçenekleri</string>
     <string name="upgrade_screen_offers_body">Her iki seçenek tam olarak aynı Pro özelliklerinin kilidini açar — sizin için uygun olanı seçin.</string>

--- a/app/src/gplay/res/values-uk/strings.xml
+++ b/app/src/gplay/res/values-uk/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Потрібен BVM Pro</string>
     <string name="upgrade_prompt_title">Оновити до BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro пропонує кращі результати, більше функцій та опцій для досвідчених користувачів.</string>
-    <string name="upgrade_prompt_upgrade_action">Підвищити статус</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Оновити на %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager не має реклами та не продає дані користувачів. Моя робота фінансується вами ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager не може підключитися до Google Play. Google Play встановлений та оновлений? Ви увійшли до облікового запису Google? Спробуйте очистити кеш Google Play та перезавантажити пристрій.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Не вдалося відкрити Google Play. Можливо, він відсутній, вимкнений або обмежений на цьому пристрої.</string>
-    <string name="upgrades_no_purchases_found_check_account">Покупки не знайдено. Ви використовуєте правильний обліковий запис?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Варіанти оновлення</string>
     <string name="upgrade_screen_offers_body">Обидва варіанти розблоковують абсолютно однакові функції Pro — виберіть той, що вам більше подобається.</string>

--- a/app/src/gplay/res/values-ur-rIN/strings.xml
+++ b/app/src/gplay/res/values-ur-rIN/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro کی ضرورت ہے</string>
     <string name="upgrade_prompt_title">BVM Pro میں اپ گریڈ کریں</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro بہتر نتائج، زیادہ خصوصیات اور پاور یوزرز کے لیے آپشنز پیش کرتا ہے۔</string>
-    <string name="upgrade_prompt_upgrade_action">اپ گریڈ کریں</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s کو اپ گریڈ کریں</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager میں کوئی اشتہار نہیں ہے اور یہ صارف کا ڈیٹا فروخت نہیں کرتا۔ میرا کام آپ کی وجہ سے فنڈ ہوتا ہے ❤️۔</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager گوگل پلے سے منسلک نہیں ہو سکتا۔ کیا گوگل پلے نصب اور تازہ کاری ہے؟ کیا آپ کا گوگل اکاؤنٹ لاگ ان ہے؟ گوگل پلے ایپ کیں صاف کریں اور ڈیوائس ریبوٹ کریں۔</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play نہیں کھل سکا۔ ہو سکتا ہے یہ موجود نہ ہو، غیر فعال ہو یا اس ڈیوائس پر محدود ہو۔</string>
-    <string name="upgrades_no_purchases_found_check_account">کوئی خریداری نہیں ملی۔ کیا آپ صحیح اکاؤنٹ استعمال کر رہے ہیں؟</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">اپ گریڈ کے اختیارات</string>
     <string name="upgrade_screen_offers_body">دونوں اختیارات بالکل ایک جیسی Pro خصوصیات کو کھولتے ہیں — جو بھی آپ کے لیے موزوں ہو وہ منتخب کریں</string>

--- a/app/src/gplay/res/values-uz/strings.xml
+++ b/app/src/gplay/res/values-uz/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">BVM Pro talab qilinadi</string>
     <string name="upgrade_prompt_title">BVM Pro ga o\'tish</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro quvvatli foydalanuvchilar uchun yaxshiroq natijalar, ko\'proq funksiyalar va opsiyalar taklif qiladi.</string>
-    <string name="upgrade_prompt_upgrade_action">Yangilash</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">%1$s ga yangilash</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager reklamasiz va foydalanuvchi ma\'lumotlarini sotmaydi. Mening ishim siz tomonidan moliyalashtiriladi ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager Google Play ga ulana olmadi. Google Play o\'rnatilgan va yangilangan? Google hisobingizda kirgansizmi? Google Play ilovasi keshini tozalab, qurilmangizni qayta yoqishga urinib ko\'ring.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Google Play\'ni ochib bo\'lmadi. Bu qurilmada yo\'q, o\'chirib qo\'yilgan yoki cheklangan bo\'lishi mumkin.</string>
-    <string name="upgrades_no_purchases_found_check_account">Hech qanday xarid topilmadi. To\'g\'ri hisobdan foydalanyapsizmi?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Yangilash variantlari</string>
     <string name="upgrade_screen_offers_body">Ikkala variant ham bir xil Pro imkoniyatlarini ochadi — o\'zingizga mos kelgan birini tanlang.</string>

--- a/app/src/gplay/res/values-vi/strings.xml
+++ b/app/src/gplay/res/values-vi/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Yêu cầu BVM Pro</string>
     <string name="upgrade_prompt_title">Nâng cấp lên BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro mang lại kết quả tốt hơn, nhiều tính năng và tùy chọn hơn cho người dùng.</string>
-    <string name="upgrade_prompt_upgrade_action">Nâng cấp</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Nâng cấp lên %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager không có quảng cáo và không bán dữ liệu người dùng. Công việc của tôi được tài trợ bởi bạn ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager không thể kết nối với Google Play. Google Play đã được cài đặt và cập nhật chưa? Bạn đã đăng nhập tài khoản Google chưa? Hãy thử xóa bộ nhớ cache của ứng dụng Google Play và khởi động lại thiết bị.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Không mở được Google Play. Có thể ứng dụng bị thiếu, bị tắt hoặc bị hạn chế trên thiết bị này.</string>
-    <string name="upgrades_no_purchases_found_check_account">Không tìm thấy giao dịch nào. Bạn có đang sử dụng đúng tài khoản không?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Các tùy chọn nâng cấp</string>
     <string name="upgrade_screen_offers_body">Cả hai tùy chọn đều mở khóa các tính năng Pro giống hệt nhau — hãy chọn tùy chọn phù hợp với bạn.</string>

--- a/app/src/gplay/res/values-zh-rCN/strings.xml
+++ b/app/src/gplay/res/values-zh-rCN/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">需要 BVM Pro</string>
     <string name="upgrade_prompt_title">升级至 BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro 为高级用户提供更好的效果、更多的功能和选项。</string>
-    <string name="upgrade_prompt_upgrade_action">升级</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">升级到%1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 没有广告，也不出售用户数据。我的工作由您资助 ❤️。</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager 无法连接到 Google Play。Google Play 是否已安装并更新至最新版本？您的 Google 账户是否已登录？请尝试清除 Google Play 应用的缓存并重启设备。</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">无法打开 Google Play。该应用可能未安装、已禁用或受到限制。</string>
-    <string name="upgrades_no_purchases_found_check_account">未找到任何购买记录。您确定账号正确吗？</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">升级选项</string>
     <string name="upgrade_screen_offers_body">两种选项都解锁相同的Pro功能——选择适合你的即可。</string>

--- a/app/src/gplay/res/values-zh-rHK/strings.xml
+++ b/app/src/gplay/res/values-zh-rHK/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">需要 BVM Pro</string>
     <string name="upgrade_prompt_title">升級到 BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro 為進階用戶提供更好的效果、更多功能和選項。</string>
-    <string name="upgrade_prompt_upgrade_action">升級</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">升級至 %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不出售用戶數據。我的工作由你支持 ❤️。</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager 無法連接 Google Play。Google Play 已安裝且是最新版本？你的 Google 帳戶已登入？請嘗試清除 Google Play 應用的快取並重新啟動裝置。</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">無法開啟 Google Play。它可能在此裝置上遺失、停用或受限。</string>
-    <string name="upgrades_no_purchases_found_check_account">找不到購買，您正在使用正確的帳戶嗎？</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">升級選項</string>
     <string name="upgrade_screen_offers_body">兩個選項都能解鎖相同的 Pro 功能 — 選擇最適合你的。</string>

--- a/app/src/gplay/res/values-zh-rTW/strings.xml
+++ b/app/src/gplay/res/values-zh-rTW/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">需要 BVM Pro</string>
     <string name="upgrade_prompt_title">升級至 BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro 提供更佳的結果、更多的功能和選項，適用於進階使用者。</string>
-    <string name="upgrade_prompt_upgrade_action">升級</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">升級到 %1$s</string>
     <string name="upgrade_screen_preamble">Bluetooth Volume Manager 沒有廣告，也不會出售使用者資料。我的工作由你贊助 ❤️。</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager 無法連接到 Google Play。Google Play 是否已安裝且為最新版本？您的 Google 帳戶是否已登入？請嘗試清除 Google Play 應用程式的快取並重新啟動您的裝置。</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">無法開啟 Google Play。此應用程式可能遺失、已停用或在此裝置上受限制。</string>
-    <string name="upgrades_no_purchases_found_check_account">找不到購買，您正在使用正確的帳戶嗎？</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">升級選項</string>
     <string name="upgrade_screen_offers_body">兩個選項都能解鎖相同的 Pro 功能 — 選擇最適合的。</string>

--- a/app/src/gplay/res/values-zu/strings.xml
+++ b/app/src/gplay/res/values-zu/strings.xml
@@ -5,7 +5,6 @@
     <string name="upgrade_feature_requires_pro">Kudingeka i-BVM Pro</string>
     <string name="upgrade_prompt_title">Buyekeza kuya ku-BVM Pro</string>
     <string name="upgrade_prompt_body">I-Bluetooth Volume Manager Pro inikezela imiphumela engcono, izici ezengeziwe nezinketho zabasebenzisi abaphakeme.</string>
-    <string name="upgrade_prompt_upgrade_action">Thuthukisa</string>
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Khulisa ku-%1$s</string>
     <string name="upgrade_screen_preamble">I-Bluetooth Volume Manager ayinazo izikhangiso futhi ayithengisi idatha yabasebenzisi. Umsebenzi wami uxhaswa nguwe ❤️.</string>
@@ -56,7 +55,6 @@
     <string name="upgrades_gplay_unavailable_error_description">I-Bluetooth Volume Manager ayikwazi ukuxhuma ku-Google Play. Ingabe i-Google Play ifakiwe futhi ibuyekeziwe? Ingabe i-Google Account yakho ingene? Zama ukukhwebula i-cache ye-Google Play uqalise kabusha idivayisi yakho.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Ayikwazanga ukuvula i-Google Play. Ingabe ayikhona, itumiwe noma imiselelwa kulolu longezelelo.</string>
-    <string name="upgrades_no_purchases_found_check_account">Akukho ukuthenga okutholiwe. Ingabe usebenzisa i-akhawunti efanele?</string>
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Okukhethwa kokukhulisa</string>
     <string name="upgrade_screen_offers_body">Izinzwalo zombili zivulela izici ze-Pro ezifanayo — khetha eyakho.</string>

--- a/app/src/gplay/res/values/strings.xml
+++ b/app/src/gplay/res/values/strings.xml
@@ -7,7 +7,6 @@
 
     <string name="upgrade_prompt_title">Upgrade to BVM Pro</string>
     <string name="upgrade_prompt_body">Bluetooth Volume Manager Pro offers better results, more features and options for power users.</string>
-    <string name="upgrade_prompt_upgrade_action">Upgrade</string>
 
     <!-- Upgrade screen title. %1$s is the app name with its Pro postfix, e.g. "BVM Pro" - keep it as a placeholder, it is inserted styled and must not be translated. -->
     <string name="upgrade_screen_title_template">Upgrade to %1$s</string>
@@ -68,7 +67,6 @@
     <string name="upgrades_gplay_unavailable_error_description">Bluetooth Volume Manager can\'t connect to Google Play. Is Google Play installed and up to date? Is your Google Account logged in? Try clearing the cache of the Google Play app and rebooting your device.</string>
     <!-- Toast shown when the "Google Play" button of an error dialog can't open Google Play's app info, e.g. Google Play is missing or blocked on this device. "Google Play" is a brand name, keep it untranslated. -->
     <string name="upgrades_gplay_not_installed_message">Couldn\'t open Google Play. It may be missing, disabled or restricted on this device.</string>
-    <string name="upgrades_no_purchases_found_check_account">No purchases found. Are you using the right account?</string>
 
     <!-- Upgrade screen: offers, ownership and restore (canonical UI parity) -->
     <string name="upgrade_screen_offers_title">Upgrade options</string>

--- a/app/src/main/res/values-af-rZA/strings.xml
+++ b/app/src/main/res/values-af-rZA/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Sommige funksies het tydens die opdatering verander. Kontroleer asseblief jou toestelinstelling om te verseker alles korrek opgestel is.</string>
     <string name="onboarding_rewrite_action">Voortgaan</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Geen onbestuurde toestelle gevind nie</string>
     <string name="discover_all_devices_managed_msg">Al jou gekoppelde toestelle word bestuur! Het jy \'n nuwe een nodig?</string>
     <string name="discover_pair_new_device_action">Koppel nuwe toestel</string>
     <string name="discover_device_speaker_desc">Hierdie selfoon se eie spreker. Die volumes daarvan word toegepas wanneer oudio terugskakel na die selfoon, bv. nadat jou Bluetooth-toestel ontkoppel.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Toestel-konfigurasie</string>
-    <string name="devices_device_config_section_general_label">Algemeen</string>
     <string name="devices_device_config_remove_device_label">Vergeet toestel</string>
-    <string name="devices_device_config_remove_device_desc">Vergeet die toestel van hierdie program en verwyder sy konfigurasie. Dit ontkoppel nie die toestel nie.</string>
     <string name="devices_device_config_remove_device_action">Vergeet</string>
     <string name="devices_device_config_remove_device_confirmation">Vergeet %s van bestuurde toestelle?</string>
-    <string name="devices_device_config_rename_device_label">Hernoem toestel</string>
-    <string name="devices_device_config_rename_device_desc">Hernoem hierdie toestel binne hierdie program, en indien moontlik, binne die stelsel.</string>
     <string name="devices_device_config_rename_device_action">Hernoem</string>
     <string name="devices_device_config_enabled_label">Geaktiveer</string>
     <string name="devices_device_config_enabled_desc">Reageer op hierdie toestel wanneer gekoppel</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Outoafspeel-bevele</string>
     <string name="devices_device_config_autoplay_keycodes_order">Bevelvolgorde</string>
     <string name="devices_device_config_autoplay_keycodes_label">Bevele</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Stel in watter bevele gestuur word en in watter volgorde</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Geen bevele gekonfigureer nie</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Voeg bevel by</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimum %1$d bevele</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Skuif op</string>
     <string name="cd_autoplay_keycode_move_down">Skuif af</string>
     <string name="cd_autoplay_keycode_remove">Verwyder</string>
-    <string name="devices_device_config_section_volumes_label">Volumes</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
     <string name="devices_device_config_alarm_volume_label">Wekker-volume</string>
     <string name="devices_device_config_alarm_volume_desc">Sommige wekker-programme gebruik eerder die musiek-volume.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Luitoon</string>
     <string name="devices_audio_stream_notification_label">Kennisgewing</string>
     <string name="devices_audio_stream_alarm_label">Wekker</string>
-    <string name="devices_neverseen_label">Nog nie gesien nie</string>
-    <string name="devices_state_connected_label">Gekoppel</string>
     <string name="devices_last_connected_label">Laas gekoppel: %s</string>
     <string name="devices_currently_connected_label">Tans gekoppel</string>
     <string name="devices_device_disabled_label">Toestel gedeaktiveer</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Instellings wat alle bestuurde toestelle beïnvloed.</string>
     <string name="label_app_enabled">Program geaktiveer</string>
     <string name="description_app_enabled">Wissel die program se vermoë om te reageer op volume en Bluetooth gebeure.</string>
-    <string name="label_visible_volume_adjustments">Sigbare aanpassings</string>
-    <string name="description_visible_volume_adjustments">Wys die stelsel se volume venster terwyl hierdie aanpassings gemaak word.</string>
     <string name="label_volume_listener">Neem verandering waar</string>
-    <string name="description_volume_listener">Bly aktief terwyl \'n toestel verbind is, en berg volume veranderinge wat nie deur die program gedoen is nie.</string>
     <string name="label_boot_restore">Herstel met \"boot\"</string>
     <string name="description_boot_restore">Herstel volume na \"booting/rebooting\" as \'n Bluetooth-toestel gekoppel is.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Leer hoe om BVM doeltreffend te gebruik</string>
     <string name="settings_support_issue_tracker_description">\'n Openbare probleemopsporing vir foutverslae en kenmerversoeke.</string>
     <string name="settings_support_issue_tracker_label">Probleemopsporing</string>
-    <string name="settings_support_debuglog_label">Ontfoutingslog</string>
     <string name="settings_support_debuglog_desc">Neem alles wat die program doen op in \'n teks-lêer wat jy kan deel.</string>
-    <string name="settings_support_debuglog_recording_desc">Tans word ontfoutingsinligting opgeneem. Tik om opname te stop.</string>
-    <string name="settings_support_debuglog_path">Log-pad: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Baie kort opname</string>
     <string name="settings_support_debuglog_short_recording_msg">Dit was \'n baie kort opname. Ontfoutingslêers is opnames, nie kiekie nie — reproduseer die probleem terwyl opname aktief is sodat die lêer nuttig is.</string>
     <string name="settings_support_debuglog_short_recording_continue">Gaan voort met opname</string>
     <string name="settings_support_debuglog_short_recording_stop">Stop tog</string>
-    <string name="settings_support_debuglog_folder_label">Ontfoutingslog-lêergids</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sessie gebruik %2$s</item>
-        <item quantity="other">%1$d sessies gebruik %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Geen ontfoutingslêers gestoor nie</string>
-    <string name="settings_support_debuglog_folder_delete_title">Alle ontfoutingslêers verwyder?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Dit sal alle gestoorde ontfoutingslogsessies permanent verwyder.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">\'n Plek om in rond te hang en vrae te stel.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Vertaling</string>
     <string name="settings_acks_translators_title">Vertalers</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Vertaal BVM</string>
-    <string name="settings_acks_translate_desc">Help om BVM in jou taal te vertaal</string>
     <string name="settings_acks_thanks_header">Dankie</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Vir die ondersteuning van die vertaling van oopbron-projekte</string>
     <string name="settings_licenses_label">Lisensies</string>
     <string name="settings_translation_label">Vertaling</string>
     <string name="settings_translation_desc">Help om die toepassing in jou gunstelingtaal te vertaal</string>
-    <string name="settings_sponsor_development_title">Borg ontwikkeling</string>
-    <string name="settings_sponsor_development_summary">Word \'n beskermheer en maak voortgesette ontwikkeling moontlik.</string>
     <string name="settings_privacy_policy_label">Privaatheidsbeleid</string>
     <string name="settings_privacy_policy_desc">Data verantwoordelik hanteer.</string>
     <string name="changelog_label">Wysigingslys</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Herstel voltooi — %1$d toestelle herstel, %2$d oorgeslaan.</string>
     <string name="backup_restore_version_warning">Hierdie rugsteun is geskep met weergawe %1$s. Jy gebruik tans %2$s. Sommige instellings word moontlik nie korrek herstel nie.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Ontfoutingskennisgewings</string>
     <string name="debug_log_consent_title">Ontfoutingslog</string>
     <string name="debug_log_consent_explanation">Hierdie funksie neem alles wat die program doen op in \'n deelbare lêer. Die gegenereerde lêer bevat sensitiewe inligting (bv. lêername en geïnstalleerde programme). Deel dit slegs met vertroude partye (bv. \'n ontwikkelaar wat \'n probleem oplos).</string>
-    <string name="debug_log_recording_progress">Ontfoutingslog word opgeneem</string>
     <string name="debug_log_record_action">Neem op</string>
     <string name="debug_log_stop_action">Stop opname</string>
     <string name="debug_log_screen_title">Ontfoutingslog-opnemer</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Gooi weg</string>
     <string name="debug_log_screen_keep_action">Bewaar</string>
-    <string name="debug_log_compressing_label">Komprimeer…</string>
     <string name="debug_log_file_label">Opgenome log-lêer</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log gestuur?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Beskryf jou vraag in detail.</string>
     <string name="contact_category_section_label">Kategorie</string>
     <string name="contact_debug_log_label">Ontfoutingslog</string>
-    <string name="contact_debug_log_select_hint">Kies \'n ontfoutingslog om aan te heg</string>
     <string name="contact_debug_log_picker_hint">Heg \'n ontfoutingslog aan om die probleem vinniger te diagnoseer.</string>
     <string name="contact_debug_log_picker_empty">Geen ontfoutingslêers beskikbaar nie. Neem eers een op.</string>
     <string name="contact_expected_behavior_label">Verwagte gedrag</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Ek lees elke boodskap self en doen my bes om te antwoord, maar aangesien ek alleen hieraan werk, kan dit \'n bietjie tyd neem. Dankie vir jou geduld.</string>
     <string name="contact_footer_msg">Jou boodskap sal per e-pos gestuur word. Toestel- en opstelinligting word outomaties aangeheg.</string>
     <string name="contact_no_email_app_msg">Geen e-postoepasssing op hierdie toestel gevind nie.</string>
-    <string name="contact_attachment_missing_msg">Ontfoutingsloglêer bestaan nie meer nie</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Gestoorde ontfoutingslêers</string>
     <string name="settings_support_stored_logs_desc">%1$d sessies (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Geen gestoorde ontfoutingslêers nie</string>
-    <string name="settings_support_stored_logs_delete_title">Gestoorde lêers verwyder?</string>
-    <string name="settings_support_stored_logs_delete_msg">Dit sal alle %1$d gestoorde ontfoutingslogsessies verwyder.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Gestoorde ontfoutingslêers verwyder</string>
-    <string name="label_bug_reports">Fout verslag</string>
-    <string name="description_bug_reports">Outomatiese fout en probleem rapportering.</string>
     <string name="label_add_device">Voeg toestel by</string>
-    <string name="label_just_a_moment_please">Net \'n oomblik, asseblief.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Opstelling vereis</string>
     <string name="monitor_notification_starting">Begin…</string>
     <string name="action_set">Stel</string>
     <string name="action_cancel">Kanselleer</string>
-    <string name="label_invalid_input">Ongeldige invoer</string>
     <string name="action_reset">Herset</string>
     <string name="label_no_connected_devices">Geen toestelle gekoppel</string>
-    <string name="label_status_idle">Luier</string>
-    <string name="label_status_adjusting_volumes">Pas Volumes aan</string>
-    <string name="label_premium_version">Premium weergawe</string>
     <string name="general_upgrade_action">Gradeer Op</string>
     <string name="common_upgrade_required_label">Opgradering benodig</string>
-    <string name="label_premium_version_required">Premium weergawe benodig</string>
-    <string name="description_intro_purpose">Hierdie program laat Android toe om die volume instellings van verskeie Bluetooth toestelle te onthou.</string>
-    <string name="upgrade_benefit_unlimited_devices">Onbeperkte toestelprofile</string>
-    <string name="upgrade_benefit_connection_actions">Outoafspeel, toepassing-begin en verbindingswaarskuwings</string>
-    <string name="upgrade_benefit_theme_customization">Tema-, styl- en kleurasepassing</string>
-    <string name="upgrade_benefit_power_controls">Volumeslot en koersbeperking</string>
-    <string name="upgrade_benefit_support">Ondersteun onafhanklike ontwikkeling</string>
     <string name="upgrade_benefit_equalizer">• Gelykmaker per toestel (vir musiek-toepassings met stelselgelykmaker-ondersteuning)</string>
-    <string name="description_intro_tap_the_button">Begin deur jou eerste toestel by te voeg.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth is gedeaktiveer.</string>
     <string name="title_bluetooth_is_off">Bluetooth is af</string>
     <string name="action_enable_bluetooth">Aktiveer Bluetooth</string>
     <string name="title_bluetooth_permission_required">Bluetooth-toestemming benodig</string>
     <string name="description_bluetooth_permission_required">Hierdie program benodig Bluetooth-toestemming om jou toestelvolumes te bestuur.</string>
     <string name="action_grant_permission">Verleen toestemming</string>
-    <string name="label_status_listening_for_changes">Luister vir volume veranderings</string>
     <string name="action_exit">Gaan uit</string>
-    <string name="action_start">Begin</string>
-    <string name="label_welcome">Welkom</string>
-    <string name="description_intro_contact">Moenie huiwer om my te kontak as jy vrae of selfs \'n idee het vir \'n nuwe kenmerk nie.</string>
-    <string name="label_translation">Vertaling</string>
-    <string name="description_help_translate">Help my asb. om hierdie program beskikbaar te maak in ander tale.</string>
     <string name="label_device_speaker">Toestel luidspreker</string>
-    <string name="label_keyevent_playpause">Speel-Wag</string>
-    <string name="label_keyevent_play">Speel</string>
-    <string name="label_keyevent_next">Volgende</string>
-    <string name="label_install_id">Installeer ID</string>
     <string name="message_copied_to_clipboard">Gekopieer na die Knipbord</string>
-    <string name="label_thanks">Dankie</string>
-    <string name="label_licenses">Lisensies</string>
-    <string name="description_ring_volume_additional_permission">Addisionele toestemming is nodig om die luitoon volume te verander.</string>
-    <string name="label_missing_permissions">Vermiste toestemmings</string>
-    <string name="action_grant">Laat toe</string>
-    <string name="label_advanced">Gevorderd</string>
-    <string name="label_exclude_health">Sluit gesondheids profiel uit</string>
-    <string name="description_exclude_health">Sommige Android toestelle hang indien \'Gesondheids Toestel\' Bluetooth profiel opgesoek word (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Sluit GATT bediener profiele uit</string>
-    <string name="label_exclude_gatt">Sluit GATT profiele uit</string>
-    <string name="description_exclude_gattserver">Moet nie Bluetooth \'Generic Attribute\' (GATT) bediener profiele bevraagteken nie.</string>
-    <string name="description_exclude_gatt">Moet nie Bluetooth \'Generic Attribute\' (GATT) bediener profiele bevraagteken nie.</string>
-    <string name="description_waiting_for_devicex">Wag vir %s om verbinding te voltooi</string>
-    <string name="action_undo">Ontdoen</string>
-    <string name="action_show">Wys</string>
     <string name="action_dismiss">Verwerp</string>
-    <string name="action_fix">Herstel</string>
-    <string name="battery_optimizations_issue_description">Battery-optimiserings is vir hierdie program geaktiveer en kan voorkom dat dit Bluetooth-gebeure ontvang. Oorweeg om optimiserings te deaktiveer as jy probleme ondervind.</string>
     <string name="label_bluetooth_settings">Bluetooth-instellings</string>
-    <string name="android10_applaunch_issue_description">Android 10 beperk hoe programme op die agtergrond gelaai kan word. Om toe te laat dat programme oopgemaak word wanneer \'n Bluetooth-toestel koppel, verleen die toestemming &quot;Vertoon oor ander programme&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Bronkode</string>
-    <string name="android13_notification_permission_description">Verleen hierdie program toestemming om kennisgewings te plaas. Dit stel in staat om \'n kennisgewing te wys wanneer hierdie program aktief is en volumeaanpassings gemaak word.</string>
-    <string name="privacy_policy_label">Privaatheidsbeleid</string>
     <string name="managed_devices_empty_message">Geen Bluetooth-toestelle opgestel nie.\nTik die +-knoppie om jou eerste toestel by te voeg.</string>
     <string name="label_pro_feature">Premium kenmerk</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Hersien</string>
     <string name="review_app_dismiss_action">Miskien later</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Aankoop gekanselleer</string>
-    <string name="error_iap_unavailable_message">In-program-aankope is nie beskikbaar nie</string>
-    <string name="error_generic_message">\'n Fout het voorgekom. Probeer asseblief weer.</string>
-    <string name="error_iap_owned_message">Jy besit hierdie item reeds</string>
     <string name="label_no_devices_title">Geen toestelle</string>
     <string name="bluemusic_mascot_description">Program-ikoon</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Kies Programme</string>
     <string name="devices_app_selection_search_hint">Soek programme…</string>
-    <string name="devices_app_selection_currently_selected">Tans gekies</string>
     <string name="devices_app_selection_selected_count">%d programme gekies</string>
     <string name="general_navigate_back_action">Navigeer terug</string>
     <string name="general_reset_action">Herstel</string>
     <string name="general_clear_action">Maak skoon</string>
-    <string name="general_save_action">Bewaar</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Sluit</string>
     <string name="devices_indicator_awake">Wakker</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Beperk</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Versterking</string>
-    <string name="devices_indicator_launch">Laai</string>
     <string name="devices_indicator_home">Tuis</string>
     <string name="devices_indicator_dnd">MS</string>
     <string name="devices_indicator_alert">Waarskuwing</string>

--- a/app/src/main/res/values-am/strings.xml
+++ b/app/src/main/res/values-am/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">አንድንድ ባ⁚ሯ በጕነት ስሪት ተቀይረዋል። ሁሉም ተገቃንነትያቸው እንዲደረገሰበት የመጡ ቅንበሮን ስሪቲዎን ይጀክሙ።</string>
     <string name="onboarding_rewrite_action">ቀጥል</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">በኤፕ ያልተቀቀሉ መሣሪያዎች አይገኙ፡ም</string>
     <string name="discover_all_devices_managed_msg">የተጀረዱ መሣሪያዎችዋበት ሁሉም ይተቀቀላሉ። አዲስጀሩ? </string>
     <string name="discover_pair_new_device_action">አዲስ መሣሪያ አወች</string>
     <string name="discover_device_speaker_desc">ይህ ስልክ ራሱ ተናጋሪ. ጎን ድምጽ ተግባር ስልክ, e.g. ከ Bluetooth መሳሪያ ስልክ ሊብ ወድ ድምጽ ተግባር.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">የመሣሪያ ውቅረት</string>
-    <string name="devices_device_config_section_general_label">አጠቃላይ</string>
     <string name="devices_device_config_remove_device_label">መሣሪያ አደሣቸዘ</string>
-    <string name="devices_device_config_remove_device_desc">መሣሪያውን ከይህ አፕሊኬሰን ይክሠኳል በኰጐቱም የተድረገበትን ውቅረት ይወገዳል። ይህ መሣሪያውን አያያዘረዘርም።</string>
     <string name="devices_device_config_remove_device_action">ክቀዘነው</string>
     <string name="devices_device_config_remove_device_confirmation">%s ከተቀቀሉ መሣሪያዎች ይክቀዘኑ።</string>
-    <string name="devices_device_config_rename_device_label">መሣሪያ ስም ሐይር</string>
-    <string name="devices_device_config_rename_device_desc">ይህን መሣሪያ በይህ አፕሊኬሰን ውስጥ እና ባኝነት በስርዓቱ ውስጥም ስም ስጥ ይቀይራል።</string>
     <string name="devices_device_config_rename_device_action">ስም ሐይር</string>
     <string name="devices_device_config_enabled_label">ተችሏል</string>
     <string name="devices_device_config_enabled_desc">መሣሪያው ሲጸራ አስተጵብ እንዲደርገስ</string>
@@ -93,7 +88,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">የራስ-ማጫወቻ ትዕዛዞች</string>
     <string name="devices_device_config_autoplay_keycodes_order">የትዕዛዝ ቅደም ተከተል</string>
     <string name="devices_device_config_autoplay_keycodes_label">ትዕዛዞች</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">የትኞቹ ትዕዛዞች እና በምን ቅደም ተከተል እንደሚላኩ ያዋቅሩ</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">ምንም ትዕዛዞች አልተዋቀሩም</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">ትዕዛዝ አክል</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">ከፍተኛ %1$d ትዕዛዞች</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">ወደ ላይ ውሰድ</string>
     <string name="cd_autoplay_keycode_move_down">ወደ ታች ውሰድ</string>
     <string name="cd_autoplay_keycode_remove">አስወግድ</string>
-    <string name="devices_device_config_section_volumes_label">ድምጣዎች</string>
     <string name="devices_device_config_section_volume_label">ድምፅ</string>
     <string name="devices_device_config_alarm_volume_label">የቃሌሚ ድምፅ</string>
     <string name="devices_device_config_alarm_volume_desc">አንድ አንድ የቃሌሚ አፕሊኬሰኖች የሚውዘታነውን ድምፅ ይጠቀማል።</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">ዚማት</string>
     <string name="devices_audio_stream_notification_label">ክርዘት</string>
     <string name="devices_audio_stream_alarm_label">ቃሌሚ</string>
-    <string name="devices_neverseen_label">አልተካከለም</string>
-    <string name="devices_state_connected_label">ተጸርቦል።</string>
     <string name="devices_last_connected_label">መጨረሻይም ሰዓት %s</string>
     <string name="devices_currently_connected_label">ዙሕን ተጸርቦል።</string>
     <string name="devices_device_disabled_label">መሣሪያ ተዘግቷል።</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">ሁሉም ተቀቀሉ መሣሪያዎችን የሚነካከሉ ስርዓቶች።</string>
     <string name="label_app_enabled">አፕሊኬሰን ተፈተራል</string>
     <string name="description_app_enabled">ዓም እና Bluetooth ሳርታትን ለማስተካካት የአፕሊኬሰንን ዘዞታ ይቀይራል።</string>
-    <string name="label_visible_volume_adjustments">የምስተካኪያ ለይት</string>
-    <string name="description_visible_volume_adjustments">ይህ አፕሊኬስን ምስተካኪያ በሜደረግበት ወቀት የስርዓቱን ድምፅ መስካኪያን ኣይጥ አሳይ።</string>
     <string name="label_volume_listener">ለውጦች ታይ</string>
-    <string name="description_volume_listener">መሣሪያ ሲጸራ ብራልት ቅበር ይህ አፕሊኬስን ካልመኃ የተደረጉት የድምፅ ለውጦችን አዓርቦም።</string>
     <string name="label_boot_restore">ሳርት በሁናተን ይመለስ</string>
     <string name="description_boot_restore">Bluetooth መሣሪያ ሲጸራ እንደ አተገባበት። ሳርት በሑሉት/ቄሀህ ዒሙብ ድምጣዎችን ይመለስ።</string>
     <!-- Settings/Support-->
@@ -203,22 +191,11 @@
     <string name="settings_support_wiki_description">BVMን ዘሪዯዊ ሀስተምገቢያ እንዲተነው ተዋደዱት</string>
     <string name="settings_support_issue_tracker_description">ለሳህተት ሪፖርቶችና ባህሪ ጥያቄዎች የሕዝብ ቁጥጥር ሰሌዳ።</string>
     <string name="settings_support_issue_tracker_label">ችግር ተከታዩ</string>
-    <string name="settings_support_debuglog_label">የመለያ ምዝግብ ማስታወሻ</string>
     <string name="settings_support_debuglog_desc">መተግበሪያው እያደረገው ያለውን ሁሉ ወደ ሊካፈሉት የሚችሉ የጽሑፍ ፋይል ይቅዱ።</string>
-    <string name="settings_support_debuglog_recording_desc">ደብግ መረዃ ካዘገበ። ለሚዘግብት መዘጋት አክሥ</string>
-    <string name="settings_support_debuglog_path">የየየድ መንገድ %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">ኰቅን ፃዝ የደብግ መዘጊ</string>
     <string name="settings_support_debuglog_short_recording_msg">ይህ በደብግ መዘጊ በደብግ ምዘጊ ልክተም ፈጥሞ ያደርጋሉ - ደብግ መዘጊ መዘገያወ። መዘጊው ኰቅን ያላደር እነደረግሴ ይተቅተም።</string>
     <string name="settings_support_debuglog_short_recording_continue">መዘግብት ቀጥል</string>
     <string name="settings_support_debuglog_short_recording_stop">እንዳልሆንም አዘጋል</string>
-    <string name="settings_support_debuglog_folder_label">የደብግ የየድ ክብዮል</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d ሰሺ %2$sን ይጅደማል</item>
-        <item quantity="other">%1$d ሰሺዎች %2$sን ይጅደማሉ</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">አያዸየየ ደብግ የየድ ክብዮል</string>
-    <string name="settings_support_debuglog_folder_delete_title">ሁሉም ደብግ የየዶችን ይሰርዑ?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">ይህ ሁሉም የተዛበብትን ደብግ የየድ ሰሺዎችን አካላይ ክበወህ ይሎሓለ</string>
     <string name="settings_support_discord_label">ዲስኮርድ</string>
     <string name="settings_support_discord_description">ሊቀመጡባቸውና ጥያቄዎችን ሊጠይቁባቸው የሚችሉባቸው ቦታ።</string>
     <!-- Settings/Acks-->
@@ -227,16 +204,12 @@
     <string name="settings_acks_translation_header">ትርጉም</string>
     <string name="settings_acks_translators_title">ተርጓሚዎች</string>
     <string name="settings_acks_translators_people">ሰው1;ሰው2(አማራጭ@ኢሜይል.com)</string>
-    <string name="settings_acks_translate_title">BVMን የርስከት አስተርጁ</string>
-    <string name="settings_acks_translate_desc">BVMን ለክርስት ባይለ የርስከት አስተርጋን ይደግፉን</string>
     <string name="settings_acks_thanks_header">አመሰግናለሁ</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">የክት-ምንዘ ፕሮጂክቶች ርስከት በም ደግፉት የተደረገበት</string>
     <string name="settings_licenses_label">ፈቃዶች</string>
     <string name="settings_translation_label">ትርጉም</string>
     <string name="settings_translation_desc">አፕሊኬሰንን ወደ ወደደዳዱ ባይለ ርስከት አስተርጋን ይደግፉን</string>
-    <string name="settings_sponsor_development_title">ልማትን ስፖንሰር አድርግ</string>
-    <string name="settings_sponsor_development_summary">ፓትሮን ሁንና ቀጣይነት ያለው ልማት ይቻል እንዲሆን አድርግ።</string>
     <string name="settings_privacy_policy_label">የግላዊነት ፖሊሲ</string>
     <string name="settings_privacy_policy_desc">ውሂቡን በኃላፊነት መያዝ።</string>
     <string name="changelog_label">የለውጥ ዝርዝር</string>
@@ -258,10 +231,8 @@
     <string name="backup_restore_success_restore">ወደ ነበሩበት መመለስ ተጠናቅቋል — %1$d መሳሪያዎች ተመልሰዋል፣ %2$d ተዘለዋል።</string>
     <string name="backup_restore_version_warning">ይህ ምትኬ በስሪት %1$s ተፈጥሯል። እርስዎ %2$s እያሄዱ ነው። አንዳንድ ቅንብሮች በትክክል ላይመለሱ ይችላሉ።</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">የመለያ ማስታወቂያዎች</string>
     <string name="debug_log_consent_title">የመለያ ምዝግብ ማስታወሻ</string>
     <string name="debug_log_consent_explanation">ይህ ባህሪ መተግበሪያው እያደረገው ያለውን ሁሉ ወደ ሊካፈል የሚችል ፋይል ይቀዳል። የተፈጠረው ፋይል ስሜታዊ መረጃዎችን ይዟል (ለምሳሌ የፋይል ስሞችና የተጫኑ መተግበሪያዎች)። ከታመኑ ወገኖች ጋር ብቻ ያጋሩ (ለምሳሌ ችግርን እየፈታ ያለ ገንቢ)።</string>
-    <string name="debug_log_recording_progress">የመለያ ምዝግብ ማስታወሻ በመቅዳት ላይ</string>
     <string name="debug_log_record_action">ዘግብ</string>
     <string name="debug_log_stop_action">መቅዳትን አቁም</string>
     <string name="debug_log_screen_title">የደብግ የየድ ዘጋ</string>
@@ -276,7 +247,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">ትው</string>
     <string name="debug_log_screen_keep_action">ኰቅኑ</string>
-    <string name="debug_log_compressing_label">እዮዳለድ።</string>
     <string name="debug_log_file_label">የተቀዳ ምዝግብ ማስታወሻ ፋይል</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">የየድ የየዳ?</string>
@@ -304,7 +274,6 @@
     <string name="contact_description_question_hint">ጥያቀዎን በደግጅ ይግለጥ።</string>
     <string name="contact_category_section_label">ምድብ</string>
     <string name="contact_debug_log_label">የመለያ ምዝግብ ማስታወሻ</string>
-    <string name="contact_debug_log_select_hint">ለማዘለፅ ደብግ የየድ ይምረጥ</string>
     <string name="contact_debug_log_picker_hint">ብግቱን በሁናተ ከግረት ለማግዘስ ደብግ የየድ አካላል።</string>
     <string name="contact_debug_log_picker_empty">ደብግ የየዶች አይገኙም። አንድ ከመዘግብት በፊት</string>
     <string name="contact_expected_behavior_label">የተቄወሰ ዓልተ</string>
@@ -318,82 +287,32 @@
     <string name="contact_welcome_msg">ሁሉም መልክት በየነስ አነበብ ይሰማለ። ብቾድ ከተበቦዘፘ፥ አንድን ደግፓ እዘዳለሁን። ገቢዬን እናዱ።</string>
     <string name="contact_footer_msg">መልክትዎን በኢሜይል ይየያለል። የመሣሪያን እና የድርግት መረዃ በዘጀማኒ ይዘለቅሳል።</string>
     <string name="contact_no_email_app_msg">በይህ መሣሪያ ላይ አይሜይል አፕሊኬሰን አልተገኙም።</string>
-    <string name="contact_attachment_missing_msg">ደብግ የየድ ፊዼል አልተገኘም</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">የተዛበቡ ደብግ የየዶች</string>
     <string name="settings_support_stored_logs_desc">%1$d ሰሺዎች (%2$s)</string>
     <string name="settings_support_stored_logs_empty">የተዛበቡ ደብግ የየድ ይለም</string>
-    <string name="settings_support_stored_logs_delete_title">የተዛበቡ የየዶች ይሰሮል?</string>
-    <string name="settings_support_stored_logs_delete_msg">ይህ ሁሉም %1$d የተዛበቡ ደብግ የየድ ሰሺዎችን ይሰርዛል።</string>
-    <string name="settings_support_stored_logs_deleted_msg">የተዛበቡ ደብግ የየዶች የተሰረዱ፡</string>
-    <string name="label_bug_reports">የቤግ ሪፖርቶች</string>
-    <string name="description_bug_reports">አውቲማቲክ የቤግ እና ክርዜ ሪፖርት።</string>
     <string name="label_add_device">መሣሪያ አክብቢ</string>
-    <string name="label_just_a_moment_please">ንዘት ይበዐዘብ።</string>
     <string name="label_notification_channel_status">ሁኔተት</string>
     <string name="label_notification_channel_setup">ማዋቀር ያስፈልጋል</string>
     <string name="monitor_notification_starting">ገና ጀምሮ…</string>
     <string name="action_set">አድርግ</string>
     <string name="action_cancel">ሰርዝ</string>
-    <string name="label_invalid_input">ልክ ያልሆነ ግባት</string>
     <string name="action_reset">እንደገና አዋቅር</string>
     <string name="label_no_connected_devices">ምንም መሣሪያ አልተጸሮም</string>
-    <string name="label_status_idle">እለባ፡</string>
-    <string name="label_status_adjusting_volumes">ድምጣዎች እዮድለድ</string>
-    <string name="label_premium_version">የዘመን ስሪት</string>
     <string name="general_upgrade_action">አሻሽል</string>
     <string name="common_upgrade_required_label">ማሻሻያ ያስፈልጋል</string>
-    <string name="label_premium_version_required">የዘመን ስሪት ክድምነት</string>
-    <string name="description_intro_purpose">ይህ አፕሊኬስን የAndroid መሣሪያዎት የዓይባይት Bluetooth መሣሪያዎችን ድምፅ እንዲያስታወስ ይያዕዝበታለ።</string>
-    <string name="upgrade_benefit_unlimited_devices">ያልተወሰኑ የመሳሪያ መገለጫዎች</string>
-    <string name="upgrade_benefit_connection_actions">ራስ-ሰር አጫወት፣ መተግበሪያ ማስጀመሪያ እና የግንኙነት ማስጠንቀቂያዎች</string>
-    <string name="upgrade_benefit_theme_customization">ጭብጥ፣ ስልት እና የቀለም ብጁ ቅንብር</string>
-    <string name="upgrade_benefit_power_controls">የድምፅ ቁልፍ እና የፍጥነት ገደብ</string>
-    <string name="upgrade_benefit_support">ገለልተኛ ልማትን ይደግፉ</string>
     <string name="upgrade_benefit_equalizer">• በመሣሪያ ደረጃ ኢኩዌላይዘር (ስርዓት ኢኩዌላይዘር ድጋፍ ላላቸው የሙዚቃ መተግበሪያዎች)</string>
-    <string name="description_intro_tap_the_button">መረሻትዎን መሣሪያ አክብቢባብ ዘርኵ።</string>
     <string name="description_bluetooth_is_disabled">ብሉቱዝ ጠፍቷል.</string>
     <string name="title_bluetooth_is_off">Bluetooth ይዘጋል</string>
     <string name="action_enable_bluetooth">Bluetooth አንቃ</string>
     <string name="title_bluetooth_permission_required">የBluetooth እዋዀ ካይይል።</string>
     <string name="description_bluetooth_permission_required">ይህ አፕሊኬስን የመሣሪያዎችን ድምፅ ለማስተካከል የBluetooth እዋዀ ክርድ ያስፈለናል።</string>
     <string name="action_grant_permission">እዋዀ ክርድ</string>
-    <string name="label_status_listening_for_changes">ለድምፅ ለውጦች እዮድለድ</string>
     <string name="action_exit">ይወጥ</string>
-    <string name="action_start">ይጀምር</string>
-    <string name="label_welcome">እንኳን ደህና መጡ</string>
-    <string name="description_intro_contact">ጥያቀዎች ወይም አዳድ ባ⁚ሪ የብክብጅ አዲስ ዬንን እያመንገብት አያፕርኙም።</string>
-    <string name="label_translation">ትርጉም</string>
-    <string name="description_help_translate">አፕሊኬስንትን በግዝች ባይለ እንዲደርግስ ይደግፉን።</string>
     <string name="label_device_speaker">የመሣሪያ ስፒከር</string>
-    <string name="label_keyevent_playpause">ዳግም-አስቀደም</string>
-    <string name="label_keyevent_play">ዳግም</string>
-    <string name="label_keyevent_next">ቀጥል</string>
-    <string name="label_install_id">የመጫን መለያ</string>
     <string name="message_copied_to_clipboard">ወደ ክልረስ-ሰሩድ ተቃለገበ፡</string>
-    <string name="label_thanks">አመሰግናለሁ</string>
-    <string name="label_licenses">ፈቃዶች</string>
-    <string name="description_ring_volume_additional_permission">የደወል ድምጽ ለመለወጥ ተጨማሪ ፈቃዶች አስፈላጊ ናቸው።</string>
-    <string name="label_missing_permissions">የፐየ እዋዀወች ክርድ</string>
-    <string name="action_grant">ክርድ ክርድ</string>
-    <string name="label_advanced">ወሰፉድ</string>
-    <string name="label_exclude_health">የጥናት ብርጦችን አድርግ</string>
-    <string name="description_exclude_health">አንድ አንድ የAndroid መሣሪያዎች \'Health Device\' Bluetooth ብርጆችን (HDP, 0x1400) ነገሮ እዾድ ዙ዗ ይቆማሉ።</string>
-    <string name="label_exclude_gattserver">የGATT አገልጋዮች ብርጦችን አድርግ</string>
-    <string name="label_exclude_gatt">የGATT ብርጦችን አድርግ</string>
-    <string name="description_exclude_gattserver">የ\'Generic Attribute\' (GATT) አገልጋዮች ብርጆችን መጥይቀር አይሁንም።</string>
-    <string name="description_exclude_gatt">የ\'Generic Attribute\' (GATT) አገልጋየ ብርጆችን መጥይቀር አይሁንም።</string>
-    <string name="description_waiting_for_devicex">%s ሴራ እንዲውቅቅ እዮዳለድ</string>
-    <string name="action_undo">መልስ</string>
-    <string name="action_show">አሳይ</string>
     <string name="action_dismiss">አስወግድ</string>
-    <string name="action_fix">ጥግኙ</string>
-    <string name="battery_optimizations_issue_description">የደም ያል አመ፥ት ለይህ አፕሊኬስን ተፈንንዎል። ቤግተንያዎችን ከዋለዝበት አድርግ አፕሊኬስን የBluetooth ቝራዎችን እንዲደርግስ ይዘርኩ።</string>
     <string name="label_bluetooth_settings">የBluetooth ስሬቶች</string>
-    <string name="android10_applaunch_issue_description">Android 10 አፕሊኬስዎች ከበድርግት እንዲደርጉ የምድርግ ኵብለ ይዘርካል። Bluetooth መሣሪያ ሲጸራ አፕሊኬስዎችን ለመስረድ “ከግብ አፕሊኬስዎች የማሳይት” (SYSTEM_ALERT_WINDOW) እዋዀ ክርድ ይስጀዘ።</string>
-    <string name="label_opensource">የምንጭ ኮድ</string>
-    <string name="android13_notification_permission_description">መረዃዎችን ለሚፕጀር እዋዀ ክርድ ይስጀዘ። ይህ እዋዀ ተፈፓ በሚተኰብበት ወቀት ድምፅ ምስተካኪያ በሜደረግበት ስተወደሪ እንዲታይ ክርድ ይገሉ።</string>
-    <string name="privacy_policy_label">የግላዊነት ፖሊሲ</string>
     <string name="managed_devices_empty_message">ምንም የBluetooth መሣሪያዎች አልተዋቀሉም።
 በምርፕ ብቱን + ከል መጀሬያ መሣሪያዌን ለማክበቢ።</string>
     <string name="label_pro_feature">የዘመን ባ⁚ራ</string>
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">ግምገማ</string>
     <string name="review_app_dismiss_action">ምናልባት በኋላ</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">ቕሌያ ተሰርዩ።</string>
-    <string name="error_iap_unavailable_message">የአፕሊኬስን ዃየቶች አይገኙም።</string>
-    <string name="error_generic_message">ስሕተት ተከስቷል። እባክዊ ይሞከር።</string>
-    <string name="error_iap_owned_message">ይህን ስለት አስቀድም አለየዎቱ።</string>
     <string name="label_no_devices_title">ምንም መሣሪያዎች ይለም</string>
     <string name="bluemusic_mascot_description">የአፕሊኬስን አዮታ</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">አፕሊኬስዎችን ይምረጥ</string>
     <string name="devices_app_selection_search_hint">አፕሊኬስዎችን ይስናል።</string>
-    <string name="devices_app_selection_currently_selected">ደሁን የተመረጠ</string>
     <string name="devices_app_selection_selected_count">%d አፕሊኬስዎች ተመርጸዋል</string>
     <string name="general_navigate_back_action">ወደ (ይየየ ባይለ ይመለስ</string>
     <string name="general_reset_action">እንደገና አዋቅር</string>
     <string name="general_clear_action">አሰንስብ</string>
-    <string name="general_save_action">አስቀምጥ</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">የትክት</string>
     <string name="devices_indicator_awake">የተገባ</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">ወሰን</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">ማጎልበቻ</string>
-    <string name="devices_indicator_launch">ዘርድ</string>
     <string name="devices_indicator_home">የምር በራ</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">ሜኵከካ</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">قد تكون بعض إعدادات الجهاز قد تم إعادة تعيينها أثناء هذا التحديث. يرجى فحص إعدادات جهازك.</string>
     <string name="onboarding_rewrite_action">متابعة</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">لم يتم العثور على أجهزة غير مُدارة</string>
     <string name="discover_all_devices_managed_msg">جميع أجهزتك المقترنة مُدارة! هل تحتاج لجهاز جديد؟</string>
     <string name="discover_pair_new_device_action">اقتران جهاز جديد</string>
     <string name="discover_device_speaker_desc">مكبر الصوت الخاص بهذا الهاتف. يتم تطبيق مستويات الصوت الخاصة به عندما ينتقل الصوت مرة أخرى إلى الهاتف، على سبيل المثال بعد قطع اتصال جهاز Bluetooth الخاص بك.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">إعدادات الجهاز</string>
-    <string name="devices_device_config_section_general_label">عام</string>
     <string name="devices_device_config_remove_device_label">نسيان الجهاز</string>
-    <string name="devices_device_config_remove_device_desc">ينسى الجهاز من هذا التطبيق ويحذف إعداداته. هذا لا يلغي اقتران الجهاز.</string>
     <string name="devices_device_config_remove_device_action">نسيان</string>
     <string name="devices_device_config_remove_device_confirmation">نسيان %s من الأجهزة المُدارة؟</string>
-    <string name="devices_device_config_rename_device_label">إعادة تسمية الجهاز</string>
-    <string name="devices_device_config_rename_device_desc">إعادة تسمية هذا الجهاز داخل هذا التطبيق، وإذا أمكن، داخل النظام.</string>
     <string name="devices_device_config_rename_device_action">إعادة تسمية</string>
     <string name="devices_device_config_enabled_label">مفعل</string>
     <string name="devices_device_config_enabled_desc">التفاعل مع هذا الجهاز عند الاتصال</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">أوامر التشغيل التلقائي</string>
     <string name="devices_device_config_autoplay_keycodes_order">تسلسل الأوامر</string>
     <string name="devices_device_config_autoplay_keycodes_label">الأوامر</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">اضبط الأوامر المراد إرسالها والترتيب الذي ستُرسَل به</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">لم يتم تعيين أوامر</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">إضافة أمر</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">الحد الأقصى %1$d أمر</string>
@@ -125,7 +119,6 @@
     <string name="cd_autoplay_keycode_move_up">تحريك للأعلى</string>
     <string name="cd_autoplay_keycode_move_down">تحريك للأسفل</string>
     <string name="cd_autoplay_keycode_remove">حذف</string>
-    <string name="devices_device_config_section_volumes_label">الأصوات</string>
     <string name="devices_device_config_section_volume_label">الصوت</string>
     <string name="devices_device_config_alarm_volume_label">مستوى صوت المنبّه</string>
     <string name="devices_device_config_alarm_volume_desc">بعض برامج المنبهات تستعيض بصوت الوسائط.</string>
@@ -159,8 +152,6 @@
     <string name="devices_audio_stream_ring_label">رنين</string>
     <string name="devices_audio_stream_notification_label">تنبيه</string>
     <string name="devices_audio_stream_alarm_label">منبّه</string>
-    <string name="devices_neverseen_label">لم يسبق رؤيته</string>
-    <string name="devices_state_connected_label">متصل</string>
     <string name="devices_last_connected_label">آخر اتصال: %s</string>
     <string name="devices_currently_connected_label">متصل حالياً</string>
     <string name="devices_device_disabled_label">الجهاز معطل</string>
@@ -195,10 +186,7 @@
     <string name="devices_settings_desc">إعدادات تؤثر على جميع الأجهزة المُدارة.</string>
     <string name="label_app_enabled">التطبيق مشغل</string>
     <string name="description_app_enabled">تبديل قدرة التطبيقات على الإستجابة لأحداث الصوت و البلوتوث.</string>
-    <string name="label_visible_volume_adjustments">تعديلات مرئية</string>
-    <string name="description_visible_volume_adjustments">إظهار نافذة حجم الصوت للنظام بينما يقوم التطبيق بإجراء تعديلات.</string>
     <string name="label_volume_listener">ملاحظة التغييرات</string>
-    <string name="description_volume_listener">تبقى فعالة عند إتصال جهاز وتحفظ التغييرات في حجم الصوت التي لم يكن سببها هذا التطبيق.</string>
     <string name="label_boot_restore">الإستعادة عند تشغيل الجهاز</string>
     <string name="description_boot_restore">استعادة حجم الصوت بعد التشغيل/إعادة التشغيل إذا كان جهاز بلوتوث متصلا.</string>
     <!-- Settings/Support-->
@@ -208,26 +196,11 @@
     <string name="settings_support_wiki_description">تعلّم كيفية استخدام BVM بفعالية</string>
     <string name="settings_support_issue_tracker_description">متعقب مشاكل عام لأخطاء وطلبات الميزات الجديدة.</string>
     <string name="settings_support_issue_tracker_label">متعقب المشاكل</string>
-    <string name="settings_support_debuglog_label">سجل التشخيص</string>
     <string name="settings_support_debuglog_desc">سجّل كل ما يفعله التطبيق في ملف نصي يمكنك مشاركته.</string>
-    <string name="settings_support_debuglog_recording_desc">يتم حالياً تسجيل معلومات التشخيص. اضغط لإيقاف التسجيل.</string>
-    <string name="settings_support_debuglog_path">مسار السجل: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">تسجيل قصير جداً</string>
     <string name="settings_support_debuglog_short_recording_msg">كان هذا تسجيلاً قصيراً جداً. سجلات التشخيص هي تسجيلات وليست لقطات — أعد إنتاج المشكلة أثناء التسجيل لكي يكون السجل مفيداً.</string>
     <string name="settings_support_debuglog_short_recording_continue">متابعة التسجيل</string>
     <string name="settings_support_debuglog_short_recording_stop">أوقف على أي حال</string>
-    <string name="settings_support_debuglog_folder_label">مجلد سجل التشخيص</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="zero">%1$d جلسة تستخدم %2$s</item>
-        <item quantity="one">%1$d جلسة تستخدم %2$s</item>
-        <item quantity="two">%1$d جلسة تستخدمان %2$s</item>
-        <item quantity="few">%1$d جلسات تستخدم %2$s</item>
-        <item quantity="many">%1$d جلسة تستخدم %2$s</item>
-        <item quantity="other">%1$d جلسة تستخدم %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">لا توجد سجلات تشخيص مخزنة</string>
-    <string name="settings_support_debuglog_folder_delete_title">حذف كل سجلات التشخيص؟</string>
-    <string name="settings_support_debuglog_folder_delete_msg">سيتم حذف جميع جلسات سجل التشخيص المخزنة بشكل دائم.</string>
     <string name="settings_support_discord_label">ديسكورد</string>
     <string name="settings_support_discord_description">مكان للتسكع وطرح الأسئلة.</string>
     <!-- Settings/Acks-->
@@ -236,16 +209,12 @@
     <string name="settings_acks_translation_header">الترجمة</string>
     <string name="settings_acks_translators_title">المترجمون</string>
     <string name="settings_acks_translators_people">Rex_sa</string>
-    <string name="settings_acks_translate_title">ترجمة BVM</string>
-    <string name="settings_acks_translate_desc">ساعد في ترجمة BVM إلى لغتك</string>
     <string name="settings_acks_thanks_header">شكر</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">لدعم ترجمة مشاريع مفتوحة المصدر</string>
     <string name="settings_licenses_label">التراخيص</string>
     <string name="settings_translation_label">الترجمة</string>
     <string name="settings_translation_desc">ساعد في ترجمة التطبيق إلى لغتك المفضلة</string>
-    <string name="settings_sponsor_development_title">رعاية التطوير</string>
-    <string name="settings_sponsor_development_summary">اصبح راعياً واجعل استمرار التطوير ممكناً.</string>
     <string name="settings_privacy_policy_label">سياسة الخصوصية</string>
     <string name="settings_privacy_policy_desc">التعامل مع البيانات بمسؤولية.</string>
     <string name="changelog_label">سجل التغييرات</string>
@@ -267,10 +236,8 @@
     <string name="backup_restore_success_restore">اكتملت الاستعادة — تم استعادة %1$d جهاز، تم تخطي %2$d.</string>
     <string name="backup_restore_version_warning">تم إنشاء هذه النسخة الاحتياطية بالإصدار %1$s. أنت تشغّل %2$s. قد لا تُستعاد بعض الإعدادات بشكل صحيح.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">إشعارات التشخيص</string>
     <string name="debug_log_consent_title">سجل التشخيص</string>
     <string name="debug_log_consent_explanation">هذه الميزة تسجّل كل ما يفعله التطبيق في ملف قابل للمشاركة. الملف المُنشأ يحتوي على معلومات حسّاسة (مثل أسماء الملفات والتطبيقات المثبتة). شاركه فقط مع أطراف موثوقة (مثل مطور يحل مشكلة).</string>
-    <string name="debug_log_recording_progress">يتم تسجيل سجل التشخيص</string>
     <string name="debug_log_record_action">تسجيل</string>
     <string name="debug_log_stop_action">إيقاف التسجيل</string>
     <string name="debug_log_screen_title">مسجّل سجل التشخيص</string>
@@ -289,7 +256,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">تجاهل</string>
     <string name="debug_log_screen_keep_action">احتفظ</string>
-    <string name="debug_log_compressing_label">جارٍ الضغط…</string>
     <string name="debug_log_file_label">ملف سجل مُسجّل</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">تم إرسال السجل؟</string>
@@ -317,7 +283,6 @@
     <string name="contact_description_question_hint">صِف سؤالك بالتفصيل.</string>
     <string name="contact_category_section_label">الفئة</string>
     <string name="contact_debug_log_label">سجل التشخيص</string>
-    <string name="contact_debug_log_select_hint">اختر سجل تشخيص لإرفاقه</string>
     <string name="contact_debug_log_picker_hint">أرفق سجل تشخيص للمساعدة في تشخيص المشكلة بشكل أسرع.</string>
     <string name="contact_debug_log_picker_empty">لا توجد سجلات تشخيص. سجّل واحداً أولاً.</string>
     <string name="contact_expected_behavior_label">السلوك المتوقع</string>
@@ -335,82 +300,32 @@
     <string name="contact_welcome_msg">أقرأ كل رسالة بنفسي وأبذل قصارى جهدي للرد، لكن بما أنني أعمل على هذا وحدي، قد يستغرق الأمر بعض الوقت. شكراً لصبرك.</string>
     <string name="contact_footer_msg">ستُرسل رسالتك عبر البريد الإلكتروني. يتم إرفاق معلومات الجهاز والإعداد تلقائياً.</string>
     <string name="contact_no_email_app_msg">لم يتم العثور على تطبيق بريد إلكتروني على هذا الجهاز.</string>
-    <string name="contact_attachment_missing_msg">ملف سجل التشخيص لم يعد موجوداً</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">سجلات التشخيص المخزنة</string>
     <string name="settings_support_stored_logs_desc">%1$d جلسات (%2$s)</string>
     <string name="settings_support_stored_logs_empty">لا توجد سجلات تشخيص مخزنة</string>
-    <string name="settings_support_stored_logs_delete_title">حذف السجلات المخزنة؟</string>
-    <string name="settings_support_stored_logs_delete_msg">سيتم حذف جميع %1$d جلسات سجل التشخيص المخزنة.</string>
-    <string name="settings_support_stored_logs_deleted_msg">تم حذف سجلات التشخيص المخزنة</string>
-    <string name="label_bug_reports">تقرير الأخطاء</string>
-    <string name="description_bug_reports">تلقائية الإبلاغ عن الأخطاء.</string>
     <string name="label_add_device">إضافة جهاز</string>
-    <string name="label_just_a_moment_please">لحظة فقط، من فضلك.</string>
     <string name="label_notification_channel_status">الحالة</string>
     <string name="label_notification_channel_setup">الإعداد مطلوب</string>
     <string name="monitor_notification_starting">جاري البدء…</string>
     <string name="action_set">ضبط</string>
     <string name="action_cancel">إلغاء</string>
-    <string name="label_invalid_input">الإدخال غير صالح</string>
     <string name="action_reset">إعادة الضبط</string>
     <string name="label_no_connected_devices">لا توجد أجهزة متصلة</string>
-    <string name="label_status_idle">متوقف</string>
-    <string name="label_status_adjusting_volumes">ضبط مستويات الصوت</string>
-    <string name="label_premium_version">الإصدار المتميز</string>
     <string name="general_upgrade_action">تحديث</string>
     <string name="common_upgrade_required_label">الترقية مطلوبة</string>
-    <string name="label_premium_version_required">يتطلب النسخة الكاملة</string>
-    <string name="description_intro_purpose">يسمح هذا التطبيق للأندرويد بتذكر حجم الصوت لمختلف أجهزة البلوتوث.</string>
-    <string name="upgrade_benefit_unlimited_devices">ملفات تعريف أجهزة غير محدودة</string>
-    <string name="upgrade_benefit_connection_actions">التشغيل التلقائي وإطلاق التطبيق وتنبيهات الاتصال</string>
-    <string name="upgrade_benefit_theme_customization">تخصيص السمة والنمط واللون</string>
-    <string name="upgrade_benefit_power_controls">قفل الصوت والحد من المعدل</string>
-    <string name="upgrade_benefit_support">دعم التطوير المستقل</string>
     <string name="upgrade_benefit_equalizer">• موازن صوت لكل جهاز على حدة (لتطبيقات الموسيقى التي تدعم موازن النظام)</string>
-    <string name="description_intro_tap_the_button">ابدأ أولا بإضافة جهازك.</string>
     <string name="description_bluetooth_is_disabled">البلوتوث غير مفعل.</string>
     <string name="title_bluetooth_is_off">البلوتوث مغلق</string>
     <string name="action_enable_bluetooth">تفعيل البلوتوث</string>
     <string name="title_bluetooth_permission_required">مطلوب إذن البلوتوث</string>
     <string name="description_bluetooth_permission_required">يحتاج هذا التطبيق إذن البلوتوث لإدارة مستويات صوت جهازك.</string>
     <string name="action_grant_permission">منح الإذن</string>
-    <string name="label_status_listening_for_changes">الاستماع للتغييرات في الحجم</string>
     <string name="action_exit">خروج</string>
-    <string name="action_start">بدء</string>
-    <string name="label_welcome">مرحباً</string>
-    <string name="description_intro_contact">لا تتردد في الاتصال بي إذا كان لديك أسئلة أو حتى فكرة لميزة جديدة.</string>
-    <string name="label_translation">الترجمة</string>
-    <string name="description_help_translate">ساعدني في جعل هذا التطبيق متاح في لغات أخرى.</string>
     <string name="label_device_speaker">مكبر الصوت</string>
-    <string name="label_keyevent_playpause">تشغيل-إيقاف</string>
-    <string name="label_keyevent_play">تشغيل</string>
-    <string name="label_keyevent_next">التالي</string>
-    <string name="label_install_id">رقم التثبيت</string>
     <string name="message_copied_to_clipboard">نسخت إلى الحافظة</string>
-    <string name="label_thanks">شكراً</string>
-    <string name="label_licenses">التراخيص</string>
-    <string name="description_ring_volume_additional_permission">صلاحيات إضافية ضرورية لتغيير مستوى صوت الرنين.</string>
-    <string name="label_missing_permissions">صلاحيات ناقصة</string>
-    <string name="action_grant">امنح</string>
-    <string name="label_advanced">متقدم</string>
-    <string name="label_exclude_health">استبعاد ملفات الصحة</string>
-    <string name="description_exclude_health">بعض أجهزة الأندرويد تجمد عند بحث \'صحة الجهاز\' في هويات البلوتوث (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">استثناء هويات سيرفر GATT</string>
-    <string name="label_exclude_gatt">استثناء هويات GATT</string>
-    <string name="description_exclude_gattserver">لا تختار هويات البلوتوث من نوع \'سمة عامة\' سيرفر (GATT).</string>
-    <string name="description_exclude_gatt">لا تختار هويات البلوتوث من نوع \'سمة عامة\' عميل (GATT).</string>
-    <string name="description_waiting_for_devicex">في انتظار %s لإتمام الاتصال</string>
-    <string name="action_undo">تراجع</string>
-    <string name="action_show">إظهار</string>
     <string name="action_dismiss">تجاهل</string>
-    <string name="action_fix">إصلاح</string>
-    <string name="battery_optimizations_issue_description">تحسينات استهلاك البطارية مفعلة لهذا التطبيق بإمكانها أن تمنع وصول أحداث البلوتوث. بإمكانك النظر في إلغاء هذه التحسينات اذا كنت تواجه مشاكل.</string>
     <string name="label_bluetooth_settings">إعدادات البلوتوث</string>
-    <string name="android10_applaunch_issue_description">يقيّد Android 10 كيفية تشغيل التطبيقات من الخلفية. للسماح بفتح التطبيقات عند توصيل جهاز بلوتوث، امنح إذن &quot;العرض فوق التطبيقات الأخرى&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">كود المصدر</string>
-    <string name="android13_notification_permission_description">امنح هذا التطبيق إذنًا لنشر الإشعارات. يتيح ذلك عرض إشعار عندما يكون التطبيق نشطًا ويتم إجراء تعديلات على مستوى الصوت.</string>
-    <string name="privacy_policy_label">سياسة الخصوصية</string>
     <string name="managed_devices_empty_message">لا توجد أجهزة بلوتوث مكوّنة.\nاضغط على زر + لإضافة جهازك الأول.</string>
     <string name="label_pro_feature">ميزة مميزة</string>
     <plurals name="discover_device_limit_banner">
@@ -445,21 +360,15 @@
     <string name="review_app_review_action">مراجعة</string>
     <string name="review_app_dismiss_action">ربما لاحقًا</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">تم إلغاء الشراء</string>
-    <string name="error_iap_unavailable_message">المشتريات داخل التطبيق غير متاحة</string>
-    <string name="error_generic_message">حدث خطأ. يرجى المحاولة مرة أخرى.</string>
-    <string name="error_iap_owned_message">أنت تمتلك هذا العنصر بالفعل</string>
     <string name="label_no_devices_title">لا توجد أجهزة</string>
     <string name="bluemusic_mascot_description">أيقونة التطبيق</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">اختيار التطبيقات</string>
     <string name="devices_app_selection_search_hint">البحث عن التطبيقات…</string>
-    <string name="devices_app_selection_currently_selected">المحدد حالياً</string>
     <string name="devices_app_selection_selected_count">%d تطبيق محدد</string>
     <string name="general_navigate_back_action">العودة</string>
     <string name="general_reset_action">إعادة تعيين</string>
     <string name="general_clear_action">مسح</string>
-    <string name="general_save_action">حفظ</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">قفل</string>
     <string name="devices_indicator_awake">يقظ</string>
@@ -469,7 +378,6 @@
     <string name="devices_indicator_limit">حد</string>
     <string name="devices_indicator_eq">موازن</string>
     <string name="devices_indicator_boost">تعزيز</string>
-    <string name="devices_indicator_launch">تشغيل</string>
     <string name="devices_indicator_home">الرئيسية</string>
     <string name="devices_indicator_dnd">عدم الإزعاج</string>
     <string name="devices_indicator_alert">تنبيه</string>

--- a/app/src/main/res/values-az/strings.xml
+++ b/app/src/main/res/values-az/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Bu yeniləmə zamanı bəzi funksiyalar dəyişdi. Hər şeyin düzgün konfiqurasiya edildiyindən əmin olmaq üçün cihaz parametrlərinizi yoxlayın.</string>
     <string name="onboarding_rewrite_action">Davam et</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">İdarəsiz cihaz tapılmadı</string>
     <string name="discover_all_devices_managed_msg">Bütün cütləşdirilmiş cihazlarınız idarə olunur! Yenisini əlavə etmək istəyirsiniz?</string>
     <string name="discover_pair_new_device_action">Yeni cihaz cütləşdir</string>
     <string name="discover_device_speaker_desc">Bu telefonun öz hoparlörü. Onun səs səviyyələri audio telefona qayıtdıqda tətbiq edilir, məsələn Bluetooth cihazınız ayırıldıqdan sonra.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Cihaz konfiqurasiyası</string>
-    <string name="devices_device_config_section_general_label">Ümumi</string>
     <string name="devices_device_config_remove_device_label">Cihazı unut</string>
-    <string name="devices_device_config_remove_device_desc">Cihazı bu tətbiqdən unudur və konfiqurasiyasını silir. Bu, cihazın cütləşməsini ləğv etmir.</string>
     <string name="devices_device_config_remove_device_action">Unut</string>
     <string name="devices_device_config_remove_device_confirmation">%s cihazını idarə olunan cihazlardan unutmaq istəyirsiniz?</string>
-    <string name="devices_device_config_rename_device_label">Cihazı yenidən adlandır</string>
-    <string name="devices_device_config_rename_device_desc">Bu cihazı tətbiq daxilində, mümkünsə sistem səviyyəsində yenidən adlandır.</string>
     <string name="devices_device_config_rename_device_action">Yenidən adlandır</string>
     <string name="devices_device_config_enabled_label">Fəal</string>
     <string name="devices_device_config_enabled_desc">Bağlantı qurulduqda bu cihaza cavab ver</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Avtomatik oynatma əmrləri</string>
     <string name="devices_device_config_autoplay_keycodes_order">Əmr ardıcıllığı</string>
     <string name="devices_device_config_autoplay_keycodes_label">Əmrlər</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Hansı əmrlərin göndəriləcəyini və hansı ardıcıllıqla konfiqurasiya edin</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Heç bir əmr konfiqurasiya edilməyib</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Əmr əlavə et</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimum %1$d əmr</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Yuxarı köçür</string>
     <string name="cd_autoplay_keycode_move_down">Aşağı köçür</string>
     <string name="cd_autoplay_keycode_remove">Çıxar</string>
-    <string name="devices_device_config_section_volumes_label">Səs səviyyələri</string>
     <string name="devices_device_config_section_volume_label">Səs</string>
     <string name="devices_device_config_alarm_volume_label">Zəngli saat səs səviyyəsi</string>
     <string name="devices_device_config_alarm_volume_desc">Bəzi zəngli saat tətbiqləri bunun əvəzinə musiqi səviyyəsi istifadə edir.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Zəng səsi</string>
     <string name="devices_audio_stream_notification_label">Bildiriş</string>
     <string name="devices_audio_stream_alarm_label">Zəngli saat</string>
-    <string name="devices_neverseen_label">Heç vaxt görünmədi</string>
-    <string name="devices_state_connected_label">Bağlantı quruldu</string>
     <string name="devices_last_connected_label">Son qoşulma: %s</string>
     <string name="devices_currently_connected_label">Hazırda qoşulub</string>
     <string name="devices_device_disabled_label">Cihaz deaktivdir</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Bütün idarə olunan cihazlara təsir edən parametrlər.</string>
     <string name="label_app_enabled">Tətbiq fəaldır</string>
     <string name="description_app_enabled">Tətbiqetmənin səs səviyyəsinə və Bluetooth vəziyyətinə reaksiya vermə bacarığını dəyişdirər.</string>
-    <string name="label_visible_volume_adjustments">Görünən nizamlamalar</string>
-    <string name="description_visible_volume_adjustments">Bu tətbiq, nizamlamalar edərkən sistemin səs pəncərəsini göstər.</string>
     <string name="label_volume_listener">Dəyişiklikləri müşahidə et</string>
-    <string name="description_volume_listener">Bir cihazla bağlantı qurduqda aktiv qal və bu tətbiqdən qaynaqlanmayan səs dəyişikliklərini saxla.</string>
     <string name="label_boot_restore">Başlanğıcda geri qaytar</string>
     <string name="description_boot_restore">Bluetooth cihazı ilə bağlantı qurulsa, açılışdan/yenidən başlatmadan sonra səs səviyyəsini geri qaytarın.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM-i effektiv istifadə etməyi öyrənin</string>
     <string name="settings_support_issue_tracker_description">Xəta hesabatları və yeni funksiya istəkləri üçün açıq problem izləyici.</string>
     <string name="settings_support_issue_tracker_label">Problem izləyici</string>
-    <string name="settings_support_debuglog_label">Sazlama jurnalı</string>
     <string name="settings_support_debuglog_desc">Tətbiqin etdiklərinin hamısını paylaşa biləcəyiniz bir mətn faylına yazın.</string>
-    <string name="settings_support_debuglog_recording_desc">Hazırda sazlama məlumatları yazılır. Yazmağı dayandırmaq üçün toxunun.</string>
-    <string name="settings_support_debuglog_path">Jurnal yolu: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Çox qısa qeyd</string>
     <string name="settings_support_debuglog_short_recording_msg">Bu çox qısa bir qeyd idi. Sazlama jurnalları anlıq görüntü deyil, qeydlərdir — faydalı olması üçün qeyd aktiv olarkən problemi yenidən yaradın.</string>
     <string name="settings_support_debuglog_short_recording_continue">Qeydə davam et</string>
     <string name="settings_support_debuglog_short_recording_stop">Yenə də dayandır</string>
-    <string name="settings_support_debuglog_folder_label">Sazlama jurnalı qovluğu</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sessiya %2$s istifadə edir</item>
-        <item quantity="other">%1$d sessiya %2$s istifadə edir</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Sazlama jurnalı saxlanılmayıb</string>
-    <string name="settings_support_debuglog_folder_delete_title">Bütün sazlama jurnallarını silin?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Bu, saxlanılan bütün sazlama jurnalı sessiyalarını həmişəlik silər.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Söhbət etmək və sual vermək üçün bir yer.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Tərcümə</string>
     <string name="settings_acks_translators_title">Tərcüməçilər</string>
     <string name="settings_acks_translators_people">Şəxs1;Şəxs2(isteğe_bağlı@email.com)</string>
-    <string name="settings_acks_translate_title">BVM-i tərcümə et</string>
-    <string name="settings_acks_translate_desc">BVM-i öz dilinizə tərcümə etməyə kömək edin</string>
     <string name="settings_acks_thanks_header">Təşəkkürlər</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Açıq mənbəli layihələrin tərcüməsini dəstəklədiyinə görə</string>
     <string name="settings_licenses_label">Lisenziyalar</string>
     <string name="settings_translation_label">Tərcümə</string>
     <string name="settings_translation_desc">Tətbiqi sevdiyiniz dilə tərcümə etməyə kömək edin</string>
-    <string name="settings_sponsor_development_title">İnkişafı sponsorlaşdır</string>
-    <string name="settings_sponsor_development_summary">Patron ol və davamlı inkişafı mümkün et.</string>
     <string name="settings_privacy_policy_label">Məxfilik siyasəti</string>
     <string name="settings_privacy_policy_desc">Məlumatları məsuliyyətlə idarə etmək.</string>
     <string name="changelog_label">Dəyişiklik jurnalı</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Bərpa tamamlandı — %1$d cihaz bərpa edildi, %2$d atlandı.</string>
     <string name="backup_restore_version_warning">Bu ehtiyat nüsxə %1$s versiyasi ilə yeradılıb. Siz %2$s versiyasini işlədirsiz. Bəzi parametrlər düzgün bərpa edilməyə bilər.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Sazlama bildirişləri</string>
     <string name="debug_log_consent_title">Sazlama jurnalı</string>
     <string name="debug_log_consent_explanation">Bu funksiya tətbiqin etdiklərinin hamısını paylaşıla bilən bir fayla yazır. Yaradılan fayl həssas məlumatlar ehtiva edir (məs. fayl adları və quraşdırılmış tətbiqlər). Yalnız etibarlı tərəflərlə paylaşın (məs. problemi həll edən bir proqramçı).</string>
-    <string name="debug_log_recording_progress">Sazlama jurnalı yazılır</string>
     <string name="debug_log_record_action">Yaz</string>
     <string name="debug_log_stop_action">Yazmağı dayandır</string>
     <string name="debug_log_screen_title">Sazlama Jurnalı Yazıcısı</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Sil</string>
     <string name="debug_log_screen_keep_action">Saxla</string>
-    <string name="debug_log_compressing_label">Sıxılır…</string>
     <string name="debug_log_file_label">Yazılmış jurnal faylı</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Jurnal göndərildi?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Sualınızı ətraflı şəkildə təsvir edin.</string>
     <string name="contact_category_section_label">Kateqoriya</string>
     <string name="contact_debug_log_label">Sazlama jurnalı</string>
-    <string name="contact_debug_log_select_hint">Əlavə etmək üçün sazlama jurnalı seçin</string>
     <string name="contact_debug_log_picker_hint">Problemi daha sürətli diaqnoz etmək üçün sazlama jurnalı əlavə edin.</string>
     <string name="contact_debug_log_picker_empty">Sazlama jurnalı yoxdur. Əvvəlcə birini qeyd edin.</string>
     <string name="contact_expected_behavior_label">Gözlənilən davranış</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Hər mesajı özüm oxuyuram və cavab verməyə çalışıram, lakin bunu tək işlədiyimə görə biraz vaxt lazım ola bilər. Səbriniz üçün təşəkkür edirik.</string>
     <string name="contact_footer_msg">Mesajınız e-poçt vasitəsilə göndəriləcəkdir. Cihaz və quraşdırma məlumatları avtomatik olaraq əlavə edilir.</string>
     <string name="contact_no_email_app_msg">Bu cihazda e-poçt tətbiqi tapılmadı.</string>
-    <string name="contact_attachment_missing_msg">Sazlama jurnalı faylı artıq mövcud deyil</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Saxlanılan sazlama jurnalları</string>
     <string name="settings_support_stored_logs_desc">%1$d sessiya (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Saxlanılan sazlama jurnalı yoxdur</string>
-    <string name="settings_support_stored_logs_delete_title">Saxlanılan jurnalları silin?</string>
-    <string name="settings_support_stored_logs_delete_msg">Bu, saxlanılan bütün %1$d sazlama jurnalı sessiyasını silər.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Saxlanılan sazlama jurnalları silindi</string>
-    <string name="label_bug_reports">Xəta hesabatı</string>
-    <string name="description_bug_reports">Avtomatik xəta və çökmə hesabatı göndərmə.</string>
     <string name="label_add_device">Cihaz əlavə et</string>
-    <string name="label_just_a_moment_please">Bir dəqiqə, zəhmət olmasa.</string>
     <string name="label_notification_channel_status">Vəziyyət</string>
     <string name="label_notification_channel_setup">Qurulum tələb olunur</string>
     <string name="monitor_notification_starting">Başladılır…</string>
     <string name="action_set">Tənzimlə</string>
     <string name="action_cancel">İmtina</string>
-    <string name="label_invalid_input">Etibarsız giriş</string>
     <string name="action_reset">Sıfırla</string>
     <string name="label_no_connected_devices">Bağlı cihaz yoxdur</string>
-    <string name="label_status_idle">Boşda</string>
-    <string name="label_status_adjusting_volumes">Səs səviyyəsini nizamla</string>
-    <string name="label_premium_version">Premium versiya</string>
     <string name="general_upgrade_action">Yüksəlt</string>
     <string name="common_upgrade_required_label">Yüksəltmə tələb olunur</string>
-    <string name="label_premium_version_required">Premium versiya tələb olunur</string>
-    <string name="description_intro_purpose">Bu tətbiq, Android cihazınıza fərqli Bluetooth cihazının səs səviyyəsini xatırlamasına icazə verər.</string>
-    <string name="upgrade_benefit_unlimited_devices">Limitsiz cihaz profilləri</string>
-    <string name="upgrade_benefit_connection_actions">Avtomatik oynatma, tətbiq işə salma və bağlantı xəbərdaqlıqları</string>
-    <string name="upgrade_benefit_theme_customization">Tema, stil və rəng fərdiləşdirməsi</string>
-    <string name="upgrade_benefit_power_controls">Səs kilidi və sürət məhdudiyyəti</string>
-    <string name="upgrade_benefit_support">Müstəqil inkəşafı dəstəkləyin</string>
     <string name="upgrade_benefit_equalizer">• Cihaz üzrə ekvalayzər (sistem ekvalayzeri dəstəkləyən musiqi tətbiqləri üçün)</string>
-    <string name="description_intro_tap_the_button">İlk cihazınızı əlavə edərək başlayın.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth sıradan çıxarıldı.</string>
     <string name="title_bluetooth_is_off">Bluetooth Söndürülüb</string>
     <string name="action_enable_bluetooth">Bluetoothu Fəallaşdır</string>
     <string name="title_bluetooth_permission_required">Bluetooth İcazəsi Tələb Olunur</string>
     <string name="description_bluetooth_permission_required">Bu tətbiq cihaz səslərini idarə etmək üçün Bluetooth icazəsinə ehtiyac duyur.</string>
     <string name="action_grant_permission">İcazə Ver</string>
-    <string name="label_status_listening_for_changes">Səs səviyyəsinin dəyişdirilməsi dinlənilir</string>
     <string name="action_exit">Çıxış</string>
-    <string name="action_start">Başlat</string>
-    <string name="label_welcome">Xoş Gəldiniz</string>
-    <string name="description_intro_contact">Yeni bir özəllik üçün sual və ya ideyanız varsa bizimlə əlaqə saxlamaqdan çəkinməyin.</string>
-    <string name="label_translation">Tərcümə</string>
-    <string name="description_help_translate">Bu tətbiqin digər dillərdə mövcud olması üçün kömək edin.</string>
     <string name="label_device_speaker">Cihaz dinamiki</string>
-    <string name="label_keyevent_playpause">Oynat-Fasilə ver</string>
-    <string name="label_keyevent_play">Oynat</string>
-    <string name="label_keyevent_next">Növbəti</string>
-    <string name="label_install_id">Quraşdırma Kimliyi</string>
     <string name="message_copied_to_clipboard">Lövhəyə kopyalandı</string>
-    <string name="label_thanks">Təşəkkürlər</string>
-    <string name="label_licenses">Lisenziyalar</string>
-    <string name="description_ring_volume_additional_permission">Zəng səsi səviyyəsini dəyişdirmək üçün əlavə icazələr lazımdır.</string>
-    <string name="label_missing_permissions">Əskik icazələr</string>
-    <string name="action_grant">İcazə ver</string>
-    <string name="label_advanced">Qabaqcıl</string>
-    <string name="label_exclude_health">Sağlamlıq profillərini burax</string>
-    <string name="description_exclude_health">Bəzi Android cihazları \'Health Device\' Bluetooth profillərinə baxarkən taxılır (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">GATT server profillərini istisna et</string>
-    <string name="label_exclude_gatt">GATT profillərini istisna et</string>
-    <string name="description_exclude_gattserver">\'Generic Attribute\' (GATT) server növlərinin Bluetooth profillərini sorğulama.</string>
-    <string name="description_exclude_gatt">\'Generic Attribute\' (GATT) müştəri növlərinin Bluetooth profillərini sorğulama.</string>
-    <string name="description_waiting_for_devicex">Bağlantının tamamlanması üçün %s gözlənilir</string>
-    <string name="action_undo">Geri al</string>
-    <string name="action_show">Göstər</string>
     <string name="action_dismiss">Rədd et</string>
-    <string name="action_fix">Düzəlt</string>
-    <string name="battery_optimizations_issue_description">Bu tətbiq üçün batareya optimallaşdırması aktivdir və Bluetooth hadisələrinin alınmasına mane ola bilər. Problemlə üzləşirsinizsə, optimallaşdırmanı söndürməyi düşünün.</string>
     <string name="label_bluetooth_settings">Bluetooth tənzimləmələri</string>
-    <string name="android10_applaunch_issue_description">Android 10, tətbiqləri arxaplandan necə başladılacağını məhdudlaşdırır. Bluetooth cihazları ilə bağlantı qurularkən tətbiqlərin açılmasına icazə vermək üçün, \"Digər tətbiqlərin üzərində görüntülə\" (SYSTEM_ALERT_WINDOW) müraciətinə icazə ver.</string>
-    <string name="label_opensource">Mənbə kodu</string>
-    <string name="android13_notification_permission_description">Bu tətbiqə bildiriş göndərmək üçün icazə ver. Bu, tətbiq aktiv olduqda və səs tənzimləmələri aparılarkən bildiriş göstərilməsinə imkan verir.</string>
-    <string name="privacy_policy_label">Məxfilik siyasəti</string>
     <string name="managed_devices_empty_message">Heç bir Bluetooth cihazı konfiqurasiya edilməyib.\nİlk cihazınızı əlavə etmək üçün + düyməsinə toxunun.</string>
     <string name="label_pro_feature">Premium xüsusiyyət</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Baxış</string>
     <string name="review_app_dismiss_action">Bəlkə sonra</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Satınalma ləğv edildi</string>
-    <string name="error_iap_unavailable_message">Tətbiq daxili alışlar mövcud deyil</string>
-    <string name="error_generic_message">Xəta baş verdi. Yenidən cəhd edin.</string>
-    <string name="error_iap_owned_message">Bu element artıq sizin mülkiyyətinizdədir</string>
     <string name="label_no_devices_title">Cihaz Yoxdur</string>
     <string name="bluemusic_mascot_description">Tətbiq ikonu</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Tətbiqləri seçin</string>
     <string name="devices_app_selection_search_hint">Tətbiqləri axtarın…</string>
-    <string name="devices_app_selection_currently_selected">Hazırda seçilmiş</string>
     <string name="devices_app_selection_selected_count">%d tətbiq seçilib</string>
     <string name="general_navigate_back_action">Geriyə naviqasiya et</string>
     <string name="general_reset_action">Sıfırla</string>
     <string name="general_clear_action">Təmizlə</string>
-    <string name="general_save_action">Saxla</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Kilit</string>
     <string name="devices_indicator_awake">Oyaq</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Məhdud</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Güçləndir</string>
-    <string name="devices_indicator_launch">Başlat</string>
     <string name="devices_indicator_home">Əsas ekran</string>
     <string name="devices_indicator_dnd">NE</string>
     <string name="devices_indicator_alert">Xəbərdarlıq</string>

--- a/app/src/main/res/values-be/strings.xml
+++ b/app/src/main/res/values-be/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Некаторыя функцыі змяніліся пад час абнаўлення. Калі ласка, праверце налады прылады, каб пераканацца, што ўсё настроена правільна.</string>
     <string name="onboarding_rewrite_action">Працягнуць</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Некіраваныя прылады не знойдзены</string>
     <string name="discover_all_devices_managed_msg">Усе вашы спалучаныя прылады кіруюцца! Патрэбна новая?</string>
     <string name="discover_pair_new_device_action">Спалучыць новую прыладу</string>
     <string name="discover_device_speaker_desc">Дынамік тэлефона. Яго гучнасці прымяняюцца, калі аўдыё вяртаецца да тэлефона, напр. пасля адключэння вашай прылады Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Канфігурацыя прылады</string>
-    <string name="devices_device_config_section_general_label">Агульныя</string>
     <string name="devices_device_config_remove_device_label">Забыць прыладу</string>
-    <string name="devices_device_config_remove_device_desc">Выдаляе прыладу з гэтага дадатку і выдаляе яе канфігурацыю. Гэта не разʼядноўвае прыладу.</string>
     <string name="devices_device_config_remove_device_action">Забыць</string>
     <string name="devices_device_config_remove_device_confirmation">Забыць %s з кіраваных прылад?</string>
-    <string name="devices_device_config_rename_device_label">Перайменаваць прыладу</string>
-    <string name="devices_device_config_rename_device_desc">Перайменавайце гэту прыладу ў гэтым дадатку і, калі магчыма, ў сістэме.</string>
     <string name="devices_device_config_rename_device_action">Перайменаваць</string>
     <string name="devices_device_config_enabled_label">Уключана</string>
     <string name="devices_device_config_enabled_desc">Рэагаваць на гэту прыладу пры падключэнні</string>
@@ -91,7 +86,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Каманды аўтаўзнаўлення</string>
     <string name="devices_device_config_autoplay_keycodes_order">Паслядоўнасць каманд</string>
     <string name="devices_device_config_autoplay_keycodes_label">Каманды</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Настройце, якія каманды адпраўляць і ў якой паслядоўнасці</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Няма настроеных каманд</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Дадаць каманду</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Максімум %1$d каманд</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">Перамясціць уверх</string>
     <string name="cd_autoplay_keycode_move_down">Перамясціць ўніз</string>
     <string name="cd_autoplay_keycode_remove">Выдаліць</string>
-    <string name="devices_device_config_section_volumes_label">Гучнасці</string>
     <string name="devices_device_config_section_volume_label">Гучнасць</string>
     <string name="devices_device_config_alarm_volume_label">Гучнасць будзільніка</string>
     <string name="devices_device_config_alarm_volume_desc">Некаторыя дадаткі будзільніка замест гэтага выкарыстоўваюць гучнасць музыкі.</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">Званок</string>
     <string name="devices_audio_stream_notification_label">Апавяшчэнне</string>
     <string name="devices_audio_stream_alarm_label">Будзільнік</string>
-    <string name="devices_neverseen_label">Ніколі не бачылася</string>
-    <string name="devices_state_connected_label">Падключана</string>
     <string name="devices_last_connected_label">Апошняе падключэнне: %s</string>
     <string name="devices_currently_connected_label">Зараз падключана</string>
     <string name="devices_device_disabled_label">Прылада адключана</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">Налады, якія ўплываюць на ўсе кіраваныя прылады.</string>
     <string name="label_app_enabled">Дадатак ўключаны</string>
     <string name="description_app_enabled">Пераключае здольнасць дадатку рэагаваць на падзеі гучнасці і Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Бачныя рэгулёўкі</string>
-    <string name="description_visible_volume_adjustments">Паказваць акно гучнасці сістэмы, пакуль гэты дадатак выконвае рэгулёўкі.</string>
     <string name="label_volume_listener">Назіраць за зменамі</string>
-    <string name="description_volume_listener">Заставацьца актыўным, пакуль прылада падключана, і захоўваць змены гучнасці, якія не зробленыя гэтым дадаткам.</string>
     <string name="label_boot_restore">Аднаўляць пры загрузцы</string>
     <string name="description_boot_restore">Аднаўляць гучнасць пасля загрузкі/перазагрузкі, калі прылада Bluetooth падключана.</string>
     <!-- Settings/Support-->
@@ -203,24 +191,11 @@
     <string name="settings_support_wiki_description">Даведайцеся, як эфектыўна выкарыстоўваць BVM</string>
     <string name="settings_support_issue_tracker_description">Публічны журнал для справаздач аб памылках і запытаў новых функцый.</string>
     <string name="settings_support_issue_tracker_label">Журнал памылак</string>
-    <string name="settings_support_debuglog_label">Журнал адладкі</string>
     <string name="settings_support_debuglog_desc">Вядзе запіс усяго, што адбываецца ў праграме, у тэкставы файл, якім вы можаце падзяліцца.</string>
-    <string name="settings_support_debuglog_recording_desc">Зараз запісваецца адладачная інфармацыя. Націсніце, каб спыніць запіс.</string>
-    <string name="settings_support_debuglog_path">Шлях да журнала: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Вельмі кароткі запіс</string>
     <string name="settings_support_debuglog_short_recording_msg">Гэта быў вельмі кароткі запіс. Журналы адладкі — гэта запісы, а не здымкі — узнаўляйце праблему пад час актыўнага запісу, каб журнал быў карысным.</string>
     <string name="settings_support_debuglog_short_recording_continue">Працягнуць запіс</string>
     <string name="settings_support_debuglog_short_recording_stop">Усё роўна спыніць</string>
-    <string name="settings_support_debuglog_folder_label">Папка журналаў адладкі</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d сесія з выкарыстаннем %2$s</item>
-        <item quantity="few">%1$d сесіі з выкарыстаннем %2$s</item>
-        <item quantity="many">%1$d сесій з выкарыстаннем %2$s</item>
-        <item quantity="other">%1$d сесіі з выкарыстаннем %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Журналы адладкі не захаваны</string>
-    <string name="settings_support_debuglog_folder_delete_title">Выдаліць усе журналы адладкі?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Гэта назаўжды выдаліць усе захаваныя сеансы журналаў адладкі.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Месца, дзе можна пагутарыць і задаць пытанні.</string>
     <!-- Settings/Acks-->
@@ -229,16 +204,12 @@
     <string name="settings_acks_translation_header">Пераклад</string>
     <string name="settings_acks_translators_title">Перакладчыкі</string>
     <string name="settings_acks_translators_people">Goshaproject</string>
-    <string name="settings_acks_translate_title">Перакласці BVM</string>
-    <string name="settings_acks_translate_desc">Дапамажыце перавесці BVM на вашу мову</string>
     <string name="settings_acks_thanks_header">Падзякі</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">За падтрымку перакладу праектаў з адкрытым зыходным кодам</string>
     <string name="settings_licenses_label">Ліцэнзіі</string>
     <string name="settings_translation_label">Пераклад</string>
     <string name="settings_translation_desc">Дапамажыце перавесці дадатак на вашу прыйманую мову</string>
-    <string name="settings_sponsor_development_title">Падтрымаць распрацоўку</string>
-    <string name="settings_sponsor_development_summary">Станьце спонсарам і зрабіце магчымай далейшую распрацоўку.</string>
     <string name="settings_privacy_policy_label">Палітыка канфідэнцыяльнасці</string>
     <string name="settings_privacy_policy_desc">Адказнае абыходжанне з данымі.</string>
     <string name="changelog_label">Журнал змяненняў</string>
@@ -260,10 +231,8 @@
     <string name="backup_restore_success_restore">Аднаўленне завершана — адноўлена %1$d прылад, прапушчана %2$d.</string>
     <string name="backup_restore_version_warning">Гэтая рэзервовая копія была створана з версіяй %1$s. Вы выкарыстоўваеце %2$s. Некаторыя налады могуць не аднавіцца правільна.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Апавяшчэнні адладкі</string>
     <string name="debug_log_consent_title">Журнал адладкі</string>
     <string name="debug_log_consent_explanation">Гэта функцыя запісвае ўсё, што робіць праграма, у файл, якім можна падзяліцца. Створаны файл змяшчае канфідэнцыяльную інфармацыю (напрыклад, назвы файлаў і спіс усталяваных праграм). Дзяліцеся ім толькі з даверанымі асобамі (напрыклад, з распрацоўшчыкам для вырашэння вашай праблемы).</string>
-    <string name="debug_log_recording_progress">Запіс журнала адладкі</string>
     <string name="debug_log_record_action">Запісаць</string>
     <string name="debug_log_stop_action">Спыніць запіс</string>
     <string name="debug_log_screen_title">Запісвальнік журналаў адладкі</string>
@@ -280,7 +249,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Адхіліць</string>
     <string name="debug_log_screen_keep_action">Захаваць</string>
-    <string name="debug_log_compressing_label">Сціск…</string>
     <string name="debug_log_file_label">Запісаны файл журнала</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Журнал адпраўлены?</string>
@@ -308,7 +276,6 @@
     <string name="contact_description_question_hint">Апішыце ваша пытанне падрабязна.</string>
     <string name="contact_category_section_label">Катэгорыя</string>
     <string name="contact_debug_log_label">Журнал адладкі</string>
-    <string name="contact_debug_log_select_hint">Выберыце журнал адладкі для прыкрэплення</string>
     <string name="contact_debug_log_picker_hint">Прыкрапце журнал адладкі, каб дапамачы хутчэй дыягнаставаць праблему.</string>
     <string name="contact_debug_log_picker_empty">Журналы адладкі недаступны. Спачатку запішыце адзін.</string>
     <string name="contact_expected_behavior_label">Чаканыя паводзіны</string>
@@ -324,82 +291,32 @@
     <string name="contact_welcome_msg">Я сам чытаю кожнае паведамленне і стараюся адказваць, але паколькі я працую над гэтым адзін, гэта можа заняць некаторы час. Дзякуй за цярпенне.</string>
     <string name="contact_footer_msg">Ваша паведамленне будзе адпраўлена па электроннай пошце. Інфармацыя аб прыладзе і наладах прыкрапляецца аўтаматычна.</string>
     <string name="contact_no_email_app_msg">На гэтай прыладзе не знойдзены дадатак электроннай пошты.</string>
-    <string name="contact_attachment_missing_msg">Файл журнала адладкі больш не існуе</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Захаваныя журналы адладкі</string>
     <string name="settings_support_stored_logs_desc">%1$d сеансаў (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Няма захаваных журналаў адладкі</string>
-    <string name="settings_support_stored_logs_delete_title">Выдаліць захаваныя журналы?</string>
-    <string name="settings_support_stored_logs_delete_msg">Гэта выдаліць усе %1$d захаваныя сеансы журналаў адладкі.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Захаваныя журналы адладкі выдалены</string>
-    <string name="label_bug_reports">Справаздачы аб памылках</string>
-    <string name="description_bug_reports">Аўтаматычная справаздача аб памылках і збоях.</string>
     <string name="label_add_device">Дадаць прыладу</string>
-    <string name="label_just_a_moment_please">Хвіліначку, калі ласка.</string>
     <string name="label_notification_channel_status">Стан</string>
     <string name="label_notification_channel_setup">Неабходна наладка</string>
     <string name="monitor_notification_starting">Запускаюцца…</string>
     <string name="action_set">Усталяваць</string>
     <string name="action_cancel">Скасаваць</string>
-    <string name="label_invalid_input">Няправільнае значэнне</string>
     <string name="action_reset">Скінуць</string>
     <string name="label_no_connected_devices">Прылады не падключаны</string>
-    <string name="label_status_idle">Прастой</string>
-    <string name="label_status_adjusting_volumes">Рэгуляванне гучнасці</string>
-    <string name="label_premium_version">Прэміум-версія</string>
     <string name="general_upgrade_action">Абнавіць</string>
     <string name="common_upgrade_required_label">Патрабуецца абнаўленне</string>
-    <string name="label_premium_version_required">Патрабуецца прэміум-версія</string>
-    <string name="description_intro_purpose">Гэты дадатак дазваляе вашай прыладзе Android запамінаць гучнасць розных прылад Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Неабмежаваная колькасць профіляў прылад</string>
-    <string name="upgrade_benefit_connection_actions">Аўтаўзнаўленне, запуск праграм і абвесткі аб падключэнні</string>
-    <string name="upgrade_benefit_theme_customization">Наладка тэмы, стылю і колеру</string>
-    <string name="upgrade_benefit_power_controls">Блакіроўка гучнасці і абмежаванне хуткасці</string>
-    <string name="upgrade_benefit_support">Падтрымаць незалежную распрацоўку</string>
     <string name="upgrade_benefit_equalizer">• Эквалайзер кожнай прылады (для музычных прыкладанняў з падтрымкай сістэмнага эквалайзера)</string>
-    <string name="description_intro_tap_the_button">Пачніце з дадання вашай першай прылады.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth адключаны.</string>
     <string name="title_bluetooth_is_off">Bluetooth выключаны</string>
     <string name="action_enable_bluetooth">Уключыць Bluetooth</string>
     <string name="title_bluetooth_permission_required">Патрэбны дазвол на Bluetooth</string>
     <string name="description_bluetooth_permission_required">Гэтаму дадатку патрэбны дазвол на Bluetooth для кіравання гучнасцю прылад.</string>
     <string name="action_grant_permission">Даць дазвол</string>
-    <string name="label_status_listening_for_changes">Слуханне змен гучнасці</string>
     <string name="action_exit">Выйсці</string>
-    <string name="action_start">Пачаць</string>
-    <string name="label_welcome">Вітаем</string>
-    <string name="description_intro_contact">Не саромейцеся звяртацца да мяне, калі ў вас есць пытанні або нават ідэя для новай функцыі.</string>
-    <string name="label_translation">Пераклад</string>
-    <string name="description_help_translate">Дапамажыце мне зрабіць гэты дадатак даступным на іншых мовах.</string>
     <string name="label_device_speaker">Дынамік прылады</string>
-    <string name="label_keyevent_playpause">Прайграць-Паўза</string>
-    <string name="label_keyevent_play">Прайграць</string>
-    <string name="label_keyevent_next">Далей</string>
-    <string name="label_install_id">Ідэнтыфікатар усталёўкі</string>
     <string name="message_copied_to_clipboard">Скапіравана ў буфер абмену</string>
-    <string name="label_thanks">Падзякі</string>
-    <string name="label_licenses">Ліцэнзіі</string>
-    <string name="description_ring_volume_additional_permission">Для змены гучнасці звонку патрэбны дадатковыя дазволы.</string>
-    <string name="label_missing_permissions">Адсутнічаюць дазволы</string>
-    <string name="action_grant">Даць</string>
-    <string name="label_advanced">Дадаткова</string>
-    <string name="label_exclude_health">Выключыць прафілі здароўя</string>
-    <string name="description_exclude_health">Некаторыя прылады Android завісаюць пры пошуку прафіляў Bluetooth \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Выключыць прафілі сервера GATT</string>
-    <string name="label_exclude_gatt">Выключыць прафілі GATT</string>
-    <string name="description_exclude_gattserver">Не запытваць прафілі Bluetooth тыпу \'Generic Attribute\' (GATT) сервер.</string>
-    <string name="description_exclude_gatt">Не запытваць прафілі Bluetooth тыпу \'Generic Attribute\' (GATT) кліент.</string>
-    <string name="description_waiting_for_devicex">Чаканне завяршэння падключэння %s</string>
-    <string name="action_undo">Скасаваць</string>
-    <string name="action_show">Паказаць</string>
     <string name="action_dismiss">Адхіліць</string>
-    <string name="action_fix">Выправіць</string>
-    <string name="battery_optimizations_issue_description">Аптымізацыя батарэі ўключана для гэтага дадатку і можа перашкодзіць яму атрымліваць падзеі Bluetooth. Разгледзце магчымасць адключэння аптымізацыі, калі у вас есць праблемы.</string>
     <string name="label_bluetooth_settings">Налады Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 абмяжвае, як дадаткі могуць запускацца з фону. Каб дазволіць адкрыць дадаткі пры падключэнні прылады Bluetooth, дайце дазвол \"Паказ над іншымі дадаткамі\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Зыходны код</string>
-    <string name="android13_notification_permission_description">Дайце гэтаму дадатку дазвол на публікацыю апавяшчэнняў. Гэта дазволіць паказваць апавяшчэнне, калі дадатак актыўны і выконваюцца рэгулёўкі гучнасці.</string>
-    <string name="privacy_policy_label">Палітыка канфідэнцыяльнасці</string>
     <string name="managed_devices_empty_message">Прылады Bluetooth не наладжаны.\nНацісніце кнопку +, каб дадаць першую прыладу.</string>
     <string name="label_pro_feature">Прэміум-функцыя</string>
     <plurals name="discover_device_limit_banner">
@@ -431,21 +348,15 @@
     <string name="review_app_review_action">Водгук</string>
     <string name="review_app_dismiss_action">Магчыма пазней</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Пакупка адменена</string>
-    <string name="error_iap_unavailable_message">Пакупкі ў дадатку недаступны</string>
-    <string name="error_generic_message">Адбылася памылка. Калі ласка, паспрабуйце яшчэ раз.</string>
-    <string name="error_iap_owned_message">Вы ўжо валодаеце гэтым элементам</string>
     <string name="label_no_devices_title">Няма прылад</string>
     <string name="bluemusic_mascot_description">Значок праграмы</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Выбраць праграмы</string>
     <string name="devices_app_selection_search_hint">Пошук праграм…</string>
-    <string name="devices_app_selection_currently_selected">Зараз выбрана</string>
     <string name="devices_app_selection_selected_count">%d праграм выбрана</string>
     <string name="general_navigate_back_action">Назад</string>
     <string name="general_reset_action">Скінуць</string>
     <string name="general_clear_action">Ачысціць</string>
-    <string name="general_save_action">Захаваць</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Заблакаваць</string>
     <string name="devices_indicator_awake">Актыўны</string>
@@ -455,7 +366,6 @@
     <string name="devices_indicator_limit">Абмежаванне</string>
     <string name="devices_indicator_eq">ЭК</string>
     <string name="devices_indicator_boost">Ўсіленне</string>
-    <string name="devices_indicator_launch">Запусціць</string>
     <string name="devices_indicator_home">Дадому</string>
     <string name="devices_indicator_dnd">Не турбаваць</string>
     <string name="devices_indicator_alert">Абвестка</string>

--- a/app/src/main/res/values-bg/strings.xml
+++ b/app/src/main/res/values-bg/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Някои функции са се променили по време на актуализацията. Моля, провери настройките на устройствата си, за да се увериш, че всичко е конфигурирано правилно.</string>
     <string name="onboarding_rewrite_action">Продължи</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Не са намерени неуправлявани устройства</string>
     <string name="discover_all_devices_managed_msg">Всички сдвоени устройства се управляват! Нужно ли ти е ново?</string>
     <string name="discover_pair_new_device_action">Сдвои ново устройство</string>
     <string name="discover_device_speaker_desc">Собственият говорител на телефона. Неговите нива на звука се прилагат, когато аудиото се върне към телефона, напр. след като вашето Bluetooth устройство се развърже.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Конфигурация на устройство</string>
-    <string name="devices_device_config_section_general_label">Основни</string>
     <string name="devices_device_config_remove_device_label">Забрави устройство</string>
-    <string name="devices_device_config_remove_device_desc">Забравя устройството от приложението и изтрива конфигурацията му. Това не разпарва устройството.</string>
     <string name="devices_device_config_remove_device_action">Забрави</string>
     <string name="devices_device_config_remove_device_confirmation">Забрави %s от управляваните устройства?</string>
-    <string name="devices_device_config_rename_device_label">Преименувай устройство</string>
-    <string name="devices_device_config_rename_device_desc">Преименувай устройството в рамките на приложението и, ако е възможно, в системата.</string>
     <string name="devices_device_config_rename_device_action">Преименувай</string>
     <string name="devices_device_config_enabled_label">Активно</string>
     <string name="devices_device_config_enabled_desc">Реагирай на това устройство, когато се свързва</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Команди за автоматично възпроизвеждане</string>
     <string name="devices_device_config_autoplay_keycodes_order">Последователност от команди</string>
     <string name="devices_device_config_autoplay_keycodes_label">Команди</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Конфигурирай кои команди да се изпращат и в какъв ред</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Няма конфигурирани команди</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Добави команда</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Максимум %1$d команди</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Премести нагоре</string>
     <string name="cd_autoplay_keycode_move_down">Премести надолу</string>
     <string name="cd_autoplay_keycode_remove">Премахване</string>
-    <string name="devices_device_config_section_volumes_label">Нива на звука</string>
     <string name="devices_device_config_section_volume_label">Звук</string>
     <string name="devices_device_config_alarm_volume_label">Звук на аларма</string>
     <string name="devices_device_config_alarm_volume_desc">Някои приложения за аларма използват нивото на музика вместо това.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Звънене</string>
     <string name="devices_audio_stream_notification_label">Известие</string>
     <string name="devices_audio_stream_alarm_label">Аларма</string>
-    <string name="devices_neverseen_label">Несвързван</string>
-    <string name="devices_state_connected_label">Свързано</string>
     <string name="devices_last_connected_label">Последно свързване: %s</string>
     <string name="devices_currently_connected_label">Свързано в момента</string>
     <string name="devices_device_disabled_label">Устройството е деактивирано</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Настройки, засягащи всички управлявани устройства.</string>
     <string name="label_app_enabled">Приложението е включено</string>
     <string name="description_app_enabled">Задейства реакциите на приложението към звука и Bluetooth събития.</string>
-    <string name="label_visible_volume_adjustments">Видими настройки</string>
-    <string name="description_visible_volume_adjustments">Показва системния прозорец за звука, докато приложението прави корекции.</string>
     <string name="label_volume_listener">Следи промените</string>
-    <string name="description_volume_listener">Записва промените на звука, които не са причинени от приложението докато устройството е свързано.</string>
     <string name="label_boot_restore">Възстанови при стартиране</string>
     <string name="description_boot_restore">Възстановява силата на звука след старт/рестарт ако Bluetooth устройство е свързано.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Научи се как да използваш BVM ефективно</string>
     <string name="settings_support_issue_tracker_description">Публичен тракер за докладване на грешки и заявки за функции.</string>
     <string name="settings_support_issue_tracker_label">Тракер на проблеми</string>
-    <string name="settings_support_debuglog_label">Дебъг лог</string>
     <string name="settings_support_debuglog_desc">Записва всичко, което прави приложението, в текстов файл, който можеш да споделиш.</string>
-    <string name="settings_support_debuglog_recording_desc">В момента се записва дебъг информация. Натисни, за да спреш записа.</string>
-    <string name="settings_support_debuglog_path">Път на лога: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Много кратък запис</string>
     <string name="settings_support_debuglog_short_recording_msg">Това беше много кратък запис. Дебъг логовете са записи, не снимки — възпроизведи проблема по време на активен запис, за да е полезен логът.</string>
     <string name="settings_support_debuglog_short_recording_continue">Продължи записа</string>
     <string name="settings_support_debuglog_short_recording_stop">Спри въпреки това</string>
-    <string name="settings_support_debuglog_folder_label">Папка с дебъг логове</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d сесия използва %2$s</item>
-        <item quantity="other">%1$d сесии използват %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Няма съхранени дебъг логове</string>
-    <string name="settings_support_debuglog_folder_delete_title">Изтрий всички дебъг логове?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Това ще изтрие трайно всички съхранени сесии на дебъг логове.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Място за разговори и задаване на въпроси.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Превод</string>
     <string name="settings_acks_translators_title">Преводачи</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Преведи BVM</string>
-    <string name="settings_acks_translate_desc">Помогни да преведем BVM на твоя език</string>
     <string name="settings_acks_thanks_header">Благодарности</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">За подкрепата на превода на проекти с отворен код</string>
     <string name="settings_licenses_label">Лицензи</string>
     <string name="settings_translation_label">Превод</string>
     <string name="settings_translation_desc">Помогнете да преведете приложението на любимия си език</string>
-    <string name="settings_sponsor_development_title">Подкрепи разработката</string>
-    <string name="settings_sponsor_development_summary">Стани патрон и направи продължаващата разработка възможна.</string>
     <string name="settings_privacy_policy_label">Политика за поверителност</string>
     <string name="settings_privacy_policy_desc">Отговорно боравене с данните.</string>
     <string name="changelog_label">Списък с промени</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Възстановяването е завършено — %1$d устройства възстановени, %2$d пропуснати.</string>
     <string name="backup_restore_version_warning">Този архив е създаден с версия %1$s. Вие използвате %2$s. Някои настройки може да не се възстановят правилно.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Дебъг известия</string>
     <string name="debug_log_consent_title">Дебъг лог</string>
     <string name="debug_log_consent_explanation">Тази функция записва всичко, което прави приложението, в споделяем файл. Генерираният файл съдържа чувствителна информация (напр. имена на файлове и инсталирани приложения). Споделяй го само с доверени лица (напр. разработчик, отстраняващ проблем).</string>
-    <string name="debug_log_recording_progress">Записва дебъг лог</string>
     <string name="debug_log_record_action">Запис</string>
     <string name="debug_log_stop_action">Спри записа</string>
     <string name="debug_log_screen_title">Записвач на дебъг лог</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Изхвърли</string>
     <string name="debug_log_screen_keep_action">Запази</string>
-    <string name="debug_log_compressing_label">Компресиране…</string>
     <string name="debug_log_file_label">Записан лог файл</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Логът изпратен ли е?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Опиши въпроса си подробно.</string>
     <string name="contact_category_section_label">Категория</string>
     <string name="contact_debug_log_label">Дебъг лог</string>
-    <string name="contact_debug_log_select_hint">Избери дебъг лог за прикачване</string>
     <string name="contact_debug_log_picker_hint">Прикачи дебъг лог, за да ускориш диагностиката.</string>
     <string name="contact_debug_log_picker_empty">Няма налични дебъг логове. Запиши такъв първо.</string>
     <string name="contact_expected_behavior_label">Очаквано поведение</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Чета всяко съобщение лично и се старая да отговарям, но тъй като работя сам, може да отнеме малко повече. Благодаря за търпението.</string>
     <string name="contact_footer_msg">Съобщението ти ще бъде изпратено по имейл. Информацията за устройството и настройките се прикачва автоматично.</string>
     <string name="contact_no_email_app_msg">Не е намерено имейл приложение на това устройство.</string>
-    <string name="contact_attachment_missing_msg">Файлът на дебъг лога вече не съществува</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Съхранени дебъг логове</string>
     <string name="settings_support_stored_logs_desc">%1$d сесии (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Няма съхранени дебъг логове</string>
-    <string name="settings_support_stored_logs_delete_title">Изтрий съхранените логове?</string>
-    <string name="settings_support_stored_logs_delete_msg">Това ще изтрие всичките %1$d съхранени сесии на дебъг логове.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Съхранените дебъг логове са изтрити</string>
-    <string name="label_bug_reports">Доклади за грешки</string>
-    <string name="description_bug_reports">Автоматични доклади за сривове и грешки.</string>
     <string name="label_add_device">Добави устройство</string>
-    <string name="label_just_a_moment_please">Момент, моля.</string>
     <string name="label_notification_channel_status">Статус</string>
     <string name="label_notification_channel_setup">Изисква се настройка</string>
     <string name="monitor_notification_starting">Стартиране…</string>
     <string name="action_set">Настрой</string>
     <string name="action_cancel">Отказ</string>
-    <string name="label_invalid_input">Невалидно въвеждане</string>
     <string name="action_reset">Нулирай</string>
     <string name="label_no_connected_devices">Няма свързани устройства</string>
-    <string name="label_status_idle">Изчакване</string>
-    <string name="label_status_adjusting_volumes">Коригира звука</string>
-    <string name="label_premium_version">Премиум версия</string>
     <string name="general_upgrade_action">Ъпгрейд</string>
     <string name="common_upgrade_required_label">Необходимо е надграждане</string>
-    <string name="label_premium_version_required">Изисква се премиум версията</string>
-    <string name="description_intro_purpose">Приложението позволява вашето устройство да запомни силата на звука за различни Bluetooth устройства.</string>
-    <string name="upgrade_benefit_unlimited_devices">Неограничени профили на устройства</string>
-    <string name="upgrade_benefit_connection_actions">Автоматично пускане, стартиране на приложения и сигнали за връзка</string>
-    <string name="upgrade_benefit_theme_customization">Персонализиране на тема, стил и цвят</string>
-    <string name="upgrade_benefit_power_controls">Заключване на силата на звука и ограничаване на скоростта</string>
-    <string name="upgrade_benefit_support">Подкрепете независимото разработване</string>
     <string name="upgrade_benefit_equalizer">• Еквалайзер за отделно устройство (за музикални приложения с поддръжка на системен еквалайзер)</string>
-    <string name="description_intro_tap_the_button">Започнете, като добавите първото си устройство.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth е изключен.</string>
     <string name="title_bluetooth_is_off">Bluetooth е изключен</string>
     <string name="action_enable_bluetooth">Включи Bluetooth</string>
     <string name="title_bluetooth_permission_required">Необходимо е разрешение за Bluetooth</string>
     <string name="description_bluetooth_permission_required">Приложението се нуждае от разрешение за Bluetooth, за да управлява нивата на звука на устройствата ти.</string>
     <string name="action_grant_permission">Предостави разрешение</string>
-    <string name="label_status_listening_for_changes">Следене за промени в силата на звука</string>
     <string name="action_exit">Изход</string>
-    <string name="action_start">Старт</string>
-    <string name="label_welcome">Добре дошли</string>
-    <string name="description_intro_contact">Не се колебайте да се свържете с мен ако имате въпроси или дори идея за нова функция.</string>
-    <string name="label_translation">Превод</string>
-    <string name="description_help_translate">Помогнете ми да направя приложението достъпно на други езици.</string>
     <string name="label_device_speaker">Високоговорител</string>
-    <string name="label_keyevent_playpause">Пусни/Спри</string>
-    <string name="label_keyevent_play">Пусни</string>
-    <string name="label_keyevent_next">Следващ</string>
-    <string name="label_install_id">Инсталационен ID</string>
     <string name="message_copied_to_clipboard">Копирано в клипборда</string>
-    <string name="label_thanks">Благодарности</string>
-    <string name="label_licenses">Лицензи</string>
-    <string name="description_ring_volume_additional_permission">Необходими са допълнителни разрешения за промяна на силата на звънене.</string>
-    <string name="label_missing_permissions">Липсващи разрешения</string>
-    <string name="action_grant">Предостави</string>
-    <string name="label_advanced">Разширени</string>
-    <string name="label_exclude_health">Изключи health профили</string>
-    <string name="description_exclude_health">Някои Android устройства се блокират при търсене на Bluetooth профили „Health Device\" (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Изключи GATT server профили</string>
-    <string name="label_exclude_gatt">Изключи GATT профили</string>
-    <string name="description_exclude_gattserver">Не питай за Bluetooth профили от тип „Generic Attribute\" (GATT) сървър.</string>
-    <string name="description_exclude_gatt">Не питай за Bluetooth профили от тип „Generic Attribute\" (GATT) клиент.</string>
-    <string name="description_waiting_for_devicex">Изчакване %s да завърши свързването</string>
-    <string name="action_undo">Отмени</string>
-    <string name="action_show">Покажи</string>
     <string name="action_dismiss">Затвори</string>
-    <string name="action_fix">Поправи</string>
-    <string name="battery_optimizations_issue_description">Оптимизациите на батерията са включени за това приложение и могат да му попречат да получава Bluetooth събития. Помисли да ги изключиш ако имаш проблеми.</string>
     <string name="label_bluetooth_settings">Bluetooth настройки</string>
-    <string name="android10_applaunch_issue_description">Android 10 ограничава как приложенията могат да се стартират от фон. За да разрешиш отваряне на приложения при свързване на Bluetooth устройство, предостави разрешението „Показване върху други приложения\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Изходен код</string>
-    <string name="android13_notification_permission_description">Предостави на приложението разрешение да публикува известия. Това позволява показване на известие, когато приложението е активно и се правят настройки на звука.</string>
-    <string name="privacy_policy_label">Политика за поверителност</string>
     <string name="managed_devices_empty_message">Няма конфигурирани Bluetooth устройства.\nНатисни бутона +, за да добавиш първото си устройство.</string>
     <string name="label_pro_feature">Премиум функция</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Преглед</string>
     <string name="review_app_dismiss_action">Може би по-късно</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Покупката е отменена</string>
-    <string name="error_iap_unavailable_message">Покупките в приложението не са налични</string>
-    <string name="error_generic_message">Възникна грешка. Моля, опитай отново.</string>
-    <string name="error_iap_owned_message">Вече притежаваш този артикул</string>
     <string name="label_no_devices_title">Няма устройства</string>
     <string name="bluemusic_mascot_description">Икона на приложението</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Избери приложения</string>
     <string name="devices_app_selection_search_hint">Търси приложения…</string>
-    <string name="devices_app_selection_currently_selected">Понастоящем избрани</string>
     <string name="devices_app_selection_selected_count">%d приложения избрани</string>
     <string name="general_navigate_back_action">Навигирай назад</string>
     <string name="general_reset_action">Нулирай</string>
     <string name="general_clear_action">Изчисти</string>
-    <string name="general_save_action">Запази</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Заключи</string>
     <string name="devices_indicator_awake">Буден</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Ограничи</string>
     <string name="devices_indicator_eq">ЕКВ</string>
     <string name="devices_indicator_boost">Усилване</string>
-    <string name="devices_indicator_launch">Стартирай</string>
     <string name="devices_indicator_home">Начало</string>
     <string name="devices_indicator_dnd">НБ</string>
     <string name="devices_indicator_alert">Известие</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">আপডেটের সময় কিছু ফিচার বদলে গেছে। সবকিছু সঠিকভাবে কনফিগার করা আছে কিনা তা নিশ্চিত করতে আপনার ডিভাইস সেটিংস দেখুন।</string>
     <string name="onboarding_rewrite_action">চালিয়ে যান</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">কোনো অপরিচালিত ডিভাইস পাওয়া যায়নি</string>
     <string name="discover_all_devices_managed_msg">আপনার সব পেয়ার করা ডিভাইস পরিচালিত! নতুন একটি দরকার?</string>
     <string name="discover_pair_new_device_action">নতুন ডিভাইস পেয়ার করুন</string>
     <string name="discover_device_speaker_desc">এই ফোনের নিজস্ব স্পিকার। যখন অডিও ফোনে ফিরে আসে তখন এর ভলিউম প্রয়োগ করা হয়, যেমন আপনার Bluetooth ডিভাইস সংযোগ বিচ্ছিন্ন হওয়ার পরে।</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ডিভাইস কনফিগারেশন</string>
-    <string name="devices_device_config_section_general_label">সাধারণ</string>
     <string name="devices_device_config_remove_device_label">ডিভাইস ভুলে যান</string>
-    <string name="devices_device_config_remove_device_desc">এই অ্যাপ থেকে ডিভাইসটি ভুলে যায় এবং এর কনফিগারেশন মুছে দেয়। এটি ডিভাইসটি আনপেয়ার করে না।</string>
     <string name="devices_device_config_remove_device_action">ভুলে যান</string>
     <string name="devices_device_config_remove_device_confirmation">পরিচালিত ডিভাইস থেকে %s ভুলে যাবেন?</string>
-    <string name="devices_device_config_rename_device_label">ডিভাইস নাম পরিবর্তন করুন</string>
-    <string name="devices_device_config_rename_device_desc">এই অ্যাপের মধ্যে এবং সম্ভব হলে সিস্টেমে, ডিভাইসটির নাম পরিবর্তন করুন।</string>
     <string name="devices_device_config_rename_device_action">নাম পরিবর্তন</string>
     <string name="devices_device_config_enabled_label">সক্রিয়</string>
     <string name="devices_device_config_enabled_desc">ডিভাইস সংযুক্ত হলে রিয়াক্ট করুন</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">অটোপ্লে কমান্ড</string>
     <string name="devices_device_config_autoplay_keycodes_order">কমান্ড ক্রম</string>
     <string name="devices_device_config_autoplay_keycodes_label">কমান্ড</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">কোন কমান্ড পাঠাতে হবে এবং কোন ক্রমে তা কনফিগার করুন</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">কোনো কমান্ড কনফিগার করা হয়নি</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">কমান্ড যোগ করুন</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">সর্বোচ্চ %1$d কমান্ড</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">উপরে সরান</string>
     <string name="cd_autoplay_keycode_move_down">নিচে সরান</string>
     <string name="cd_autoplay_keycode_remove">অপসারণ করুন</string>
-    <string name="devices_device_config_section_volumes_label">ভলিউমসমূহ</string>
     <string name="devices_device_config_section_volume_label">ভলিউম</string>
     <string name="devices_device_config_alarm_volume_label">অ্যালার্ম ভলিউম</string>
     <string name="devices_device_config_alarm_volume_desc">কিছু অ্যালার্ম অ্যাপ পরিবর্তে মিউজিক ভলিউম ব্যবহার করে।</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">রিং</string>
     <string name="devices_audio_stream_notification_label">নোটিফিকেশন</string>
     <string name="devices_audio_stream_alarm_label">অ্যালার্ম</string>
-    <string name="devices_neverseen_label">কখনো দেখা যায়নি</string>
-    <string name="devices_state_connected_label">সংযুক্ত</string>
     <string name="devices_last_connected_label">শেষ সংযোগ: %s</string>
     <string name="devices_currently_connected_label">এখন সংযুক্ত</string>
     <string name="devices_device_disabled_label">ডিভাইস নিষ্ক্রিয়</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">সমস্ত পরিচালিত ডিভাইসের ুপর প্রভাবিত সেটিংস।</string>
     <string name="label_app_enabled">অ্যাপ সক্রিয়</string>
     <string name="description_app_enabled">ভলিউম এবং ব্লুটুথ ইভেন্টে প্রতিক্রিয়া করার অ্যাপের ক্ষমতা টোগল করে।</string>
-    <string name="label_visible_volume_adjustments">দৃশ্যমান সমন্বয়</string>
-    <string name="description_visible_volume_adjustments">এই অ্যাপ সমন্বয় করার সময় সিস্টেমের ভলিউম উইন্ডো দেখান।</string>
     <string name="label_volume_listener">পরিবর্তন লক্ষ্য করুন</string>
-    <string name="description_volume_listener">ডিভাইস সংযুক্ত থাকাকালীন সক্রিয় থাকুন এবং এই অ্যাপ দ্বারা হয়নি এমন ভলিউম পরিবর্তন সরিয়ে রাখুন।</string>
     <string name="label_boot_restore">বুটে পুনরুদ্ধার</string>
     <string name="description_boot_restore">ব্লুটুথ ডিভাইস সংযুক্ত থাকলে বুট/রিবুটের পরে ভলিউম পুনরুদ্ধার করুন।</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM কার্যকরভাবে ব্যবহার শিখুন</string>
     <string name="settings_support_issue_tracker_description">বাগ রিপোর্ট এবং ফিচার রিকোয়েস্টের জন্য একটি সর্বজনীন সমস্যা ট্র্যাকার।</string>
     <string name="settings_support_issue_tracker_label">সমস্যা শনাক্তকারী</string>
-    <string name="settings_support_debuglog_label">ডিবাগ লগ</string>
     <string name="settings_support_debuglog_desc">অ্যাপটি কী করছে তা একটি টেক্সট ফাইলে রেকর্ড করুন যাতে আপনি শেয়ার করতে পারেন।</string>
-    <string name="settings_support_debuglog_recording_desc">বর্তমানে ডিবাগ তথ্য রেকর্ড হচ্ছে। রেকর্ডিং বন্ধ করতে ট্যাপ করুন।</string>
-    <string name="settings_support_debuglog_path">লগ পাথ: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">অতি স্বল্প রেকর্ডিং</string>
     <string name="settings_support_debuglog_short_recording_msg">রেকর্ডিং অতি স্বল্প সময়ের ছিল। ডিবাগ লগ হলো রেকর্ডিং, স্ন্যাপশট নয় — লগ উপদকারী হতে রেকর্ডিং সক্রিয় থাকাকালীন সমস্যা পুনরায় ঘটান।</string>
     <string name="settings_support_debuglog_short_recording_continue">রেকর্ডিং জারি রাখুন</string>
     <string name="settings_support_debuglog_short_recording_stop">যাইহোক বন্ধ করুন</string>
-    <string name="settings_support_debuglog_folder_label">ডিবাগ লগ ফোল্ডার</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$dটি সেশন %2$s ব্যবহার করছে</item>
-        <item quantity="other">%1$dটি সেশন %2$s ব্যবহার করছে</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">কোনো ডিবাগ লগ সংরক্ষিত নেই</string>
-    <string name="settings_support_debuglog_folder_delete_title">সব ডিবাগ লগ মুছে দেবেন?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">এটি সব সংরক্ষিত ডিবাগ লগ সেশন স্থায়ীভাবে মুছে দেবে।</string>
     <string name="settings_support_discord_label">ডিসকর্ড</string>
     <string name="settings_support_discord_description">আড্ডা দেওয়ার এবং প্রশ্ন করার জায়গা।</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">অনুবাদ</string>
     <string name="settings_acks_translators_title">অনুবাদক</string>
     <string name="settings_acks_translators_people">Fattain Naime(iamnaime@builderhall.com);মোরশেদুল আলম(morshedintouch@gmail.com)</string>
-    <string name="settings_acks_translate_title">BVM অনুবাদ করুন</string>
-    <string name="settings_acks_translate_desc">BVM আপনার ভাষায় অনুবাদ করতে সাহায্য করুন</string>
     <string name="settings_acks_thanks_header">ধন্যবাদ</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">ওপেন-সোর্স প্রকল্পের অনুবাদ সমর্থন করার জন্য</string>
     <string name="settings_licenses_label">লাইসেন্সসমূহ</string>
     <string name="settings_translation_label">অনুবাদ</string>
     <string name="settings_translation_desc">আপনার পছন্দের ভাষায় অ্যাপটি অনুবাদ করতে সাহায্য করুন</string>
-    <string name="settings_sponsor_development_title">স্পনসর ডেভলপমেন্ট</string>
-    <string name="settings_sponsor_development_summary">একজন পৃষ্ঠপোষক হয়ে উঠুন এবং অব্যাহত উন্নয়ন সম্ভবপর করে তুলুন।</string>
     <string name="settings_privacy_policy_label">গোপনীয়তার নীতিমালা</string>
     <string name="settings_privacy_policy_desc">দায়িত্বের সাথে ডেটা পরিচালনা করা।</string>
     <string name="changelog_label">পরিবর্তনসূচী</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">পুনরুদ্ধার সম্পন্ন — %1$d টি ডিভাইস পুনরুদ্ধার করা হয়েছে, %2$d টি এড়িয়ে যাওয়া হয়েছে।</string>
     <string name="backup_restore_version_warning">এই ব্যাকআপটি %1$s সংস্করণ দিয়ে তৈরি করা হয়েছিল। তুমি %2$s চালাচ্ছো। কিছু সেটিংস সঠিকভাবে পুনরুদ্ধার নাও হতে পারে।</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">ডিবাগ নোটিফিকেশন</string>
     <string name="debug_log_consent_title">ডিবাগ লগ</string>
     <string name="debug_log_consent_explanation">এই বৈশিষ্ট্যটি অ্যাপটি যা করছে তা একটি শেয়ারযোগ্য ফাইলে রেকর্ড করে। তৈরি হওয়া ফাইলটিতে সংবেদনশীল তথ্য থাকে (যেমন ফাইলের নাম এবং ইনস্টল করা অ্যাপ)। এটি শুধুমাত্র বিশ্বস্ত পক্ষের সাথেই শেয়ার করুন (যেমন, কোনও ডেভেলপার কোনও সমস্যার সমাধান করছেন)।</string>
-    <string name="debug_log_recording_progress">রেকর্ডিং ডিবাগ লগ</string>
     <string name="debug_log_record_action">রেকর্ড</string>
     <string name="debug_log_stop_action">রেকর্ডিং বন্ধ করুন</string>
     <string name="debug_log_screen_title">ডিবাগ লগ রেকর্ডার</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">বাতিল করুন</string>
     <string name="debug_log_screen_keep_action">রাখুন</string>
-    <string name="debug_log_compressing_label">সংকুচিত হচ্ছে…</string>
     <string name="debug_log_file_label">রেকর্ড করা লগ ফাইল</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">লগ পাঠানো হয়েছে?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">আপনার প্রশ্নটি বিস্তারিতভাবে বর্ণনা করুন।</string>
     <string name="contact_category_section_label">বিভাগ</string>
     <string name="contact_debug_log_label">ডিবাগ লগ</string>
-    <string name="contact_debug_log_select_hint">সংযুক্ত করতে ডিবাগ লগ নির্বাচন করুন</string>
     <string name="contact_debug_log_picker_hint">সমস্যা দ্রুতর সনাক্ত করতে ডিবাগ লগ সংযুক্ত করুন।</string>
     <string name="contact_debug_log_picker_empty">কোনো ডিবাগ লগ পাওয়া যাচ্ছে না। প্রথমে একটি রেকর্ড করুন।</string>
     <string name="contact_expected_behavior_label">প্রত্যাশিত আচরণ</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">আমি নিজেই প্রতিটি বার্তা পড়ি এবং রিপ্লাই দেওয়ার যথাসাধ্য চেষ্টা করি, তবে একা কাজ করার কারণে সময় লাগতে পারে। ধৈর্যের জন্য ধন্যবাদ।</string>
     <string name="contact_footer_msg">আপনার বার্তা ইমেইলে পাঠানো হবে। ডিভাইস এবং সেটআপ তথ্য স্বয়ংক্রিয়ভাবে সংযুক্ত থাকে।</string>
     <string name="contact_no_email_app_msg">এই ডিভাইসে কোনো ইমেইল অ্যাপ পাওয়া যায়নি।</string>
-    <string name="contact_attachment_missing_msg">ডিবাগ লগ ফাইল আর বিদ্যমান নেই</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">সংরক্ষিত ডিবাগ লগ</string>
     <string name="settings_support_stored_logs_desc">%1$dটি সেশন (%2$s)</string>
     <string name="settings_support_stored_logs_empty">কোনো সংরক্ষিত ডিবাগ লগ নেই</string>
-    <string name="settings_support_stored_logs_delete_title">সংরক্ষিত লগ মুছে দেবেন?</string>
-    <string name="settings_support_stored_logs_delete_msg">এটি সব %1$dটি সংরক্ষিত ডিবাগ লগ সেশন মুছে দেবে।</string>
-    <string name="settings_support_stored_logs_deleted_msg">সংরক্ষিত ডিবাগ লগ মুছে গেছে</string>
-    <string name="label_bug_reports">বাগ রিপোর্ট</string>
-    <string name="description_bug_reports">স্বয়ংক্রিয় বাগ সে ক্র্যাশ রিপোর্টিং।</string>
     <string name="label_add_device">ডিভাইস যোগ করুন</string>
-    <string name="label_just_a_moment_please">একটু অপেক্ষা করুন।</string>
     <string name="label_notification_channel_status">অবস্থা</string>
     <string name="label_notification_channel_setup">সেটআপ প্রয়োজন</string>
     <string name="monitor_notification_starting">চালু হচ্ছে…</string>
     <string name="action_set">সেট</string>
     <string name="action_cancel">বাতিল করুন</string>
-    <string name="label_invalid_input">অবৈধ ইনপুট</string>
     <string name="action_reset">রিসেট করুন</string>
     <string name="label_no_connected_devices">কোনো ডিভাইস সংযুক্ত নেই</string>
-    <string name="label_status_idle">নিষ্ক্রিয়</string>
-    <string name="label_status_adjusting_volumes">ভলিউম সমন্বয় করা হচ্ছে</string>
-    <string name="label_premium_version">প্রিমিয়াম সংস্করণ</string>
     <string name="general_upgrade_action">আপগ্রেড করুন</string>
     <string name="common_upgrade_required_label">আপগ্রেড প্রয়োজন</string>
-    <string name="label_premium_version_required">প্রিমিয়াম সংস্করণ প্রয়োজন</string>
-    <string name="description_intro_purpose">এই অ্যাপ আপনার আন্ড্রয়েড ডিভাইসকে বিভিন্ন ব্লুটুথ ডিভাইসের ভলিউম মনে রাখতে দেয়।</string>
-    <string name="upgrade_benefit_unlimited_devices">সীমাহীন ডিভাইস প্রোফাইল</string>
-    <string name="upgrade_benefit_connection_actions">অটোপ্লে, অ্যাপ লঞ্চ এবং কানেকশন অ্যালার্ট</string>
-    <string name="upgrade_benefit_theme_customization">থিম, স্টাইল এবং রঙ কাস্টমাইজেশন</string>
-    <string name="upgrade_benefit_power_controls">ভলিউম লক এবং রেট লিমিটিং</string>
-    <string name="upgrade_benefit_support">স্বতন্ত্র ডেভেলপমেন্ট সমর্থন করো</string>
     <string name="upgrade_benefit_equalizer">• প্রতি-ডিভাইস ইকুয়ালাইজার (সিস্টেম ইকুয়ালাইজার সাপোর্ট সহ সঙ্গীত অ্যাপের জন্য)</string>
-    <string name="description_intro_tap_the_button">আপনার প্রথম ডিভাইস যোগ করে শুরু করুন।</string>
     <string name="description_bluetooth_is_disabled">ব্লুটুথ বন্ধ আছে।</string>
     <string name="title_bluetooth_is_off">ব্লুটুথ বন্ধ</string>
     <string name="action_enable_bluetooth">ব্লুটুথ চালু করুন</string>
     <string name="title_bluetooth_permission_required">ব্লুটুথ অনুমতি প্রয়োজন</string>
     <string name="description_bluetooth_permission_required">আপনার ডিভাইসের ভলিউম পরিচালনা করতে এই অ্যাপের ব্লুটুথ অনুমতি দরকার।</string>
     <string name="action_grant_permission">অনুমতি দিন</string>
-    <string name="label_status_listening_for_changes">ভলিউম পরিবর্তন শুনছে</string>
     <string name="action_exit">বাহির</string>
-    <string name="action_start">শুরু</string>
-    <string name="label_welcome">স্বাগত</string>
-    <string name="description_intro_contact">প্রশ্ন থাকলে বা নতুন ফিচারের আইডিয়া থাকলে যোগাযোগ করতে কুণ্ঠিত হবেন না।</string>
-    <string name="label_translation">অনুবাদ</string>
-    <string name="description_help_translate">অ্যাপটি অন্য ভাষায় পাওয়া যাবে অনুগ্রহ করে সাহায্য করুন।</string>
     <string name="label_device_speaker">ডিভাইস স্পিকার</string>
-    <string name="label_keyevent_playpause">প্লে-প্যানেল</string>
-    <string name="label_keyevent_play">প্লে</string>
-    <string name="label_keyevent_next">পরবর্তী</string>
-    <string name="label_install_id">ইনস্টল আইডি</string>
     <string name="message_copied_to_clipboard">ক্লিপবোর্ডে কপি হয়েছে</string>
-    <string name="label_thanks">ধন্যবাদ</string>
-    <string name="label_licenses">লাইসেন্স</string>
-    <string name="description_ring_volume_additional_permission">রিং ভলিউম পরিবর্তন করতে অতিরিক্ত অনুমতি প্রয়োজন।</string>
-    <string name="label_missing_permissions">অনুপস্থিত অনুমতি</string>
-    <string name="action_grant">মতা দিন</string>
-    <string name="label_advanced">উন্নত</string>
-    <string name="label_exclude_health">স্বাস্থ্য প্রোফাইল বাদ দিন</string>
-    <string name="description_exclude_health">কিছু আন্ড্রয়েড ডিভাইস \'হেলথ ডিভাইস\' ব্লুটুথ প্রোফাইল (HDP, 0x1400) খোঁজার সময় হ্যাং হয়ে যায়।</string>
-    <string name="label_exclude_gattserver">GATT সার্ভার প্রোফাইল বাদ দিন</string>
-    <string name="label_exclude_gatt">GATT প্রোফাইল বাদ দিন</string>
-    <string name="description_exclude_gattserver">\'Generic Attribute\' (GATT) সার্ভার ধরনের ব্লুটুথ প্রোফাইল ক্যুয়েরি করবেন না।</string>
-    <string name="description_exclude_gatt">\'Generic Attribute\' (GATT) ক্লায়েন্ট ধরনের ব্লুটুথ প্রোফাইল ক্যুয়েরি করবেন না।</string>
-    <string name="description_waiting_for_devicex">%s সংযোগ সম্পূর্ণ হওয়ার জন্য অপেক্ষা করা হচ্ছে</string>
-    <string name="action_undo">পূর্বাবস্থায় ফিরিয়ে আনুন</string>
-    <string name="action_show">দেখান</string>
     <string name="action_dismiss">খারিজ করুন</string>
-    <string name="action_fix">ঠিক করুন</string>
-    <string name="battery_optimizations_issue_description">এই অ্যাপের জন্য ব্যাটারি অপ্টিমাইজেশন সক্রিয় এবং ব্লুটুথ ইভেন্ট গ্রহণ থেকে বিরত রাখতে পারে। সমস্যা হলে অপ্টিমাইজেশন নিষ্ক্রিয় করুন।</string>
     <string name="label_bluetooth_settings">ব্লুটুথ সেটিংস</string>
-    <string name="android10_applaunch_issue_description">Android 10 ব্যাকগ্রাউন্ড থেকে অ্যাপ চালু করা সীমিত করে। ব্লুটুথ ডিভাইস সংযুক্ত হলে অ্যাপ খুলতে দিতে, \"Display over other apps\" (SYSTEM_ALERT_WINDOW) অনুমতি দিন।</string>
-    <string name="label_opensource">সোর্স কোড</string>
-    <string name="android13_notification_permission_description">নোটিফিকেশন পোস্ট করতে এই অ্যাপকে অনুমতি দিন। এটি এই অ্যাপ সক্রিয় থাকাকালীন এবং ভলিউম সমন্বয়ের সময় নোটিফিকেশন দেখাতে সক্ষম করে।</string>
-    <string name="privacy_policy_label">গোপনীয়তার নীতিমালা</string>
     <string name="managed_devices_empty_message">কোনো ব্লুটুথ ডিভাইস কনফিগার নেই।\nপ্রথম ডিভাইস যোগ করতে + বাটন ট্যাপ করুন।</string>
     <string name="label_pro_feature">প্রিমিয়াম ফিচার</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">পর্যালোচনা করুন</string>
     <string name="review_app_dismiss_action">হয়তো পরে</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">কেনাকাটা বাতিল</string>
-    <string name="error_iap_unavailable_message">ইন-অ্যাপ কেনাকাটা পাওয়া যাচ্ছে না</string>
-    <string name="error_generic_message">ভুল হয়েছে। আবার চেষ্টা করুন।</string>
-    <string name="error_iap_owned_message">আপনি ইতোমধ্যে এটি কিনে ফেলেছেন</string>
     <string name="label_no_devices_title">কোনো ডিভাইস নেই</string>
     <string name="bluemusic_mascot_description">অ্যাপ আইকন</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">অ্যাপ নির্বাচন করুন</string>
     <string name="devices_app_selection_search_hint">অ্যাপ খুঁজুন…</string>
-    <string name="devices_app_selection_currently_selected">বর্তমানে নির্বাচিত</string>
     <string name="devices_app_selection_selected_count">%dটি অ্যাপ নির্বাচন করা হয়েছে</string>
     <string name="general_navigate_back_action">পিছনে যান</string>
     <string name="general_reset_action">রিসেট করুন</string>
     <string name="general_clear_action">মুছে দিন</string>
-    <string name="general_save_action">সংরক্ষণ করুন</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">লক</string>
     <string name="devices_indicator_awake">জাগ্রত</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">সীমা</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">বুস্ট</string>
-    <string name="devices_indicator_launch">চালু</string>
     <string name="devices_indicator_home">হোম</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">সতর্কতা</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Algunes funcions han canviat durant l\'actualització. Comprova la configuració del dispositiu per assegurar-te que tot estigui ben configurat.</string>
     <string name="onboarding_rewrite_action">Continua</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">No s\'han trobat dispositius no gestionats</string>
     <string name="discover_all_devices_managed_msg">Tots els dispositius emparellats estan gestionats! En necessites un de nou?</string>
     <string name="discover_pair_new_device_action">Emparella un dispositiu nou</string>
     <string name="discover_device_speaker_desc">L\'altaveu propi del telèfon. Els seus volums s\'apliquen quan l\'àudio canvia de nou al telèfon, per exemple, després que es desconnecti el dispositiu Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuració del dispositiu</string>
-    <string name="devices_device_config_section_general_label">General</string>
     <string name="devices_device_config_remove_device_label">Oblida el dispositiu</string>
-    <string name="devices_device_config_remove_device_desc">Oblida el dispositiu d\'aquesta aplicació i elimina la seva configuració. Això no desemparella el dispositiu.</string>
     <string name="devices_device_config_remove_device_action">Oblida</string>
     <string name="devices_device_config_remove_device_confirmation">Vols oblidar %s dels dispositius gestionats?</string>
-    <string name="devices_device_config_rename_device_label">Reanomena el dispositiu</string>
-    <string name="devices_device_config_rename_device_desc">Reanomena aquest dispositiu dins d\'aquesta aplicació i, si és possible, dins del sistema.</string>
     <string name="devices_device_config_rename_device_action">Reanomena</string>
     <string name="devices_device_config_enabled_label">Activat</string>
     <string name="devices_device_config_enabled_desc">Reacciona a aquest dispositiu quan es connecti</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Ordres de reproducció automàtica</string>
     <string name="devices_device_config_autoplay_keycodes_order">Seqüència d\'ordres</string>
     <string name="devices_device_config_autoplay_keycodes_label">Ordres</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configura quines ordres enviar i en quin ordre</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Cap ordre configurada</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Afegeix una ordre</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Màxim %1$d ordres</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Mou amunt</string>
     <string name="cd_autoplay_keycode_move_down">Mou avall</string>
     <string name="cd_autoplay_keycode_remove">Elimina</string>
-    <string name="devices_device_config_section_volumes_label">Volums</string>
     <string name="devices_device_config_section_volume_label">Volum</string>
     <string name="devices_device_config_alarm_volume_label">Volum de l\'alarma</string>
     <string name="devices_device_config_alarm_volume_desc">Algunes aplicacions d\'alarma utilitzen el volum de música al seu lloc.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">To</string>
     <string name="devices_audio_stream_notification_label">Notificació</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="devices_neverseen_label">Mai vist</string>
-    <string name="devices_state_connected_label">Connectat</string>
     <string name="devices_last_connected_label">Última connexió: %s</string>
     <string name="devices_currently_connected_label">Connectat actualment</string>
     <string name="devices_device_disabled_label">Dispositiu desactivat</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Configuració que afecta tots els dispositius gestionats.</string>
     <string name="label_app_enabled">Aplicació activada</string>
     <string name="description_app_enabled">Commuta la capacitat de les aplicacions per reaccionar davant d\'esdeveniments de volum i Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Configuracions visibles</string>
-    <string name="description_visible_volume_adjustments">Mostra la finestra de volum del sistema mentre aquesta aplicació realitza configuracions.</string>
     <string name="label_volume_listener">Observa els canvis</string>
-    <string name="description_volume_listener">Roman actiu mentre un dispositiu estigui connectat i desa els canvis de volum que no hagin estat causats per aquesta aplicació.</string>
     <string name="label_boot_restore">Restableix a l\'inici</string>
     <string name="description_boot_restore">Restableix el volum després d\'iniciar/reiniciar si un dispositiu Bluetooth està connectat.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Aprèn a usar BVM de manera efectiva</string>
     <string name="settings_support_issue_tracker_description">Un sistema públic de seguiment d\'incidències per a informes d\'errors i sol·licituds de funcions.</string>
     <string name="settings_support_issue_tracker_label">Seguiment d\'incidències</string>
-    <string name="settings_support_debuglog_label">Registre de depuració</string>
     <string name="settings_support_debuglog_desc">Enregistra tot el que fa l\'aplicació en un fitxer de text que pots compartir.</string>
-    <string name="settings_support_debuglog_recording_desc">S\'està enregistrant informació de depuració. Toca per aturar l\'enregistrament.</string>
-    <string name="settings_support_debuglog_path">Ruta del registre: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Enregistrament molt curt</string>
     <string name="settings_support_debuglog_short_recording_msg">Això ha estat un enregistrament molt curt. Els registres de depuració són enregistraments, no instantànies — reprodueix el problema mentre l\'enregistrament és actiu perquè el registre sigui útil.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continua l\'enregistrament</string>
     <string name="settings_support_debuglog_short_recording_stop">Atura igualment</string>
-    <string name="settings_support_debuglog_folder_label">Carpeta de registres de depuració</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sessió usant %2$s</item>
-        <item quantity="other">%1$d sessions usant %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">No hi ha registres de depuració emmagatzemats</string>
-    <string name="settings_support_debuglog_folder_delete_title">Elimina tots els registres de depuració?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Això eliminarà permanentment totes les sessions de registre de depuració emmagatzemades.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Un lloc on quedar i fer preguntes.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Traducció</string>
     <string name="settings_acks_translators_title">Traductors</string>
     <string name="settings_acks_translators_people">Jaime Muñoz</string>
-    <string name="settings_acks_translate_title">Tradueix BVM</string>
-    <string name="settings_acks_translate_desc">Ajuda a traduir BVM al teu idioma</string>
     <string name="settings_acks_thanks_header">Gràcies</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Per donar suport a la traducció de projectes de codi obert</string>
     <string name="settings_licenses_label">Llicències</string>
     <string name="settings_translation_label">Traducció</string>
     <string name="settings_translation_desc">Ajudeu a traduir l\'aplicació al vostre idioma preferit</string>
-    <string name="settings_sponsor_development_title">Desenvolupament del patrocinador</string>
-    <string name="settings_sponsor_development_summary">Convertiu-vos en mecenes i feu possible el desenvolupament constant de l\'aplicació.</string>
     <string name="settings_privacy_policy_label">Política de privadesa</string>
     <string name="settings_privacy_policy_desc">Gestió responsable de dades.</string>
     <string name="changelog_label">Registre de canvis</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restauració completa — %1$d dispositius restaurats, %2$d omesos.</string>
     <string name="backup_restore_version_warning">Aquesta còpia de seguretat es va crear amb la versió %1$s. Estàs executant %2$s. Alguns paràmetres potó no es restaurin correctament.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notificacions de depuració</string>
     <string name="debug_log_consent_title">Registre de depuració</string>
     <string name="debug_log_consent_explanation">Aquesta funció enregistra tot el que fa l\'aplicació en un fitxer compartible. El fitxer generat conté informació sensible (p. ex. noms de fitxers i aplicacions instal·lades). Comparteix-lo només amb persones de confiança (p. ex. un desenvolupador resolent un problema).</string>
-    <string name="debug_log_recording_progress">Enregistrant el registre de depuració</string>
     <string name="debug_log_record_action">Enregistra</string>
     <string name="debug_log_stop_action">Atura l\'enregistrament</string>
     <string name="debug_log_screen_title">Gravador de registre de depuració</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Descarta</string>
     <string name="debug_log_screen_keep_action">Conserva</string>
-    <string name="debug_log_compressing_label">Comprimint…</string>
     <string name="debug_log_file_label">Fitxer de registre enregistrat</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Registre enviat?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Descriu la teva pregunta amb detall.</string>
     <string name="contact_category_section_label">Categoria</string>
     <string name="contact_debug_log_label">Registre de depuració</string>
-    <string name="contact_debug_log_select_hint">Selecciona un registre de depuració per adjuntar</string>
     <string name="contact_debug_log_picker_hint">Adjunta un registre de depuració per ajudar a diagnosticar el problema més ràpidament.</string>
     <string name="contact_debug_log_picker_empty">No hi ha registres de depuració disponibles. Enregistra\'n un primer.</string>
     <string name="contact_expected_behavior_label">Comportament esperat</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Llegeixo tots els missatges personalment i faig tot el possible per respondre, però com que treballo sol, pot trigar una mica. Gràcies per la teva paciència.</string>
     <string name="contact_footer_msg">El teu missatge s\'enviarà per correu electrònic. La informació del dispositiu i la configuració s\'adjunta automàticament.</string>
     <string name="contact_no_email_app_msg">No s\'ha trobat cap aplicació de correu en aquest dispositiu.</string>
-    <string name="contact_attachment_missing_msg">El fitxer de registre de depuració ja no existeix</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Registres de depuració emmagatzemats</string>
     <string name="settings_support_stored_logs_desc">%1$d sessions (%2$s)</string>
     <string name="settings_support_stored_logs_empty">No hi ha registres de depuració emmagatzemats</string>
-    <string name="settings_support_stored_logs_delete_title">Elimina els registres emmagatzemats?</string>
-    <string name="settings_support_stored_logs_delete_msg">Això eliminarà totes les %1$d sessions de registre de depuració emmagatzemades.</string>
-    <string name="settings_support_stored_logs_deleted_msg">S\'han eliminat els registres de depuració emmagatzemats</string>
-    <string name="label_bug_reports">Informes d\'errors</string>
-    <string name="description_bug_reports">Informes automàtics d\'errors i fallades.</string>
     <string name="label_add_device">Afegeix un dispositiu</string>
-    <string name="label_just_a_moment_please">Un moment.</string>
     <string name="label_notification_channel_status">Estat</string>
     <string name="label_notification_channel_setup">Cal configurar</string>
     <string name="monitor_notification_starting">Iniciant…</string>
     <string name="action_set">Estableix</string>
     <string name="action_cancel">Cancel·la</string>
-    <string name="label_invalid_input">Entrada no vàlida</string>
     <string name="action_reset">Restableix</string>
     <string name="label_no_connected_devices">No hi ha dispositius connectats</string>
-    <string name="label_status_idle">Inactiu</string>
-    <string name="label_status_adjusting_volumes">Configura els volums</string>
-    <string name="label_premium_version">Versió prèmium</string>
     <string name="general_upgrade_action">Millora</string>
     <string name="common_upgrade_required_label">Cal actualitzar</string>
-    <string name="label_premium_version_required">Cal la versió prèmium</string>
-    <string name="description_intro_purpose">Aquesta aplicació permet als dispositius Android recordar el volum de diferents dispositius Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Perfils de dispositiu il·limitats</string>
-    <string name="upgrade_benefit_connection_actions">Reproducció automàtica, llançament d’aplicacions i alertes de connexió</string>
-    <string name="upgrade_benefit_theme_customization">Personalització de tema, estil i color</string>
-    <string name="upgrade_benefit_power_controls">Bloqueig de volum i limitació de velocitat</string>
-    <string name="upgrade_benefit_support">Dóna suport al desenvolupament independent</string>
     <string name="upgrade_benefit_equalizer">• Equalizador per dispositiu (per a aplicacions de música amb suport d\'equalizador del sistema)</string>
-    <string name="description_intro_tap_the_button">Comenceu afegint el primer dispositiu.</string>
     <string name="description_bluetooth_is_disabled">El Bluetooth està desactivat.</string>
     <string name="title_bluetooth_is_off">El Bluetooth està apagat</string>
     <string name="action_enable_bluetooth">Activa el Bluetooth</string>
     <string name="title_bluetooth_permission_required">Cal el permís de Bluetooth</string>
     <string name="description_bluetooth_permission_required">Aquesta aplicació necessita el permís de Bluetooth per gestionar els volums del dispositiu.</string>
     <string name="action_grant_permission">Concedeix el permís</string>
-    <string name="label_status_listening_for_changes">S\'està escoltant els canvis de volum</string>
     <string name="action_exit">Surt</string>
-    <string name="action_start">Inicia</string>
-    <string name="label_welcome">Us donem la benvinguda</string>
-    <string name="description_intro_contact">No dubteu en contactar-me si teniu preguntes o fins i tot una idea per a una nova funció.</string>
-    <string name="label_translation">Traducció</string>
-    <string name="description_help_translate">Ajuda\'m a fer que aquesta aplicació estigui disponible en altres idiomes.</string>
     <string name="label_device_speaker">Altaveu del dispositiu</string>
-    <string name="label_keyevent_playpause">Reprodueix-Pausa</string>
-    <string name="label_keyevent_play">Reprodueix</string>
-    <string name="label_keyevent_next">Següent</string>
-    <string name="label_install_id">ID d\'instal·lació</string>
     <string name="message_copied_to_clipboard">Copiat al porta-retalls</string>
-    <string name="label_thanks">Gràcies</string>
-    <string name="label_licenses">Llicències</string>
-    <string name="description_ring_volume_additional_permission">Els permisos addicionals són necessaris per canviar el volum del to.</string>
-    <string name="label_missing_permissions">Permisos que manquen</string>
-    <string name="action_grant">Permet</string>
-    <string name="label_advanced">Avançat</string>
-    <string name="label_exclude_health">Exclou els perfils de salut</string>
-    <string name="description_exclude_health">Alguns dispositius Android es bloquegen en cercar perfils Bluetooth «Dispositiu de salut» (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Exclou perfils de servidor GATT</string>
-    <string name="label_exclude_gatt">Exclou perfils GATT</string>
-    <string name="description_exclude_gattserver">No consulta els perfils Bluetooth del tipus «Atribut genèric» (GATT) del servidor.</string>
-    <string name="description_exclude_gatt">No consulta els perfils Bluetooth del tipus «Atribut genèric» (GATT) del client.</string>
-    <string name="description_waiting_for_devicex">S\'està esperant que %s completi la connexió</string>
-    <string name="action_undo">Desfés</string>
-    <string name="action_show">Mostra</string>
     <string name="action_dismiss">Ignora</string>
-    <string name="action_fix">Corregeix</string>
-    <string name="battery_optimizations_issue_description">Les optimitzacions de la bateria estan activades per a aquesta aplicació i poden evitar que rebeu esdeveniments Bluetooth. Considereu la possibilitat de desactivar les optimitzacions si teniu problemes.</string>
     <string name="label_bluetooth_settings">Configuració del Bluetooth</string>
-    <string name="android10_applaunch_issue_description">L\'Android 10 restringeix el mode com es poden obrir les aplicacions en segon pla. Per permetre l\'inici d\'aplicacions quan es connecta un dispositiu Bluetooth, concediu el permís «Mostra a sobre d\'altres aplicacions» (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Codi font</string>
-    <string name="android13_notification_permission_description">Concedeix a aquesta aplicació el permís per publicar notificacions. Això permet mostrar una notificació quan l\'aplicació està activa i s\'estan fent ajustos de volum.</string>
-    <string name="privacy_policy_label">Política de privadesa</string>
     <string name="managed_devices_empty_message">No hi ha dispositius Bluetooth configurats.\nToca el botó + per afegir el teu primer dispositiu.</string>
     <string name="label_pro_feature">Funció premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Revisió</string>
     <string name="review_app_dismiss_action">Potser més tard</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Compra cancel·lada</string>
-    <string name="error_iap_unavailable_message">Les compres integrades no estan disponibles</string>
-    <string name="error_generic_message">S\'ha produït un error. Torna-ho a intentar.</string>
-    <string name="error_iap_owned_message">Ja tens aquest article</string>
     <string name="label_no_devices_title">Cap dispositiu</string>
     <string name="bluemusic_mascot_description">Icona de l\'aplicació</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Selecciona aplicacions</string>
     <string name="devices_app_selection_search_hint">Cerca aplicacions…</string>
-    <string name="devices_app_selection_currently_selected">Seleccionat actualment</string>
     <string name="devices_app_selection_selected_count">%d aplicacions seleccionades</string>
     <string name="general_navigate_back_action">Navega enrere</string>
     <string name="general_reset_action">Restableix</string>
     <string name="general_clear_action">Neteja</string>
-    <string name="general_save_action">Desa</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Bloqueig</string>
     <string name="devices_indicator_awake">Actiu</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Límit</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Potència</string>
-    <string name="devices_indicator_launch">Iniciar</string>
     <string name="devices_indicator_home">Inici</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Alerta</string>

--- a/app/src/main/res/values-cs/strings.xml
+++ b/app/src/main/res/values-cs/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">V rámci aktualizace došlo ke změnám některých funkcí. Zkontrolujte prosím nastavení svého zařízení, abyste se ujistili, že je vše správně nakonfigurováno.</string>
     <string name="onboarding_rewrite_action">Pokračovat</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nebyla nalezena žádná nespravovaná zařízení</string>
     <string name="discover_all_devices_managed_msg">Všechna vaše spárovaná zařízení jsou pod kontrolou! Potřebujete nové?</string>
     <string name="discover_pair_new_device_action">Spárovat nové zařízení</string>
     <string name="discover_device_speaker_desc">Vlastní reproduktor telefonu. Jeho hlasitost se aplikuje, když se zvuk vrátí do telefonu, například poté, co se vaše zařízení Bluetooth odpojí.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfigurace zařízení</string>
-    <string name="devices_device_config_section_general_label">Obecné</string>
     <string name="devices_device_config_remove_device_label">Zapomenout zařízení</string>
-    <string name="devices_device_config_remove_device_desc">Zapomene zařízení z této aplikace a smaže jeho konfiguraci. Nezruší spárování zařízení.</string>
     <string name="devices_device_config_remove_device_action">Zapomenout</string>
     <string name="devices_device_config_remove_device_confirmation">Zapomenout %s ze spravovaných zařízení?</string>
-    <string name="devices_device_config_rename_device_label">Přejmenovat zařízení</string>
-    <string name="devices_device_config_rename_device_desc">Přejmenuje toto zařízení v této aplikaci a pokud možno i v systému.</string>
     <string name="devices_device_config_rename_device_action">Přejmenovat</string>
     <string name="devices_device_config_enabled_label">Povoleno</string>
     <string name="devices_device_config_enabled_desc">Reagovat na toto zařízení při připojení</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Příkazy automatického přehrávání</string>
     <string name="devices_device_config_autoplay_keycodes_order">Pořadí příkazů</string>
     <string name="devices_device_config_autoplay_keycodes_label">Příkazy</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Nakonfigurujte, které příkazy se mají odeslat a v jakém pořadí</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Žádné příkazy nenakonfigurovány</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Přidat příkaz</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximálně %1$d příkazů</string>
@@ -123,7 +117,6 @@
     <string name="cd_autoplay_keycode_move_up">Posunout nahoru</string>
     <string name="cd_autoplay_keycode_move_down">Posunout dolů</string>
     <string name="cd_autoplay_keycode_remove">Odebrat</string>
-    <string name="devices_device_config_section_volumes_label">Hlasitosti</string>
     <string name="devices_device_config_section_volume_label">Hlasitost</string>
     <string name="devices_device_config_alarm_volume_label">Hlasitost budíku</string>
     <string name="devices_device_config_alarm_volume_desc">Některé aplikace budíku používají místo toho hlasitost hudby.</string>
@@ -157,8 +150,6 @@
     <string name="devices_audio_stream_ring_label">Vyzvánění</string>
     <string name="devices_audio_stream_notification_label">Oznámení</string>
     <string name="devices_audio_stream_alarm_label">Budík</string>
-    <string name="devices_neverseen_label">Nikdy neviděno</string>
-    <string name="devices_state_connected_label">Připojeno</string>
     <string name="devices_last_connected_label">Naposledy připojeno: %s</string>
     <string name="devices_currently_connected_label">Aktuálně připojeno</string>
     <string name="devices_device_disabled_label">Zařízení zakázáno</string>
@@ -193,10 +184,7 @@
     <string name="devices_settings_desc">Nastavení, které ovlivňují všechna spravovaná zařízení.</string>
     <string name="label_app_enabled">Aplikace je povolena</string>
     <string name="description_app_enabled">Přepíná schopnost této aplikace reagovat na události hlasitosti a Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Viditelné změny</string>
-    <string name="description_visible_volume_adjustments">Zobrazí systémové okno hlasitosti, zatímco aplikace provádí změny.</string>
     <string name="label_volume_listener">Sledování změn</string>
-    <string name="description_volume_listener">Zůstaňte na pozoru, když je toto zařízení připojeno a uložte změny hlasitosti, které nepocházejí z této aplikace.</string>
     <string name="label_boot_restore">Obnovit při spuštění</string>
     <string name="description_boot_restore">Obnoví hlasitosti po spuštění/restartování, když je zařízení připojeno.</string>
     <!-- Settings/Support-->
@@ -206,24 +194,11 @@
     <string name="settings_support_wiki_description">Naučte se, jak efektivně používat BVM</string>
     <string name="settings_support_issue_tracker_description">Veřejný nástroj pro sledování hlášení chyb a požadavků na nové funkce.</string>
     <string name="settings_support_issue_tracker_label">Nástroj pro sledování chyb</string>
-    <string name="settings_support_debuglog_label">Log ladění</string>
     <string name="settings_support_debuglog_desc">Zaznamenávejte vše, co aplikace dělá do textového souboru, který můžete sdílet.</string>
-    <string name="settings_support_debuglog_recording_desc">Právě se zaznamenávají ladicí informace. Klepnutím zaznamenávání zastavíte.</string>
-    <string name="settings_support_debuglog_path">Cesta k logu: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Velmi krátký záznam</string>
     <string name="settings_support_debuglog_short_recording_msg">Záznam byl velmi krátký. Logy ladění jsou záznamy, nikoli snímky — aby byl log užitečný, je třeba problém reprodukovat během aktivního záznamu.</string>
     <string name="settings_support_debuglog_short_recording_continue">Pokračovat v záznamu</string>
     <string name="settings_support_debuglog_short_recording_stop">Přesto ukončit</string>
-    <string name="settings_support_debuglog_folder_label">Složka logů ladění</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d relace používá %2$s</item>
-        <item quantity="few">%1$d relace používají %2$s</item>
-        <item quantity="many">%1$d relací používá %2$s</item>
-        <item quantity="other">%1$d relací používá %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Žádné uložené logy ladění</string>
-    <string name="settings_support_debuglog_folder_delete_title">Smazat všechny logy ladění?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Toto trvale smaže všechny uložené relace logu ladění.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Místo, kde se můžete scházet a klást otázky.</string>
     <!-- Settings/Acks-->
@@ -232,16 +207,12 @@
     <string name="settings_acks_translation_header">Překlad</string>
     <string name="settings_acks_translators_title">Překladatelé</string>
     <string name="settings_acks_translators_people">novas78@xda;Matthias (darken)</string>
-    <string name="settings_acks_translate_title">Přeložit BVM</string>
-    <string name="settings_acks_translate_desc">Pomozte přeložit BVM do svého jazyka</string>
     <string name="settings_acks_thanks_header">Poděkování</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Za podporu překladu open-source projektů</string>
     <string name="settings_licenses_label">Licence</string>
     <string name="settings_translation_label">Překlad</string>
     <string name="settings_translation_desc">Pomozte přeložit aplikaci do svého oblíbeného jazyka</string>
-    <string name="settings_sponsor_development_title">Sponzorovat vývoj</string>
-    <string name="settings_sponsor_development_summary">Staňte se patronem a umožněte další vývoj.</string>
     <string name="settings_privacy_policy_label">Zásady ochrany osobních údajů</string>
     <string name="settings_privacy_policy_desc">Zodpovědné nakládání s daty.</string>
     <string name="changelog_label">Seznam změn</string>
@@ -263,10 +234,8 @@
     <string name="backup_restore_success_restore">Obnovení dokončeno — obnoveno %1$d zařízení, přeskočeno %2$d.</string>
     <string name="backup_restore_version_warning">Tato záloha byla vytvořena ve verzi %1$s. Spouštíte verzi %2$s. Některá nastavení nemusí být obnovena správně.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Oznámení o ladění</string>
     <string name="debug_log_consent_title">Log ladění</string>
     <string name="debug_log_consent_explanation">Tato funkce zaznamenává vše, co aplikace dělá do souboru, který lze sdílet. Vygenerovaný soubor obsahuje citlivé informace (např. názvy souborů a nainstalovaných aplikací). Sdílejte je pouze s důvěryhodnými stranami (např. s vývojáři, kteří řeší nějaký problém).</string>
-    <string name="debug_log_recording_progress">Zaznamenávání logu ladění</string>
     <string name="debug_log_record_action">Zaznamenat</string>
     <string name="debug_log_stop_action">Ukončit zaznamenávání</string>
     <string name="debug_log_screen_title">Záznam logu ladění</string>
@@ -283,7 +252,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Zahodit</string>
     <string name="debug_log_screen_keep_action">Ponechat</string>
-    <string name="debug_log_compressing_label">Komprimování…</string>
     <string name="debug_log_file_label">Zaznamenaný log soubor</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log odeslán?</string>
@@ -311,7 +279,6 @@
     <string name="contact_description_question_hint">Podrobně popište svůj dotaz.</string>
     <string name="contact_category_section_label">Kategorie</string>
     <string name="contact_debug_log_label">Log ladění</string>
-    <string name="contact_debug_log_select_hint">Vyberte log ladění jako přílohu</string>
     <string name="contact_debug_log_picker_hint">Připojte log ladění pro rychlejší diagnostiku problému.</string>
     <string name="contact_debug_log_picker_empty">Nebyly nalezeny žádné logy ladění. Nejdříve je zaznamenejte.</string>
     <string name="contact_expected_behavior_label">Očekávané chování</string>
@@ -327,82 +294,32 @@
     <string name="contact_welcome_msg">Všechny zprávy čtu sám a snažím se na ně odpovídat, ale protože na tom pracuji sám, může to chvíli trvat. Děkuji za trpělivost.</string>
     <string name="contact_footer_msg">Vaše zpráva bude odeslána e-mailem. Údaje o zařízení a nastavení se připojí automaticky.</string>
     <string name="contact_no_email_app_msg">V tomto zařízení nebyla nalezena žádná e-mailová aplikace.</string>
-    <string name="contact_attachment_missing_msg">Soubor logu ladění již neexistuje</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Uložené logy ladění</string>
     <string name="settings_support_stored_logs_desc">%1$d relací (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Žádné uložené logy ladění</string>
-    <string name="settings_support_stored_logs_delete_title">Smazat uložené logy?</string>
-    <string name="settings_support_stored_logs_delete_msg">Tím se odstraní všech %1$d uložených relací logu ladění.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Uložené logy ladění smazány</string>
-    <string name="label_bug_reports">Hlášení chyb</string>
-    <string name="description_bug_reports">Automatické hlášení chyb a selhání.</string>
     <string name="label_add_device">Přidat zařízení</string>
-    <string name="label_just_a_moment_please">Chviličku prosím.</string>
     <string name="label_notification_channel_status">Stav</string>
     <string name="label_notification_channel_setup">Vyžadováno nastavení</string>
     <string name="monitor_notification_starting">Spouštění…</string>
     <string name="action_set">Nastavit</string>
     <string name="action_cancel">Zrušit</string>
-    <string name="label_invalid_input">Neplatný vstup</string>
     <string name="action_reset">Resetovat</string>
     <string name="label_no_connected_devices">Není připojeno žádné zařízení</string>
-    <string name="label_status_idle">Neaktivní</string>
-    <string name="label_status_adjusting_volumes">Nastavení hlasitosti</string>
-    <string name="label_premium_version">Verze Premium</string>
     <string name="general_upgrade_action">Upgradovat</string>
     <string name="common_upgrade_required_label">Vyžadován upgrade</string>
-    <string name="label_premium_version_required">Je vyžadována verze Premium</string>
-    <string name="description_intro_purpose">Tato aplikace umožňuje zařízení Android zapamatovat si hlasitost různých zařízení Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Neomezené profily zařízení</string>
-    <string name="upgrade_benefit_connection_actions">Automatické přehrávání, spuštění aplikace a upozornění na připojení</string>
-    <string name="upgrade_benefit_theme_customization">Přizpůsobení motivu, stylu a barev</string>
-    <string name="upgrade_benefit_power_controls">Zámek hlasitosti a omezení rychlosti</string>
-    <string name="upgrade_benefit_support">Podpora nezávislého vývoje</string>
     <string name="upgrade_benefit_equalizer">• Ekvalizér pro jednotlivá zařízení (pro hudební aplikace s podporou systémového ekvalizéru)</string>
-    <string name="description_intro_tap_the_button">Začněte přidáním prvního zařízení.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth je vypnuto.</string>
     <string name="title_bluetooth_is_off">Bluetooth je vypnuto</string>
     <string name="action_enable_bluetooth">Zapnout Bluetooth</string>
     <string name="title_bluetooth_permission_required">Potřebné oprávnění pro Bluetooth</string>
     <string name="description_bluetooth_permission_required">Tato aplikace potřebuje oprávnění k použití Bluetooth, aby mohla spravovat hlasitost vašeho zařízení.</string>
     <string name="action_grant_permission">Udělit oprávnění</string>
-    <string name="label_status_listening_for_changes">Naslouchání změn hlasitosti</string>
     <string name="action_exit">Ukončit</string>
-    <string name="action_start">Spustit</string>
-    <string name="label_welcome">Vítejte</string>
-    <string name="description_intro_contact">Pokud máte nějaké dotazy nebo i nápad na novou funkci, neváhejte mě kontaktovat.</string>
-    <string name="label_translation">Překlad</string>
-    <string name="description_help_translate">Pomozte mi přeložit tuto aplikaci do ostatních jazyků.</string>
     <string name="label_device_speaker">Reproduktor zařízení</string>
-    <string name="label_keyevent_playpause">Přehrát/pozastavit</string>
-    <string name="label_keyevent_play">Přehrát</string>
-    <string name="label_keyevent_next">Další</string>
-    <string name="label_install_id">ID instalace</string>
     <string name="message_copied_to_clipboard">Zkopírováno do schránky</string>
-    <string name="label_thanks">Díky</string>
-    <string name="label_licenses">Licence</string>
-    <string name="description_ring_volume_additional_permission">Pro změnu hlasitosti vyzvánění je potřeba další oprávnění.</string>
-    <string name="label_missing_permissions">Chybějící oprávnění</string>
-    <string name="action_grant">Udělit</string>
-    <string name="label_advanced">Pokročilé</string>
-    <string name="label_exclude_health">Vyloučit zdravotní profily</string>
-    <string name="description_exclude_health">Některá zařízení Android zamrznou při vyhledávání profilů Bluetooth \'Zdravotní zařízení\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Vyloučit profily serveru GATT</string>
-    <string name="label_exclude_gatt">Vyloučit profily GATT</string>
-    <string name="description_exclude_gattserver">Neptat se na Bluetooth profily typu \'Obecný atribut\' serveru (GATT).</string>
-    <string name="description_exclude_gatt">Neptat se na Bluetooth profily typu \'Obecný atribut\' klienta (GATT).</string>
-    <string name="description_waiting_for_devicex">Čekám, až %s dokončí připojení</string>
-    <string name="action_undo">Zpět</string>
-    <string name="action_show">Zobrazit</string>
     <string name="action_dismiss">Zrušit</string>
-    <string name="action_fix">Opravit</string>
-    <string name="battery_optimizations_issue_description">Optimalizace baterie je pro tuto aplikaci povolena a může zabránit přijímání událostí Bluetooth. Vezměte v úvahu zakázání optimalizace, pokud máte potíže.</string>
     <string name="label_bluetooth_settings">Nastavení Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 omezuje způsob spouštění aplikací na pozadí. Pro povolení spouštění aplikací po připojení Bluetooth zařízení udělte oprávnění „Vykreslit přes další aplikace“ (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Zdrojový kód</string>
-    <string name="android13_notification_permission_description">Udělte této aplikaci oprávnění k odesílání oznámení. Tím se umožní zobrazování oznámení, když je tato aplikace aktivní a dochází k úpravám hlasitosti.</string>
-    <string name="privacy_policy_label">Zásady ochrany osobních údajů</string>
     <string name="managed_devices_empty_message">Není nakonfigurováno žádné zařízení Bluetooth.\nKlepnutím na tlačítko + přidejte své první zařízení.</string>
     <string name="label_pro_feature">Prémiová funkce</string>
     <plurals name="discover_device_limit_banner">
@@ -435,21 +352,15 @@
     <string name="review_app_review_action">Posoudit</string>
     <string name="review_app_dismiss_action">Možná později</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Nákup zrušen</string>
-    <string name="error_iap_unavailable_message">Nákupy v aplikaci nejsou dostupné</string>
-    <string name="error_generic_message">Nastala chyba. Zkus to prosím znovu.</string>
-    <string name="error_iap_owned_message">Tuto položku již vlastníte</string>
     <string name="label_no_devices_title">Žádná zařízení</string>
     <string name="bluemusic_mascot_description">Ikona aplikace</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Vybrat aplikace</string>
     <string name="devices_app_selection_search_hint">Hledat aplikace…</string>
-    <string name="devices_app_selection_currently_selected">Aktuálně vybrané</string>
     <string name="devices_app_selection_selected_count">%d aplikací vybráno</string>
     <string name="general_navigate_back_action">Navigovat zpět</string>
     <string name="general_reset_action">Resetovat</string>
     <string name="general_clear_action">Vyčistit</string>
-    <string name="general_save_action">Uložit</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Uzamčeno</string>
     <string name="devices_indicator_awake">Aktivní</string>
@@ -459,7 +370,6 @@
     <string name="devices_indicator_limit">Limit</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Zesílení</string>
-    <string name="devices_indicator_launch">Spustit</string>
     <string name="devices_indicator_home">Domů</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Upozornění</string>

--- a/app/src/main/res/values-da/strings.xml
+++ b/app/src/main/res/values-da/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Nogle enhedsindstillinger kan være blevet nulstillet under denne opdatering. Tjek venligst dine enhedskonfigurationer.</string>
     <string name="onboarding_rewrite_action">Fortsæt</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Ingen uhåndterede enheder fundet</string>
     <string name="discover_all_devices_managed_msg">Alle dine parrede enheder er allerede håndteret! Har du brug for en ny?</string>
     <string name="discover_pair_new_device_action">Par ny enhed</string>
     <string name="discover_device_speaker_desc">Denne telefons egen højttaler. Dens lydstyrker bruges, når lyd skifter tilbage til telefonen, f.eks. efter at din Bluetooth-enhed afbryder forbindelsen.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Enhedskonfiguration</string>
-    <string name="devices_device_config_section_general_label">Generelt</string>
     <string name="devices_device_config_remove_device_label">Glem enhed</string>
-    <string name="devices_device_config_remove_device_desc">Glemmer enheden fra denne app og sletter dens konfiguration. Dette afparrer ikke enheden.</string>
     <string name="devices_device_config_remove_device_action">Glem</string>
     <string name="devices_device_config_remove_device_confirmation">Glem %s fra administrerede enheder?</string>
-    <string name="devices_device_config_rename_device_label">Omdøb enhed</string>
-    <string name="devices_device_config_rename_device_desc">Omdøb denne enhed i denne app og, hvis muligt, i systemet.</string>
     <string name="devices_device_config_rename_device_action">Omdøb</string>
     <string name="devices_device_config_enabled_label">Aktiveret</string>
     <string name="devices_device_config_enabled_desc">Reager på denne enhed når den tilsluttes</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Autoplay-kommandoer</string>
     <string name="devices_device_config_autoplay_keycodes_order">Kommandosekvens</string>
     <string name="devices_device_config_autoplay_keycodes_label">Kommandoer</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Konfigurer hvilke kommandoer der skal sendes og i hvilken rækkefølge</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Ingen kommandoer konfigureret</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Tilføj kommando</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimum %1$d kommandoer</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Flyt op</string>
     <string name="cd_autoplay_keycode_move_down">Flyt ned</string>
     <string name="cd_autoplay_keycode_remove">Fjern</string>
-    <string name="devices_device_config_section_volumes_label">Lydstyrker</string>
     <string name="devices_device_config_section_volume_label">Lydstyrke</string>
     <string name="devices_device_config_alarm_volume_label">Alarmvolume</string>
     <string name="devices_device_config_alarm_volume_desc">Nogle alarm-apps bruger musikvolumen i stedet.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Ringetone</string>
     <string name="devices_audio_stream_notification_label">Notifikation</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Aldrig set</string>
-    <string name="devices_state_connected_label">Forbundet</string>
     <string name="devices_last_connected_label">Sidst tilsluttet: %s</string>
     <string name="devices_currently_connected_label">Aktuelt tilsluttet</string>
     <string name="devices_device_disabled_label">Enhed deaktiveret</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Indstillinger som påvirker alle administrerede enheder.</string>
     <string name="label_app_enabled">App aktiveret</string>
     <string name="description_app_enabled">Skifter appens evne til at reagere på lydstyrke og Bluetooth-hendelser.</string>
-    <string name="label_visible_volume_adjustments">Synlige justeringer</string>
-    <string name="description_visible_volume_adjustments">Vis systemets lydstyrkevindue når denne app laver ændringer.</string>
     <string name="label_volume_listener">Observer ændringer</string>
-    <string name="description_volume_listener">Forbliv aktiv når en enhed tilkobler, og gem lydstyrke-ændringer som ikke er ændret af denne app.</string>
     <string name="label_boot_restore">Gendan på opstart</string>
     <string name="description_boot_restore">Gendan lydstyrken efter opstart/genstart, hvis en Bluetooth-enhed er tilsluttet.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Lær hvordan du bruger BVM effektivt</string>
     <string name="settings_support_issue_tracker_description">En offentlig issue tracker til fejlrapporter og ønsker om funktioner.</string>
     <string name="settings_support_issue_tracker_label">Issue tracker</string>
-    <string name="settings_support_debuglog_label">Fejlfindingslog</string>
     <string name="settings_support_debuglog_desc">Optag alt hvad appen gør i en tekstfil du kan dele.</string>
-    <string name="settings_support_debuglog_recording_desc">Optager lige nu debug-information. Tryk for at stoppe optagelsen.</string>
-    <string name="settings_support_debuglog_path">Log-sti: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Meget kort optagelse</string>
     <string name="settings_support_debuglog_short_recording_msg">Det var en meget kort optagelse. Debug-logs er optagelser, ikke øjebliksbilleder — reproducer problemet mens optagelsen er aktiv for at loggen er nyttig.</string>
     <string name="settings_support_debuglog_short_recording_continue">Fortsæt optagelse</string>
     <string name="settings_support_debuglog_short_recording_stop">Stop alligevel</string>
-    <string name="settings_support_debuglog_folder_label">Debug log-mappe</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d session bruger %2$s</item>
-        <item quantity="other">%1$d sessioner bruger %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Ingen debug-logs gemt</string>
-    <string name="settings_support_debuglog_folder_delete_title">Slet alle debug-logs?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Dette vil permanent slette alle gemte debug log-sessioner.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Et sted at hænge ud og stille spørgsmål.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Oversættelse</string>
     <string name="settings_acks_translators_title">Oversættere</string>
     <string name="settings_acks_translators_people">Person1;Person2(valgfri@email.com)</string>
-    <string name="settings_acks_translate_title">Oversæt BVM</string>
-    <string name="settings_acks_translate_desc">Hjælp med at oversætte BVM til dit sprog</string>
     <string name="settings_acks_thanks_header">Tak</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">For at støtte oversættelse af open-source projekter</string>
     <string name="settings_licenses_label">Licenser</string>
     <string name="settings_translation_label">Oversættelse</string>
     <string name="settings_translation_desc">Hjælp med at oversætte appen til dit yndlingssprog</string>
-    <string name="settings_sponsor_development_title">Sponsor udvikling</string>
-    <string name="settings_sponsor_development_summary">Bliv patron og gør fortsat udvikling mulig.</string>
     <string name="settings_privacy_policy_label">Privatlivspolitik</string>
     <string name="settings_privacy_policy_desc">Håndtering af data ansvarligt.</string>
     <string name="changelog_label">Ændringslog</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Gendannelse fuldført — %1$d enheder gendannet, %2$d sprunget over.</string>
     <string name="backup_restore_version_warning">Denne sikkerhedskopi blev oprettet med version %1$s. Du kører %2$s. Nogle indstillinger gendannes muligvis ikke korrekt.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Debug-notifikationer</string>
     <string name="debug_log_consent_title">Fejlfindingslog</string>
     <string name="debug_log_consent_explanation">Denne funktion optager alt hvad appen laver i en delbar fil. Den genererede fil indeholder følsomme oplysninger (f.eks. filnavne og installerede apps). Del den kun med betroede parter (f.eks. en udvikler der fejlsøger et problem).</string>
-    <string name="debug_log_recording_progress">Optager debug log</string>
     <string name="debug_log_record_action">Optag</string>
     <string name="debug_log_stop_action">Stop optagelse</string>
     <string name="debug_log_screen_title">Debug Log Optager</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Slet</string>
     <string name="debug_log_screen_keep_action">Behold</string>
-    <string name="debug_log_compressing_label">Komprimerer…</string>
     <string name="debug_log_file_label">Optaget log-fil</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log sendt?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Beskriv dit spørgsmål i detaljer.</string>
     <string name="contact_category_section_label">Kategori</string>
     <string name="contact_debug_log_label">Debug-log</string>
-    <string name="contact_debug_log_select_hint">Vælg en debug-log til at vedhæfte</string>
     <string name="contact_debug_log_picker_hint">Vedhæft en debug-log for at hjælpe med at diagnosticere problemet hurtigere.</string>
     <string name="contact_debug_log_picker_empty">Ingen debug-logs tilgængelige. Optag en først.</string>
     <string name="contact_expected_behavior_label">Forventet adfærd</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Jeg læser selv hver besked og gør mit bedste for at svare, men da jeg arbejder på dette alene, kan det tage lidt tid. Tak for tålmodigheden.</string>
     <string name="contact_footer_msg">Din besked sendes via e-mail. Enheds- og opsætningsoplysninger vedhæftes automatisk.</string>
     <string name="contact_no_email_app_msg">Ingen e-mail-app fundet på denne enhed.</string>
-    <string name="contact_attachment_missing_msg">Debug log-filen eksisterer ikke længere</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Gemte debug-logs</string>
     <string name="settings_support_stored_logs_desc">%1$d sessioner (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Ingen gemte debug-logs</string>
-    <string name="settings_support_stored_logs_delete_title">Slet gemte logs?</string>
-    <string name="settings_support_stored_logs_delete_msg">Dette vil slette alle %1$d gemte debug log-sessioner.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Gemte debug-logs slettet</string>
-    <string name="label_bug_reports">Fejlrapporter</string>
-    <string name="description_bug_reports">Automatisk fejl- og nedbrudsrapportering.</string>
     <string name="label_add_device">Tilføj enhed</string>
-    <string name="label_just_a_moment_please">Et øjeblik.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Opsætning påkrævet</string>
     <string name="monitor_notification_starting">Starter op…</string>
     <string name="action_set">Vælg</string>
     <string name="action_cancel">Annuller</string>
-    <string name="label_invalid_input">Ugyldigt input</string>
     <string name="action_reset">Gendan</string>
     <string name="label_no_connected_devices">Ingen enheder tilsluttet</string>
-    <string name="label_status_idle">Inaktiv</string>
-    <string name="label_status_adjusting_volumes">Justerer lydstyrker</string>
-    <string name="label_premium_version">Premium-version</string>
     <string name="general_upgrade_action">Opgrader</string>
     <string name="common_upgrade_required_label">Opgradering påkrævet</string>
-    <string name="label_premium_version_required">Premium-versionen påkrævet</string>
-    <string name="description_intro_purpose">Denne app tillader din Android at huske lydstyrken for forskellige Bluetooth-enheder.</string>
-    <string name="upgrade_benefit_unlimited_devices">Ubegrænsede enhedsprofiler</string>
-    <string name="upgrade_benefit_connection_actions">Autoafspilning, app-start og forbindelsesadvarsler</string>
-    <string name="upgrade_benefit_theme_customization">Tema-, stil- og farvetilpasning</string>
-    <string name="upgrade_benefit_power_controls">Lydstyrkelås og hastighedsbegrænsning</string>
-    <string name="upgrade_benefit_support">Støt uafhængig udvikling</string>
     <string name="upgrade_benefit_equalizer">• Equalizer pr. enhed (til musikapps med understøttelse af systemequalizer)</string>
-    <string name="description_intro_tap_the_button">Start med at tilføje din første enhed.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth er deaktiveret.</string>
     <string name="title_bluetooth_is_off">Bluetooth er slukket</string>
     <string name="action_enable_bluetooth">Aktiver Bluetooth</string>
     <string name="title_bluetooth_permission_required">Bluetooth-tilladelse krævet</string>
     <string name="description_bluetooth_permission_required">Denne app har brug for Bluetooth-tilladelse for at administrere dine enheds-volumener.</string>
     <string name="action_grant_permission">Giv tilladelse</string>
-    <string name="label_status_listening_for_changes">Lytter efter volumeændringer</string>
     <string name="action_exit">Afslut</string>
-    <string name="action_start">Start</string>
-    <string name="label_welcome">Velkommen</string>
-    <string name="description_intro_contact">Tøv ikke med at kontakte mig hvis du har spørgsmål eller en idé til en ny funktion.</string>
-    <string name="label_translation">Oversættelse</string>
-    <string name="description_help_translate">Hjælp mig med at gøre appen tilgængelig på andre sprog.</string>
     <string name="label_device_speaker">Enhedens højtaler</string>
-    <string name="label_keyevent_playpause">Afspil-Pause</string>
-    <string name="label_keyevent_play">Afspil</string>
-    <string name="label_keyevent_next">Næste</string>
-    <string name="label_install_id">Installations-ID</string>
     <string name="message_copied_to_clipboard">Kopieret til udklipsholderen</string>
-    <string name="label_thanks">Tak</string>
-    <string name="label_licenses">Licenser</string>
-    <string name="description_ring_volume_additional_permission">Yderligere tilladelser er nødvendige for at ændre ringelydstyrken.</string>
-    <string name="label_missing_permissions">Manglende tilladelser</string>
-    <string name="action_grant">Tillad</string>
-    <string name="label_advanced">Avanceret</string>
-    <string name="label_exclude_health">Udelad sundhedsprofiler</string>
-    <string name="description_exclude_health">Nogle Android-enheder hænger sig når de slår \'Sundhedsenhed\' Bluetooth-profiler op (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Udelad GATT server profiler</string>
-    <string name="label_exclude_gatt">Udelad GATT profiler</string>
-    <string name="description_exclude_gattserver">Ikke spørg efter Bluetooth-profiler af typen \"Generisk Attribut\" (GATT) server.</string>
-    <string name="description_exclude_gatt">Ikke spørg efter Bluetooth-profiler af typen \"Generisk Attribut\" (GATT) klient.</string>
-    <string name="description_waiting_for_devicex">Venter på at %s fuldfører forbindelse</string>
-    <string name="action_undo">Fortryd</string>
-    <string name="action_show">Vis</string>
     <string name="action_dismiss">Afvis</string>
-    <string name="action_fix">Ret</string>
-    <string name="battery_optimizations_issue_description">Batteri-optimering er aktiveret for denne app og kan forhindre den i at modtage Bluetooth-hændelser. Overvej at deaktivere optimeringer hvis du oplever problemer.</string>
     <string name="label_bluetooth_settings">Bluetooth-indstillinger</string>
-    <string name="android10_applaunch_issue_description">Android 10 begrænser, hvordan apps kan startes i baggrunden. For at tillade åbning af apps, når en Bluetooth-enhed tilsluttes, skal du give tilladelsen &quot;Vis over andre apps&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Kildekode</string>
-    <string name="android13_notification_permission_description">Giv denne app tilladelse til at vise notifikationer. Dette muliggør visning af en notifikation når denne app er aktiv og lydstyrke-justeringer laves.</string>
-    <string name="privacy_policy_label">Privatlivspolitik</string>
     <string name="managed_devices_empty_message">Ingen Bluetooth-enheder konfigureret.\nTryk på + knappen for at tilføje din første enhed.</string>
     <string name="label_pro_feature">Premium-funktion</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Bedøm</string>
     <string name="review_app_dismiss_action">Måske senere</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Køb annulleret</string>
-    <string name="error_iap_unavailable_message">In-app køb er ikke tilgængelige</string>
-    <string name="error_generic_message">Der opstod en fejl. Prøv igen.</string>
-    <string name="error_iap_owned_message">Du ejer allerede denne vare</string>
     <string name="label_no_devices_title">Ingen enheder</string>
     <string name="bluemusic_mascot_description">App-ikon</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Vælg Apps</string>
     <string name="devices_app_selection_search_hint">Søg apps…</string>
-    <string name="devices_app_selection_currently_selected">Aktuelt valgte</string>
     <string name="devices_app_selection_selected_count">%d apps valgt</string>
     <string name="general_navigate_back_action">Naviger tilbage</string>
     <string name="general_reset_action">Nulstil</string>
     <string name="general_clear_action">Ryd</string>
-    <string name="general_save_action">Gem</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Lås</string>
     <string name="devices_indicator_awake">Vågen</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Begræns</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Boost</string>
-    <string name="devices_indicator_launch">Start</string>
     <string name="devices_indicator_home">Hjem</string>
     <string name="devices_indicator_dnd">FI</string>
     <string name="devices_indicator_alert">Advarsel</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Einige Funktionen haben sich während des Updates geändert. Bitte überprüfe deine Geräteeinstellungen, um sicherzustellen, dass alles korrekt konfiguriert ist.</string>
     <string name="onboarding_rewrite_action">Weiter</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Keine nicht verwalteten Geräte gefunden</string>
     <string name="discover_all_devices_managed_msg">Alle deine gekoppelten Geräte werden verwaltet! Brauchst du ein neues?</string>
     <string name="discover_pair_new_device_action">Neues Gerät koppeln</string>
     <string name="discover_device_speaker_desc">Der eigene Lautsprecher dieses Telefons. Seine Lautstärkeeinstellungen werden angewendet, wenn der Ton zum Telefon zurückschaltet, z. B. nachdem dein Bluetooth-Gerät getrennt wurde.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Gerätekonfiguration</string>
-    <string name="devices_device_config_section_general_label">Allgemein</string>
     <string name="devices_device_config_remove_device_label">Gerät vergessen</string>
-    <string name="devices_device_config_remove_device_desc">Vergisst das Gerät aus dieser App und löscht seine Konfiguration. Dies hebt die Kopplung des Geräts nicht auf.</string>
     <string name="devices_device_config_remove_device_action">Vergessen</string>
     <string name="devices_device_config_remove_device_confirmation">%s aus verwalteten Geräten vergessen?</string>
-    <string name="devices_device_config_rename_device_label">Gerät umbenennen</string>
-    <string name="devices_device_config_rename_device_desc">Benenne dieses Gerät innerhalb dieser App und, wenn möglich, im System um.</string>
     <string name="devices_device_config_rename_device_action">Umbenennen</string>
     <string name="devices_device_config_enabled_label">Aktiviert</string>
     <string name="devices_device_config_enabled_desc">Auf dieses Gerät reagieren, wenn es verbunden ist</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Autoplay-Befehle</string>
     <string name="devices_device_config_autoplay_keycodes_order">Befehlsreihenfolge</string>
     <string name="devices_device_config_autoplay_keycodes_label">Befehle</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Konfiguriere, welche Befehle in welcher Reihenfolge gesendet werden</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Keine Befehle konfiguriert</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Befehl hinzufügen</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximal %1$d Befehle</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Nach oben</string>
     <string name="cd_autoplay_keycode_move_down">Nach unten</string>
     <string name="cd_autoplay_keycode_remove">Entfernen</string>
-    <string name="devices_device_config_section_volumes_label">Lautstärken</string>
     <string name="devices_device_config_section_volume_label">Lautstärke</string>
     <string name="devices_device_config_alarm_volume_label">Alarmlautstärke</string>
     <string name="devices_device_config_alarm_volume_desc">Einige Alarm-Apps verwenden stattdessen die Musiklautstärke.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Klingeln</string>
     <string name="devices_audio_stream_notification_label">Benachrichtigung</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Nie gesehen</string>
-    <string name="devices_state_connected_label">Verbunden</string>
     <string name="devices_last_connected_label">Zuletzt verbunden: %s</string>
     <string name="devices_currently_connected_label">Aktuell verbunden</string>
     <string name="devices_device_disabled_label">Gerät deaktiviert</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Einstellungen, die alle verwalteten Geräte betreffen.</string>
     <string name="label_app_enabled">App aktiviert</string>
     <string name="description_app_enabled">Schaltet die Fähigkeit dieser App ein bzw. aus, auf Lautstärken- und Bluetooth-Ereignisse zu reagieren.</string>
-    <string name="label_visible_volume_adjustments">Sichtbare Anpassungen</string>
-    <string name="description_visible_volume_adjustments">Zeigt das Lautstärken-Fenster des System an, während diese App Änderungen vornimmt.</string>
     <string name="label_volume_listener">Änderungen beobachten</string>
-    <string name="description_volume_listener">Aktiv bleiben, während ein Gerät verbunden ist und Lautstärke-Änderungen speichern, die nicht von dieser App ausgelöst wurden.</string>
     <string name="label_boot_restore">Wiederherstellen bei Neustart</string>
     <string name="description_boot_restore">Stellt die Lautstärke nach einem Neustart wieder her, falls ein Bluetooth-Gerät verbunden ist.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Lerne, wie Du BLM effektiv nutzt</string>
     <string name="settings_support_issue_tracker_description">Ein öffentlicher Problemtracker für Fehlerberichte und Funktionsanfragen.</string>
     <string name="settings_support_issue_tracker_label">Problemtracker</string>
-    <string name="settings_support_debuglog_label">Debug-Protokoll</string>
     <string name="settings_support_debuglog_desc">Zeichne alle Aktivitäten der App in einer Textdatei auf, die du weitergeben kannst.</string>
-    <string name="settings_support_debuglog_recording_desc">Zeichnet derzeit Debug-Informationen auf. Tippen Sie, um die Aufzeichnung zu stoppen.</string>
-    <string name="settings_support_debuglog_path">Protokollpfad: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Sehr kurze Aufzeichnung</string>
     <string name="settings_support_debuglog_short_recording_msg">Das war eine sehr kurze Aufzeichnung. Debug-Protokolle sind Aufzeichnungen, keine Schnappschüsse — reproduziere das Problem während die Aufzeichnung aktiv ist, damit das Protokoll nützlich ist.</string>
     <string name="settings_support_debuglog_short_recording_continue">Aufzeichnung fortsetzen</string>
     <string name="settings_support_debuglog_short_recording_stop">Trotzdem stoppen</string>
-    <string name="settings_support_debuglog_folder_label">Debug-Protokoll-Ordner</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d Sitzung verwendet %2$s</item>
-        <item quantity="other">%1$d Sitzungen verwenden %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Keine Debug-Protokolle gespeichert</string>
-    <string name="settings_support_debuglog_folder_delete_title">Alle Debug-Protokolle löschen?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Hierdurch werden alle gespeicherten Debug-Protokoll-Sitzungen dauerhaft gelöscht.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Ein Ort zum Abhängen und Fragen stellen.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Übersetzung</string>
     <string name="settings_acks_translators_title">Übersetzer</string>
     <string name="settings_acks_translators_people">Gamechanger181;Darken;uli;derPacifist</string>
-    <string name="settings_acks_translate_title">BLM übersetzen</string>
-    <string name="settings_acks_translate_desc">Hilf mit, BLM in deine Sprache zu übersetzen</string>
     <string name="settings_acks_thanks_header">Danke</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Zur Unterstützung der Übersetzung von Open-Source-Projekten</string>
     <string name="settings_licenses_label">Lizenzen</string>
     <string name="settings_translation_label">Übersetzung</string>
     <string name="settings_translation_desc">Hilf mit, die App in deine Lieblingssprache zu übersetzen</string>
-    <string name="settings_sponsor_development_title">Entwicklung sponsern</string>
-    <string name="settings_sponsor_development_summary">Werde Förderer und ermögliche die weitere Entwicklung.</string>
     <string name="settings_privacy_policy_label">Datenschutzbestimmungen</string>
     <string name="settings_privacy_policy_desc">Verantwortungsvoller Umgang mit Daten.</string>
     <string name="changelog_label">Änderungsprotokoll</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Wiederherstellung abgeschlossen — %1$d Geräte wiederhergestellt, %2$d übersprungen.</string>
     <string name="backup_restore_version_warning">Diese Sicherung wurde mit Version %1$s erstellt. Du verwendest %2$s. Einige Einstellungen werden möglicherweise nicht korrekt wiederhergestellt.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Debug-Benachrichtigungen</string>
     <string name="debug_log_consent_title">Debug-Protokoll</string>
     <string name="debug_log_consent_explanation">Diese Funktion zeichnet alles auf, was die App tut, in eine teilbare Datei. Die generierte Datei enthält sensible Informationen (z.B. Dateinamen und installierte Apps). Teile sie nur mit vertrauenswürdigen Parteien (z.B. einem Entwickler, der ein Problem behebt).</string>
-    <string name="debug_log_recording_progress">Zeichne Debug-Protokoll auf</string>
     <string name="debug_log_record_action">Aufzeichnen</string>
     <string name="debug_log_stop_action">Aufzeichnung stoppen</string>
     <string name="debug_log_screen_title">Debug Log Rekorder</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Verwerfen</string>
     <string name="debug_log_screen_keep_action">Behalten</string>
-    <string name="debug_log_compressing_label">Komprimieren…</string>
     <string name="debug_log_file_label">Aufgezeichnete Protokolldatei</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Protokoll gesendet?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Beschreibe deine Frage im Detail.</string>
     <string name="contact_category_section_label">Kategorie</string>
     <string name="contact_debug_log_label">Debug-Protokoll</string>
-    <string name="contact_debug_log_select_hint">Ein Debug-Protokoll zum Anhängen auswählen</string>
     <string name="contact_debug_log_picker_hint">Hänge ein Debug-Protokoll an, um das Problem schneller zu diagnostizieren.</string>
     <string name="contact_debug_log_picker_empty">Keine Debug-Protokolle verfügbar. Zuerst eines aufzeichnen.</string>
     <string name="contact_expected_behavior_label">Erwartetes Verhalten</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Ich lese jede Nachricht selbst und gebe mein Bestes zu antworten, aber da ich alleine daran arbeite, kann es etwas dauern. Danke für deine Geduld.</string>
     <string name="contact_footer_msg">Deine Nachricht wird per E-Mail gesendet. Geräte- und Einrichtungsinformationen werden automatisch angehängt.</string>
     <string name="contact_no_email_app_msg">Keine E-Mail-App auf diesem Gerät gefunden.</string>
-    <string name="contact_attachment_missing_msg">Die Debug-Protokoll-Datei existiert nicht mehr</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Gespeicherte Debug-Protokolle</string>
     <string name="settings_support_stored_logs_desc">%1$d Sitzungen (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Keine gespeicherten Debug-Protokolle</string>
-    <string name="settings_support_stored_logs_delete_title">Gespeicherte Protokolle löschen?</string>
-    <string name="settings_support_stored_logs_delete_msg">Hierdurch werden alle %1$d gespeicherten Debug-Protokoll-Sitzungen gelöscht.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Gespeicherte Debug-Protokolle gelöscht</string>
-    <string name="label_bug_reports">Fehlerberichte</string>
-    <string name="description_bug_reports">Automatische Fehler- und Absturzberichte.</string>
     <string name="label_add_device">Gerät hinzufügen</string>
-    <string name="label_just_a_moment_please">Einen Moment bitte.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Einrichtung erforderlich</string>
     <string name="monitor_notification_starting">Wird gestartet…</string>
     <string name="action_set">Übernehmen</string>
     <string name="action_cancel">Abbrechen</string>
-    <string name="label_invalid_input">Ungültige Eingabe</string>
     <string name="action_reset">Zurücksetzen</string>
     <string name="label_no_connected_devices">Keine Geräte verbunden</string>
-    <string name="label_status_idle">Leerlauf</string>
-    <string name="label_status_adjusting_volumes">Lautstärken werden angepasst</string>
-    <string name="label_premium_version">Premium-Version</string>
     <string name="general_upgrade_action">Upgrade</string>
     <string name="common_upgrade_required_label">Upgrade erforderlich</string>
-    <string name="label_premium_version_required">Premium-Version erforderlich</string>
-    <string name="description_intro_purpose">Diese App erlaubt es Deinem Android-Gerät, die Lautstärke verschiedener Bluetooth-Geräte zu speichern.</string>
-    <string name="upgrade_benefit_unlimited_devices">Unbegrenzte Geräteprofile</string>
-    <string name="upgrade_benefit_connection_actions">Autoplay, App-Start und Verbindungsbenachrichtigungen</string>
-    <string name="upgrade_benefit_theme_customization">Design-, Stil- und Farbanpassung</string>
-    <string name="upgrade_benefit_power_controls">Lautstärkesperre und Ratenbegrenzung</string>
-    <string name="upgrade_benefit_support">Unabhängige Entwicklung unterstützen</string>
     <string name="upgrade_benefit_equalizer">• Equalizer pro Gerät (für Musik-Apps mit System-Equalizer-Unterstützung)</string>
-    <string name="description_intro_tap_the_button">Beginne durch Hinzufügen Deines ersten Geräts.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth ist ausgeschaltet.</string>
     <string name="title_bluetooth_is_off">Bluetooth ist aus</string>
     <string name="action_enable_bluetooth">Bluetooth aktivieren</string>
     <string name="title_bluetooth_permission_required">Bluetooth-Berechtigung erforderlich</string>
     <string name="description_bluetooth_permission_required">Diese App benötigt Bluetooth-Berechtigung, um Deine Gerätelautstärken zu verwalten.</string>
     <string name="action_grant_permission">Berechtigung erteilen</string>
-    <string name="label_status_listening_for_changes">Beobachte Lautstärkeänderungen</string>
     <string name="action_exit">Beenden</string>
-    <string name="action_start">Starten</string>
-    <string name="label_welcome">Willkommen</string>
-    <string name="description_intro_contact">Zögere nicht, mich zu kontaktieren, wenn Du Fragen oder sogar eine Idee zu einer neuen Funktion hast.</string>
-    <string name="label_translation">Übersetzung</string>
-    <string name="description_help_translate">Hilf mir, diese App in weiteren Sprachen verfügbar zu machen.</string>
     <string name="label_device_speaker">Gerätelautsprecher</string>
-    <string name="label_keyevent_playpause">Play/Pause</string>
-    <string name="label_keyevent_play">Play</string>
-    <string name="label_keyevent_next">Nächste</string>
-    <string name="label_install_id">Installations ID</string>
     <string name="message_copied_to_clipboard">In die Zwischenablage kopiert</string>
-    <string name="label_thanks">Danke</string>
-    <string name="label_licenses">Lizenzen</string>
-    <string name="description_ring_volume_additional_permission">Zusätzliche Berechtigungen sind erforderlich, um die Lautstärke des Klingeltons ändern.</string>
-    <string name="label_missing_permissions">Fehlende Berechtigungen</string>
-    <string name="action_grant">Gewähren</string>
-    <string name="label_advanced">Erweitert</string>
-    <string name="label_exclude_health">Gesundheitsprofile ausschließen</string>
-    <string name="description_exclude_health">Einige Android-Geräte hängen sich auf, wenn sie das Bluetooth-Profil eines \"Gesundheitsgeräts\" auflösen (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">GATT-Server-Profile ausschließen</string>
-    <string name="label_exclude_gatt">GATT-Profile ausschließen</string>
-    <string name="description_exclude_gattserver">Bluetooth-Profile des Typs \"Generisches Attribut\" (GATT) Server nicht abfragen.</string>
-    <string name="description_exclude_gatt">Bluetooth-Profile des Typs \"Generisches Attribut\" (GATT) Client nicht abfragen.</string>
-    <string name="description_waiting_for_devicex">Warte auf %s, um die Verbindung abzuschließen</string>
-    <string name="action_undo">Rückgängig machen</string>
-    <string name="action_show">Anzeigen</string>
     <string name="action_dismiss">Verwerfen</string>
-    <string name="action_fix">Beheben</string>
-    <string name="battery_optimizations_issue_description">Die Akku-Leistungsoptimierung ist für diese App aktiviert und kann sie daran hindern, Bluetooth-Events zu empfangen. Falls Du Probleme wahrnimmst, erwäge, die Optimierung zu deaktivieren.</string>
     <string name="label_bluetooth_settings">Bluetooth-Einstellungen</string>
-    <string name="android10_applaunch_issue_description">Android 10 beschränkt, wie Apps im Hintergrund gestartet werden können. Um das Öffnen von Apps zu gestatten, sobald sich ein Bluetooth-Gerät verbindet, gewähre die Berechtigung \"Display over other apps\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Quellcode</string>
-    <string name="android13_notification_permission_description">Erteile dieser App die Berechtigung, Benachrichtigungen zu senden. Dies ermöglicht die Anzeige einer Benachrichtigung, wenn diese App aktiv ist und Lautstärkeanpassungen vorgenommen werden.</string>
-    <string name="privacy_policy_label">Datenschutzerklärung</string>
     <string name="managed_devices_empty_message">Keine Bluetooth-Geräte konfiguriert.\nTippe auf +, um Dein erstes Gerät hinzuzufügen.</string>
     <string name="label_pro_feature">Premium-Funktion</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Bewerten</string>
     <string name="review_app_dismiss_action">Vielleicht später</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Kauf abgebrochen</string>
-    <string name="error_iap_unavailable_message">In-App-Käufe sind nicht verfügbar</string>
-    <string name="error_generic_message">Ein Fehler ist aufgetreten. Bitte versuche es erneut.</string>
-    <string name="error_iap_owned_message">Du besitzt diesen Artikel bereits</string>
     <string name="label_no_devices_title">Keine Geräte</string>
     <string name="bluemusic_mascot_description">App-Symbol</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Apps auswählen</string>
     <string name="devices_app_selection_search_hint">Apps suchen…</string>
-    <string name="devices_app_selection_currently_selected">Aktuell ausgewählt</string>
     <string name="devices_app_selection_selected_count">%d Apps ausgewählt</string>
     <string name="general_navigate_back_action">Zurück navigieren</string>
     <string name="general_reset_action">Zurücksetzen</string>
     <string name="general_clear_action">Löschen</string>
-    <string name="general_save_action">Speichern</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Sperren</string>
     <string name="devices_indicator_awake">Wach</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Begrenzen</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Boost</string>
-    <string name="devices_indicator_launch">Starten</string>
     <string name="devices_indicator_home">Start</string>
     <string name="devices_indicator_dnd">Bitte-nicht-stören</string>
     <string name="devices_indicator_alert">Alarm</string>

--- a/app/src/main/res/values-el/strings.xml
+++ b/app/src/main/res/values-el/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Κάποιες ρυθμίσεις συσκευών μπορεί να επαναφέρθηκαν κατά τη διάρκεια αυτής της ενημέρωσης. Παρακαλώ ελέγξτε τις διαμορφώσεις των συσκευών σας.</string>
     <string name="onboarding_rewrite_action">Συνέχεια</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Δεν βρέθηκαν μη διαχειρισμένες συσκευές</string>
     <string name="discover_all_devices_managed_msg">Όλες οι συζευγμένες συσκευές σας διαχειρίζονται ήδη! Χρειάζεστε κάποια καινούρια;</string>
     <string name="discover_pair_new_device_action">Σύζευξη νέας συσκευής</string>
     <string name="discover_device_speaker_desc">Το ηχείο του τηλεφώνου. Οι εντάσεις του εφαρμόζονται όταν ο ήχος επιστρέφει στο τηλέφωνο, π.χ. μετά την αποσύνδεση της συσκευής Bluetooth σας.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Διαμόρφωση συσκευής</string>
-    <string name="devices_device_config_section_general_label">Γενικά</string>
     <string name="devices_device_config_remove_device_label">Λήθη συσκευής</string>
-    <string name="devices_device_config_remove_device_desc">Ξεχνάει τη συσκευή από αυτή την εφαρμογή και διαγράφει τη διαμόρφωσή της. Αυτό δεν αποσυζεύγει τη συσκευή.</string>
     <string name="devices_device_config_remove_device_action">Λήθη</string>
     <string name="devices_device_config_remove_device_confirmation">Να λησμονήσω τη συσκευή %s από τις διαχειρισμένες συσκευές;</string>
-    <string name="devices_device_config_rename_device_label">Μετονομασία συσκευής</string>
-    <string name="devices_device_config_rename_device_desc">Μετονομάστε αυτή τη συσκευή μέσα σε αυτή την εφαρμογή, και αν είναι δυνατόν, στο σύστημα.</string>
     <string name="devices_device_config_rename_device_action">Μετονομασία</string>
     <string name="devices_device_config_enabled_label">Ενεργοποιημένη</string>
     <string name="devices_device_config_enabled_desc">Αντίδραση σε αυτή τη συσκευή όταν συνδέεται</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Εντολές αυτόματης αναπαραγωγής</string>
     <string name="devices_device_config_autoplay_keycodes_order">Σειρά εντολών</string>
     <string name="devices_device_config_autoplay_keycodes_label">Εντολές</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Ρύθμιση ποιες εντολές να στέλνονται και με ποια σειρά</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Δεν έχουν ρυθμιστεί εντολές</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Προσθήκη εντολής</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Μέγιστο %1$d εντολές</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Μετακίνηση προς τα πάνω</string>
     <string name="cd_autoplay_keycode_move_down">Μετακίνηση προς τα κάτω</string>
     <string name="cd_autoplay_keycode_remove">Αφαίρεση</string>
-    <string name="devices_device_config_section_volumes_label">Εντάσεις</string>
     <string name="devices_device_config_section_volume_label">Ένταση</string>
     <string name="devices_device_config_alarm_volume_label">Ένταση ήχου ξυπνητηριού</string>
     <string name="devices_device_config_alarm_volume_desc">Ορισμένες εφαρμογές ξυπνητηριού χρησιμοποιούν την ένταση μουσικής αντ \'αυτού.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Κλήση</string>
     <string name="devices_audio_stream_notification_label">Ειδοποίηση</string>
     <string name="devices_audio_stream_alarm_label">Ξυπνητήρι</string>
-    <string name="devices_neverseen_label">Ποτέ δεν συνδέθηκε</string>
-    <string name="devices_state_connected_label">Συνδέθηκε</string>
     <string name="devices_last_connected_label">Τελευταία σύνδεση: %s</string>
     <string name="devices_currently_connected_label">Συνδεδεμένη τώρα</string>
     <string name="devices_device_disabled_label">Συσκευή απενεργοποιημένη</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Ρυθμίσεις που επηρεάζουν όλες τις διαχειρισμένες συσκευές.</string>
     <string name="label_app_enabled">Ενεργοποίηση Εφαρμογής</string>
     <string name="description_app_enabled">Εναλλάσσει την ικανότητα της εφαρμογής να αντιδράσει στις εκδηλώσεις έντασης και Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Ορατές προσαρμογές</string>
-    <string name="description_visible_volume_adjustments">Εμφάνιση του παραθύρου ήχου του συστήματος, ενώ αυτή η εφαρμογή κάνει τις προσαρμογές.</string>
     <string name="label_volume_listener">Παρατήρηση αλλαγών</string>
-    <string name="description_volume_listener">Η εφαρμογή παραμένει ενεργή όσο η συσκευή είναι συνδεδεμένη και αποθηκεύει τις αλλαγές εντάσεων του ήχου που δεν έχουν γίνει από αυτή την εφαρμογή.</string>
     <string name="label_boot_restore">Επαναφορά κατά την εκκίνηση</string>
     <string name="description_boot_restore">Αποκατάσταση της έντασης μετά την εκκίνηση/επανεκκίνηση αν είναι συνδεδεμένη μια συσκευή Bluetooth.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Μάθετε πώς να χρησιμοποιείτε αποτελεσματικά το BVM</string>
     <string name="settings_support_issue_tracker_description">Ένας δημόσιος ιχνηλάτης ζητημάτων για αναφορές σφαλμάτων και αιτήματα για νέα χαρακτηριστικά.</string>
     <string name="settings_support_issue_tracker_label">Ιχνηλάτης ζητημάτων</string>
-    <string name="settings_support_debuglog_label">Αρχείο debug</string>
     <string name="settings_support_debuglog_desc">Καταγράφει όλα όσα κάνει η εφαρμογή σε ένα αρχείο κειμένου που μπορείτε να μοιραστείτε.</string>
-    <string name="settings_support_debuglog_recording_desc">Καταγράφει τώρα πληροφορίες debug. Πατήστε για να σταματήσει η καταγραφή.</string>
-    <string name="settings_support_debuglog_path">Διαδρομή αρχείου: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Πολύ σύντομη εγγραφή</string>
     <string name="settings_support_debuglog_short_recording_msg">Αυτή ήταν μια πολύ σύντομη εγγραφή. Τα αρχεία debug είναι εγγραφές, όχι στιγμιότυπα — αναπαράγετε το πρόβλημα ενώ η εγγραφή είναι ενεργή για να είναι χρήσιμο το αρχείο.</string>
     <string name="settings_support_debuglog_short_recording_continue">Συνέχεια εγγραφής</string>
     <string name="settings_support_debuglog_short_recording_stop">Σταμάτα ούτως ή άλλως</string>
-    <string name="settings_support_debuglog_folder_label">Φάκελος αρχείων debug</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d συνεδρία χρησιμοποιεί %2$s</item>
-        <item quantity="other">%1$d συνεδρίες χρησιμοποιούν %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Δεν υπάρχουν αποθηκευμένα αρχεία debug</string>
-    <string name="settings_support_debuglog_folder_delete_title">Διαγραφή όλων των αρχείων debug;</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Αυτό θα διαγράψει μόνιμα όλες τις αποθηκευμένες συνεδρίες αρχείων debug.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Ένα μέρος να συναναστρέφεστε και να κάνετε ερωτήσεις.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Μετάφραση</string>
     <string name="settings_acks_translators_title">Μεταφραστές</string>
     <string name="settings_acks_translators_people">Retrial, Vagelis1608;Theodoros;Asimakopoulos(theoasima@gmail.com);iplayradio;ggb_st;Nick Komninos</string>
-    <string name="settings_acks_translate_title">Μετάφραση BVM</string>
-    <string name="settings_acks_translate_desc">Βοηθήστε να μεταφραστεί το BVM στη γλώσσα σας</string>
     <string name="settings_acks_thanks_header">Ευχαριστίες</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Για την υποστήριξη της μετάφρασης προγραμμάτων ανοιχτού κώδικα</string>
     <string name="settings_licenses_label">Άδειες</string>
     <string name="settings_translation_label">Μετάφραση</string>
     <string name="settings_translation_desc">Βοηθήστε να μεταφράσετε την εφαρμογή στην αγαπημένη σας γλώσσα</string>
-    <string name="settings_sponsor_development_title">Χρηματοδότηση ανάπτυξης</string>
-    <string name="settings_sponsor_development_summary">Γίνετε χορηγός και κάντε δυνατή τη συνεχή ανάπτυξη.</string>
     <string name="settings_privacy_policy_label">Πολιτική απορρήτου</string>
     <string name="settings_privacy_policy_desc">Διαχείριση δεδομένων με υπευθυνότητα.</string>
     <string name="changelog_label">Αρχείο αλλαγών</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Επαναφορά ολοκληρώθηκε — %1$d συσκευές επαναφέρθηκαν, %2$d παραλείφθηκαν.</string>
     <string name="backup_restore_version_warning">Αυτό το αντίγραφο ασφαλείας δημιουργήθηκε με την έκδοση %1$s. Χρησιμοποιείτε την %2$s. Ορισμένες ρυθμίσεις ενδέχεται να μην επαναφερθούν σωστά.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Ειδοποιήσεις debug</string>
     <string name="debug_log_consent_title">Αρχείο debug</string>
     <string name="debug_log_consent_explanation">Αυτό το χαρακτηριστικό καταγράφει όλα όσα κάνει η εφαρμογή σε ένα αρχείο που μπορεί να μοιραστεί. Το αρχείο που δημιουργείται περιέχει ευαίσθητες πληροφορίες (π.χ. ονόματα αρχείων και εγκατεστημένες εφαρμογές). Μοιραστείτε το μόνο με έμπιστα άτομα (π.χ. ένα προγραμματιστή που επιλύει ένα πρόβλημα).</string>
-    <string name="debug_log_recording_progress">Καταγραφή αρχείου debug</string>
     <string name="debug_log_record_action">Καταγραφή</string>
     <string name="debug_log_stop_action">Σταμάτηση καταγραφής</string>
     <string name="debug_log_screen_title">Καταγραφέας Αρχείου Debug</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Απόρριψη</string>
     <string name="debug_log_screen_keep_action">Διατήρηση</string>
-    <string name="debug_log_compressing_label">Συμπίεση…</string>
     <string name="debug_log_file_label">Καταγεγραμμένο αρχείο καταγραφής</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Αρχείο απεστάλη;</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Περιγράψτε την ερώτησή σας λεπτομερώς.</string>
     <string name="contact_category_section_label">Κατηγορία</string>
     <string name="contact_debug_log_label">Αρχείο debug</string>
-    <string name="contact_debug_log_select_hint">Επιλέξτε αρχείο debug για επισύναψη</string>
     <string name="contact_debug_log_picker_hint">Επισυνάψτε αρχείο debug για ταχύτερη διάγνωση του προβλήματος.</string>
     <string name="contact_debug_log_picker_empty">Δεν υπάρχουν διαθέσιμα αρχεία debug. Πρώτα καταγράψτε ένα.</string>
     <string name="contact_expected_behavior_label">Αναμενόμενη συμπεριφορά</string>
@@ -319,83 +288,32 @@
     <string name="contact_welcome_msg">Διαβάζω κάθε μήνυμα μόνος μου και κάνω ό,τι μπορώ για να απαντήσω, αλλά επειδή εργάζομαι μόνος μου, μπορεί να πάρει λίγο χρόνο. Ευχαριστώ για την υπομονή σας.</string>
     <string name="contact_footer_msg">Το μήνυμά σας θα αποσταλεί μέσω email. Οι πληροφορίες συσκευής και ρύθμισης επισυνάπτονται αυτόματα.</string>
     <string name="contact_no_email_app_msg">Δεν βρέθηκε εφαρμογή email σε αυτή τη συσκευή.</string>
-    <string name="contact_attachment_missing_msg">Το αρχείο debug δεν υπάρχει πλέον</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Αποθηκευμένα αρχεία debug</string>
     <string name="settings_support_stored_logs_desc">%1$d συνεδρίες (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Δεν υπάρχουν αποθηκευμένα αρχεία debug</string>
-    <string name="settings_support_stored_logs_delete_title">Διαγραφή αποθηκευμένων αρχείων;</string>
-    <string name="settings_support_stored_logs_delete_msg">Αυτό θα διαγράψει όλες τις %1$d αποθηκευμένες συνεδρίες αρχείων debug.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Τα αποθηκευμένα αρχεία debug διαγράφηκαν</string>
-    <string name="label_bug_reports">Αναφορές σφαλμάτων</string>
-    <string name="description_bug_reports">Αυτόματη αναφορά σφαλμάτων και απρόσμενων κλεισιμάτων εφαρμογής.</string>
     <string name="label_add_device">Προσθήκη συσκευής</string>
-    <string name="label_just_a_moment_please">Μια στιγμή, παρακαλώ.</string>
     <string name="label_notification_channel_status">Κατάσταση</string>
     <string name="label_notification_channel_setup">Απαιτείται ρύθμιση</string>
     <string name="monitor_notification_starting">Εκκίνηση…</string>
     <string name="action_set">Ορισμός</string>
     <string name="action_cancel">Ακύρωση</string>
-    <string name="label_invalid_input">Μή έκγυρη εισαγωγή</string>
     <string name="action_reset">Επαναφορά</string>
     <string name="label_no_connected_devices">Δεν υπάρχουν συνδεδεμένες συσκευές</string>
-    <string name="label_status_idle">Σε αδράνεια</string>
-    <string name="label_status_adjusting_volumes">Ρύθμιση εντάσεων</string>
-    <string name="label_premium_version">Premium έκδοση</string>
     <string name="general_upgrade_action">Αναβάθμιση</string>
     <string name="common_upgrade_required_label">Απαιτείται αναβάθμιση</string>
-    <string name="label_premium_version_required">Απαιτείται η Premium έκδοση</string>
-    <string name="description_intro_purpose">Αυτή η εφαρμογή επιτρέπει στην συσκευή Android σας να θυμάται την ένταση όλων των διαφορετικών συσκευών Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Απεριόριστα προφίλ συσκευών</string>
-    <string name="upgrade_benefit_connection_actions">Αυτόματη αναπαραγωγή, εκκίνηση εφαρμογής και ειδοποιήσεις σύνδεσης</string>
-    <string name="upgrade_benefit_theme_customization">Προσαρμογή θέματος, στυλ και χρώματος</string>
-    <string name="upgrade_benefit_power_controls">Κλείδωμα έντασης και περιορισμός ρυθμού</string>
-    <string name="upgrade_benefit_support">Υποστήριξη ανεξάρτητης ανάπτυξης</string>
     <string name="upgrade_benefit_equalizer">• Εξισωτής ανά συσκευή (για εφαρμογές μουσικής με υποστήριξη εξισωτή συστήματος)</string>
-    <string name="description_intro_tap_the_button">Ξεκινήστε προσθέτοντας την πρώτη συσκευή σας.</string>
     <string name="description_bluetooth_is_disabled">Το Bluetooth είναι απενεργοποιημένο.</string>
     <string name="title_bluetooth_is_off">Το Bluetooth είναι απενεργοποιημένο</string>
     <string name="action_enable_bluetooth">Ενεργοποίηση Bluetooth</string>
     <string name="title_bluetooth_permission_required">Απαιτείται Άδεια Bluetooth</string>
     <string name="description_bluetooth_permission_required">Αυτή η εφαρμογή χρειάζεται άδεια Bluetooth για να διαχειρίζεται τις εντάσεις των συσκευών σας.</string>
     <string name="action_grant_permission">Χορήγηση Άδειας</string>
-    <string name="label_status_listening_for_changes">Ακρόαση για μεταβολές του ήχου</string>
     <string name="action_exit">Έξοδος</string>
-    <string name="action_start">Έναρξη</string>
-    <string name="label_welcome">Καλώς ήρθατε</string>
-    <string name="description_intro_contact">Μην διστάσετε να επικοινωνήσετε μαζί μου, αν έχετε απορίες ή ακόμα και μια ιδέα για ένα νέο χαρακτηριστικό γνώρισμα.</string>
-    <string name="label_translation">Μετάφραση</string>
-    <string name="description_help_translate">Βοηθήστε με να γίνει αυτή η εφαρμογή διαθέσιμη και σε άλλες γλώσσες.</string>
     <string name="label_device_speaker">Ηχείο συσκευής</string>
-    <string name="label_keyevent_playpause">Αναπαραγωγή-Παύση</string>
-    <string name="label_keyevent_play">Αναπαραγωγή</string>
-    <string name="label_keyevent_next">Επόμενο</string>
-    <string name="label_install_id">Εγκατεστημένο ID</string>
     <string name="message_copied_to_clipboard">Αντιγράφηκε στο πρόχειρο</string>
-    <string name="label_thanks">Ευχαριστώ</string>
-    <string name="label_licenses">Άδειες Xρήσης</string>
-    <string name="description_ring_volume_additional_permission">Πρόσθετα δικαιώματα είναι αναγκαία για να αλλάξετε την ένταση του ήχου κλήσης.</string>
-    <string name="label_missing_permissions">Ελλειπή δικαιώματα</string>
-    <string name="action_grant">Χορήγηση</string>
-    <string name="label_advanced">Προχωρημένα</string>
-    <string name="label_exclude_health">Παράκαμψη προφίλ υγείας</string>
-    <string name="description_exclude_health">Ορισμένες συσκευές Android κολλάνε όταν ψάχνουν για τα προφίλ Bluetooth «Συσκευή Υγείας» (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Παράκαμψη προφίλ GATT server</string>
-    <string name="label_exclude_gatt">Παράκαμψη προφίλ GATT</string>
-    <string name="description_exclude_gattserver">Μην τρέξετε ερώτημα για προφίλ Bluetooth τύπου \'Generic Attribute\' (GATT) server.</string>
-    <string name="description_exclude_gatt">Μην τρέξετε ερώτημα για προφίλ Bluetooth τύπου \'Generic Attribute\' (GATT) client.</string>
-    <string name="description_waiting_for_devicex">Αναμονή του %s για να ολοκληρωθεί η σύνδεση</string>
-    <string name="action_undo">Αναίρεση</string>
-    <string name="action_show">Εμφάνιση</string>
     <string name="action_dismiss">Παράβλεψη</string>
-    <string name="action_fix">Επιδιόρθωση</string>
-    <string name="battery_optimizations_issue_description">Οι βελτιστοποήσεις μπαταρίας είναι ενεργοποιημένες για αυτήν την εφαρμογή και ενδέχεται να αποτρέψουν την λήψη δεδομένων Bluetooth.
-Παρακαλώ απενεργοποιήστε τις βελτιστοποιήσεις αυτές, εάν αντιμετωπίζετε προβλήματα.</string>
     <string name="label_bluetooth_settings">Ρυθμίσεις Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Το Android 10 περιορίζει το πως οι εφαρμογές μπορούν να τρέχουν στο παρασκήνιο. Για να αφήσετε να ανοίγουν οι εφαρμογές όταν μια συσκευή Bluetooth συνδέεται, παραχωρήστε το δικαίωμα \"Εμφάνιση πάνω από τις εφαρμογές\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Πηγαίος κώδικας</string>
-    <string name="android13_notification_permission_description">Δώστε σε αυτή την εφαρμογή άδεια για αποστολή ειδοποιήσεων. Αυτό επιτρέπει την εμφάνιση ειδοποίησης όταν η εφαρμογή είναι ενεργή και γίνονται ρυθμίσεις έντασης.</string>
-    <string name="privacy_policy_label">Πολιτική απορρήτου</string>
     <string name="managed_devices_empty_message">Δεν έχουν ρυθμιστεί συσκευές Bluetooth.\nΠατήστε το κουμπί + για να προσθέσετε την πρώτη συσκευή σας.</string>
     <string name="label_pro_feature">Λειτουργία premium</string>
     <plurals name="discover_device_limit_banner">
@@ -426,21 +344,15 @@
     <string name="review_app_review_action">Αξιολόγηση</string>
     <string name="review_app_dismiss_action">Ίσως αργότερα</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Αγορά ακυρώθηκε</string>
-    <string name="error_iap_unavailable_message">Οι αγορές μέσα στην εφαρμογή δεν είναι διαθέσιμες</string>
-    <string name="error_generic_message">Προέκυψε σφάλμα. Παρακαλώ δοκιμάστε ξανά.</string>
-    <string name="error_iap_owned_message">Προμηθευτείτε ήδη αυτό το αντικείμενο</string>
     <string name="label_no_devices_title">Καμία Συσκευή</string>
     <string name="bluemusic_mascot_description">Εικονίδιο Εφαρμογής</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Επιλογή Εφαρμογών</string>
     <string name="devices_app_selection_search_hint">Αναζήτηση εφαρμογών…</string>
-    <string name="devices_app_selection_currently_selected">Τρέχον επιλεγμένο</string>
     <string name="devices_app_selection_selected_count">%d εφαρμογές επιλέχθηκαν</string>
     <string name="general_navigate_back_action">Πλοήγηση πίσω</string>
     <string name="general_reset_action">Επαναφορά</string>
     <string name="general_clear_action">Εκκαθάριση</string>
-    <string name="general_save_action">Αποθήκευση</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Κλείδωμα</string>
     <string name="devices_indicator_awake">Ενεργό</string>
@@ -450,7 +362,6 @@
     <string name="devices_indicator_limit">Όριο</string>
     <string name="devices_indicator_eq">Εξισωτής</string>
     <string name="devices_indicator_boost">Ενίσχυση</string>
-    <string name="devices_indicator_launch">Εκκίνηση</string>
     <string name="devices_indicator_home">Αρχική</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Ειδοποίηση</string>

--- a/app/src/main/res/values-eo-rUY/strings.xml
+++ b/app/src/main/res/values-eo-rUY/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Kelkaj funkcioj ŝanĝiĝis dum la ĝisdatigo. Bonvolu kontroli viajn aparatajn agordojn por certigi ke ĉio estas ĝjuste agordita.</string>
     <string name="onboarding_rewrite_action">Daŭrigi</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Neniuj neadministrataj aparatoj trovitaj</string>
     <string name="discover_all_devices_managed_msg">Ĉiuj viaj parigitaj aparatoj estas administrataj! Bezonas novan?</string>
     <string name="discover_pair_new_device_action">Pari novan aparaton</string>
     <string name="discover_device_speaker_desc">La propra son-aparato de ĉi tiu telefono. Ĝia sonlaŭto estas aplikata kiam la sono revenas al la telefono, ekz. post kiam via Bluetooth-aparato malkonektiĝas.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Aparata agordo</string>
-    <string name="devices_device_config_section_general_label">Ĝenerala</string>
     <string name="devices_device_config_remove_device_label">Forgesi aparaton</string>
-    <string name="devices_device_config_remove_device_desc">Forgesigos la aparaton el ĉi tiu apo kaj viŝos ĝian agordon. Ĉi tio ne malparigas la aparaton.</string>
     <string name="devices_device_config_remove_device_action">Forgesi</string>
     <string name="devices_device_config_remove_device_confirmation">Forgesi %s el administrataj aparatoj?</string>
-    <string name="devices_device_config_rename_device_label">Renomi aparaton</string>
-    <string name="devices_device_config_rename_device_desc">Renomi ĉi tiun aparaton ene de ĉi tiu apo, kaj se eble, ene de la sistemo.</string>
     <string name="devices_device_config_rename_device_action">Renomi</string>
     <string name="devices_device_config_enabled_label">Ebligita</string>
     <string name="devices_device_config_enabled_desc">Reagi al ĉi tiu aparato kiam konektita</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Aŭtomata ludado komandoj</string>
     <string name="devices_device_config_autoplay_keycodes_order">Komanda sinsekvo</string>
     <string name="devices_device_config_autoplay_keycodes_label">Komandoj</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Agordu kiujn komandojn sendi kaj en kiu ordo</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Neniuj komandoj agordita</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Aldoni komandon</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimume %1$d komandoj</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Movi supren</string>
     <string name="cd_autoplay_keycode_move_down">Movi malsupren</string>
     <string name="cd_autoplay_keycode_remove">Forigi</string>
-    <string name="devices_device_config_section_volumes_label">Volumenoj</string>
     <string name="devices_device_config_section_volume_label">Volumeno</string>
     <string name="devices_device_config_alarm_volume_label">Alarma volumeno</string>
     <string name="devices_device_config_alarm_volume_desc">Kelkaj alarmaj apoj uzas anstataŭe la muzikan volumenon.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Sonorilo</string>
     <string name="devices_audio_stream_notification_label">Sciiĝo</string>
     <string name="devices_audio_stream_alarm_label">Alarmo</string>
-    <string name="devices_neverseen_label">Neniam vidita</string>
-    <string name="devices_state_connected_label">Konektita</string>
     <string name="devices_last_connected_label">Laste konektita: %s</string>
     <string name="devices_currently_connected_label">Nuntempe konektita</string>
     <string name="devices_device_disabled_label">Aparato malŝaltita</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Agordoj kiuj influas ĉiujn administritajn aparatojn.</string>
     <string name="label_app_enabled">Apo ebligita</string>
     <string name="description_app_enabled">Ŝaltas la kapablon de la apo reagi al volumeno kaj Bluetooth-eventoj.</string>
-    <string name="label_visible_volume_adjustments">Videblaj ĝustigoj</string>
-    <string name="description_visible_volume_adjustments">Montri la volumenfenestron de la sistemo dum ĉi tiu apo faras ĝustigojn.</string>
     <string name="label_volume_listener">Observi ŝanĝojn</string>
-    <string name="description_volume_listener">Resti aktiva dum aparato estas konektita kaj konservi volumenŝanĝojn kiuj ne estis kaŭzitaj de ĉi tiu apo.</string>
     <string name="label_boot_restore">Restarigi ĉe ekfunkciigo</string>
     <string name="description_boot_restore">Restarigi volumenon post ekfunkciigo/reekfunkciigo se Bluetooth-aparato estas konektita.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Lernu kiel efike uzi BVM</string>
     <string name="settings_support_issue_tracker_description">Publika problempistilo por cimraportoj kaj funkciaj petoj.</string>
     <string name="settings_support_issue_tracker_label">Problempistilo</string>
-    <string name="settings_support_debuglog_label">Senarariga protokolo</string>
     <string name="settings_support_debuglog_desc">Registri ĉion kion la apo faras en tekstan dosieron kiun vi povas dividi.</string>
-    <string name="settings_support_debuglog_recording_desc">Nuntempe registrante senararigan informon. Tuŝu por halti registradon.</string>
-    <string name="settings_support_debuglog_path">Protokola vojo: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Tre mallonga registrado</string>
     <string name="settings_support_debuglog_short_recording_msg">Tio estis tre mallonga registrado. Senararigaj protokoloj estas registradoj, ne momentbildoj — reproduktu la problemon dum registrado estas aktiva por ke la protokolo estu utila.</string>
     <string name="settings_support_debuglog_short_recording_continue">Daŭrigi registradon</string>
     <string name="settings_support_debuglog_short_recording_stop">Halti tamen</string>
-    <string name="settings_support_debuglog_folder_label">Senarariga protokola dosierujo</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d seanco uzante %2$s</item>
-        <item quantity="other">%1$d seancoj uzantaj %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Neniuj senararigaj protokoloj konservitaj</string>
-    <string name="settings_support_debuglog_folder_delete_title">Forigi ĉiujn senararigajn protokolojn?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Ĉi tio permanente forigos ĉiujn konservitajn senararigajn protokolajn seancojn.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Loko por kolektiĝi kaj demandi.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Tradukado</string>
     <string name="settings_acks_translators_title">Tradukistoj</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Traduki BVM</string>
-    <string name="settings_acks_translate_desc">Helpu traduki BVM en vian lingvon</string>
     <string name="settings_acks_thanks_header">Dankon</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Por subteni tradukado de malfermitkodaj projektoj</string>
     <string name="settings_licenses_label">Licencoj</string>
     <string name="settings_translation_label">Tradukado</string>
     <string name="settings_translation_desc">Helpu traduki la apon en vian plej ŝatatan lingvon</string>
-    <string name="settings_sponsor_development_title">Sponsori disvolvadon</string>
-    <string name="settings_sponsor_development_summary">Fariĝu patrono kaj ebligu daŭran disvolvadon.</string>
     <string name="settings_privacy_policy_label">Privateca politiko</string>
     <string name="settings_privacy_policy_desc">Traktante datumojn respondece.</string>
     <string name="changelog_label">Ŝanĝoregistro</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restaŭro kompleta — %1$d aparatoj restaŭrita, %2$d preterpasita.</string>
     <string name="backup_restore_version_warning">Ĉi tiu sekurkopio estis kreita kun versio %1$s. Vi uzas %2$s. Kelkaj agordoj eble ne restaŭros ĝuste.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Senararigaj sciigoj</string>
     <string name="debug_log_consent_title">Senarariga protokolo</string>
     <string name="debug_log_consent_explanation">Ĉi tiu funkcio registras ĉion kion la apo faras en divideblan dosieron. La generita dosiero enhavas sentemajn informojn (ekz. dosieronomojn kaj instalitajn apojn). Dividu ĝin nur kun fidindaj partioj (ekz. programisto solvanta problemon).</string>
-    <string name="debug_log_recording_progress">Registrante senararigan protokolon</string>
     <string name="debug_log_record_action">Registri</string>
     <string name="debug_log_stop_action">Halti registradon</string>
     <string name="debug_log_screen_title">Senarariga Protokola Registristo</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Forĵeti</string>
     <string name="debug_log_screen_keep_action">Konservi</string>
-    <string name="debug_log_compressing_label">Kunpremante…</string>
     <string name="debug_log_file_label">Registrita protokola dosiero</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Protokolo sendita?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Priskribu vian demandon detale.</string>
     <string name="contact_category_section_label">Kategorio</string>
     <string name="contact_debug_log_label">Senarariga protokolo</string>
-    <string name="contact_debug_log_select_hint">Elekti senararigan protokolon por alfiksi</string>
     <string name="contact_debug_log_picker_hint">Alfiksi senararigan protokolon por helpi diagnozi la problemon pli rapide.</string>
     <string name="contact_debug_log_picker_empty">Neniuj senararigaj protokoloj disponeblaj. Unue registru unu.</string>
     <string name="contact_expected_behavior_label">Atendita konduto</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Mi mem legas ĉiun mesaĝon kaj klopodas respondi, sed ĉar mi laboras ĉi tie sola, tio povas preni iom da tempo. Dankon pro via pacienco.</string>
     <string name="contact_footer_msg">Via mesaĝo estos sendita per retpoŝto. Aparataj kaj agordaj informoj estas alfikstitaj aŭtomate.</string>
     <string name="contact_no_email_app_msg">Neniu retpoŝta apo trovita sur ĉi tiu aparato.</string>
-    <string name="contact_attachment_missing_msg">Senarariga protokola dosiero ne plu ekzistas</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Konservitaj senararigaj protokoloj</string>
     <string name="settings_support_stored_logs_desc">%1$d seancoj (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Neniuj konservitaj senararigaj protokoloj</string>
-    <string name="settings_support_stored_logs_delete_title">Forigi konservitajn protokolojn?</string>
-    <string name="settings_support_stored_logs_delete_msg">Ĉi tio forigos ĉiujn %1$d konservitajn senararigajn protokolajn seancojn.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Konservitaj senararigaj protokoloj forigitaj</string>
-    <string name="label_bug_reports">Cimraportoj</string>
-    <string name="description_bug_reports">Aŭtomata cim- kaj kraŝo-raportado.</string>
     <string name="label_add_device">Aldoni aparaton</string>
-    <string name="label_just_a_moment_please">Nur momenton, bonvolu.</string>
     <string name="label_notification_channel_status">Stato</string>
     <string name="label_notification_channel_setup">Agordado necesa</string>
     <string name="monitor_notification_starting">Komencas…</string>
     <string name="action_set">Agordi</string>
     <string name="action_cancel">Nuligi</string>
-    <string name="label_invalid_input">Nevalida enigo</string>
     <string name="action_reset">Restarigi</string>
     <string name="label_no_connected_devices">Neniuj aparatoj konektitaj</string>
-    <string name="label_status_idle">Senfara</string>
-    <string name="label_status_adjusting_volumes">ĝustigante volumenojn</string>
-    <string name="label_premium_version">Premiumversio</string>
     <string name="general_upgrade_action">Plibonigi</string>
     <string name="common_upgrade_required_label">Apgrejdo necesa</string>
-    <string name="label_premium_version_required">Premiumversio bezonata</string>
-    <string name="description_intro_purpose">Ĉi tiu apo permesas al via Android-aparato memorigi la volumenon de malsamaj Bluetooth-aparatoj.</string>
-    <string name="upgrade_benefit_unlimited_devices">Senlimaj aparataj profiloj</string>
-    <string name="upgrade_benefit_connection_actions">Aŭtoludado, lanĉo de aplikaĵo kaj konektaj sciigoj</string>
-    <string name="upgrade_benefit_theme_customization">Personagigo de temo, stilo kaj koloro</string>
-    <string name="upgrade_benefit_power_controls">Volumsloso kaj kvanta limigado</string>
-    <string name="upgrade_benefit_support">Subteni sendependan disvolvadon</string>
     <string name="upgrade_benefit_equalizer">• Aparatspecifa egalizilo (por muzikaj aplikoj kun sistema egalizilo-subteno)</string>
-    <string name="description_intro_tap_the_button">Komencu per aldono de via unua aparato.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth estas malŝaltita.</string>
     <string name="title_bluetooth_is_off">Bluetooth estas Malŝaltita</string>
     <string name="action_enable_bluetooth">Ebligi Bluetooth</string>
     <string name="title_bluetooth_permission_required">Bluetooth-permeso Bezonata</string>
     <string name="description_bluetooth_permission_required">Ĉi tiu apo bezonas Bluetooth-permeson por administri viajn aparatajn volumenojn.</string>
     <string name="action_grant_permission">Doni Permeson</string>
-    <string name="label_status_listening_for_changes">Aŭskultante por volumenŝanĝoj</string>
     <string name="action_exit">Eliri</string>
-    <string name="action_start">Komenci</string>
-    <string name="label_welcome">Bonvenon</string>
-    <string name="description_intro_contact">Ne hezitu kontakti min se vi havas demandojn aŭ eĉ ideon por nova funkcio.</string>
-    <string name="label_translation">Tradukado</string>
-    <string name="description_help_translate">Helpu min fari ĉi tiun apon disponebla en aliaj lingvoj.</string>
     <string name="label_device_speaker">Aparata laŭtparolilo</string>
-    <string name="label_keyevent_playpause">Ludi-Paŭzi</string>
-    <string name="label_keyevent_play">Ludi</string>
-    <string name="label_keyevent_next">Sekva</string>
-    <string name="label_install_id">Instala ID</string>
     <string name="message_copied_to_clipboard">Kopiita al tondujo</string>
-    <string name="label_thanks">Dankon</string>
-    <string name="label_licenses">Licencoj</string>
-    <string name="description_ring_volume_additional_permission">Pliaj permesoj estas necesaj por ŝanĝi la sonorilan volumenon.</string>
-    <string name="label_missing_permissions">Mankantaj permesoj</string>
-    <string name="action_grant">Doni</string>
-    <string name="label_advanced">Altnivela</string>
-    <string name="label_exclude_health">Ekskludi sano-profilojn</string>
-    <string name="description_exclude_health">Kelkaj Android-aparatoj blokas dum serĉado de Bluetooth-profiloj \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Ekskludi GATT-servilajn profilojn</string>
-    <string name="label_exclude_gatt">Ekskludi GATT-profilojn</string>
-    <string name="description_exclude_gattserver">Ne demandu Bluetooth-profilojn de tipo \'Generic Attribute\' (GATT)-servilo.</string>
-    <string name="description_exclude_gatt">Ne demandu Bluetooth-profilojn de tipo \'Generic Attribute\' (GATT)-kliento.</string>
-    <string name="description_waiting_for_devicex">Atendante ke %s kompletigu konekton</string>
-    <string name="action_undo">Malfari</string>
-    <string name="action_show">Montri</string>
     <string name="action_dismiss">Ignori</string>
-    <string name="action_fix">Ripari</string>
-    <string name="battery_optimizations_issue_description">Bateriooptimumigoj estas ebligitaj por ĉi tiu apo kaj povas malhelpi ĝin ricevi Bluetooth-eventojn. Konsideru malŝalti optimumigojn se vi havas problemojn.</string>
     <string name="label_bluetooth_settings">Bluetooth-agordoj</string>
-    <string name="android10_applaunch_issue_description">Android 10 limigas kiel apojn povas lanĉi el la fono. Por permesi malfermi apojn kiam Bluetooth-aparato konektas, donu la permeson \"Montri super aliaj apoj\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Fontkodo</string>
-    <string name="android13_notification_permission_description">Donu al ĉi tiu apo permeson por afisŝi sciigojn. Ĉi tio ebligas montri sciigon kiam ĉi tiu apo estas aktiva kaj volumenĝustigoj estas farataj.</string>
-    <string name="privacy_policy_label">Privateca politiko</string>
     <string name="managed_devices_empty_message">Neniuj Bluetooth-aparatoj agordita.\nTuŝu la +-butonon por aldoni vian unuan aparaton.</string>
     <string name="label_pro_feature">Premiumfunkcio</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Recenzo</string>
     <string name="review_app_dismiss_action">Eble poste</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Aĉeto nuligita</string>
-    <string name="error_iap_unavailable_message">Enaĉetoj ne disponeblaj</string>
-    <string name="error_generic_message">Eraro okazis. Bonvolu reprovi.</string>
-    <string name="error_iap_owned_message">Vi jam posedas ĉi tiun eron</string>
     <string name="label_no_devices_title">Neniuj Aparatoj</string>
     <string name="bluemusic_mascot_description">Apo-Ikono</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Elekti Apojn</string>
     <string name="devices_app_selection_search_hint">Serĉi apojn…</string>
-    <string name="devices_app_selection_currently_selected">Nuntempe elektita</string>
     <string name="devices_app_selection_selected_count">%d apoj elektitaj</string>
     <string name="general_navigate_back_action">Navigaci reen</string>
     <string name="general_reset_action">Restarigi</string>
     <string name="general_clear_action">Purigi</string>
-    <string name="general_save_action">Konservi</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Ŝlosi</string>
     <string name="devices_indicator_awake">Veka</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Limigi</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Pliigaĵo</string>
-    <string name="devices_indicator_launch">Lanĉi</string>
     <string name="devices_indicator_home">Hejmo</string>
     <string name="devices_indicator_dnd">NĜ</string>
     <string name="devices_indicator_alert">Averto</string>

--- a/app/src/main/res/values-es-rAR/strings.xml
+++ b/app/src/main/res/values-es-rAR/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Algunas funciones cambiaron durante la actualización. Por favor, revisá la configuración de tu dispositivo para asegurarte de que todo esté configurado correctamente.</string>
     <string name="onboarding_rewrite_action">Continuar</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">No se encontraron dispositivos sin gestionar</string>
     <string name="discover_all_devices_managed_msg">¡Todos tus dispositivos vinculados están gestionados! ¿Necesás uno nuevo?</string>
     <string name="discover_pair_new_device_action">Vincular nuevo dispositivo</string>
     <string name="discover_device_speaker_desc">El altavoz del teléfono. Sus volúmenes se aplican cuando el audio vuelve al teléfono, p. ej. después de que se desconecte tu dispositivo Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuración del dispositivo</string>
-    <string name="devices_device_config_section_general_label">General</string>
     <string name="devices_device_config_remove_device_label">Olvidar dispositivo</string>
-    <string name="devices_device_config_remove_device_desc">Olvida el dispositivo de esta app y elimina su configuración. Esto no desvincula el dispositivo.</string>
     <string name="devices_device_config_remove_device_action">Olvidar</string>
     <string name="devices_device_config_remove_device_confirmation">¿Olvidar %s de los dispositivos gestionados?</string>
-    <string name="devices_device_config_rename_device_label">Renombrar dispositivo</string>
-    <string name="devices_device_config_rename_device_desc">Renombra este dispositivo dentro de esta app y, si es posible, también en el sistema.</string>
     <string name="devices_device_config_rename_device_action">Renombrar</string>
     <string name="devices_device_config_enabled_label">Activado</string>
     <string name="devices_device_config_enabled_desc">Reaccionar a este dispositivo cuando se conecta</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Comandos de reproducción automática</string>
     <string name="devices_device_config_autoplay_keycodes_order">Secuencia de comandos</string>
     <string name="devices_device_config_autoplay_keycodes_label">Comandos</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configurá qué comandos enviar y en qué orden</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Sin comandos configurados</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Agregar comando</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Máximo %1$d comandos</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Subir</string>
     <string name="cd_autoplay_keycode_move_down">Bajar</string>
     <string name="cd_autoplay_keycode_remove">Quitar</string>
-    <string name="devices_device_config_section_volumes_label">Volúmenes</string>
     <string name="devices_device_config_section_volume_label">Volumen</string>
     <string name="devices_device_config_alarm_volume_label">Volumen de alarma</string>
     <string name="devices_device_config_alarm_volume_desc">Algunas apps de alarma usan el volumen de música en su lugar.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Tono</string>
     <string name="devices_audio_stream_notification_label">Notificación</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="devices_neverseen_label">Nunca visto</string>
-    <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Última conexión: %s</string>
     <string name="devices_currently_connected_label">Conectado actualmente</string>
     <string name="devices_device_disabled_label">Dispositivo desactivado</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Configuración que afecta a todos los dispositivos gestionados.</string>
     <string name="label_app_enabled">App activada</string>
     <string name="description_app_enabled">Activa o desactiva la capacidad de la app de reaccionar a eventos de volumen y Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Ajustes visibles</string>
-    <string name="description_visible_volume_adjustments">Muestra la ventana de volumen del sistema mientras esta app realiza ajustes.</string>
     <string name="label_volume_listener">Observar cambios</string>
-    <string name="description_volume_listener">Permanece activo mientras un dispositivo esté conectado y guarda los cambios de volumen que no hayan sido realizados por esta app.</string>
     <string name="label_boot_restore">Restaurar al iniciar</string>
     <string name="description_boot_restore">Restaura el volumen después de arrancar o reiniciar si hay un dispositivo Bluetooth conectado.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Aprendé a usar BVM de forma efectiva</string>
     <string name="settings_support_issue_tracker_description">Un rastreador de problemas público para reportes de errores y peticiones de características.</string>
     <string name="settings_support_issue_tracker_label">Rastreador de problemas</string>
-    <string name="settings_support_debuglog_label">Registro de depuración</string>
     <string name="settings_support_debuglog_desc">Registra todo lo que hace la aplicación en un archivo de texto que puedas compartir.</string>
-    <string name="settings_support_debuglog_recording_desc">Grabando información de depuración. Tapá para detener la grabación.</string>
-    <string name="settings_support_debuglog_path">Ruta del registro: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Grabación muy corta</string>
     <string name="settings_support_debuglog_short_recording_msg">Esa grabación fue muy corta. Los registros de depuración son grabaciones, no capturas — reproducí el problema mientras la grabación esté activa para que el registro sea útil.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continuar grabando</string>
     <string name="settings_support_debuglog_short_recording_stop">Detener de todas formas</string>
-    <string name="settings_support_debuglog_folder_label">Carpeta de registros de depuración</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sesión usando %2$s</item>
-        <item quantity="other">%1$d sesiones usando %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">No hay registros de depuración almacenados</string>
-    <string name="settings_support_debuglog_folder_delete_title">¿Eliminar todos los registros de depuración?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Esto eliminará permanentemente todas las sesiones de registro de depuración almacenadas.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Un lugar para pasar el rato y hacer preguntas.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Traducción</string>
     <string name="settings_acks_translators_title">Traductores</string>
     <string name="settings_acks_translators_people">Benjamín R.(benjaluth09@gmail.com)</string>
-    <string name="settings_acks_translate_title">Traducir BVM</string>
-    <string name="settings_acks_translate_desc">Ayudá a traducir BVM a tu idioma</string>
     <string name="settings_acks_thanks_header">Gracias</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Por apoyar la traducción de proyectos de código abierto</string>
     <string name="settings_licenses_label">Licencias</string>
     <string name="settings_translation_label">Traducción</string>
     <string name="settings_translation_desc">Ayudá a traducir la app a tu idioma favorito</string>
-    <string name="settings_sponsor_development_title">Sponsorear el desarrollo</string>
-    <string name="settings_sponsor_development_summary">Convertite en patrocinador y hacé posible el desarrollo continuo de la aplicación.</string>
     <string name="settings_privacy_policy_label">Política de privacidad</string>
     <string name="settings_privacy_policy_desc">Manejando datos de forma responsable.</string>
     <string name="changelog_label">Registro de cambios</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restauración completa — %1$d dispositivos restaurados, %2$d omitidos.</string>
     <string name="backup_restore_version_warning">Esta copia de seguridad fue creada con la versión %1$s. Estás usando %2$s. Es posible que algunos ajustes no se restauren correctamente.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notificaciones de depuración</string>
     <string name="debug_log_consent_title">Registro de depuración</string>
     <string name="debug_log_consent_explanation">Esta función registra todo lo que hace la aplicación en un archivo que se puede compartir. El archivo generado contiene información confidencial (por ejemplo, nombres de archivos y aplicaciones instaladas). Compártalo solo con terceros de confianza (por ejemplo, un desarrollador que soluciona un problema).</string>
-    <string name="debug_log_recording_progress">Grabando el registro de depuración</string>
     <string name="debug_log_record_action">Grabar</string>
     <string name="debug_log_stop_action">Detener la grabación</string>
     <string name="debug_log_screen_title">Grabador de registros de depuración</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Descartar</string>
     <string name="debug_log_screen_keep_action">Conservar</string>
-    <string name="debug_log_compressing_label">Comprimiendo…</string>
     <string name="debug_log_file_label">Archivo de registro grabado</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">¿Registro enviado?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Describí tu pregunta en detalle.</string>
     <string name="contact_category_section_label">Categoría</string>
     <string name="contact_debug_log_label">Registro de depuración</string>
-    <string name="contact_debug_log_select_hint">Seleccioná un registro de depuración para adjuntar</string>
     <string name="contact_debug_log_picker_hint">Adjuntá un registro de depuración para ayudar a diagnosticar el problema más rápido.</string>
     <string name="contact_debug_log_picker_empty">No hay registros de depuración disponibles. Grabá uno primero.</string>
     <string name="contact_expected_behavior_label">Comportamiento esperado</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Leo cada mensaje personalmente y hago todo lo posible por responder, pero como trabajo solo, puede llevar un poco de tiempo. Gracias por tu paciencia.</string>
     <string name="contact_footer_msg">Tu mensaje se enviará por email. La información del dispositivo y configuración se adjunta automáticamente.</string>
     <string name="contact_no_email_app_msg">No se encontró ninguna app de correo en este dispositivo.</string>
-    <string name="contact_attachment_missing_msg">El archivo de registro de depuración ya no existe</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Registros de depuración almacenados</string>
     <string name="settings_support_stored_logs_desc">%1$d sesiones (%2$s)</string>
     <string name="settings_support_stored_logs_empty">No hay registros de depuración almacenados</string>
-    <string name="settings_support_stored_logs_delete_title">¿Eliminar registros almacenados?</string>
-    <string name="settings_support_stored_logs_delete_msg">Esto eliminará todas las %1$d sesiones de registro de depuración almacenadas.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Registros de depuración almacenados eliminados</string>
-    <string name="label_bug_reports">Reportes de errores</string>
-    <string name="description_bug_reports">Reporte automático de errores y fallos.</string>
     <string name="label_add_device">Agregar dispositivo</string>
-    <string name="label_just_a_moment_please">Solo un momento, por favor.</string>
     <string name="label_notification_channel_status">Estado</string>
     <string name="label_notification_channel_setup">Configuración necesaria</string>
     <string name="monitor_notification_starting">Iniciando…</string>
     <string name="action_set">Establecer</string>
     <string name="action_cancel">Cancelar</string>
-    <string name="label_invalid_input">Entrada inválida</string>
     <string name="action_reset">Resetear</string>
     <string name="label_no_connected_devices">No hay dispositivos conectados</string>
-    <string name="label_status_idle">En espera</string>
-    <string name="label_status_adjusting_volumes">Ajustando volúmenes</string>
-    <string name="label_premium_version">Versión premium</string>
     <string name="general_upgrade_action">Mejorar</string>
     <string name="common_upgrade_required_label">Se requiere actualización</string>
-    <string name="label_premium_version_required">Se requiere la versión premium</string>
-    <string name="description_intro_purpose">Esta app permite a tu dispositivo Android recordar el volumen de diferentes dispositivos Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Perfiles de dispositivos ilimitados</string>
-    <string name="upgrade_benefit_connection_actions">Reproducción automática, apertura de apps y alertas de conexión</string>
-    <string name="upgrade_benefit_theme_customization">Personalización de tema, estilo y color</string>
-    <string name="upgrade_benefit_power_controls">Bloqueo de volumen y limitación de velocidad</string>
-    <string name="upgrade_benefit_support">Apoyá el desarrollo independiente</string>
     <string name="upgrade_benefit_equalizer">• Ecualizador por dispositivo (para apps de música compatibles con el ecualizador del sistema)</string>
-    <string name="description_intro_tap_the_button">Empezá agregando tu primer dispositivo.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth desactivado.</string>
     <string name="title_bluetooth_is_off">Bluetooth desactivado</string>
     <string name="action_enable_bluetooth">Activar Bluetooth</string>
     <string name="title_bluetooth_permission_required">Permiso de Bluetooth requerido</string>
     <string name="description_bluetooth_permission_required">Esta app necesita permiso de Bluetooth para gestionar los volúmenes de tu dispositivo.</string>
     <string name="action_grant_permission">Conceder permiso</string>
-    <string name="label_status_listening_for_changes">Escuchando cambios de volumen</string>
     <string name="action_exit">Salir</string>
-    <string name="action_start">Iniciar</string>
-    <string name="label_welcome">Bienvenido</string>
-    <string name="description_intro_contact">No dudés en contactarme si tenés preguntas o incluso una idea para una nueva función.</string>
-    <string name="label_translation">Traducción</string>
-    <string name="description_help_translate">Ayudáme a hacer que esta app esté disponible en otros idiomas.</string>
     <string name="label_device_speaker">Altavoz del dispositivo</string>
-    <string name="label_keyevent_playpause">Play-Pausa</string>
-    <string name="label_keyevent_play">Play</string>
-    <string name="label_keyevent_next">Siguiente</string>
-    <string name="label_install_id">Identificador de la instalación</string>
     <string name="message_copied_to_clipboard">Copiado al portapapeles</string>
-    <string name="label_thanks">Gracias</string>
-    <string name="label_licenses">Licencias</string>
-    <string name="description_ring_volume_additional_permission">Se necesitan permisos adicionales para cambiar el volumen del tono.</string>
-    <string name="label_missing_permissions">Permisos faltantes</string>
-    <string name="action_grant">Conceder</string>
-    <string name="label_advanced">Avanzado</string>
-    <string name="label_exclude_health">Excluir perfiles de salud</string>
-    <string name="description_exclude_health">Algunos dispositivos Android se bloquean al buscar perfiles Bluetooth de tipo \'Dispositivo de salud\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Excluir perfiles de servidor GATT</string>
-    <string name="label_exclude_gatt">Excluir perfiles GATT</string>
-    <string name="description_exclude_gattserver">No consultar perfiles Bluetooth de tipo servidor \'Atributo genérico\' (GATT).</string>
-    <string name="description_exclude_gatt">No consultar perfiles Bluetooth de tipo cliente \'Atributo genérico\' (GATT).</string>
-    <string name="description_waiting_for_devicex">Esperando que %s complete la conexión</string>
-    <string name="action_undo">Deshacer</string>
-    <string name="action_show">Mostrar</string>
     <string name="action_dismiss">Descartar</string>
-    <string name="action_fix">Reparar</string>
-    <string name="battery_optimizations_issue_description">Las optimizaciones de batería están activadas para esta app y pueden impedir que reciba eventos de Bluetooth. Considerá desactivar las optimizaciones si tenés problemas.</string>
     <string name="label_bluetooth_settings">Configuración de Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 restringe cómo las apps pueden lanzarse en segundo plano. Para permitir abrir apps cuando se conecta un dispositivo Bluetooth, concede el permiso \"Mostrar sobre otras apps\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Código fuente</string>
-    <string name="android13_notification_permission_description">Concede a esta app permiso para publicar notificaciones. Esto permite mostrar una notificación cuando la app está activa y se están realizando ajustes de volumen.</string>
-    <string name="privacy_policy_label">Política de privacidad</string>
     <string name="managed_devices_empty_message">No hay dispositivos Bluetooth configurados.\nTapá el botón + para agregar tu primer dispositivo.</string>
     <string name="label_pro_feature">Función premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Reseña</string>
     <string name="review_app_dismiss_action">Quizás más tarde</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Compra cancelada</string>
-    <string name="error_iap_unavailable_message">Las compras dentro de la app no están disponibles</string>
-    <string name="error_generic_message">Ocurrió un error. Por favor intentá de nuevo.</string>
-    <string name="error_iap_owned_message">Ya tenés este ítem</string>
     <string name="label_no_devices_title">Sin dispositivos</string>
     <string name="bluemusic_mascot_description">Ícono de app</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Seleccionar apps</string>
     <string name="devices_app_selection_search_hint">Buscar apps…</string>
-    <string name="devices_app_selection_currently_selected">Seleccionadas actualmente</string>
     <string name="devices_app_selection_selected_count">%d apps seleccionadas</string>
     <string name="general_navigate_back_action">Navegar atrás</string>
     <string name="general_reset_action">Resetear</string>
     <string name="general_clear_action">Limpiar</string>
-    <string name="general_save_action">Guardar</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Bloquear</string>
     <string name="devices_indicator_awake">Activo</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Límite</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Refuerzo</string>
-    <string name="devices_indicator_launch">Lanzar</string>
     <string name="devices_indicator_home">Inicio</string>
     <string name="devices_indicator_dnd">NM</string>
     <string name="devices_indicator_alert">Alerta</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Algunas funciones cambiaron durante la actualización. Por favor revisa la configuración de tu dispositivo para asegurarte de que todo esté configurado correctamente.</string>
     <string name="onboarding_rewrite_action">Continuar</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">No se encontraron dispositivos no gestionados</string>
     <string name="discover_all_devices_managed_msg">¡Todos tus dispositivos emparejados están gestionados! ¿Necesitas uno nuevo?</string>
     <string name="discover_pair_new_device_action">Emparejar nuevo dispositivo</string>
     <string name="discover_device_speaker_desc">El altavoz propio del teléfono. Sus volúmenes se aplican cuando el audio vuelve al teléfono, por ejemplo, después de que se desconecte tu dispositivo Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuración del dispositivo</string>
-    <string name="devices_device_config_section_general_label">General</string>
     <string name="devices_device_config_remove_device_label">Olvidar dispositivo</string>
-    <string name="devices_device_config_remove_device_desc">Elimina el dispositivo de esta app y borra su configuración. Esto no desempareja el dispositivo.</string>
     <string name="devices_device_config_remove_device_action">Olvidar</string>
     <string name="devices_device_config_remove_device_confirmation">¿Olvidar %s de los dispositivos gestionados?</string>
-    <string name="devices_device_config_rename_device_label">Renombrar dispositivo</string>
-    <string name="devices_device_config_rename_device_desc">Renombra este dispositivo dentro de esta app y, si es posible, también en el sistema.</string>
     <string name="devices_device_config_rename_device_action">Renombrar</string>
     <string name="devices_device_config_enabled_label">Habilitada</string>
     <string name="devices_device_config_enabled_desc">Reaccionar a este dispositivo al conectarse</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Comandos de reproducción automática</string>
     <string name="devices_device_config_autoplay_keycodes_order">Secuencia de comandos</string>
     <string name="devices_device_config_autoplay_keycodes_label">Comandos</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configura qué comandos enviar y en qué orden</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Sin comandos configurados</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Agregar comando</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Máximo %1$d comandos</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Subir</string>
     <string name="cd_autoplay_keycode_move_down">Bajar</string>
     <string name="cd_autoplay_keycode_remove">Quitar</string>
-    <string name="devices_device_config_section_volumes_label">Volúmenes</string>
     <string name="devices_device_config_section_volume_label">Volumen</string>
     <string name="devices_device_config_alarm_volume_label">Volumen de alarma</string>
     <string name="devices_device_config_alarm_volume_desc">Algunas apps de alarma usan el volumen de música en su lugar.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Tono</string>
     <string name="devices_audio_stream_notification_label">Notificación</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="devices_neverseen_label">Nunca visto</string>
-    <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Última conexión: %s</string>
     <string name="devices_currently_connected_label">Actualmente conectado</string>
     <string name="devices_device_disabled_label">Dispositivo deshabilitado</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Configuración que afecta a todos los dispositivos gestionados.</string>
     <string name="label_app_enabled">App habilitada</string>
     <string name="description_app_enabled">Activa o desactiva la capacidad de la app para reaccionar a eventos de volumen y Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Ajustes visibles</string>
-    <string name="description_visible_volume_adjustments">Mostrar la ventana de volumen del sistema mientras esta app realiza ajustes.</string>
     <string name="label_volume_listener">Observar cambios</string>
-    <string name="description_volume_listener">Permanecer activo mientras haya un dispositivo conectado y guardar los cambios de volumen que no hayan sido causados por esta app.</string>
     <string name="label_boot_restore">Restaurar al iniciar</string>
     <string name="description_boot_restore">Restaurar el volumen después de iniciar o reiniciar si hay un dispositivo Bluetooth conectado.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Aprende a usar BVM de manera efectiva</string>
     <string name="settings_support_issue_tracker_description">Un rastreador de los problemas para informar de los errores y las solicitudes de nuevas funciones.</string>
     <string name="settings_support_issue_tracker_label">Rastreador de problemas</string>
-    <string name="settings_support_debuglog_label">Registro de depuración</string>
     <string name="settings_support_debuglog_desc">Registra todo lo que hace la aplicación en un archivo de texto que puede compartir.</string>
-    <string name="settings_support_debuglog_recording_desc">Grabando información de depuración. Toca para detener la grabación.</string>
-    <string name="settings_support_debuglog_path">Ruta del registro: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Grabación muy corta</string>
     <string name="settings_support_debuglog_short_recording_msg">Esa fue una grabación muy corta. Los registros de depuración son grabaciones, no instantáneas. Reproduce el problema mientras la grabación esté activa para que el registro sea útil.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continuar grabando</string>
     <string name="settings_support_debuglog_short_recording_stop">Detener de todos modos</string>
-    <string name="settings_support_debuglog_folder_label">Carpeta de registros de depuración</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sesión usando %2$s</item>
-        <item quantity="other">%1$d sesiones usando %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">No hay registros de depuración almacenados</string>
-    <string name="settings_support_debuglog_folder_delete_title">¿Eliminar todos los registros de depuración?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Esto eliminará permanentemente todas las sesiones de registro de depuración almacenadas.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Un lugar donde pasar el rato y preguntar.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Traducción</string>
     <string name="settings_acks_translators_title">Traductores</string>
     <string name="settings_acks_translators_people">Persona1;Persona2(correo@opcional.com)</string>
-    <string name="settings_acks_translate_title">Traducir BVM</string>
-    <string name="settings_acks_translate_desc">Ayuda a traducir BVM a tu idioma</string>
     <string name="settings_acks_thanks_header">Agradecimientos</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Por apoyar la traducción de proyectos de código abierto</string>
     <string name="settings_licenses_label">Licencias</string>
     <string name="settings_translation_label">Traducción</string>
     <string name="settings_translation_desc">Ayuda a traducir la app a tu idioma favorito</string>
-    <string name="settings_sponsor_development_title">Patrocinar el desarrollo</string>
-    <string name="settings_sponsor_development_summary">Conviértete en patrocinador y haz posible el desarrollo constante de la aplicación.</string>
     <string name="settings_privacy_policy_label">Política de privacidad</string>
     <string name="settings_privacy_policy_desc">Tratamiento responsable de datos.</string>
     <string name="changelog_label">Historial de cambios</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restauración completa — %1$d dispositivos restaurados, %2$d omitidos.</string>
     <string name="backup_restore_version_warning">Este respaldo fue creado con la versión %1$s. Estás usando %2$s. Puede que algunos ajustes no se restauren correctamente.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notificaciones de depuración</string>
     <string name="debug_log_consent_title">Registro de depuración</string>
     <string name="debug_log_consent_explanation">Esta función registra todo lo que hace la aplicación en un archivo compartible. El archivo generado contiene información sensible (p. ej., nombres de archivos y aplicaciones instaladas). Solo compártelo con partes de confianza (p. ej., un desarrollador resolviendo un problema).</string>
-    <string name="debug_log_recording_progress">Grabando registro de depuración</string>
     <string name="debug_log_record_action">Grabar</string>
     <string name="debug_log_stop_action">Detener grabación</string>
     <string name="debug_log_screen_title">Grabador de registros de depuración</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Desechar</string>
     <string name="debug_log_screen_keep_action">Conservar</string>
-    <string name="debug_log_compressing_label">Comprimiendo…</string>
     <string name="debug_log_file_label">Archivo de registro grabado</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">¿Registro enviado?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Describe tu pregunta en detalle.</string>
     <string name="contact_category_section_label">Categoría</string>
     <string name="contact_debug_log_label">Registro de depuración</string>
-    <string name="contact_debug_log_select_hint">Selecciona un registro de depuración para adjuntar</string>
     <string name="contact_debug_log_picker_hint">Adjunta un registro de depuración para ayudar a diagnosticar el problema más rápido.</string>
     <string name="contact_debug_log_picker_empty">No hay registros de depuración disponibles. Primero graba uno.</string>
     <string name="contact_expected_behavior_label">Comportamiento esperado</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Leo cada mensaje personalmente y hago lo posible por responder, pero como trabajo en esto solo, puede tomar un poco de tiempo. Gracias por tu paciencia.</string>
     <string name="contact_footer_msg">Tu mensaje se enviará por correo electrónico. La información del dispositivo y configuración se adjunta automáticamente.</string>
     <string name="contact_no_email_app_msg">No se encontró una app de correo en este dispositivo.</string>
-    <string name="contact_attachment_missing_msg">El archivo de registro de depuración ya no existe</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Registros de depuración almacenados</string>
     <string name="settings_support_stored_logs_desc">%1$d sesiones (%2$s)</string>
     <string name="settings_support_stored_logs_empty">No hay registros de depuración almacenados</string>
-    <string name="settings_support_stored_logs_delete_title">¿Eliminar registros almacenados?</string>
-    <string name="settings_support_stored_logs_delete_msg">Esto eliminará las %1$d sesiones de registro de depuración almacenadas.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Registros de depuración almacenados eliminados</string>
-    <string name="label_bug_reports">Informes de errores</string>
-    <string name="description_bug_reports">Informe automático de errores y fallos.</string>
     <string name="label_add_device">Agregar dispositivo</string>
-    <string name="label_just_a_moment_please">Un momento, por favor.</string>
     <string name="label_notification_channel_status">Estado</string>
     <string name="label_notification_channel_setup">Se requiere configuración</string>
     <string name="monitor_notification_starting">Iniciando…</string>
     <string name="action_set">Establecer</string>
     <string name="action_cancel">Cancelar</string>
-    <string name="label_invalid_input">Entrada inválida</string>
     <string name="action_reset">Restablecer</string>
     <string name="label_no_connected_devices">No hay dispositivos conectados</string>
-    <string name="label_status_idle">Inactivo</string>
-    <string name="label_status_adjusting_volumes">Ajustando volúmenes</string>
-    <string name="label_premium_version">Versión premium</string>
     <string name="general_upgrade_action">Actualizar</string>
     <string name="common_upgrade_required_label">Actualización requerida</string>
-    <string name="label_premium_version_required">Se requiere versión premium</string>
-    <string name="description_intro_purpose">Esta app permite que tu dispositivo Android recuerde el volumen de diferentes dispositivos Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Perfiles de dispositivo ilimitados</string>
-    <string name="upgrade_benefit_connection_actions">Reproducción automática, inicio de app y alertas de conexión</string>
-    <string name="upgrade_benefit_theme_customization">Personalización de tema, estilo y color</string>
-    <string name="upgrade_benefit_power_controls">Bloqueo de volumen y limitación de velocidad</string>
-    <string name="upgrade_benefit_support">Apoya el desarrollo independiente</string>
     <string name="upgrade_benefit_equalizer">• Ecualizador por dispositivo (para apps de música compatibles con el ecualizador del sistema)</string>
-    <string name="description_intro_tap_the_button">Empieza agregando tu primer dispositivo.</string>
     <string name="description_bluetooth_is_disabled">El Bluetooth está desactivado.</string>
     <string name="title_bluetooth_is_off">El Bluetooth está desactivado</string>
     <string name="action_enable_bluetooth">Activar Bluetooth</string>
     <string name="title_bluetooth_permission_required">Se requiere permiso de Bluetooth</string>
     <string name="description_bluetooth_permission_required">Esta app necesita permiso de Bluetooth para gestionar los volúmenes de tu dispositivo.</string>
     <string name="action_grant_permission">Otorgar permiso</string>
-    <string name="label_status_listening_for_changes">Escuchando cambios de volumen</string>
     <string name="action_exit">Salir</string>
-    <string name="action_start">Iniciar</string>
-    <string name="label_welcome">Bienvenido</string>
-    <string name="description_intro_contact">No dudes en contactarme si tienes preguntas o incluso una idea para una nueva función.</string>
-    <string name="label_translation">Traducción</string>
-    <string name="description_help_translate">Ayúdame a hacer esta app disponible en otros idiomas.</string>
     <string name="label_device_speaker">Altavoz del dispositivo</string>
-    <string name="label_keyevent_playpause">Reproducir-Pausar</string>
-    <string name="label_keyevent_play">Reproducir</string>
-    <string name="label_keyevent_next">Siguiente</string>
-    <string name="label_install_id">Identificador de la instalación</string>
     <string name="message_copied_to_clipboard">Copiado al portapapeles</string>
-    <string name="label_thanks">Agradecimientos</string>
-    <string name="label_licenses">Licencias</string>
-    <string name="description_ring_volume_additional_permission">Se necesitan permisos adicionales para cambiar el volumen del tono de llamada.</string>
-    <string name="label_missing_permissions">Permisos faltantes</string>
-    <string name="action_grant">Otorgar</string>
-    <string name="label_advanced">Avanzado</string>
-    <string name="label_exclude_health">Excluir perfiles de salud</string>
-    <string name="description_exclude_health">Algunos dispositivos Android se cuelgan al buscar perfiles Bluetooth de \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Excluir perfiles de servidor GATT</string>
-    <string name="label_exclude_gatt">Excluir perfiles GATT</string>
-    <string name="description_exclude_gattserver">No consultar perfiles Bluetooth de tipo servidor \'Generic Attribute\' (GATT).</string>
-    <string name="description_exclude_gatt">No consultar perfiles Bluetooth de tipo cliente \'Generic Attribute\' (GATT).</string>
-    <string name="description_waiting_for_devicex">Esperando que %s complete la conexión</string>
-    <string name="action_undo">Deshacer</string>
-    <string name="action_show">Mostrar</string>
     <string name="action_dismiss">Descartar</string>
-    <string name="action_fix">Arreglar</string>
-    <string name="battery_optimizations_issue_description">Las optimizaciones de batería están activas para esta app y pueden impedir que reciba eventos Bluetooth. Considera desactivar las optimizaciones si tienes problemas.</string>
     <string name="label_bluetooth_settings">Configuración de Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 restringe cómo las apps pueden abrirse desde el fondo. Para permitir abrir apps cuando se conecta un dispositivo Bluetooth, otorga el permiso \"Mostrar sobre otras apps\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Código fuente</string>
-    <string name="android13_notification_permission_description">Otorga a esta app permiso para publicar notificaciones. Esto permite mostrar una notificación cuando esta app está activa y se están haciendo ajustes de volumen.</string>
-    <string name="privacy_policy_label">Política de privacidad</string>
     <string name="managed_devices_empty_message">No hay dispositivos Bluetooth configurados.\nToca el botón + para agregar tu primer dispositivo.</string>
     <string name="label_pro_feature">Función premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Reseñar</string>
     <string name="review_app_dismiss_action">Quizás más tarde</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Compra cancelada</string>
-    <string name="error_iap_unavailable_message">Las compras dentro de la app no están disponibles</string>
-    <string name="error_generic_message">Ocurrió un error. Por favor, inténtalo de nuevo.</string>
-    <string name="error_iap_owned_message">Ya tienes este artículo</string>
     <string name="label_no_devices_title">Sin dispositivos</string>
     <string name="bluemusic_mascot_description">Ícono de la app</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Seleccionar apps</string>
     <string name="devices_app_selection_search_hint">Buscar apps…</string>
-    <string name="devices_app_selection_currently_selected">Actualmente seleccionado</string>
     <string name="devices_app_selection_selected_count">%d apps seleccionadas</string>
     <string name="general_navigate_back_action">Navegar atrás</string>
     <string name="general_reset_action">Restablecer</string>
     <string name="general_clear_action">Limpiar</string>
-    <string name="general_save_action">Guardar</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Bloquear</string>
     <string name="devices_indicator_awake">Activo</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Límite</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Aumento</string>
-    <string name="devices_indicator_launch">Iniciar</string>
     <string name="devices_indicator_home">Inicio</string>
     <string name="devices_indicator_dnd">No molestar</string>
     <string name="devices_indicator_alert">Alerta</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Algunas funciones han cambiado durante la actualización. Por favor, revisa la configuración de tus dispositivos para asegurarte de que todo esté configurado correctamente.</string>
     <string name="onboarding_rewrite_action">Continuar</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">No se encontraron dispositivos no administrados</string>
     <string name="discover_all_devices_managed_msg">¡Todos tus dispositivos emparejados están administrados! ¿Necesitas uno nuevo?</string>
     <string name="discover_pair_new_device_action">Emparejar nuevo dispositivo</string>
     <string name="discover_device_speaker_desc">El altavoz del teléfono. Sus volúmenes se aplican cuando el audio vuelve al teléfono, por ejemplo, después de que tu dispositivo Bluetooth se desconecte.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuración del dispositivo</string>
-    <string name="devices_device_config_section_general_label">General</string>
     <string name="devices_device_config_remove_device_label">Olvidar dispositivo</string>
-    <string name="devices_device_config_remove_device_desc">Olvida el dispositivo de esta aplicación y elimina su configuración. Esto no desvincula el dispositivo.</string>
     <string name="devices_device_config_remove_device_action">Olvidar</string>
     <string name="devices_device_config_remove_device_confirmation">¿Olvidar %s de los dispositivos administrados?</string>
-    <string name="devices_device_config_rename_device_label">Cambiar nombre del dispositivo</string>
-    <string name="devices_device_config_rename_device_desc">Cambiar el nombre de este dispositivo dentro de esta aplicación y, si es posible, dentro del sistema.</string>
     <string name="devices_device_config_rename_device_action">Cambiar nombre</string>
     <string name="devices_device_config_enabled_label">Habilitado</string>
     <string name="devices_device_config_enabled_desc">Reaccionar a este dispositivo cuando se conecte</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Comandos de reproducción automática</string>
     <string name="devices_device_config_autoplay_keycodes_order">Secuencia de comandos</string>
     <string name="devices_device_config_autoplay_keycodes_label">Comandos</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configura qué comandos enviar y en qué orden</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Sin comandos configurados</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Añadir comando</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Máximo %1$d comandos</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Subir</string>
     <string name="cd_autoplay_keycode_move_down">Bajar</string>
     <string name="cd_autoplay_keycode_remove">Eliminar</string>
-    <string name="devices_device_config_section_volumes_label">Volúmenes</string>
     <string name="devices_device_config_section_volume_label">Volumen</string>
     <string name="devices_device_config_alarm_volume_label">Volumen de la alarma</string>
     <string name="devices_device_config_alarm_volume_desc">Algunas aplicaciones de alarma usan el volumen de la música en su lugar.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Timbre</string>
     <string name="devices_audio_stream_notification_label">Notificación</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="devices_neverseen_label">Nunca se ha visto</string>
-    <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Última conexión: %s</string>
     <string name="devices_currently_connected_label">Actualmente conectado</string>
     <string name="devices_device_disabled_label">Dispositivo deshabilitado</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Configuraciones que afectan a todos los dispositivos administrados.</string>
     <string name="label_app_enabled">Aplicación habilitada</string>
     <string name="description_app_enabled">Activa la capacidad de la aplicación para reaccionar a eventos con el volumen y el Bluetooth..</string>
-    <string name="label_visible_volume_adjustments">Ajustes visibles</string>
-    <string name="description_visible_volume_adjustments">Muestra la ventana de volumen del sistema mientras esta aplicación realiza los ajustes.</string>
     <string name="label_volume_listener">Observar los cambios</string>
-    <string name="description_volume_listener">Mantente activo mientras tu dispositivo está conectado y guarda los cambios de volumen no realizadas por la aplicación.</string>
     <string name="label_boot_restore">Restaurar al arrancar</string>
     <string name="description_boot_restore">Restaurar el volumen después de iniciar/reiniciar, si un dispositivo Bluetooth está conectado.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Aprende a usar BVM de manera efectiva</string>
     <string name="settings_support_issue_tracker_description">Un rastreador público de problemas para informes de errores y solicitudes de funciones.</string>
     <string name="settings_support_issue_tracker_label">Rastreador de problemas</string>
-    <string name="settings_support_debuglog_label">Registro de depuración</string>
     <string name="settings_support_debuglog_desc">Graba todo lo que la aplicación está haciendo en un archivo de texto que puedes compartir.</string>
-    <string name="settings_support_debuglog_recording_desc">Actualmente grabando información de depuración. Toca para detener la grabación.</string>
-    <string name="settings_support_debuglog_path">Ruta del registro: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Grabación muy corta</string>
     <string name="settings_support_debuglog_short_recording_msg">Esa fue una grabación muy corta. Los registros de depuración son grabaciones, no instantáneas — reproduce el problema mientras la grabación está activa para que el registro sea útil.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continuar grabando</string>
     <string name="settings_support_debuglog_short_recording_stop">Detener de todos modos</string>
-    <string name="settings_support_debuglog_folder_label">Carpeta de registros de depuración</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sesión usando %2$s</item>
-        <item quantity="other">%1$d sesiones usando %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">No hay registros de depuración almacenados</string>
-    <string name="settings_support_debuglog_folder_delete_title">¿Eliminar todos los registros de depuración?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Esto eliminará permanentemente todas las sesiones de registro de depuración almacenadas.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Un lugar para pasar el rato y hacer preguntas.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Traducción</string>
     <string name="settings_acks_translators_title">Traductores</string>
     <string name="settings_acks_translators_people">Diego F.(diegobautista100@gmail.com)</string>
-    <string name="settings_acks_translate_title">Traducir BVM</string>
-    <string name="settings_acks_translate_desc">Ayuda a traducir BVM a tu idioma</string>
     <string name="settings_acks_thanks_header">Gracias</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Por apoyar la traducción de proyectos de código abierto</string>
     <string name="settings_licenses_label">Licencias</string>
     <string name="settings_translation_label">Traducción</string>
     <string name="settings_translation_desc">Ayuda a traducir la aplicación a tu idioma favorito</string>
-    <string name="settings_sponsor_development_title">Patrocinar el desarrollo</string>
-    <string name="settings_sponsor_development_summary">Conviértete en un patrocinador y haz posible el desarrollo continuo.</string>
     <string name="settings_privacy_policy_label">Política de privacidad</string>
     <string name="settings_privacy_policy_desc">Manejo responsable de los datos.</string>
     <string name="changelog_label">Registro de cambios</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restauración completa — %1$d dispositivos restaurados, %2$d omitidos.</string>
     <string name="backup_restore_version_warning">Esta copia de seguridad se creó con la versión %1$s. Estás usando %2$s. Algunos ajustes pueden no restaurarse correctamente.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notificaciones de depuración</string>
     <string name="debug_log_consent_title">Registro de depuración</string>
     <string name="debug_log_consent_explanation">Esta función graba todo lo que la aplicación está haciendo en un archivo compartible. El archivo generado contiene información sensible (p. ej., nombres de archivos y aplicaciones instaladas). Solo compártelo con partes de confianza (p. ej., un desarrollador solucionando un problema).</string>
-    <string name="debug_log_recording_progress">Grabando registro de depuración</string>
     <string name="debug_log_record_action">Grabar</string>
     <string name="debug_log_stop_action">Detener grabación</string>
     <string name="debug_log_screen_title">Grabador de registro de depuración</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Descartar</string>
     <string name="debug_log_screen_keep_action">Conservar</string>
-    <string name="debug_log_compressing_label">Comprimiendo…</string>
     <string name="debug_log_file_label">Archivo de registro grabado</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">¿Registro enviado?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Describe tu pregunta en detalle.</string>
     <string name="contact_category_section_label">Categoría</string>
     <string name="contact_debug_log_label">Registro de depuración</string>
-    <string name="contact_debug_log_select_hint">Selecciona un registro de depuración para adjuntar</string>
     <string name="contact_debug_log_picker_hint">Adjunta un registro de depuración para ayudar a diagnosticar el problema más rápido.</string>
     <string name="contact_debug_log_picker_empty">No hay registros de depuración disponibles. Graba uno primero.</string>
     <string name="contact_expected_behavior_label">Comportamiento esperado</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Leo cada mensaje personalmente y hago todo lo posible por responder, pero como trabajo solo, puede tomar un poco de tiempo. Gracias por tu paciencia.</string>
     <string name="contact_footer_msg">Tu mensaje se enviará por correo electrónico. La información del dispositivo y la configuración se adjunta automáticamente.</string>
     <string name="contact_no_email_app_msg">No se encontró ninguna aplicación de correo en este dispositivo.</string>
-    <string name="contact_attachment_missing_msg">El archivo de registro de depuración ya no existe</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Registros de depuración almacenados</string>
     <string name="settings_support_stored_logs_desc">%1$d sesiones (%2$s)</string>
     <string name="settings_support_stored_logs_empty">No hay registros de depuración almacenados</string>
-    <string name="settings_support_stored_logs_delete_title">¿Eliminar registros almacenados?</string>
-    <string name="settings_support_stored_logs_delete_msg">Esto eliminará todas las %1$d sesiones de registro de depuración almacenadas.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Registros de depuración almacenados eliminados</string>
-    <string name="label_bug_reports">Informes de errores</string>
-    <string name="description_bug_reports">Informes automáticos de errores y bloqueos.</string>
     <string name="label_add_device">Agregar un dispositivo</string>
-    <string name="label_just_a_moment_please">Un momento, por favor.</string>
     <string name="label_notification_channel_status">Estado</string>
     <string name="label_notification_channel_setup">Configuración necesaria</string>
     <string name="monitor_notification_starting">Iniciando…</string>
     <string name="action_set">Establecer</string>
     <string name="action_cancel">Cancelar</string>
-    <string name="label_invalid_input">Entrada no válida</string>
     <string name="action_reset">Restablecer</string>
     <string name="label_no_connected_devices">Ningún dispositivo conectado</string>
-    <string name="label_status_idle">Inactivo</string>
-    <string name="label_status_adjusting_volumes">Ajustes del volúmen</string>
-    <string name="label_premium_version">Versión Premium</string>
     <string name="general_upgrade_action">Actualizar</string>
     <string name="common_upgrade_required_label">Se requiere actualización</string>
-    <string name="label_premium_version_required">Versión Premium requerida</string>
-    <string name="description_intro_purpose">Esta aplicación permite que tu dispositivo Android recuerde el volumen de los diferentes dispositivos Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Perfiles de dispositivos ilimitados</string>
-    <string name="upgrade_benefit_connection_actions">Reproducción automática, inicio de apps y alertas de conexión</string>
-    <string name="upgrade_benefit_theme_customization">Personalización de tema, estilo y color</string>
-    <string name="upgrade_benefit_power_controls">Bloqueo de volumen y limitación de velocidad</string>
-    <string name="upgrade_benefit_support">Apoya el desarrollo independiente</string>
     <string name="upgrade_benefit_equalizer">• Ecualizador por dispositivo (para apps de música compatibles con el ecualizador del sistema)</string>
-    <string name="description_intro_tap_the_button">Comienza agregando tu primer dispositivo.</string>
     <string name="description_bluetooth_is_disabled">El Bluetooth está deshabilitado.</string>
     <string name="title_bluetooth_is_off">Bluetooth está apagado</string>
     <string name="action_enable_bluetooth">Habilitar Bluetooth</string>
     <string name="title_bluetooth_permission_required">Permiso de Bluetooth requerido</string>
     <string name="description_bluetooth_permission_required">Esta aplicación necesita permiso de Bluetooth para administrar los volúmenes de tu dispositivo.</string>
     <string name="action_grant_permission">Otorgar permiso</string>
-    <string name="label_status_listening_for_changes">Escuchar los cambios del volumen</string>
     <string name="action_exit">Salir</string>
-    <string name="action_start">Iniciar</string>
-    <string name="label_welcome">Bienvenido</string>
-    <string name="description_intro_contact">No dudes en ponerte en contacto conmigo si tienes preguntas o incluso una idea para una nueva característica.</string>
-    <string name="label_translation">Traducción</string>
-    <string name="description_help_translate">Ayúdame a hacer que esta aplicación esté disponible en otros idiomas.</string>
     <string name="label_device_speaker">Altavoz del dispositivo</string>
-    <string name="label_keyevent_playpause">Reproducir-Pausar</string>
-    <string name="label_keyevent_play">Reproducir</string>
-    <string name="label_keyevent_next">Siguiente</string>
-    <string name="label_install_id">ID de la instalación</string>
     <string name="message_copied_to_clipboard">Copiado al portapapeles</string>
-    <string name="label_thanks">Gracias</string>
-    <string name="label_licenses">Licencias</string>
-    <string name="description_ring_volume_additional_permission">Se necesitan permisos adicionales para cambiar el volumen del timbre.</string>
-    <string name="label_missing_permissions">Faltan permisos</string>
-    <string name="action_grant">Conceder</string>
-    <string name="label_advanced">Avanzado</string>
-    <string name="label_exclude_health">Excluir los perfiles de salud</string>
-    <string name="description_exclude_health">Algunos dispositivos Android se bloquean al buscar perfiles de Bluetooth \'Dispositivo de salud\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Excluir perfiles del servidor GATT</string>
-    <string name="label_exclude_gatt">Excluir los perfiles GATT</string>
-    <string name="description_exclude_gattserver">No consultes los perfiles del Bluetooth del servidor del tipo \'Atributo genérico\' (GATT).</string>
-    <string name="description_exclude_gatt">No consultes los perfiles del Bluetooth del cliente de tipo \'Atributo genérico\' (GATT).</string>
-    <string name="description_waiting_for_devicex">Esperando a que %s complete la conexión</string>
-    <string name="action_undo">Deshacer</string>
-    <string name="action_show">Mostrar</string>
     <string name="action_dismiss">Descartar</string>
-    <string name="action_fix">Reparar</string>
-    <string name="battery_optimizations_issue_description">Las optimizaciones de batería están habilitadas para esta aplicación y pueden evitar que reciba eventos de Bluetooth. Considera deshabilitar las optimizaciones si tiene problemas.</string>
     <string name="label_bluetooth_settings">Configuración del Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 restringe cómo se pueden iniciar las aplicaciones desde el fondo. Para permitir la apertura de aplicaciones cuando se conecta un dispositivo Bluetooth, otorgue el permiso &quot;Mostrar sobre otras aplicaciones&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Código fuente</string>
-    <string name="android13_notification_permission_description">Otorga el permiso a esta aplicación para publicar notificaciones. Esto permite mostrar una notificación cuando esta aplicación está activa y se están realizando los ajustes del volumen.</string>
-    <string name="privacy_policy_label">Política de privacidad</string>
     <string name="managed_devices_empty_message">No hay dispositivos Bluetooth configurados.\nToca el botón + para agregar tu primer dispositivo.</string>
     <string name="label_pro_feature">Función premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Revisar</string>
     <string name="review_app_dismiss_action">Quizás más tarde</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Compra cancelada</string>
-    <string name="error_iap_unavailable_message">Las compras dentro de la aplicación no están disponibles</string>
-    <string name="error_generic_message">Ocurrió un error. Por favor intenta de nuevo.</string>
-    <string name="error_iap_owned_message">Ya posees este artículo</string>
     <string name="label_no_devices_title">Sin dispositivos</string>
     <string name="bluemusic_mascot_description">Icono de la aplicación</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Seleccionar aplicaciones</string>
     <string name="devices_app_selection_search_hint">Buscar aplicaciones…</string>
-    <string name="devices_app_selection_currently_selected">Actualmente seleccionada</string>
     <string name="devices_app_selection_selected_count">%d aplicaciones seleccionadas</string>
     <string name="general_navigate_back_action">Navegar hacia atrás</string>
     <string name="general_reset_action">Restablecer</string>
     <string name="general_clear_action">Limpiar</string>
-    <string name="general_save_action">Guardar</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Bloqueo</string>
     <string name="devices_indicator_awake">Activo</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Límite</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Refuerzo</string>
-    <string name="devices_indicator_launch">Iniciar</string>
     <string name="devices_indicator_home">Inicio</string>
     <string name="devices_indicator_dnd">No molestar</string>
     <string name="devices_indicator_alert">Alerta</string>

--- a/app/src/main/res/values-et-rEE/strings.xml
+++ b/app/src/main/res/values-et-rEE/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Mõned seadme seaded võivad selle värskenduse käigus olla lähtestatud. Palun kontrolli oma seadmete konfiguratsioone.</string>
     <string name="onboarding_rewrite_action">Jätka</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Haldamata seadmeid ei leitud</string>
     <string name="discover_all_devices_managed_msg">Kõik sinu seotud seadmed on hallatud! Vajad uut?</string>
     <string name="discover_pair_new_device_action">Seo uus seade</string>
     <string name="discover_device_speaker_desc">Telefoni enda kõlar. Selle helitugevused rakendatakse, kui heli lülitub tagasi telefoni, nt pärast Bluetooth-seadme lahtiühendamist.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Seadme seaded</string>
-    <string name="devices_device_config_section_general_label">Üldine</string>
     <string name="devices_device_config_remove_device_label">Unusta seade</string>
-    <string name="devices_device_config_remove_device_desc">Unustab seadme sellest rakendusest ja kustutab selle seaded. See ei tühista seadme sidumist.</string>
     <string name="devices_device_config_remove_device_action">Unusta</string>
     <string name="devices_device_config_remove_device_confirmation">Unustada %s hallatud seadmetest?</string>
-    <string name="devices_device_config_rename_device_label">Nimeta seade ümber</string>
-    <string name="devices_device_config_rename_device_desc">Nimeta seade selles rakenduses ümber, ja võimalusel ka süsteemis.</string>
     <string name="devices_device_config_rename_device_action">Nimeta ümber</string>
     <string name="devices_device_config_enabled_label">Lubatud</string>
     <string name="devices_device_config_enabled_desc">Reageeri sellele seadmele ühendamisel</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Automaatesitus käsud</string>
     <string name="devices_device_config_autoplay_keycodes_order">Käskude järjekord</string>
     <string name="devices_device_config_autoplay_keycodes_label">Käsud</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Seadista, milliseid käske saata ja mis järjekorras</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Käske pole seadistatud</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Lisa käsk</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimaalselt %1$d käsku</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Liiguta üles</string>
     <string name="cd_autoplay_keycode_move_down">Liiguta alla</string>
     <string name="cd_autoplay_keycode_remove">Eemalda</string>
-    <string name="devices_device_config_section_volumes_label">Helid</string>
     <string name="devices_device_config_section_volume_label">Helitugevus</string>
     <string name="devices_device_config_alarm_volume_label">Häire helitugevus</string>
     <string name="devices_device_config_alarm_volume_desc">Osa häirerakendustest kasutavad hoopis muusika heli.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Helin</string>
     <string name="devices_audio_stream_notification_label">Teavitus</string>
     <string name="devices_audio_stream_alarm_label">Häire</string>
-    <string name="devices_neverseen_label">Esmakordne</string>
-    <string name="devices_state_connected_label">Ühendatud</string>
     <string name="devices_last_connected_label">Viimati ühendatud: %s</string>
     <string name="devices_currently_connected_label">Praegu ühendatud</string>
     <string name="devices_device_disabled_label">Seade keelatud</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Seaded, mis mõjutavad kõiki hallatud seadmeid.</string>
     <string name="label_app_enabled">Rakendus lubatud</string>
     <string name="description_app_enabled">Lubab rakendustel reageerida heli ja sinihambaga seotud sündmustele.</string>
-    <string name="label_visible_volume_adjustments">Muudatuste nägemine</string>
-    <string name="description_visible_volume_adjustments">Kuva süsteemi heli aken hetkel, mil rakendus teeb muudatusi.</string>
     <string name="label_volume_listener">Jälgi muudatusi</string>
-    <string name="description_volume_listener">Olge tähelepanelik, kui seadet ühendatakse ja salvestatakse heli muudatusi, mis ei pärine praegusest rakendusest.</string>
     <string name="label_boot_restore">Taasta käivitumisel</string>
     <string name="description_boot_restore">Taasta heli pärast käivitumist/taaskäivitumist, kui sinihammast toetavad seadet ühendatakse.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Õpi BVM-i tõhusalt kasutama</string>
     <string name="settings_support_issue_tracker_description">Avalik probleemijälgija veateadete ja funktsioonipäringute jaoks.</string>
     <string name="settings_support_issue_tracker_label">Probleemijälgija</string>
-    <string name="settings_support_debuglog_label">Silumislogi</string>
     <string name="settings_support_debuglog_desc">Salvesta kõik, mida rakendus teeb, tekstifaili, mida saad jagada.</string>
-    <string name="settings_support_debuglog_recording_desc">Salvestatakse silumisteavet. Puuduta salvestamise peatamiseks.</string>
-    <string name="settings_support_debuglog_path">Logi asukoht: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Väga lühike salvestus</string>
     <string name="settings_support_debuglog_short_recording_msg">See oli väga lühike salvestus. Silumislogid on salvestused, mitte hetktõmmised — reprodutseeri probleem salvestamise ajal, et logi oleks kasulik.</string>
     <string name="settings_support_debuglog_short_recording_continue">Jätka salvestamist</string>
     <string name="settings_support_debuglog_short_recording_stop">Peata ikkagi</string>
-    <string name="settings_support_debuglog_folder_label">Silumislogi kaust</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d seanss, kasutab %2$s</item>
-        <item quantity="other">%1$d seanssi, kasutab %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Silumisloge pole salvestatud</string>
-    <string name="settings_support_debuglog_folder_delete_title">Kustuta kõik silumislogid?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">See kustutab jäädavalt kõik salvestatud silumislogi seansid.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Koht, kus saad vestelda ja küsimusi esitada.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Tõlge</string>
     <string name="settings_acks_translators_title">Tõlkijad</string>
     <string name="settings_acks_translators_people">Olav Mägi(olav.magi@gmail.com)</string>
-    <string name="settings_acks_translate_title">Tõlgi BVM-i</string>
-    <string name="settings_acks_translate_desc">Aita tõlkida BVM-i oma keelde</string>
     <string name="settings_acks_thanks_header">Tänud</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Avatud lähtekoodiga projektide tõlkimise toetamise eest</string>
     <string name="settings_licenses_label">Litsentsid</string>
     <string name="settings_translation_label">Tõlge</string>
     <string name="settings_translation_desc">Aita rakendust oma lemmikkeelde tõlkida</string>
-    <string name="settings_sponsor_development_title">Toeta arendust</string>
-    <string name="settings_sponsor_development_summary">Saa patrooniks ja tee jätkuv arendus võimalikuks.</string>
     <string name="settings_privacy_policy_label">Privaatsuspoliitika</string>
     <string name="settings_privacy_policy_desc">Andmete vastutustundlik käitlemine.</string>
     <string name="changelog_label">Muudatuste logi</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Taastamine lõpetatud — %1$d seadet taastatud, %2$d vahele jäetud.</string>
     <string name="backup_restore_version_warning">See varukoopia loodi versiooniga %1$s. Sul on käimas %2$s. Mõned sätted ei pruugi õigesti taastuda.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Silumisteavitused</string>
     <string name="debug_log_consent_title">Silumislogi</string>
     <string name="debug_log_consent_explanation">See funktsioon salvestab kõik, mida rakendus teeb, jagatavasse faili. Loodud fail sisaldab tundlikku teavet (nt failinimed ja installitud rakendused). Jaga seda ainult usaldusväärsetele isikutele (nt arendajale probleemi lahendamisel).</string>
-    <string name="debug_log_recording_progress">Silumislogi salvestamine</string>
     <string name="debug_log_record_action">Salvesta</string>
     <string name="debug_log_stop_action">Peata salvestamine</string>
     <string name="debug_log_screen_title">Silumislogi salvestaja</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Hülga</string>
     <string name="debug_log_screen_keep_action">Hoia alles</string>
-    <string name="debug_log_compressing_label">Tihendamine…</string>
     <string name="debug_log_file_label">Salvestatud logifail</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Logi saadetud?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Kirjelda oma küsimust üksikasjalikult.</string>
     <string name="contact_category_section_label">Kategooria</string>
     <string name="contact_debug_log_label">Silumislogi</string>
-    <string name="contact_debug_log_select_hint">Vali manustamiseks silumislogi</string>
     <string name="contact_debug_log_picker_hint">Lisa silumislogi, et aidata probleemi kiiremini diagnoosida.</string>
     <string name="contact_debug_log_picker_empty">Silumisloge pole saadaval. Salvesta esmalt üks.</string>
     <string name="contact_expected_behavior_label">Oodatav käitumine</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Loen iga sõnumi ise läbi ja teen kõik, et vastata, kuid kuna töötan üksi, võib see veidi aega võtta. Tänan kannatlikkuse eest.</string>
     <string name="contact_footer_msg">Sinu sõnum saadetakse e-kirjaga. Seadme ja seadistuse teave lisatakse automaatselt.</string>
     <string name="contact_no_email_app_msg">Sellel seadmel ei leitud meilirakendust.</string>
-    <string name="contact_attachment_missing_msg">Silumislogi fail pole enam olemas</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Salvestatud silumislogid</string>
     <string name="settings_support_stored_logs_desc">%1$d seanssi (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Salvestatud silumisloge pole</string>
-    <string name="settings_support_stored_logs_delete_title">Kustuta salvestatud logid?</string>
-    <string name="settings_support_stored_logs_delete_msg">See kustutab kõik %1$d salvestatud silumislogi seanssi.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Salvestatud silumislogid kustutatud</string>
-    <string name="label_bug_reports">Veateatised</string>
-    <string name="description_bug_reports">Veast ja kokkujooksmisest automaatselt teatamine.</string>
     <string name="label_add_device">Lisa seade</string>
-    <string name="label_just_a_moment_please">Palun oodake üks hetk.</string>
     <string name="label_notification_channel_status">Olek</string>
     <string name="label_notification_channel_setup">Seadistamine vajalik</string>
     <string name="monitor_notification_starting">Käivitamine…</string>
     <string name="action_set">Määra</string>
     <string name="action_cancel">Tühista</string>
-    <string name="label_invalid_input">Vigane sisend</string>
     <string name="action_reset">Lähtesta</string>
     <string name="label_no_connected_devices">Ühtegi seadet pole ühendatud</string>
-    <string name="label_status_idle">Ootel</string>
-    <string name="label_status_adjusting_volumes">Helide reguleerimine</string>
-    <string name="label_premium_version">Tasuline versioon</string>
     <string name="general_upgrade_action">Täienda</string>
     <string name="common_upgrade_required_label">Uuendamine nõutav</string>
-    <string name="label_premium_version_required">Vaja on tasulist versiooni</string>
-    <string name="description_intro_purpose">See rakendus võimaldab teie Androidi seadmel meelde jätta erinevaid sinihammast toetavate seadmete heli.</string>
-    <string name="upgrade_benefit_unlimited_devices">Piiramatu arv seadmeprofiile</string>
-    <string name="upgrade_benefit_connection_actions">Automaatesitus, rakenduse käivitus ja ühendusmärguanded</string>
-    <string name="upgrade_benefit_theme_customization">Teema, stiili ja värvi kohandamine</string>
-    <string name="upgrade_benefit_power_controls">Helitugevuse lukk ja piiramise määr</string>
-    <string name="upgrade_benefit_support">Toeta iseseisvat arendust</string>
     <string name="upgrade_benefit_equalizer">• Seadmepõhine ekvalaiser (muusikarakendustele, mis toetavad süsteemi ekvalaiserit)</string>
-    <string name="description_intro_tap_the_button">Alustage lisades üks seade.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth on välja lülitatud.</string>
     <string name="title_bluetooth_is_off">Bluetooth on väljas</string>
     <string name="action_enable_bluetooth">Lülita Bluetooth sisse</string>
     <string name="title_bluetooth_permission_required">Bluetoothi luba on vajalik</string>
     <string name="description_bluetooth_permission_required">See rakendus vajab Bluetoothi luba, et hallata seadme helitugevust.</string>
     <string name="action_grant_permission">Anna luba</string>
-    <string name="label_status_listening_for_changes">Heli muudatuste ootel</string>
     <string name="action_exit">Välju</string>
-    <string name="action_start">Alusta</string>
-    <string name="label_welcome">Tere tulemast</string>
-    <string name="description_intro_contact">Küsimuste korral ja uute võimaluste soovitamiseks võtke kindlasti minuga ühendust.</string>
-    <string name="label_translation">Tõlge</string>
-    <string name="description_help_translate">Aita mul seda rakendust kasutada muus keeles.</string>
     <string name="label_device_speaker">Seadme kõlar</string>
-    <string name="label_keyevent_playpause">Esita-peata</string>
-    <string name="label_keyevent_play">Esita</string>
-    <string name="label_keyevent_next">Järgmine</string>
-    <string name="label_install_id">Paigaldamise ID</string>
     <string name="message_copied_to_clipboard">Kopeeritud lõikelauale</string>
-    <string name="label_thanks">Tänan</string>
-    <string name="label_licenses">Litsentsid</string>
-    <string name="description_ring_volume_additional_permission">Helina heli muutmine nõuab lisalubasid.</string>
-    <string name="label_missing_permissions">Puuduvad load</string>
-    <string name="action_grant">Luba</string>
-    <string name="label_advanced">Lisavalikud</string>
-    <string name="label_exclude_health">Eira tervise profiile</string>
-    <string name="description_exclude_health">Osa Android seadmetest jooksevad kokku „Tervise seadme„ sinihamba profiilide otsimisel (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Eira GATT-serveri profiilid</string>
-    <string name="label_exclude_gatt">Eira GATT-profiilid</string>
-    <string name="description_exclude_gattserver">Ära otsi „Generic Attribute\" (GATT) serveri sinihamba profiile.</string>
-    <string name="description_exclude_gatt">Ära otsi „Generic Attribute\" (GATT) sinihamba profilee.</string>
-    <string name="description_waiting_for_devicex">Oodatakse, millal saabub ühendus seadmega %s</string>
-    <string name="action_undo">Tühista</string>
-    <string name="action_show">Näita</string>
     <string name="action_dismiss">Loobu</string>
-    <string name="action_fix">Paranda</string>
-    <string name="battery_optimizations_issue_description">Sellele rakendusele kehtib aku optimeerimine, mis võib sel rakendusel ennetada sinihamba sündmuste vastuvõtmist. Probleemide ilmnemisel kaalu optimeerimise keelamist.</string>
     <string name="label_bluetooth_settings">Bluetoothi ​​sätted</string>
-    <string name="android10_applaunch_issue_description">Android 10 piirab rakenduste taustal käivitamist. Rakenduste avamiseks sinihambaga seadme ühendamisel anna nõusolek „Näita teiste rakenduste peal\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Lähtekood</string>
-    <string name="android13_notification_permission_description">Anna sellele rakendusele luba teavituste saatmiseks. See võimaldab kuvada teavituse, kui rakendus on aktiivne ja helitugevust reguleeritakse.</string>
-    <string name="privacy_policy_label">Privaatsuspoliitika</string>
     <string name="managed_devices_empty_message">Ühtegi Bluetooth-seadet pole seadistatud.\nPuuduta nuppu +, et lisada oma esimene seade.</string>
     <string name="label_pro_feature">Tasuline funktsioon</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Arvustus</string>
     <string name="review_app_dismiss_action">Võib-olla hiljem</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Ost tühistatud</string>
-    <string name="error_iap_unavailable_message">Rakendusesisesed ostud pole saadaval</string>
-    <string name="error_generic_message">Tekkis viga. Proovi uuesti.</string>
-    <string name="error_iap_owned_message">See ese on sul juba olemas</string>
     <string name="label_no_devices_title">Seadmeid pole</string>
     <string name="bluemusic_mascot_description">Rakenduse ikoon</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Vali rakendused</string>
     <string name="devices_app_selection_search_hint">Otsi rakendusi…</string>
-    <string name="devices_app_selection_currently_selected">Hetkel valitud</string>
     <string name="devices_app_selection_selected_count">%d rakendust valitud</string>
     <string name="general_navigate_back_action">Navigeeri tagasi</string>
     <string name="general_reset_action">Lähtesta</string>
     <string name="general_clear_action">Tühjenda</string>
-    <string name="general_save_action">Salvesta</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Lukk</string>
     <string name="devices_indicator_awake">Ärkvel</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Piira</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Võimendus</string>
-    <string name="devices_indicator_launch">Käivita</string>
     <string name="devices_indicator_home">Avakuva</string>
     <string name="devices_indicator_dnd">MS</string>
     <string name="devices_indicator_alert">Teavitus</string>

--- a/app/src/main/res/values-eu-rES/strings.xml
+++ b/app/src/main/res/values-eu-rES/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Zenbait ezaugarri aldatu dira eguneratzean. Mesedez, egiaztatu zure gailuaren ezarpenak dena behar bezala konfiguratuta dagoela ziurtatzeko.</string>
     <string name="onboarding_rewrite_action">Jarraitu</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Ez da kudeatugabeko gailurik aurkitu</string>
     <string name="discover_all_devices_managed_msg">Zure emparejatutako gailu guztiak kudeatuta daude! Berri bat behar duzu?</string>
     <string name="discover_pair_new_device_action">Gailu berria emparejatu</string>
     <string name="discover_device_speaker_desc">Telefonoaren besteriko altabotzaile. Bere bolumenak aplikatzen dira entzungarria telefonora itzultzen denean, adibidez Bluetooth gailua deskonektatzen denean.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Gailuaren konfigurazioa</string>
-    <string name="devices_device_config_section_general_label">Orokorra</string>
     <string name="devices_device_config_remove_device_label">Ahaztu gailua</string>
-    <string name="devices_device_config_remove_device_desc">Aplikaziotik gailua ahaztea eta bere konfigurazioa ezabatzea. Honek ez du gailua desemanpareatu.</string>
     <string name="devices_device_config_remove_device_action">Ahaztu</string>
     <string name="devices_device_config_remove_device_confirmation">Ahaztu %s kudeatutako gailuetatik?</string>
-    <string name="devices_device_config_rename_device_label">Gailu izena aldatu</string>
-    <string name="devices_device_config_rename_device_desc">Gailu honen izena aldatu aplikazio honetan, eta ahal bada, sisteman ere bai.</string>
     <string name="devices_device_config_rename_device_action">Izena aldatu</string>
     <string name="devices_device_config_enabled_label">Gaituta</string>
     <string name="devices_device_config_enabled_desc">Gailu honi konektatzen denean erantzun</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Erreprodukzio automatikoko komandoak</string>
     <string name="devices_device_config_autoplay_keycodes_order">Komando sekuentzia</string>
     <string name="devices_device_config_autoplay_keycodes_label">Komandoak</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Konfiguratu zein komando bidali eta zein ordenatan</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Ez dago komandorik konfiguratuta</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Gehitu komandoa</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Gehienez %1$d komando</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Igo</string>
     <string name="cd_autoplay_keycode_move_down">Jaitsi</string>
     <string name="cd_autoplay_keycode_remove">Kendu</string>
-    <string name="devices_device_config_section_volumes_label">Bolumenak</string>
     <string name="devices_device_config_section_volume_label">Bolumena</string>
     <string name="devices_device_config_alarm_volume_label">Alarma bolumena</string>
     <string name="devices_device_config_alarm_volume_desc">Alarma aplikazio batzuek musika bolumena erabiltzen dute horren ordez.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Tonua</string>
     <string name="devices_audio_stream_notification_label">Jakinarazpena</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="devices_neverseen_label">Inoiz ikusi ez</string>
-    <string name="devices_state_connected_label">Konektatuta</string>
     <string name="devices_last_connected_label">Azken konexioa: %s</string>
     <string name="devices_currently_connected_label">Une honetan konektatuta</string>
     <string name="devices_device_disabled_label">Gailua desgaituta</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Kudeatutako gailu guztiei eragiten dieten ezarpenak.</string>
     <string name="label_app_enabled">Aplikazioa gaituta</string>
     <string name="description_app_enabled">Aldatzen du aplikazioaren gaitasuna bolumen eta Bluetooth gertaerei erantzuteko.</string>
-    <string name="label_visible_volume_adjustments">Doikuntza ikusgarriak</string>
-    <string name="description_visible_volume_adjustments">Erakutsi sistemaren bolumen leihoa aplikazio honek doikuntzak egiten dituen bitartean.</string>
     <string name="label_volume_listener">Aldaketak behatu</string>
-    <string name="description_volume_listener">Aktibo egon gailu bat konektatuta dagoen bitartean eta aplikazio honek eragin ez dituen bolumen aldaketak gorde.</string>
     <string name="label_boot_restore">Berrezarri abiatzean</string>
     <string name="description_boot_restore">Berrezarri bolumena abiarazi/berrabiarazi ondoren Bluetooth gailu bat konektatuta badago.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Ikasi BVM nola erabili modu eraginkorrean</string>
     <string name="settings_support_issue_tracker_description">Akats-txostenetarako eta ezaugarri-eskaeretarako arazo-jarraipen publikoa.</string>
     <string name="settings_support_issue_tracker_label">Arazo-jarraipena</string>
-    <string name="settings_support_debuglog_label">Arazketa-erregistroa</string>
     <string name="settings_support_debuglog_desc">Grabatu aplikazioak egiten duen guztia parteka dezakezun testu-fitxategi batean.</string>
-    <string name="settings_support_debuglog_recording_desc">Une honetan arazketa-informazioa grabatzen ari da. Sakatu grabaketa gelditzeko.</string>
-    <string name="settings_support_debuglog_path">Erregistro bidea: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Grabaketa oso laburra</string>
     <string name="settings_support_debuglog_short_recording_msg">Grabaketa oso laburra izan zen. Arazketa erregistroak grabaketak dira, ez argazkiak — erreproduzitu arazoa grabaketa aktibo dagoen bitartean erregistroa erabilgarria izateko.</string>
     <string name="settings_support_debuglog_short_recording_continue">Jarraitu grabatzen</string>
     <string name="settings_support_debuglog_short_recording_stop">Gelditu hala ere</string>
-    <string name="settings_support_debuglog_folder_label">Arazketa erregistro karpeta</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d saio %2$s erabiliz</item>
-        <item quantity="other">%1$d saio %2$s erabiliz</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Ez dago arazketa erregistrorik gordetuta</string>
-    <string name="settings_support_debuglog_folder_delete_title">Ezabatu arazketa erregistro guztiak?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Honek gordeta dauden arazketa erregistro saio guztiak betirako ezabatuko ditu.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Ibiltzeko eta galderak egiteko lekua.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Itzulpena</string>
     <string name="settings_acks_translators_title">Itzultzaileak</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Itzuli BVM</string>
-    <string name="settings_acks_translate_desc">Lagundu BVM zure hizkuntzara itzultzen</string>
     <string name="settings_acks_thanks_header">Esker</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Kode irekiko proiektuen itzulpena laguntzeagatik</string>
     <string name="settings_licenses_label">Lizentziak</string>
     <string name="settings_translation_label">Itzulpena</string>
     <string name="settings_translation_desc">Lagundu aplikazioa zure hizkuntza gogokoenera itzultzen</string>
-    <string name="settings_sponsor_development_title">Garapen babestailetu</string>
-    <string name="settings_sponsor_development_summary">Bihur zaitez babesle eta egin garapen jarraitua posible.</string>
     <string name="settings_privacy_policy_label">Pribatutasun-politika</string>
     <string name="settings_privacy_policy_desc">Datuak erantzunkidetasunez kudeatzea.</string>
     <string name="changelog_label">Aldaketa-erregistroa</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Leheneratzea osatuta — %1$d gailu leheneratuta, %2$d saltatuta.</string>
     <string name="backup_restore_version_warning">Babeskopia hau %1$s bertsioarekin sortu zen. %2$s exekutatzen ari zara. Baliteke ezarpen batzuk ez leheneratzea zuzen.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Arazketa-jakinarazpenak</string>
     <string name="debug_log_consent_title">Arazketa-erregistroa</string>
     <string name="debug_log_consent_explanation">Eginbide honek aplikazioak egiten dituen guztiak partekagarria den fitxategi batean grabatzen ditu. Sortutako fitxategiak informazio sentikorra dauka (adib. fitxategi-izenak eta instalatutako aplikazioak). Soilik pertsona fidagarriekin partekatu (adib. arazo bat konpontzen ari den garatzaile batekin).</string>
-    <string name="debug_log_recording_progress">Arazketa-erregistroa grabatzea</string>
     <string name="debug_log_record_action">Grabatu</string>
     <string name="debug_log_stop_action">Grabaketa geldiarazi</string>
     <string name="debug_log_screen_title">Arazketa erregistro grabagailua</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Baztertu</string>
     <string name="debug_log_screen_keep_action">Mantendu</string>
-    <string name="debug_log_compressing_label">Konprimatzen…</string>
     <string name="debug_log_file_label">Erregistratutako erregistro-fitxategia</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Erregistroa bidali da?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Deskribatu zure galdera xehetasunez.</string>
     <string name="contact_category_section_label">Kategoria</string>
     <string name="contact_debug_log_label">Arazketa-erregistroa</string>
-    <string name="contact_debug_log_select_hint">Hautatu eransteko arazketa erregistroa</string>
     <string name="contact_debug_log_picker_hint">Erantsi arazketa erregistroa arazoa azkarrago diagnostikatzen laguntzeko.</string>
     <string name="contact_debug_log_picker_empty">Ez dago arazketa erregistrorik erabilgarri. Grabatu bat lehenik.</string>
     <string name="contact_expected_behavior_label">Espero zen portaera</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Mezu bakoitza nik neuk irakurtzen dut eta erantzuten saiatzen naiz, baina bakarrik lan egiten dudanez, denbora pixka bat behar izaten da. Eskerrik asko zure pazientziagatik.</string>
     <string name="contact_footer_msg">Zure mezua mezu elektronikoaren bidez bidaliko da. Gailuen eta konfigurazio informazioa automatikoki eransten da.</string>
     <string name="contact_no_email_app_msg">Ez da mezu elektronikoa aplikaziorik aurkitu gailu honetan.</string>
-    <string name="contact_attachment_missing_msg">Arazketa erregistro fitxategia ez da jadanik existitzen</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Gordetako arazketa erregistroak</string>
     <string name="settings_support_stored_logs_desc">%1$d saio (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Ez dago gordetako arazketa erregistrorik</string>
-    <string name="settings_support_stored_logs_delete_title">Gordetako erregistroak ezabatu?</string>
-    <string name="settings_support_stored_logs_delete_msg">Honek gordetako %1$d arazketa erregistro saio guztiak ezabatuko ditu.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Gordetako arazketa erregistroak ezabatuta</string>
-    <string name="label_bug_reports">Errore txostenak</string>
-    <string name="description_bug_reports">Errore eta crash txosten automatikoa.</string>
     <string name="label_add_device">Gehitu gailua</string>
-    <string name="label_just_a_moment_please">Mesedez, itxoin une bat.</string>
     <string name="label_notification_channel_status">Egoera</string>
     <string name="label_notification_channel_setup">Ezarpena beharrezkoa</string>
     <string name="monitor_notification_starting">Hasieratzen…</string>
     <string name="action_set">Ezarri</string>
     <string name="action_cancel">Utzi</string>
-    <string name="label_invalid_input">Sarrera baliogabea</string>
     <string name="action_reset">Berrezarri</string>
     <string name="label_no_connected_devices">Ez dago gailurik konektatuta</string>
-    <string name="label_status_idle">Geldirik</string>
-    <string name="label_status_adjusting_volumes">Bolumenak doitzen</string>
-    <string name="label_premium_version">Premium bertsioa</string>
     <string name="general_upgrade_action">Eguneratu</string>
     <string name="common_upgrade_required_label">Berritzea beharrezkoa</string>
-    <string name="label_premium_version_required">Premium bertsioa beharrezkoa da</string>
-    <string name="description_intro_purpose">Aplikazio honek zure Android gailuari Bluetooth gailu desberdinen bolumena gogoratzeko aukera ematen dio.</string>
-    <string name="upgrade_benefit_unlimited_devices">Gailu profil mugagabeak</string>
-    <string name="upgrade_benefit_connection_actions">Autoerreproduzioa, aplikazioa abiaraztea eta konexio alertak</string>
-    <string name="upgrade_benefit_theme_customization">Gaia, estiloa eta koloreen pertsonalizazioa</string>
-    <string name="upgrade_benefit_power_controls">Bolumen blokeoa eta abiadura murriztea</string>
-    <string name="upgrade_benefit_support">Garapen independentea babestu</string>
     <string name="upgrade_benefit_equalizer">• Gailuaren ekualizatzailea (sistema-ekualizatzaileak onartzen dituzten musikaren aplikazioetarako)</string>
-    <string name="description_intro_tap_the_button">Hasi zure lehen gailua gehituz.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth desgaituta dago.</string>
     <string name="title_bluetooth_is_off">Bluetooth itzalita dago</string>
     <string name="action_enable_bluetooth">Gaitu Bluetooth</string>
     <string name="title_bluetooth_permission_required">Bluetooth baimena beharrezkoa da</string>
     <string name="description_bluetooth_permission_required">Aplikazio honek Bluetooth baimena behar du zure gailuen bolumenak kudeatzeko.</string>
     <string name="action_grant_permission">Eman baimena</string>
-    <string name="label_status_listening_for_changes">Bolumen aldaketak entzuten</string>
     <string name="action_exit">Irten</string>
-    <string name="action_start">Hasi</string>
-    <string name="label_welcome">Ongi etorri</string>
-    <string name="description_intro_contact">Ez hesitatu nirekin harremanetan jartzeko galderak badituzu edo ezaugarri berri baten ideia ere.</string>
-    <string name="label_translation">Itzulpena</string>
-    <string name="description_help_translate">Lagundu aplikazio hau beste hizkuntza batzuetan erabilgarri egiten.</string>
     <string name="label_device_speaker">Gailuaren bozgorailua</string>
-    <string name="label_keyevent_playpause">Erreproduzitu-Pausatu</string>
-    <string name="label_keyevent_play">Erreproduzitu</string>
-    <string name="label_keyevent_next">Hurrengoa</string>
-    <string name="label_install_id">Instalazio IDa</string>
     <string name="message_copied_to_clipboard">Arbelean kopiatu da</string>
-    <string name="label_thanks">Esker</string>
-    <string name="label_licenses">Lizentziak</string>
-    <string name="description_ring_volume_additional_permission">Baimen gehigarriak beharrezkoak dira tonu bolumena aldatzeko.</string>
-    <string name="label_missing_permissions">Baimenak falta dira</string>
-    <string name="action_grant">Eman</string>
-    <string name="label_advanced">Aurreratua</string>
-    <string name="label_exclude_health">Baztertu osasun profilak</string>
-    <string name="description_exclude_health">Android gailu batzuk blokeatzen dira \'Osasun Gailua\' Bluetooth profilak (HDP, 0x1400) bilatzen direnean.</string>
-    <string name="label_exclude_gattserver">Baztertu GATT zerbitzari profilak</string>
-    <string name="label_exclude_gatt">Baztertu GATT profilak</string>
-    <string name="description_exclude_gattserver">Ez kontsultatu \'Generic Attribute\' (GATT) zerbitzari motako Bluetooth profilak.</string>
-    <string name="description_exclude_gatt">Ez kontsultatu \'Generic Attribute\' (GATT) bezero motako Bluetooth profilak.</string>
-    <string name="description_waiting_for_devicex">Itxaroten %s konexioa osatu arte</string>
-    <string name="action_undo">Desegin</string>
-    <string name="action_show">Erakutsi</string>
     <string name="action_dismiss">Baztertu</string>
-    <string name="action_fix">Konpondu</string>
-    <string name="battery_optimizations_issue_description">Bateria optimizazioak gaituta daude aplikazio honetarako eta Bluetooth gertaerak jasotzea eragotzi dezakete. Kontuan hartu optimizazioak desgaitzea arazoak izanez gero.</string>
     <string name="label_bluetooth_settings">Bluetooth ezarpenak</string>
-    <string name="android10_applaunch_issue_description">Android 10-ek mugatzen du nola abiarazi daitezkeen aplikazioak atzealdetik. Bluetooth gailu bat konektatzean aplikazioak irekitzeko baimena emateko, eman \"Beste aplikazioen gainean bistaratu\" (SYSTEM_ALERT_WINDOW) baimena.</string>
-    <string name="label_opensource">Iturburu kodea</string>
-    <string name="android13_notification_permission_description">Eman aplikazio honi jakinarazpenak bidaltzeko baimena. Honek jakinarazpena bistaratzea ahalbidetzen du aplikazioa aktibo dagoenean eta bolumen doikuntzak egiten ari direnean.</string>
-    <string name="privacy_policy_label">Pribatutasun-politika</string>
     <string name="managed_devices_empty_message">Ez dago Bluetooth gailurik konfiguratuta.\nSakatu + botoia zure lehen gailua gehitzeko.</string>
     <string name="label_pro_feature">Premium ezaugarria</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Berrikuspen</string>
     <string name="review_app_dismiss_action">Agian geroago</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Erosketa bertan behera utzi da</string>
-    <string name="error_iap_unavailable_message">Aplikazioko erosketak ez daude erabilgarri</string>
-    <string name="error_generic_message">Errore bat gertatu da. Saiatu berriro.</string>
-    <string name="error_iap_owned_message">Elementu honen jabea zara jadanik</string>
     <string name="label_no_devices_title">Gailurik ez</string>
     <string name="bluemusic_mascot_description">Aplikazioaren ikonoa</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Hautatu aplikazioak</string>
     <string name="devices_app_selection_search_hint">Bilatu aplikazioak…</string>
-    <string name="devices_app_selection_currently_selected">Une honetan hautatuta</string>
     <string name="devices_app_selection_selected_count">%d aplikazio hautatuta</string>
     <string name="general_navigate_back_action">Atzera nabigatu</string>
     <string name="general_reset_action">Berrezarri</string>
     <string name="general_clear_action">Garbitu</string>
-    <string name="general_save_action">Gorde</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Blokeoa</string>
     <string name="devices_indicator_awake">Esnai</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Muga</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Indarra</string>
-    <string name="devices_indicator_launch">Abiarazi</string>
     <string name="devices_indicator_home">Hasiera</string>
     <string name="devices_indicator_dnd">EMN</string>
     <string name="devices_indicator_alert">Alerta</string>

--- a/app/src/main/res/values-fa/strings.xml
+++ b/app/src/main/res/values-fa/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">برخی ویژگی‌ها در طول به‌روزرسانی تغییر کرده‌اند. لطفاً تنظیمات دستگاه خود را بررسی کنید تا همه چیز درست پیکربندی شده باشد.</string>
     <string name="onboarding_rewrite_action">ادامه</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">دستگاه مدیریت‌نشده‌ای یافت نشد</string>
     <string name="discover_all_devices_managed_msg">همه دستگاه‌های جفت‌شده شما مدیریت می‌شوند! به یکی جدید نیاز دارید؟</string>
     <string name="discover_pair_new_device_action">جفت کردن دستگاه جدید</string>
     <string name="discover_device_speaker_desc">بلندگوی خود این تلفن. صدای آن زمانی اعمال می‌شود که صدا به تلفن بازگردد، مثلاً بعد از قطع اتصال دستگاه بلوتوث شما.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">پیکربندی دستگاه</string>
-    <string name="devices_device_config_section_general_label">عمومی</string>
     <string name="devices_device_config_remove_device_label">فراموش کردن دستگاه</string>
-    <string name="devices_device_config_remove_device_desc">دستگاه را از این برنامه فراموش کرده و تنظیمات آن را حذف می‌کند. این کار جفت دستگاه را لغو نمی‌کند.</string>
     <string name="devices_device_config_remove_device_action">فراموش کن</string>
     <string name="devices_device_config_remove_device_confirmation">آیا %s از دستگاه‌های مدیریت‌شده حذف شود؟</string>
-    <string name="devices_device_config_rename_device_label">تغییر نام دستگاه</string>
-    <string name="devices_device_config_rename_device_desc">نام این دستگاه را در این برنامه و در صورت امکان در سیستم تغییر دهید.</string>
     <string name="devices_device_config_rename_device_action">تغییر نام</string>
     <string name="devices_device_config_enabled_label">فعال</string>
     <string name="devices_device_config_enabled_desc">هنگام اتصال این دستگاه واکنش نشان بده</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">دستورهای پخش خودکار</string>
     <string name="devices_device_config_autoplay_keycodes_order">ترتیب دستورها</string>
     <string name="devices_device_config_autoplay_keycodes_label">دستورها</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">تنظیم کن کدام دستورها و به چه ترتیبی ارسال شوند</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">هیچ دستوری پیکربندی نشده</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">افزودن دستور</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">حداکثر %1$d دستور</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">انتقال به بالا</string>
     <string name="cd_autoplay_keycode_move_down">انتقال به پایین</string>
     <string name="cd_autoplay_keycode_remove">حذف</string>
-    <string name="devices_device_config_section_volumes_label">صداها</string>
     <string name="devices_device_config_section_volume_label">صدا</string>
     <string name="devices_device_config_alarm_volume_label">صدای هشدار</string>
     <string name="devices_device_config_alarm_volume_desc">برخی برنامه‌های هشدار به جای آن از صدای موزیک استفاده می‌کنند.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">زنگ</string>
     <string name="devices_audio_stream_notification_label">اعلان</string>
     <string name="devices_audio_stream_alarm_label">هشدار</string>
-    <string name="devices_neverseen_label">هرگز دیده نشده</string>
-    <string name="devices_state_connected_label">متصل</string>
     <string name="devices_last_connected_label">آخرین اتصال: %s</string>
     <string name="devices_currently_connected_label">در حال اتصال</string>
     <string name="devices_device_disabled_label">دستگاه غیرفعال</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">تنظیماتی که بر همه دستگاه‌های مدیریت‌شده تأثیر می‌گذارد.</string>
     <string name="label_app_enabled">برنامه فعال</string>
     <string name="description_app_enabled">توانایی برنامه برای واکنش به رویدادهای صدا و بلوتوث را روشن/خاموش می‌کند.</string>
-    <string name="label_visible_volume_adjustments">تنظیمات قابل مشاهده</string>
-    <string name="description_visible_volume_adjustments">نمایش پنجره صدای سیستم حین اعمال تنظیمات برنامه.</string>
     <string name="label_volume_listener">پایش تغییرات</string>
-    <string name="description_volume_listener">حین اتصال دستگاه فعال بمان و تغییرات صدایی که توسط این برنامه ایجاد نشده را ذخیره کن.</string>
     <string name="label_boot_restore">بازیابی پس از راه‌اندازی</string>
     <string name="description_boot_restore">بازیابی صدا پس از راه‌اندازی/راه‌اندازی مجدد در صورت اتصال دستگاه بلوتوث.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">یادبگیر استفاده مؤثر از BVM</string>
     <string name="settings_support_issue_tracker_description">یک ردیاب عمومی مشکلات برای گزارش اشکالات و درخواست‌های ویژگی‌های جدید.</string>
     <string name="settings_support_issue_tracker_label">رهگیری مشکل</string>
-    <string name="settings_support_debuglog_label">گزارش خطاء</string>
     <string name="settings_support_debuglog_desc">ضبط همه چیزهایی که برنامه انجام می‌دهد در یک فایل متنی که می‌توانید به اشتراک بگذارید.</string>
-    <string name="settings_support_debuglog_recording_desc">در حال یادداشت اطلاعات باگشناسی. برای توقف ضربه بزنید.</string>
-    <string name="settings_support_debuglog_path">مسیر گزارش: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">یادداشت خیلی کوتاه</string>
     <string name="settings_support_debuglog_short_recording_msg">یادداشت خیلی کوتاه بود. گزارش‌های باگشناسی یادداشت هستند، نه عکس گرفته — برای مفید بودن گزارش، مشکل را حین یادداشت فعال دوباره تکرار کنید.</string>
     <string name="settings_support_debuglog_short_recording_continue">ادامه یادداشت</string>
     <string name="settings_support_debuglog_short_recording_stop">هرحال توقف</string>
-    <string name="settings_support_debuglog_folder_label">پوشه گزارش باگشناسی</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d جلسه که %2$s استفاده می‌کند</item>
-        <item quantity="other">%1$d جلسه که %2$s استفاده می‌کنند</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">گزارش باگشناسی ذخیره نشده</string>
-    <string name="settings_support_debuglog_folder_delete_title">حذف همه گزارش‌های باگشناسی؟</string>
-    <string name="settings_support_debuglog_folder_delete_msg">این کار همه جلسات گزارش باگشناسی ذخیره‌شده را به طور دائمی حذف خواهد کرد.</string>
     <string name="settings_support_discord_label">دیسکورد</string>
     <string name="settings_support_discord_description">یک مکان برای وقت گذرانی و پرسش سوالات.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">ترجمه</string>
     <string name="settings_acks_translators_title">مترجمان</string>
     <string name="settings_acks_translators_people">شخص1؛شخص2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">ترجمه BVM</string>
-    <string name="settings_acks_translate_desc">در ترجمه BVM به زبانت کمک کن</string>
     <string name="settings_acks_thanks_header">ممنون</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">برای پشتیبانی از ترجمه پروژه‌های متن‌باز</string>
     <string name="settings_licenses_label">مجوزها</string>
     <string name="settings_translation_label">ترجمه</string>
     <string name="settings_translation_desc">در ترجمه برنامه به زبان مورد علاقهت کمک کن</string>
-    <string name="settings_sponsor_development_title">حامی توسعه دهنده</string>
-    <string name="settings_sponsor_development_summary">به حامی تبدیل شوید و توسعه مداوم را ممکن کنید.</string>
     <string name="settings_privacy_policy_label">سیاست حفظ حریم خصوصی</string>
     <string name="settings_privacy_policy_desc">رعایت مسئولانه داده‌ها.</string>
     <string name="changelog_label">گزارش تغییرات</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">بازیابی کامل شد — %1$d دستگاه بازیابی شد، %2$d نادیده گرفته شد.</string>
     <string name="backup_restore_version_warning">این پشتیبان با نسخه %1$s ایجاد شده. شما نسخه %2$s را اجرا می‌کنید. ممکن است برخی تنظیمات به درستی بازیابی نشوند.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">اعلانهای اشکال زدایی</string>
     <string name="debug_log_consent_title">گزارش خطاء</string>
     <string name="debug_log_consent_explanation">این ویژگی هر کاری را که برنامه انجام می دهد در یک فایل قابل اشتراک گذاری ثبت می کند. فایل تولید شده حاوی اطلاعات حساس است (مانند نام فایل ها و برنامه های نصب شده). آن را فقط با اشخاص مورد اعتماد به اشتراک بگذارید (مثلاً برنامه‌نویسی که در حال عیب‌یابی یک مشکل است).</string>
-    <string name="debug_log_recording_progress">در حال ظبط کردن گزارش خطا</string>
     <string name="debug_log_record_action">یادداشت</string>
     <string name="debug_log_stop_action">توقف ضبط کردن</string>
     <string name="debug_log_screen_title">یادداشتگر گزارش باگشناسی</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">صرف‌نظر کردن</string>
     <string name="debug_log_screen_keep_action">نگه دار</string>
-    <string name="debug_log_compressing_label">در حال فشرده‌سازی…</string>
     <string name="debug_log_file_label">فایل گزارش خطا ظبط شده</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">گزارش فرستاده شد؟</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">سوالت را با جزئیات توضیح دهید.</string>
     <string name="contact_category_section_label">دسته</string>
     <string name="contact_debug_log_label">گزارش خطاء</string>
-    <string name="contact_debug_log_select_hint">یک گزارش باگشناسی برای پیوست کردن انتخاب کنید</string>
     <string name="contact_debug_log_picker_hint">برای تشخیص سریعتر مشکل، گزارش باگشناسی پیوست کنید.</string>
     <string name="contact_debug_log_picker_empty">گزارش باگشناسی موجود نیست. اول یکی یادداشت کنید.</string>
     <string name="contact_expected_behavior_label">رفتار مورد انتظار</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">هر پیامی را خودم می‌خوانم و تمام تلاشم را می‌کنم جواب بدهم، اما چون تنها کار می‌کنم، ممکنه کمی طول بکشه. ممنون صبرت.</string>
     <string name="contact_footer_msg">پیام شما از طریق ایمیل فرستاده خواهد شد. اطلاعات دستگاه و تنظیمات به صورت خودکار پیوست می‌شوند.</string>
     <string name="contact_no_email_app_msg">هیچ برنامه ایمیلی روی این دستگاه یافت نشد.</string>
-    <string name="contact_attachment_missing_msg">فایل گزارش باگشناسی دیگر وجود ندارد</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">گزارش‌های باگشناسی ذخیره‌شده</string>
     <string name="settings_support_stored_logs_desc">%1$d جلسه (%2$s)</string>
     <string name="settings_support_stored_logs_empty">گزارش باگشناسی ذخیره‌شده‌ای وجود ندارد</string>
-    <string name="settings_support_stored_logs_delete_title">حذف گزارش‌های ذخیره‌شده؟</string>
-    <string name="settings_support_stored_logs_delete_msg">این کار همه %1$d جلسه گزارش باگشناسی ذخیره‌شده را حذف خواهد کرد.</string>
-    <string name="settings_support_stored_logs_deleted_msg">گزارش‌های باگشناسی ذخیره‌شده حذف شدند</string>
-    <string name="label_bug_reports">گزارش اشکالات</string>
-    <string name="description_bug_reports">گزارش خودکار اشکال و کرش.</string>
     <string name="label_add_device">افزودن دستگاه</string>
-    <string name="label_just_a_moment_please">یه لحظه صبر کن.</string>
     <string name="label_notification_channel_status">وضعیت</string>
     <string name="label_notification_channel_setup">نیاز به راه‌اندازی</string>
     <string name="monitor_notification_starting">در حال شروع…</string>
     <string name="action_set">تنظیم</string>
     <string name="action_cancel">لفو</string>
-    <string name="label_invalid_input">ورودی نامعتبر</string>
     <string name="action_reset">بازنشانی</string>
     <string name="label_no_connected_devices">هیچ دستگاهی متصل نیست</string>
-    <string name="label_status_idle">بیکار</string>
-    <string name="label_status_adjusting_volumes">در حال تنظیم صداها</string>
-    <string name="label_premium_version">نسخه پریمیوم</string>
     <string name="general_upgrade_action">ارتقاء</string>
     <string name="common_upgrade_required_label">ارتقا لازم است</string>
-    <string name="label_premium_version_required">نسخه پریمیوم لازم است</string>
-    <string name="description_intro_purpose">این برنامه به دستگاه اندروید شما امکان می‌دهد صدای دستگاه‌های بلوتوث مختلف را به خاطر بسپارد.</string>
-    <string name="upgrade_benefit_unlimited_devices">پروفایل‌های دستگاه نامحدود</string>
-    <string name="upgrade_benefit_connection_actions">پخش خودکار، راه‌اندازی برنامه و هشدارهای اتصال</string>
-    <string name="upgrade_benefit_theme_customization">شخصی‌سازی تم، سبک و رنگ</string>
-    <string name="upgrade_benefit_power_controls">قفل صدا و محدودسازی نرخ</string>
-    <string name="upgrade_benefit_support">حمایت از توسعه مستقل</string>
     <string name="upgrade_benefit_equalizer">• اکولایزر مخصوص هر دستگاه (برای برنامه‌های موسیقی دارای پشتیبانی از اکولایزر سیستمی)</string>
-    <string name="description_intro_tap_the_button">با اضافه کردن اولین دستگاهت شروع کن.</string>
     <string name="description_bluetooth_is_disabled">بلوتوث غیرفعال است.</string>
     <string name="title_bluetooth_is_off">بلوتوث خاموش است</string>
     <string name="action_enable_bluetooth">فعال‌سازی بلوتوث</string>
     <string name="title_bluetooth_permission_required">نیاز به مجوز بلوتوث</string>
     <string name="description_bluetooth_permission_required">این برنامه برای مدیریت صدای دستگاه‌ها به مجوز بلوتوث نیاز دارد.</string>
     <string name="action_grant_permission">اعطای مجوز</string>
-    <string name="label_status_listening_for_changes">در حال گوش دادن به تغییرات صدا</string>
     <string name="action_exit">خروج</string>
-    <string name="action_start">شروع</string>
-    <string name="label_welcome">خوش آمدید</string>
-    <string name="description_intro_contact">هرتیموقت سوال داری یا حتی ایده‌ای برای ویژگی جدید، خجالت نکش با من تماس بگیر.</string>
-    <string name="label_translation">ترجمه</string>
-    <string name="description_help_translate">در دسترس بودن برنامه به زبان‌های دیگر کمک کن.</string>
     <string name="label_device_speaker">بلندگوی دستگاه</string>
-    <string name="label_keyevent_playpause">پخش-مکث</string>
-    <string name="label_keyevent_play">پخش</string>
-    <string name="label_keyevent_next">بعدی</string>
-    <string name="label_install_id">شناسه نصب</string>
     <string name="message_copied_to_clipboard">کپی شد</string>
-    <string name="label_thanks">ممنون</string>
-    <string name="label_licenses">مجوزها</string>
-    <string name="description_ring_volume_additional_permission">برای تغییر صدای زنگ مجوزهای اضافی لازم است.</string>
-    <string name="label_missing_permissions">مجوزهای لازم وجود ندارد</string>
-    <string name="action_grant">اعطا</string>
-    <string name="label_advanced">پیشرفته</string>
-    <string name="label_exclude_health">حذف پروفایل‌های سلامت</string>
-    <string name="description_exclude_health">برخی دستگاه‌های اندروید هنگام جستجوی پروفایل بلوتوث سلامت (پروتکل HDP، 0x1400) آویز می‌کنند.</string>
-    <string name="label_exclude_gattserver">حذف پروفایل‌های GATT سرور</string>
-    <string name="label_exclude_gatt">حذف پروفایل‌های GATT</string>
-    <string name="description_exclude_gattserver">پروفایل‌های بلوتوث نوع \'ویژگی عمومی\' (GATT) سرور را جستجو نکن.</string>
-    <string name="description_exclude_gatt">پروفایل‌های بلوتوث نوع \'ویژگی عمومی\' (GATT) کلاینت را جستجو نکن.</string>
-    <string name="description_waiting_for_devicex">در انتظار اتمام اتصال %s</string>
-    <string name="action_undo">واگرد</string>
-    <string name="action_show">نمایش</string>
     <string name="action_dismiss">نادیده گرفتن</string>
-    <string name="action_fix">اصلاح</string>
-    <string name="battery_optimizations_issue_description">بهینه‌سازی باتری برای این برنامه فعال است و می‌تواند دریافت رویداده‌های بلوتوث را مختل کند. اگر مشکل دارید، غیرفعال‌سازی آن را بررسی کنید.</string>
     <string name="label_bluetooth_settings">تنظیمات بلوتوث</string>
-    <string name="android10_applaunch_issue_description">اندروید 10 محدودیتی بر راه‌اندازی برنامه‌ها از پس‌زمینه دارد. برای اجازه باز کردن برنامه‌ها هنگام اتصال دستگاه بلوتوث، مجوز «نمایش روی برنامه‌های دیگر» (مجوز SYSTEM_ALERT_WINDOW) را اعطا کنید.</string>
-    <string name="label_opensource">کد منبع</string>
-    <string name="android13_notification_permission_description">به این برنامه مجوز ارسال اعلان بدهید. این امکان نمایش اعلان هنگام فعال بودن برنامه و تنظیم صدا را فراهم می‌کند.</string>
-    <string name="privacy_policy_label">سیاست حفظ حریم خصوصی</string>
     <string name="managed_devices_empty_message">هیچ دستگاه بلوتوثی تنظیم نشده.\nبرای افزودن اولین دستگاهت روی دکمه + ضربه بزنید.</string>
     <string name="label_pro_feature">ویژگی پریمیوم</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">مرور</string>
     <string name="review_app_dismiss_action">شاید بعداً</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">خرید لغو شد</string>
-    <string name="error_iap_unavailable_message">خرید درون‌برنامهای در دسترس نیست</string>
-    <string name="error_generic_message">خطایی رخ داد. لطفاً دوباره امتحان کنید.</string>
-    <string name="error_iap_owned_message">شما قبلاً این آیتم را خریدید</string>
     <string name="label_no_devices_title">هیچ دستگاهی</string>
     <string name="bluemusic_mascot_description">آیکون برنامه</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">انتخاب برنامه‌ها</string>
     <string name="devices_app_selection_search_hint">جستجوی برنامه‌ها…</string>
-    <string name="devices_app_selection_currently_selected">در حال حاضر</string>
     <string name="devices_app_selection_selected_count">%d برنامه انتخاب شده</string>
     <string name="general_navigate_back_action">بازگشت</string>
     <string name="general_reset_action">بازنشانی</string>
     <string name="general_clear_action">پاک کردن</string>
-    <string name="general_save_action">ذخيره</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">قفل</string>
     <string name="devices_indicator_awake">بیدار</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">محدودیت</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">افزایش</string>
-    <string name="devices_indicator_launch">راه‌اندازی</string>
     <string name="devices_indicator_home">خانه</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">هشدار</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Jotkut ominaisuudet ovat muuttuneet päivityksen aikana. Tarkista laiteasetuksesi varmistaaksesi, että kaikki on määritetty oikein.</string>
     <string name="onboarding_rewrite_action">Jatka</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Hallitsemattomia laitteita ei löydy</string>
     <string name="discover_all_devices_managed_msg">Kaikki paritetut laitteesi on hallittu! Tarvitsetko uuden?</string>
     <string name="discover_pair_new_device_action">Parита uusi laite</string>
     <string name="discover_device_speaker_desc">Tämän puhelimen oma kaiutin. Sen äänenvoimakkuuksia käytetään, kun ääni vaihtuu takaisin puhelimeen, esim. Bluetooth-laitteen irrottamisen jälkeen.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Laitteen asetukset</string>
-    <string name="devices_device_config_section_general_label">Yleiset</string>
     <string name="devices_device_config_remove_device_label">Unohda laite</string>
-    <string name="devices_device_config_remove_device_desc">Poistaa laitteen tästä sovelluksesta ja poistaa sen asetukset. Tämä ei poista laitteen paritusta.</string>
     <string name="devices_device_config_remove_device_action">Unohda</string>
     <string name="devices_device_config_remove_device_confirmation">Unohdetaanko %s hallituista laitteista?</string>
-    <string name="devices_device_config_rename_device_label">Nimeä laite uudelleen</string>
-    <string name="devices_device_config_rename_device_desc">Nimeä laite uudelleen tässä sovelluksessa ja mahdollisuuksien mukaan myös järjestelmässä.</string>
     <string name="devices_device_config_rename_device_action">Nimeä uudelleen</string>
     <string name="devices_device_config_enabled_label">Käytössä</string>
     <string name="devices_device_config_enabled_desc">Reagoi tähän laitteeseen, kun se yhdistää</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Automaattisen toiston komennot</string>
     <string name="devices_device_config_autoplay_keycodes_order">Komentojen järjestys</string>
     <string name="devices_device_config_autoplay_keycodes_label">Komennot</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Määritä lähetettävät komennot ja niiden järjestys</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Ei määritettyjä komentoja</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Lisää komento</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Enintään %1$d komentoa</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Siirrä ylös</string>
     <string name="cd_autoplay_keycode_move_down">Siirrä alas</string>
     <string name="cd_autoplay_keycode_remove">Poista</string>
-    <string name="devices_device_config_section_volumes_label">Äänenvoimakkuudet</string>
     <string name="devices_device_config_section_volume_label">Äänenvoimakkuus</string>
     <string name="devices_device_config_alarm_volume_label">Hälytysäänenvoimakkuus</string>
     <string name="devices_device_config_alarm_volume_desc">Jotkut hälytyssovellukset käyttävät musiikkiäänenvoimakkuutta sen sijaan.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Soitto</string>
     <string name="devices_audio_stream_notification_label">Ilmoitus</string>
     <string name="devices_audio_stream_alarm_label">Hälytys</string>
-    <string name="devices_neverseen_label">Ei nähty</string>
-    <string name="devices_state_connected_label">Yhdistetty</string>
     <string name="devices_last_connected_label">Viimeksi yhdistetty: %s</string>
     <string name="devices_currently_connected_label">Tällä hetkellä yhdistetty</string>
     <string name="devices_device_disabled_label">Laite pois käytöstä</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Asetukset, jotka vaikuttavat kaikkiin hallittuihin laitteisiin.</string>
     <string name="label_app_enabled">Sovellus aktiivinen</string>
     <string name="description_app_enabled">Sallii sovelluksen reagoida äänenvoimakkuus ja bluetooth tapahtumiin.</string>
-    <string name="label_visible_volume_adjustments">Näkyvät muutokset</string>
-    <string name="description_visible_volume_adjustments">Näytä järjestelmän äänenvoimakkuus säätimet, kun tämä ohjelma tekee muutoksia.</string>
     <string name="label_volume_listener">Tarkkaile muutoksia</string>
-    <string name="description_volume_listener">Pysy aktiivisena kun laite on yhteydessä ja tallenna äänenvoimakkuus muutokset, mitkä ei ole tämän sovelluksen tekemiä.</string>
     <string name="label_boot_restore">Palauta uudelleenkäynnistyksen yhteydessä</string>
     <string name="description_boot_restore">Palauta äänenvoimakkuus käynnistyksen yhteydessä jos Bluetooth laite on yhdistettynä.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Opi käyttämään BVM:a tehokkaasti</string>
     <string name="settings_support_issue_tracker_description">Julkinen ongelmaseuranta virheilmoituksia ja ominaisuuspyyntöjä varten.</string>
     <string name="settings_support_issue_tracker_label">Ongelmaseuranta</string>
-    <string name="settings_support_debuglog_label">Debug-loki</string>
     <string name="settings_support_debuglog_desc">Tallenna kaikki mitä sovellus tekee tekstitiedostoon, jonka voit jakaa.</string>
-    <string name="settings_support_debuglog_recording_desc">Tallentaa parhaillaan debug-tietoja. Napauta lopettaaksesi tallennuksen.</string>
-    <string name="settings_support_debuglog_path">Lokitiedoston polku: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Hyvin lyhyt tallennus</string>
     <string name="settings_support_debuglog_short_recording_msg">Tuo oli hyvin lyhyt tallennus. Debug-logit ovat tallenteita, eivät tilannekuvia — toista ongelma tallennuksen aikana, jotta lokista on hyötyä.</string>
     <string name="settings_support_debuglog_short_recording_continue">Jatka tallennusta</string>
     <string name="settings_support_debuglog_short_recording_stop">Pysäytä silti</string>
-    <string name="settings_support_debuglog_folder_label">Debug-lokikansio</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d istunto, käyttää %2$s</item>
-        <item quantity="other">%1$d istuntoa, käyttää %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Ei tallennettuja debug-lokeja</string>
-    <string name="settings_support_debuglog_folder_delete_title">Poista kaikki debug-logit?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Tämä poistaa pysyvästi kaikki tallennetut debug-lokin istunnot.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Paikka viettää aikaa ja kysellä kysymyksiä.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Käännös</string>
     <string name="settings_acks_translators_title">Kääntäjät</string>
     <string name="settings_acks_translators_people">Henkilö1;Henkilö2(valinnainen@sähköposti.com)</string>
-    <string name="settings_acks_translate_title">Käännä BVM</string>
-    <string name="settings_acks_translate_desc">Auta kääntämään BVM sinun kiellesi</string>
     <string name="settings_acks_thanks_header">Kiitokset</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Avoimen lähdekoodin projektien käännösten tukemisesta</string>
     <string name="settings_licenses_label">Lisenssit</string>
     <string name="settings_translation_label">Käännös</string>
     <string name="settings_translation_desc">Auta kääntämään sovellus suosikkikielellesi</string>
-    <string name="settings_sponsor_development_title">Sponsoroi kehitystä</string>
-    <string name="settings_sponsor_development_summary">Ryhdy suojelijaksi ja tee jatkuva kehitys mahdolliseksi.</string>
     <string name="settings_privacy_policy_label">Tietosuojakäytäntö</string>
     <string name="settings_privacy_policy_desc">Tietojen vastuullinen käsittely.</string>
     <string name="changelog_label">Muutosloki</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Palautus valmis — %1$d laitetta palautettu, %2$d ohitettu.</string>
     <string name="backup_restore_version_warning">Tämä varmuuskopio on luotu versiolla %1$s. Käytät versiota %2$s. Osa asetuksista ei välttämättä palaudu oikein.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Debug-ilmoitukset</string>
     <string name="debug_log_consent_title">Debug-loki</string>
     <string name="debug_log_consent_explanation">Tämä ominaisuus tallentaa kaiken mitä sovellus tekee jaettavaan tiedostoon. Luotu tiedosto sisältää arkaluonteisia tietoja (esim. tiedostonimet ja asennetut sovellukset). Jaa se vain luotettavien tahojen kanssa (esim. kehittäjän kanssa ongelman ratkaisemiseksi).</string>
-    <string name="debug_log_recording_progress">Tallennetaan debug-lokia</string>
     <string name="debug_log_record_action">Tallenna</string>
     <string name="debug_log_stop_action">Lopeta tallentaminen</string>
     <string name="debug_log_screen_title">Debug-lokin tallennin</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Hylkää</string>
     <string name="debug_log_screen_keep_action">Säilytä</string>
-    <string name="debug_log_compressing_label">Pakataan…</string>
     <string name="debug_log_file_label">Tallennettu lokitiedosto</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Loki lähetetty?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Kuvaile kysymyksesi yksityiskohtaisesti.</string>
     <string name="contact_category_section_label">Kategoria</string>
     <string name="contact_debug_log_label">Debug-loki</string>
-    <string name="contact_debug_log_select_hint">Valitse liitettävä debug-loki</string>
     <string name="contact_debug_log_picker_hint">Liitä debug-loki auttaaksesi diagnosoimaan ongelman nopeammin.</string>
     <string name="contact_debug_log_picker_empty">Debug-lokeja ei ole saatavilla. Tallenna ensin yksi.</string>
     <string name="contact_expected_behavior_label">Odotettu toiminta</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Luen jokaisen viestin itse ja teen parhaani vastatakseni, mutta koska työskentelen yksin, se voi kestää hetken. Kiitos kärsivällisyydestäsi.</string>
     <string name="contact_footer_msg">Viestisi lähetetään sähköpostitse. Laite- ja asetustiedot liitetään automaattisesti.</string>
     <string name="contact_no_email_app_msg">Tällä laitteella ei löydy sähköpostisovellusta.</string>
-    <string name="contact_attachment_missing_msg">Debug-lokitiedostoa ei enää ole</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Tallennetut debug-logit</string>
     <string name="settings_support_stored_logs_desc">%1$d istuntoa (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Ei tallennettuja debug-lokeja</string>
-    <string name="settings_support_stored_logs_delete_title">Poista tallennetut logit?</string>
-    <string name="settings_support_stored_logs_delete_msg">Tämä poistaa kaikki %1$d tallennettu debug-lokin istuntoa.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Tallennetut debug-logit poistettu</string>
-    <string name="label_bug_reports">Virheraportti</string>
-    <string name="description_bug_reports">Automaattinen virhe- ja kaatumis raportointi.</string>
     <string name="label_add_device">Lisää laite</string>
-    <string name="label_just_a_moment_please">Pieni hetki, odotathan.</string>
     <string name="label_notification_channel_status">Tila</string>
     <string name="label_notification_channel_setup">Määritys vaaditaan</string>
     <string name="monitor_notification_starting">Käynnistetään…</string>
     <string name="action_set">Aseta</string>
     <string name="action_cancel">Peruuta</string>
-    <string name="label_invalid_input">Virheellinen syöte</string>
     <string name="action_reset">Nollaa</string>
     <string name="label_no_connected_devices">Ei laitteita yhdistettynä</string>
-    <string name="label_status_idle">Ei aktiivisia toimintoja</string>
-    <string name="label_status_adjusting_volumes">Säädetään äänenvoimakkuuksia</string>
-    <string name="label_premium_version">Premium versio</string>
     <string name="general_upgrade_action">Päivitä</string>
     <string name="common_upgrade_required_label">Päivitys vaaditaan</string>
-    <string name="label_premium_version_required">Vaatii premium version</string>
-    <string name="description_intro_purpose">Tämä sovellus mahdollistaa Android laitteesi muistaa erillisten Bluetooth laitteiden äänenvoimakkuuden.</string>
-    <string name="upgrade_benefit_unlimited_devices">Rajattomat laiteprofiillit</string>
-    <string name="upgrade_benefit_connection_actions">Automaattinen toisto, sovelluksen käynnistys ja yhteysilmoitukset</string>
-    <string name="upgrade_benefit_theme_customization">Teeman, tyylin ja värin mukauttaminen</string>
-    <string name="upgrade_benefit_power_controls">Äänenvoimakkuuden lukitus ja nopeusrajoitus</string>
-    <string name="upgrade_benefit_support">Tue itsenäistä kehitystä</string>
     <string name="upgrade_benefit_equalizer">• Laitekohtainen taajuuskorjain (musiikkisovelluksille, jotka tukevat järjestelmän taajuuskorjainta)</string>
-    <string name="description_intro_tap_the_button">Aloita lisäämällä ensimmäinen laitteesi.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth ei ole käytössä.</string>
     <string name="title_bluetooth_is_off">Bluetooth on pois päältä</string>
     <string name="action_enable_bluetooth">Ota Bluetooth käyttöön</string>
     <string name="title_bluetooth_permission_required">Bluetooth-lupa vaaditaan</string>
     <string name="description_bluetooth_permission_required">Tämä sovellus tarvitsee Bluetooth-luvan hallitakseen laitteidesi äänenvoimakkuuksia.</string>
     <string name="action_grant_permission">Myönnä lupa</string>
-    <string name="label_status_listening_for_changes">Seuraa äänenvoimakkuus muutoksia</string>
     <string name="action_exit">Poistu</string>
-    <string name="action_start">Aloita</string>
-    <string name="label_welcome">Tervetuloa</string>
-    <string name="description_intro_contact">Älä epäröi ottaa yhteyttä jos sinulla on kysymyksia tai vaikka idea uudesta ominaisuudesta.</string>
-    <string name="label_translation">Käännös</string>
-    <string name="description_help_translate">Auta minua kääntämään tämä sovellus muille kielille.</string>
     <string name="label_device_speaker">Kaiutin</string>
-    <string name="label_keyevent_playpause">Toista-Tauko</string>
-    <string name="label_keyevent_play">Toista</string>
-    <string name="label_keyevent_next">Seuraava</string>
-    <string name="label_install_id">Asennustunnus</string>
     <string name="message_copied_to_clipboard">Kopioitu leikepöydälle</string>
-    <string name="label_thanks">Kiitos</string>
-    <string name="label_licenses">Lisenssit</string>
-    <string name="description_ring_volume_additional_permission">Lisäoikeudet on välttämättömiä soittoäänen äänenvoimakkuuden säätämiseksi.</string>
-    <string name="label_missing_permissions">Käyttöoikeuksia puuttuu</string>
-    <string name="action_grant">Myönnä</string>
-    <string name="label_advanced">Lisäasetukset</string>
-    <string name="label_exclude_health">Jätä pois terveys profiilit</string>
-    <string name="description_exclude_health">Jotkut Android laitteet menevät jumiin tarkastellessaan \'Terveys laitteiden\' Bluetooth profiileita (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Jätä pois GATT palvelin profiilit</string>
-    <string name="label_exclude_gatt">Jätä pois GATT profiileja</string>
-    <string name="description_exclude_gattserver">Älä hae \'Generic Attribute\' (GATT) tyyppisiä palvelin Bluetooth profiileja.</string>
-    <string name="description_exclude_gatt">Älä hae \'Generic Attribute\' (GATT) tyyppisiä asiakas Bluetooth profiileja.</string>
-    <string name="description_waiting_for_devicex">Odotetaan %s yhteyden valmistumista</string>
-    <string name="action_undo">Kumoa</string>
-    <string name="action_show">Näytä</string>
     <string name="action_dismiss">Pois</string>
-    <string name="action_fix">Korjaa</string>
-    <string name="battery_optimizations_issue_description">Akun optimointi on käytössä tälle sovellukselle ja saattaa estää sitä vastaanottamasta tietoa Bluetooth tapahtumista. Harkitse optimointien poistamista käytöstä, jos huomaat ongelmia.</string>
     <string name="label_bluetooth_settings">Bluetooth asetukset</string>
-    <string name="android10_applaunch_issue_description">Android 10 rajoittaa kuinka sovelluksia voidaan käynnistää taustalta. Jotta sovellukset voidaan avata kun Bluetooth-laite yhdistää, myönnä käyttöoikeus \"Näytä muiden sovellusten päällä\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Lähdekoodi</string>
-    <string name="android13_notification_permission_description">Myönnä tälle sovellukselle käyttöoikeus lähettää ilmoituksia. Tämä mahdollistaa ilmoituksen näyttämisen kun sovellus on aktiivinen ja äänenvoimakkuussäätöjä tehdään.</string>
-    <string name="privacy_policy_label">Tietosuojakäytäntö</string>
     <string name="managed_devices_empty_message">Bluetooth-laitteita ei ole määritetty.\nNapauta + painiketta lisätäksesi ensimmäisen laitteesi.</string>
     <string name="label_pro_feature">Premium-ominaisuus</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Arvostele</string>
     <string name="review_app_dismiss_action">Ehkä myöhemmin</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Osto peruutettu</string>
-    <string name="error_iap_unavailable_message">Sovelluksen sisäiset ostokset eivät ole saatavilla</string>
-    <string name="error_generic_message">Tapahtui virhe. Yritä uudelleen.</string>
-    <string name="error_iap_owned_message">Omistat jo tämän tuotteen</string>
     <string name="label_no_devices_title">Ei laitteita</string>
     <string name="bluemusic_mascot_description">Sovelluskuvake</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Valitse sovellukset</string>
     <string name="devices_app_selection_search_hint">Hae sovelluksia…</string>
-    <string name="devices_app_selection_currently_selected">Tällä hetkellä valittu</string>
     <string name="devices_app_selection_selected_count">%d sovellusta valittu</string>
     <string name="general_navigate_back_action">Siirry takaisin</string>
     <string name="general_reset_action">Nollaa</string>
     <string name="general_clear_action">Tyhjennä</string>
-    <string name="general_save_action">Tallenna</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Lukitus</string>
     <string name="devices_indicator_awake">Hereillä</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Rajaus</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Tehostus</string>
-    <string name="devices_indicator_launch">Käynnistä</string>
     <string name="devices_indicator_home">Koti</string>
     <string name="devices_indicator_dnd">ÄH</string>
     <string name="devices_indicator_alert">Hälytys</string>

--- a/app/src/main/res/values-fil/strings.xml
+++ b/app/src/main/res/values-fil/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Nagbago ang ilang feature sa panahon ng update. Pakisuri ang iyong mga setting ng device para matiyak na tama ang lahat ng configuration.</string>
     <string name="onboarding_rewrite_action">Ituloy</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Walang nahanap na hindi pinamahalaaang device</string>
     <string name="discover_all_devices_managed_msg">Lahat ng iyong paired na device ay pinamamahalaan na! Kailangan ng bago?</string>
     <string name="discover_pair_new_device_action">Mag-pair ng bagong device</string>
     <string name="discover_device_speaker_desc">Ang sariling speaker ng phone na ito. Ang mga volume nito ay inilalapat kapag bumalik ang audio sa phone, hal. pagkatapos ang iyong Bluetooth device ay nag-disconnect.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuration ng device</string>
-    <string name="devices_device_config_section_general_label">Pangkalahatan</string>
     <string name="devices_device_config_remove_device_label">Kalimutan ang device</string>
-    <string name="devices_device_config_remove_device_desc">Iniaalis ang device mula sa app na ito at binubura ang configuration nito. Hindi nito ina-unpair ang device.</string>
     <string name="devices_device_config_remove_device_action">Kalimutan</string>
     <string name="devices_device_config_remove_device_confirmation">Kalimutan ang %s mula sa mga pinamamahalaaang device?</string>
-    <string name="devices_device_config_rename_device_label">Palitan ang pangalan ng device</string>
-    <string name="devices_device_config_rename_device_desc">Palitan ang pangalan ng device na ito sa loob ng app na ito, at kung maaari, sa loob ng system.</string>
     <string name="devices_device_config_rename_device_action">Palitan ng pangalan</string>
     <string name="devices_device_config_enabled_label">Pinagana</string>
     <string name="devices_device_config_enabled_desc">Tumugon sa device na ito kapag nakakonekta</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Mga autoplay command</string>
     <string name="devices_device_config_autoplay_keycodes_order">Pagkakasunod ng command</string>
     <string name="devices_device_config_autoplay_keycodes_label">Mga Command</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">I-configure kung aling mga command ang ipapadala at sa anong pagkakasunod</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Walang na-configure na mga command</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Magdagdag ng command</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximum na %1$d na command</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Ilipat pataas</string>
     <string name="cd_autoplay_keycode_move_down">Ilipat pababa</string>
     <string name="cd_autoplay_keycode_remove">Tanggalin</string>
-    <string name="devices_device_config_section_volumes_label">Mga Volume</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
     <string name="devices_device_config_alarm_volume_label">Volume ng alarm</string>
     <string name="devices_device_config_alarm_volume_desc">Ang ilang alarm app ay gumagamit ng music volume sa halip.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Ring</string>
     <string name="devices_audio_stream_notification_label">Notification</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Hindi nakikita</string>
-    <string name="devices_state_connected_label">Nakakonekta</string>
     <string name="devices_last_connected_label">Huling nakakonekta: %s</string>
     <string name="devices_currently_connected_label">Kasalukuyang nakakonekta</string>
     <string name="devices_device_disabled_label">Naka-disable na device</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Mga setting na nakakaapekto sa lahat ng pinamamahalaaang device.</string>
     <string name="label_app_enabled">Pinaganang App</string>
     <string name="description_app_enabled">Nagto-toggle sa abilidad ng app na makaramdam sa volume at mga kaganapan sa Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Makikitang pagbabago</string>
-    <string name="description_visible_volume_adjustments">Ipakita ang volume window ng sistema habang gumagawa ng pagbabago ang app na ito.</string>
     <string name="label_volume_listener">Obserbahan ang mga pagbabago</string>
-    <string name="description_volume_listener">Manatiling aktibo habang konektado ang isang device at i-save ang mga pagbabago sa volume na hindi kagagawan ng app na ito.</string>
     <string name="label_boot_restore">Ibalik pagkatapos magboot</string>
     <string name="description_boot_restore">Ibalik ang volume pagkatapos magboot/magreboot kung ang isang Bluetooth device ay nakakonekta.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Alamin kung paano epektibong gamitin ang BVM</string>
     <string name="settings_support_issue_tracker_description">Isang pampublikong issue tracker para sa mga bug report at feature request.</string>
     <string name="settings_support_issue_tracker_label">Tracker ng mga isyu</string>
-    <string name="settings_support_debuglog_label">Debug log</string>
     <string name="settings_support_debuglog_desc">I-record ang lahat ng ginagawa ng app sa isang text file na maaari mong ibahagi.</string>
-    <string name="settings_support_debuglog_recording_desc">Kasalukuyang nag-rerecord ng debug information. I-tap para ihinto ang pag-record.</string>
-    <string name="settings_support_debuglog_path">Path ng log: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Napakaikling recording</string>
     <string name="settings_support_debuglog_short_recording_msg">Napakaikling recording iyon. Ang mga debug log ay mga recording, hindi snapshots — i-reproduce ang isyu habang aktibo ang recording para maging kapaki-pakinabang ang log.</string>
     <string name="settings_support_debuglog_short_recording_continue">Ituloy ang pag-record</string>
     <string name="settings_support_debuglog_short_recording_stop">Itigil kahit na</string>
-    <string name="settings_support_debuglog_folder_label">Folder ng debug log</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sesyon na gumagamit ng %2$s</item>
-        <item quantity="other">%1$d mga sesyon na gumagamit ng %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Walang nakaimbak na debug log</string>
-    <string name="settings_support_debuglog_folder_delete_title">Burahin ang lahat ng debug log?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Permanenteng mabubura ang lahat ng nakaimbak na debug log session.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Isang lugar para makipagkita at magtanong.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Pagsasalin</string>
     <string name="settings_acks_translators_title">Mga Tagasalin</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Isalin ang BVM</string>
-    <string name="settings_acks_translate_desc">Tulungan ang pagsasalin ng BVM sa iyong wika</string>
     <string name="settings_acks_thanks_header">Salamat</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Para sa pagsuporta sa pagsasalin ng mga open-source na proyekto</string>
     <string name="settings_licenses_label">Mga Lisensya</string>
     <string name="settings_translation_label">Pagsasalin</string>
     <string name="settings_translation_desc">Tumulong sa pagsasalin ng app sa iyong paboritong wika</string>
-    <string name="settings_sponsor_development_title">I-sponsor ang development</string>
-    <string name="settings_sponsor_development_summary">Maging patron at gawing posible ang patuloy na pag-develop.</string>
     <string name="settings_privacy_policy_label">Patakaran sa Privacy</string>
     <string name="settings_privacy_policy_desc">Responsableng pangangasiwa ng data.</string>
     <string name="changelog_label">Talaan ng mga pagbabago</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Kumpleto na ang restore — %1$d mga device ang na-restore, %2$d ang nilaktawan.</string>
     <string name="backup_restore_version_warning">Ang backup na ito ay ginawa sa bersyon %1$s. Nagpapatakbo ka ng %2$s. Maaaring hindi ma-restore nang tama ang ilang mga setting.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Mga debug na notification</string>
     <string name="debug_log_consent_title">Debug log</string>
     <string name="debug_log_consent_explanation">Ini-record ng feature na ito ang lahat ng ginagawa ng app sa isang file na maaaring ibahagi. Ang nabuong file ay naglalaman ng sensitibong impormasyon (hal. mga pangalan ng file at mga naka-install na app). Ibahagi lamang ito sa mga pinagkakatiwalaang tao (hal. isang developer na nag-aayos ng isyu).</string>
-    <string name="debug_log_recording_progress">Nag-rerecord ng debug log</string>
     <string name="debug_log_record_action">I-record</string>
     <string name="debug_log_stop_action">Ihinto ang pag-record</string>
     <string name="debug_log_screen_title">Recorder ng Debug Log</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Itapon</string>
     <string name="debug_log_screen_keep_action">Panatilihin</string>
-    <string name="debug_log_compressing_label">Kinokompres…</string>
     <string name="debug_log_file_label">Naka-record na log file</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Naipadala na ang log?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Ilarawan ang iyong tanong nang detalyado.</string>
     <string name="contact_category_section_label">Kategorya</string>
     <string name="contact_debug_log_label">Debug log</string>
-    <string name="contact_debug_log_select_hint">Pumili ng debug log para i-attach</string>
     <string name="contact_debug_log_picker_hint">Mag-attach ng debug log para makatulong na mas mabilis na ma-diagnose ang isyu.</string>
     <string name="contact_debug_log_picker_empty">Walang available na debug log. Mag-record muna ng isa.</string>
     <string name="contact_expected_behavior_label">Inaasahang gawi</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Binabasa ko ang bawat mensahe nang personal at ginagawa ko ang lahat para sumagot, ngunit dahil nagtatrabaho ako nang mag-isa, maaaring tumagal ng kaunti. Salamat sa iyong pasensya.</string>
     <string name="contact_footer_msg">Ang iyong mensahe ay ipapadala sa pamamagitan ng email. Ang impormasyon ng device at setup ay awtomatikong naka-attach.</string>
     <string name="contact_no_email_app_msg">Walang nahanap na email app sa device na ito.</string>
-    <string name="contact_attachment_missing_msg">Hindi na umiiral ang debug log file</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Nakaimbak na mga debug log</string>
     <string name="settings_support_stored_logs_desc">%1$d mga sesyon (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Walang nakaimbak na debug log</string>
-    <string name="settings_support_stored_logs_delete_title">Burahin ang nakaimbak na mga log?</string>
-    <string name="settings_support_stored_logs_delete_msg">Mabubura nito ang lahat ng %1$d nakaimbak na debug log session.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Nabura ang nakaimbak na mga debug log</string>
-    <string name="label_bug_reports">Ulat sa mga bug</string>
-    <string name="description_bug_reports">Awtomatikong pag-uulat sa mga bug at crash.</string>
     <string name="label_add_device">Magdagdag ng device</string>
-    <string name="label_just_a_moment_please">Sandali lang, pakiusap.</string>
     <string name="label_notification_channel_status">Katayuan</string>
     <string name="label_notification_channel_setup">Kailangan ng pag-setup</string>
     <string name="monitor_notification_starting">Nagsisimula…</string>
     <string name="action_set">I-set</string>
     <string name="action_cancel">Kanselahin</string>
-    <string name="label_invalid_input">Maling input</string>
     <string name="action_reset">I-reset</string>
     <string name="label_no_connected_devices">Walang konektadong device</string>
-    <string name="label_status_idle">Walang ginagawa</string>
-    <string name="label_status_adjusting_volumes">Pagbabago sa mga volume</string>
-    <string name="label_premium_version">Bersyong premium</string>
     <string name="general_upgrade_action">I-upgrade</string>
     <string name="common_upgrade_required_label">Kailangan ng upgrade</string>
-    <string name="label_premium_version_required">Kailangan ang bersyong premium</string>
-    <string name="description_intro_purpose">Binibigyang daan ng app na maalala ng iyong Android device ang mga volume ng iba\'t-ibang mga Bluetooth device.</string>
-    <string name="upgrade_benefit_unlimited_devices">Walang limitasyong mga profile ng device</string>
-    <string name="upgrade_benefit_connection_actions">Autoplay, paglulunsad ng app at mga alerto sa koneksyon</string>
-    <string name="upgrade_benefit_theme_customization">Pag-customize ng tema, estilo at kulay</string>
-    <string name="upgrade_benefit_power_controls">Volume lock at rate limiting</string>
-    <string name="upgrade_benefit_support">Suportahan ang independiyenteng pag-unlad</string>
     <string name="upgrade_benefit_equalizer">• Equalizer bawat device (para sa mga music app na sumusuporta sa system equalizer)</string>
-    <string name="description_intro_tap_the_button">Magsimula sa pamamagitan ng pagdagdag ng iyong unang device.</string>
     <string name="description_bluetooth_is_disabled">Hindi pinagana ang bluetooth.</string>
     <string name="title_bluetooth_is_off">Naka-off ang Bluetooth</string>
     <string name="action_enable_bluetooth">I-enable ang Bluetooth</string>
     <string name="title_bluetooth_permission_required">Kailangan ng Bluetooth Permission</string>
     <string name="description_bluetooth_permission_required">Kailangan ng app na ito ng Bluetooth permission para pamahalaan ang mga volume ng iyong device.</string>
     <string name="action_grant_permission">Bigyan ng Permission</string>
-    <string name="label_status_listening_for_changes">Nakikinig sa mga pagbabago sa volume</string>
     <string name="action_exit">Lumabas</string>
-    <string name="action_start">Magsimula</string>
-    <string name="label_welcome">Maligayang pagdating</string>
-    <string name="description_intro_contact">Huwag mag-alinlangang kontakin ako kung may mga katanungan, pati na ideya tungkol sa isang bagong katangian.</string>
-    <string name="label_translation">Pagsasalin</string>
-    <string name="description_help_translate">Tulungan akong isalin ang app na ito sa ibang mga wika.</string>
     <string name="label_device_speaker">Speaker ng Device</string>
-    <string name="label_keyevent_playpause">I-play-Pause</string>
-    <string name="label_keyevent_play">I-play</string>
-    <string name="label_keyevent_next">Susunod</string>
-    <string name="label_install_id">Install ID</string>
     <string name="message_copied_to_clipboard">Nakopya sa clipboard</string>
-    <string name="label_thanks">Salamat</string>
-    <string name="label_licenses">Mga Lisensya</string>
-    <string name="description_ring_volume_additional_permission">Kailangan ng karagdagang permiso para baguhin ang ring volume.</string>
-    <string name="label_missing_permissions">Nawawalang mga permiso</string>
-    <string name="action_grant">Bigyan</string>
-    <string name="label_advanced">Advanced</string>
-    <string name="label_exclude_health">Ibukod ang mga health profile</string>
-    <string name="description_exclude_health">Ang ilang Android device ay nag-a-hang kapag naghahanap ng \'Health Device\' Bluetooth profiles (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Ibukod ang mga GATT server profile</string>
-    <string name="label_exclude_gatt">Ibukod ang mga GATT profile</string>
-    <string name="description_exclude_gattserver">Huwag i-query ang mga Bluetooth profile ng uri na \'Generic Attribute\' (GATT) server.</string>
-    <string name="description_exclude_gatt">Huwag i-query ang mga Bluetooth profile ng uri na \'Generic Attribute\' (GATT) client.</string>
-    <string name="description_waiting_for_devicex">Naghihintay sa %s para makumpleto ang koneksyon</string>
-    <string name="action_undo">I-undo</string>
-    <string name="action_show">Ipakita</string>
     <string name="action_dismiss">I-dismiss</string>
-    <string name="action_fix">Ayusin</string>
-    <string name="battery_optimizations_issue_description">Naka-enable ang battery optimizations para sa app na ito at maaaring pumigil sa pagtanggap ng mga Bluetooth event. Pag-isipang i-disable ang optimizations kung nararamdaman mong may mga isyu.</string>
     <string name="label_bluetooth_settings">Mga Bluetooth setting</string>
-    <string name="android10_applaunch_issue_description">Nililimitahan ng Android 10 kung paano maaaring ilunsad ang mga app mula sa background. Para payagan ang pagbubukas ng mga app kapag kumonekta ang isang Bluetooth device, bigyan ng permisong \"Display over other apps\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Source code</string>
-    <string name="android13_notification_permission_description">Bigyan ang app na ito ng permiso para mag-post ng mga notification. Nagbibigay-daan ito sa pagpapakita ng notification kapag aktibo ang app at gumagawa ng mga pagsasaayos ng volume.</string>
-    <string name="privacy_policy_label">Patakaran sa Privacy</string>
     <string name="managed_devices_empty_message">Walang Bluetooth device na na-configure.\nI-tap ang button na + para idagdag ang iyong unang device.</string>
     <string name="label_pro_feature">Premium na feature</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Pagsusuri</string>
     <string name="review_app_dismiss_action">Siguro mamaya</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Kinansela ang pagbili</string>
-    <string name="error_iap_unavailable_message">Hindi available ang mga in-app na pagbili</string>
-    <string name="error_generic_message">May naganap na error. Subukan muli.</string>
-    <string name="error_iap_owned_message">Pag-aari mo na ang item na ito</string>
     <string name="label_no_devices_title">Walang Device</string>
     <string name="bluemusic_mascot_description">Icon ng App</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Piliin ang mga App</string>
     <string name="devices_app_selection_search_hint">Maghanap ng mga app…</string>
-    <string name="devices_app_selection_currently_selected">Kasalukuyang napili</string>
     <string name="devices_app_selection_selected_count">%d mga app na napili</string>
     <string name="general_navigate_back_action">Bumalik</string>
     <string name="general_reset_action">I-reset</string>
     <string name="general_clear_action">I-clear</string>
-    <string name="general_save_action">I-save</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Naka-lock</string>
     <string name="devices_indicator_awake">Gising</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Limitado</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Boost</string>
-    <string name="devices_indicator_launch">Ilunsad</string>
     <string name="devices_indicator_home">Home</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Alerto</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Certaines fonctionnalités ont changé pendant la mise à jour. Veuillez vérifier les paramètres de vos appareils pour vous assurer que tout est configuré correctement.</string>
     <string name="onboarding_rewrite_action">Continuer</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Aucun périphérique non géré trouvé</string>
     <string name="discover_all_devices_managed_msg">Tous vos appareils appairés sont gérés ! Besoin d\'un nouveau ?</string>
     <string name="discover_pair_new_device_action">Appairer un nouvel appareil</string>
     <string name="discover_device_speaker_desc">Le haut-parleur propre de ce téléphone. Ses volumes sont appliqués lorsque l\'audio revient au téléphone, par exemple après la déconnexion de votre appareil Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuration du périphérique</string>
-    <string name="devices_device_config_section_general_label">Général</string>
     <string name="devices_device_config_remove_device_label">Oublier le périphérique</string>
-    <string name="devices_device_config_remove_device_desc">Oublie le périphérique de cette application et supprime sa configuration. Cela ne déconnecte pas le périphérique.</string>
     <string name="devices_device_config_remove_device_action">Oublier</string>
     <string name="devices_device_config_remove_device_confirmation">Oublier %s des périphériques gérés ?</string>
-    <string name="devices_device_config_rename_device_label">Renommer le périphérique</string>
-    <string name="devices_device_config_rename_device_desc">Renommer ce périphérique dans cette application, et si possible, dans le système.</string>
     <string name="devices_device_config_rename_device_action">Renommer</string>
     <string name="devices_device_config_enabled_label">Activé</string>
     <string name="devices_device_config_enabled_desc">Réagir à ce périphérique quand il se connecte</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Commandes de lecture automatique</string>
     <string name="devices_device_config_autoplay_keycodes_order">Séquence de commandes</string>
     <string name="devices_device_config_autoplay_keycodes_label">Commandes</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configurer les commandes à envoyer et leur ordre</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Aucune commande configurée</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Ajouter une commande</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximum %1$d commandes</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Déplacer vers le haut</string>
     <string name="cd_autoplay_keycode_move_down">Déplacer vers le bas</string>
     <string name="cd_autoplay_keycode_remove">Supprimer</string>
-    <string name="devices_device_config_section_volumes_label">Volumes</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
     <string name="devices_device_config_alarm_volume_label">Volume d\'alarme</string>
     <string name="devices_device_config_alarm_volume_desc">Certaines applis d\'alarme utilisent plutôt le volume de la musique.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Sonnerie</string>
     <string name="devices_audio_stream_notification_label">Notification</string>
     <string name="devices_audio_stream_alarm_label">Alarme</string>
-    <string name="devices_neverseen_label">Jamais rencontré</string>
-    <string name="devices_state_connected_label">Connecté</string>
     <string name="devices_last_connected_label">Dernière connexion : %s</string>
     <string name="devices_currently_connected_label">Actuellement connecté</string>
     <string name="devices_device_disabled_label">Périphérique désactivé</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Paramètres qui affectent tous les périphériques gérés.</string>
     <string name="label_app_enabled">Activation et désactivation de l\'appli</string>
     <string name="description_app_enabled">Active ou désactive la capacité de l\'appli de réagir aux événements de volume et Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Réglages visibles</string>
-    <string name="description_visible_volume_adjustments">Affiche la fenêtre de volume du système quand l\'appli effectue des réglages.</string>
     <string name="label_volume_listener">Observer les changements</string>
-    <string name="description_volume_listener">Rester active tant qu\'un périphérique est connecté et enregistrer les changements de volume qui ne proviennent pas de cette appli.</string>
     <string name="label_boot_restore">Restaurer au démarrage</string>
     <string name="description_boot_restore">Restaurer le volume après démarrage ou redémarrage si un périphérique Bluetooth est connecté.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Apprenez à utiliser BVM efficacement</string>
     <string name="settings_support_issue_tracker_description">Un système de suivi public pour les rapports de bogues et les demandes de fonctionnalités.</string>
     <string name="settings_support_issue_tracker_label">Suivi des problèmes</string>
-    <string name="settings_support_debuglog_label">Journal de débogage</string>
     <string name="settings_support_debuglog_desc">Enregistrez tout ce que fait l\'application dans un fichier texte que vous pouvez partager.</string>
-    <string name="settings_support_debuglog_recording_desc">Enregistrement en cours des informations de débogage. Appuyez pour arrêter l\'enregistrement.</string>
-    <string name="settings_support_debuglog_path">Chemin du journal : %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Enregistrement très court</string>
     <string name="settings_support_debuglog_short_recording_msg">C\'était un enregistrement très court. Les journaux de débogage sont des enregistrements, pas des instantanés — reproduisez le problème pendant l\'enregistrement pour que le journal soit utile.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continuer l\'enregistrement</string>
     <string name="settings_support_debuglog_short_recording_stop">Arrêter quand même</string>
-    <string name="settings_support_debuglog_folder_label">Dossier des journaux de débogage</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d session utilisant %2$s</item>
-        <item quantity="other">%1$d sessions utilisant %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Aucun journal de débogage enregistré</string>
-    <string name="settings_support_debuglog_folder_delete_title">Supprimer tous les journaux de débogage ?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Ceci supprimera définitivement toutes les sessions de journaux de débogage enregistrées.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Un endroit pour se retrouver et poser des questions.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Traduction</string>
     <string name="settings_acks_translators_title">Traducteurs</string>
     <string name="settings_acks_translators_people">yahoe.001 – Coordinateur de la traduction en français;V.Oberson;Choukajohn;Mickael81</string>
-    <string name="settings_acks_translate_title">Traduire BVM</string>
-    <string name="settings_acks_translate_desc">Aidez à traduire BVM dans votre langue</string>
     <string name="settings_acks_thanks_header">Merci</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Pour le soutien à la traduction de projets open-source</string>
     <string name="settings_licenses_label">Licences</string>
     <string name="settings_translation_label">Traduction</string>
     <string name="settings_translation_desc">Aidez à traduire l\'appli dans votre langue préférée</string>
-    <string name="settings_sponsor_development_title">Soutenir le développement</string>
-    <string name="settings_sponsor_development_summary">Devenez mécène et rendez possible le développement continu.</string>
     <string name="settings_privacy_policy_label">Politique de confidentialité</string>
     <string name="settings_privacy_policy_desc">Gérer les données de manière responsable.</string>
     <string name="changelog_label">Historique des modifications</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restauration terminée — %1$d appareils restaurés, %2$d ignorés.</string>
     <string name="backup_restore_version_warning">Cette sauvegarde a été créée avec la version %1$s. Vous utilisez la version %2$s. Certains paramètres peuvent ne pas être restaurés correctement.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notifications de débogage</string>
     <string name="debug_log_consent_title">Journal de débogage</string>
     <string name="debug_log_consent_explanation">Cette fonctionnalité enregistre tout ce que fait l\'application dans un fichier partageable. Le fichier généré contient des informations sensibles (par exemple, noms de fichiers et applications installées). Ne le partagez qu\'avec des parties de confiance (par exemple, un développeur résolvant un problème).</string>
-    <string name="debug_log_recording_progress">Enregistrement du journal de débogage</string>
     <string name="debug_log_record_action">Enregistrer</string>
     <string name="debug_log_stop_action">Arrêter l\'enregistrement</string>
     <string name="debug_log_screen_title">Enregistreur de journal de débogage</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Supprimer</string>
     <string name="debug_log_screen_keep_action">Conserver</string>
-    <string name="debug_log_compressing_label">Compression…</string>
     <string name="debug_log_file_label">Fichier journal enregistré</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Journal envoyé ?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Décrivez votre question en détail.</string>
     <string name="contact_category_section_label">Catégorie</string>
     <string name="contact_debug_log_label">Journal de débogage</string>
-    <string name="contact_debug_log_select_hint">Sélectionner un journal de débogage à joindre</string>
     <string name="contact_debug_log_picker_hint">Joignez un journal de débogage pour aider à diagnostiquer le problème plus rapidement.</string>
     <string name="contact_debug_log_picker_empty">Aucun journal de débogage disponible. Enregistrez-en un d\'abord.</string>
     <string name="contact_expected_behavior_label">Comportement attendu</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Je lis chaque message moi-même et fais de mon mieux pour répondre, mais comme je travaille seul, cela peut prendre un peu de temps. Merci de votre patience.</string>
     <string name="contact_footer_msg">Votre message sera envoyé par e-mail. Les informations sur l\'appareil et la configuration sont jointes automatiquement.</string>
     <string name="contact_no_email_app_msg">Aucune application e-mail trouvée sur cet appareil.</string>
-    <string name="contact_attachment_missing_msg">Le fichier journal de débogage n\'existe plus</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Journaux de débogage enregistrés</string>
     <string name="settings_support_stored_logs_desc">%1$d sessions (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Aucun journal de débogage enregistré</string>
-    <string name="settings_support_stored_logs_delete_title">Supprimer les journaux enregistrés ?</string>
-    <string name="settings_support_stored_logs_delete_msg">Ceci supprimera les %1$d sessions de journaux de débogage enregistrées.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Journaux de débogage enregistrés supprimés</string>
-    <string name="label_bug_reports">Relevés de bogues</string>
-    <string name="description_bug_reports">Signalement automatiquement des bogues et plantages.</string>
     <string name="label_add_device">Ajouter un périphérique</string>
-    <string name="label_just_a_moment_please">Un instant, s\'il vous plaît.</string>
     <string name="label_notification_channel_status">État</string>
     <string name="label_notification_channel_setup">Configuration requise</string>
     <string name="monitor_notification_starting">Démarrage…</string>
     <string name="action_set">Définir</string>
     <string name="action_cancel">Annuler</string>
-    <string name="label_invalid_input">Entrée invalide</string>
     <string name="action_reset">Réinitialiser</string>
     <string name="label_no_connected_devices">Aucun périphérique n\'est connecté</string>
-    <string name="label_status_idle">Inactif</string>
-    <string name="label_status_adjusting_volumes">Réglages des volumes</string>
-    <string name="label_premium_version">Version Pro</string>
     <string name="general_upgrade_action">Surclasser</string>
     <string name="common_upgrade_required_label">Mise à niveau requise</string>
-    <string name="label_premium_version_required">La version Pro est exigée</string>
-    <string name="description_intro_purpose">Cette appli permet à votre appareil Android de mémoriser le volume de différents périphériques Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Profils d’appareils illimités</string>
-    <string name="upgrade_benefit_connection_actions">Lecture automatique, lancement d’appli et alertes de connexion</string>
-    <string name="upgrade_benefit_theme_customization">Personnalisation du thème, du style et des couleurs</string>
-    <string name="upgrade_benefit_power_controls">Verrou de volume et limitation du débit</string>
-    <string name="upgrade_benefit_support">Soutenir le développement indépendant</string>
     <string name="upgrade_benefit_equalizer">• Égaliseur par appareil (pour les applis musicales avec prise en charge de l\'égaliseur système)</string>
-    <string name="description_intro_tap_the_button">Commencez en ajoutant votre premier périphérique.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth est désactivé.</string>
     <string name="title_bluetooth_is_off">Bluetooth est désactivé</string>
     <string name="action_enable_bluetooth">Activer Bluetooth</string>
     <string name="title_bluetooth_permission_required">Permission Bluetooth requise</string>
     <string name="description_bluetooth_permission_required">Cette application nécessite la permission Bluetooth pour gérer les volumes de vos périphériques.</string>
     <string name="action_grant_permission">Accorder la permission</string>
-    <string name="label_status_listening_for_changes">En attente de modifications du volume</string>
     <string name="action_exit">Quitter</string>
-    <string name="action_start">Commencer</string>
-    <string name="label_welcome">Bienvenue</string>
-    <string name="description_intro_contact">N\'hésitez pas à me contacter si vous avez des questions ou encore une idée pour une nouvelle fonction.</string>
-    <string name="label_translation">Traduction</string>
-    <string name="description_help_translate">Aidez-moi à proposer cette appli en d\'autres langues.</string>
     <string name="label_device_speaker">Haut-parleur de l\'appareil</string>
-    <string name="label_keyevent_playpause">Lecture-Pause</string>
-    <string name="label_keyevent_play">Lecture</string>
-    <string name="label_keyevent_next">Suivant</string>
-    <string name="label_install_id">ID d\'installation</string>
     <string name="message_copied_to_clipboard">A été copié dans le presse-papiers</string>
-    <string name="label_thanks">Merci</string>
-    <string name="label_licenses">Licences</string>
-    <string name="description_ring_volume_additional_permission">Des permissions supplémentaires sont requises pour changer le volume de la sonnerie.</string>
-    <string name="label_missing_permissions">Permissions insuffisantes</string>
-    <string name="action_grant">Accorder</string>
-    <string name="label_advanced">Avancé</string>
-    <string name="label_exclude_health">Exclure les profiles de santé</string>
-    <string name="description_exclude_health">Certains appareils Android gèlent lors de la recherche de profiles Bluetooth « Périphériques de santé » (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Exclure les profils serveur GATT</string>
-    <string name="label_exclude_gatt">Exclure les profils GATT</string>
-    <string name="description_exclude_gattserver">Ne pas demander les profils Bluetooth de type serveur « Attribut générique » (GATT).</string>
-    <string name="description_exclude_gatt">Ne pas demander les profils Bluetooth de type client « Attribut générique » (GATT).</string>
-    <string name="description_waiting_for_devicex">Attente de connexion effective de %s</string>
-    <string name="action_undo">Rétablir</string>
-    <string name="action_show">Afficher</string>
     <string name="action_dismiss">Ignorer</string>
-    <string name="action_fix">Corriger</string>
-    <string name="battery_optimizations_issue_description">Les optimisations de la pile sont activées pour cette appli et peuvent l\'empêcher de recevoir les événements Bluetooth. Envisagez de désactiver ces optimisations si vous éprouvez des problèmes.</string>
     <string name="label_bluetooth_settings">Paramètres Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 restreint la façon dont les applis peuvent être lancées en arrière-plan. Pour permettre l\'ouverture d\'applis quand un appareil Bluetooth se connecte, accordez l\'autorisation « Afficher par dessus les autres applis » (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Code source</string>
-    <string name="android13_notification_permission_description">Accordez à cette application la permission de publier des notifications. Cela permet d\'afficher une notification lorsque cette application est active et que des ajustements de volume sont effectués.</string>
-    <string name="privacy_policy_label">Politique de confidentialité</string>
     <string name="managed_devices_empty_message">Aucun périphérique Bluetooth configuré.\nAppuyez sur le bouton + pour ajouter votre premier périphérique.</string>
     <string name="label_pro_feature">Fonctionnalité premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Évaluation</string>
     <string name="review_app_dismiss_action">Plus tard, peut-être</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Achat annulé</string>
-    <string name="error_iap_unavailable_message">Les achats intégrés ne sont pas disponibles</string>
-    <string name="error_generic_message">Une erreur s\'est produite. Veuillez réessayer.</string>
-    <string name="error_iap_owned_message">Vous possédez déjà cet article</string>
     <string name="label_no_devices_title">Aucun périphérique</string>
     <string name="bluemusic_mascot_description">Icône de l\'application</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Sélectionner les applis</string>
     <string name="devices_app_selection_search_hint">Rechercher des applis…</string>
-    <string name="devices_app_selection_currently_selected">Actuellement sélectionné</string>
     <string name="devices_app_selection_selected_count">%d applis sélectionnées</string>
     <string name="general_navigate_back_action">Retour</string>
     <string name="general_reset_action">Réinitialiser</string>
     <string name="general_clear_action">Effacer</string>
-    <string name="general_save_action">Sauvegarder</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Verrouillé</string>
     <string name="devices_indicator_awake">Éveillé</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Limiter</string>
     <string name="devices_indicator_eq">ÉQ</string>
     <string name="devices_indicator_boost">Boost</string>
-    <string name="devices_indicator_launch">Lancer</string>
     <string name="devices_indicator_home">Accueil</string>
     <string name="devices_indicator_dnd">NPD</string>
     <string name="devices_indicator_alert">Alerte</string>

--- a/app/src/main/res/values-gl-rES/strings.xml
+++ b/app/src/main/res/values-gl-rES/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Algunhas funcionalidades cambiaron durante a actualización. Por favor, revisa a configuración dos teus dispositivos para asegurarte de que todo está configurado correctamente.</string>
     <string name="onboarding_rewrite_action">Continuar</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Non se atoparon dispositivos non xestionados</string>
     <string name="discover_all_devices_managed_msg">Todos os teus dispositivos emparellados están xestionados! Necesitas un novo?</string>
     <string name="discover_pair_new_device_action">Emparellar novo dispositivo</string>
     <string name="discover_device_speaker_desc">O propio altofalante do teléfono. Os seus volumes aplícanse cando o audio volve ao teléfono, p.e., despois de que se desconecte o teu dispositivo Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuración do dispositivo</string>
-    <string name="devices_device_config_section_general_label">Xeral</string>
     <string name="devices_device_config_remove_device_label">Esquecer dispositivo</string>
-    <string name="devices_device_config_remove_device_desc">Esquece o dispositivo desta aplicación e elimina a súa configuración. Isto non desemparella o dispositivo.</string>
     <string name="devices_device_config_remove_device_action">Esquecer</string>
     <string name="devices_device_config_remove_device_confirmation">Esquecer %s dos dispositivos xestionados?</string>
-    <string name="devices_device_config_rename_device_label">Cambiar nome do dispositivo</string>
-    <string name="devices_device_config_rename_device_desc">Cambia o nome deste dispositivo nesta aplicación e, se é posible, no sistema.</string>
     <string name="devices_device_config_rename_device_action">Cambiar nome</string>
     <string name="devices_device_config_enabled_label">Activado</string>
     <string name="devices_device_config_enabled_desc">Reaccionar a este dispositivo cando se conecte</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Comandos de reprodución automática</string>
     <string name="devices_device_config_autoplay_keycodes_order">Secuencia de comandos</string>
     <string name="devices_device_config_autoplay_keycodes_label">Comandos</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configura que comandos enviar e en que orde</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Sen comandos configurados</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Engadir comando</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Máximo %1$d comandos</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Mover cara arriba</string>
     <string name="cd_autoplay_keycode_move_down">Mover cara abaixo</string>
     <string name="cd_autoplay_keycode_remove">Quitar</string>
-    <string name="devices_device_config_section_volumes_label">Volumes</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
     <string name="devices_device_config_alarm_volume_label">Volume da alarma</string>
     <string name="devices_device_config_alarm_volume_desc">Algunhas aplicacións de alarma usan o volume da música en vez do da alarma.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Ton</string>
     <string name="devices_audio_stream_notification_label">Notificación</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="devices_neverseen_label">Nunca visto</string>
-    <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Último acceso: %s</string>
     <string name="devices_currently_connected_label">Conectado actualmente</string>
     <string name="devices_device_disabled_label">Dispositivo desactivado</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Configuración que afecta a todos os dispositivos xestionados.</string>
     <string name="label_app_enabled">Aplicación activada</string>
     <string name="description_app_enabled">Alterna a capacidade das aplicacións para reaccionar ante eventos de volume e bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Axustes visibles</string>
-    <string name="description_visible_volume_adjustments">Mostra o volume do sistema mentres esta aplicación realiza axustes.</string>
     <string name="label_volume_listener">Observar os cambios</string>
-    <string name="description_volume_listener">Mantense activo mentres un dispositivo está conectado e garda os cambios de volume non causados por esta aplicación.</string>
     <string name="label_boot_restore">Restaurar ao inicio</string>
     <string name="description_boot_restore">Restaura o volume logo de iniciar ou reiniciar en caso de que estea conectado un dispositivo bluetooth.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Aprende a usar BVM de forma eficaz</string>
     <string name="settings_support_issue_tracker_description">Un rastreador público de problemas para informes de erros e solicitudes de funcionalidades.</string>
     <string name="settings_support_issue_tracker_label">Rastreador de problemas</string>
-    <string name="settings_support_debuglog_label">Rexistro de depuración</string>
     <string name="settings_support_debuglog_desc">Grava todo o que fai a aplicación nun ficheiro de texto que podes compartir.</string>
-    <string name="settings_support_debuglog_recording_desc">Gravando información de depuración actualmente. Toca para deter a gravación.</string>
-    <string name="settings_support_debuglog_path">Ruta do rexistro: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Gravación moi curta</string>
     <string name="settings_support_debuglog_short_recording_msg">Esa foi unha gravación moi curta. Os rexistros de depuración son gravacións, non instantáneas — reproduce o problema mentres a gravación está activa para que o rexistro sexa útil.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continuar gravando</string>
     <string name="settings_support_debuglog_short_recording_stop">Deter de todos modos</string>
-    <string name="settings_support_debuglog_folder_label">Cartafol de rexistros de depuración</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sesión usando %2$s</item>
-        <item quantity="other">%1$d sesións usando %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Non hai rexistros de depuración almacenados</string>
-    <string name="settings_support_debuglog_folder_delete_title">Eliminar todos os rexistros de depuración?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Isto eliminará permanentemente todas as sesións de rexistro de depuración almacenadas.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Un lugar para pasar o tempo e facer preguntas.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Tradución</string>
     <string name="settings_acks_translators_title">Tradutores</string>
     <string name="settings_acks_translators_people">Persoa1;Persoa2(opcional@email.com)</string>
-    <string name="settings_acks_translate_title">Traducir BVM</string>
-    <string name="settings_acks_translate_desc">Axuda a traducir BVM ao teu idioma</string>
     <string name="settings_acks_thanks_header">Grazas</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Por apoiar a tradución de proxectos de código aberto</string>
     <string name="settings_licenses_label">Licenzas</string>
     <string name="settings_translation_label">Tradución</string>
     <string name="settings_translation_desc">Axuda a traducir a aplicación ao teu idioma favorito</string>
-    <string name="settings_sponsor_development_title">Patrocinar o desenvolvemento</string>
-    <string name="settings_sponsor_development_summary">Convértete en mecenas e fai posible o desenvolvemento continuo.</string>
     <string name="settings_privacy_policy_label">Política de privacidade</string>
     <string name="settings_privacy_policy_desc">Xestión responsable dos datos.</string>
     <string name="changelog_label">Rexistro de cambios</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restauración completa — %1$d dispositivos restaurados, %2$d omitidos.</string>
     <string name="backup_restore_version_warning">Esta copia de seguridade foi creada coa versión %1$s. Estás usando %2$s. É posible que algúns axustes non se restauren correctamente.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notificacións de depuración</string>
     <string name="debug_log_consent_title">Rexistro de depuración</string>
     <string name="debug_log_consent_explanation">Esta función grava todo o que fai a aplicación nun ficheiro compartible. O ficheiro xerado contén información sensible (p. ex. nomes de ficheiros e aplicacións instaladas). Compárteo só con partes de confianza (p. ex. un desenvolvedor que resolve un problema).</string>
-    <string name="debug_log_recording_progress">Gravando rexistro de depuración</string>
     <string name="debug_log_record_action">Gravar</string>
     <string name="debug_log_stop_action">Deter gravación</string>
     <string name="debug_log_screen_title">Gravador de rexistro de depuración</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Descartar</string>
     <string name="debug_log_screen_keep_action">Conservar</string>
-    <string name="debug_log_compressing_label">Comprimindo…</string>
     <string name="debug_log_file_label">Ficheiro de rexistro gravado</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Rexistro enviado?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Describe a túa pregunta en detalle.</string>
     <string name="contact_category_section_label">Categoría</string>
     <string name="contact_debug_log_label">Rexistro de depuración</string>
-    <string name="contact_debug_log_select_hint">Selecciona un rexistro de depuración para adxuntar</string>
     <string name="contact_debug_log_picker_hint">Adxunta un rexistro de depuración para axudar a diagnosticar o problema máis rápido.</string>
     <string name="contact_debug_log_picker_empty">Non hai rexistros de depuración dispoñibles. Grava un primeiro.</string>
     <string name="contact_expected_behavior_label">Comportamento esperado</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Leo cada mensaxe eu mesmo e fago todo o posible por responder, pero como traballo só, pode levar un pouco de tempo. Grazas pola túa paciencia.</string>
     <string name="contact_footer_msg">A túa mensaxe enviarase por correo electrónico. A información do dispositivo e da configuración adxúntase automaticamente.</string>
     <string name="contact_no_email_app_msg">Non se atopou ningunha aplicación de correo neste dispositivo.</string>
-    <string name="contact_attachment_missing_msg">O ficheiro de rexistro de depuración xa non existe</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Rexistros de depuración almacenados</string>
     <string name="settings_support_stored_logs_desc">%1$d sesións (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Non hai rexistros de depuración almacenados</string>
-    <string name="settings_support_stored_logs_delete_title">Eliminar rexistros almacenados?</string>
-    <string name="settings_support_stored_logs_delete_msg">Isto eliminará todas as %1$d sesións de rexistro de depuración almacenadas.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Rexistros de depuración almacenados eliminados</string>
-    <string name="label_bug_reports">Informes de erros</string>
-    <string name="description_bug_reports">Informes automáticos de erros e caídas.</string>
     <string name="label_add_device">Engadir dispositivo</string>
-    <string name="label_just_a_moment_please">Agarda un intre, por favor.</string>
     <string name="label_notification_channel_status">Estado</string>
     <string name="label_notification_channel_setup">Configuración necesaria</string>
     <string name="monitor_notification_starting">Iniciando…</string>
     <string name="action_set">Establecer</string>
     <string name="action_cancel">Cancelar</string>
-    <string name="label_invalid_input">Entrada non válida</string>
     <string name="action_reset">Restablecer</string>
     <string name="label_no_connected_devices">Ningún dispositivo conectado</string>
-    <string name="label_status_idle">Inactivo</string>
-    <string name="label_status_adjusting_volumes">Axuste de volumes</string>
-    <string name="label_premium_version">Versión Premium</string>
     <string name="general_upgrade_action">Actualizar</string>
     <string name="common_upgrade_required_label">Actualización requirida</string>
-    <string name="label_premium_version_required">Versión Premium obrigatoria</string>
-    <string name="description_intro_purpose">Esta aplicación permite que o teu Android lembre o volume dos diferentes dispositivos bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Perfís de dispositivos ilimitados</string>
-    <string name="upgrade_benefit_connection_actions">Reprodución automática, inicio de aplicación e alertas de conexión</string>
-    <string name="upgrade_benefit_theme_customization">Personalización do tema, estilo e cor</string>
-    <string name="upgrade_benefit_power_controls">Bloqueo de volume e limitación de velocidade</string>
-    <string name="upgrade_benefit_support">Apoiar o desenvolvemento independente</string>
     <string name="upgrade_benefit_equalizer">• Ecualizador por dispositivo (para apps de música compatibles co ecualizador do sistema)</string>
-    <string name="description_intro_tap_the_button">Comeza engadindo o teu primeiro dispositivo.</string>
     <string name="description_bluetooth_is_disabled">O bluetooth está desactivado.</string>
     <string name="title_bluetooth_is_off">Bluetooth desactivado</string>
     <string name="action_enable_bluetooth">Activar Bluetooth</string>
     <string name="title_bluetooth_permission_required">Permiso Bluetooth requirido</string>
     <string name="description_bluetooth_permission_required">Esta aplicación necesita o permiso de Bluetooth para xestionar os volumes dos teus dispositivos.</string>
     <string name="action_grant_permission">Conceder permiso</string>
-    <string name="label_status_listening_for_changes">Escoitar os cambios de volume</string>
     <string name="action_exit">Saír</string>
-    <string name="action_start">Iniciar</string>
-    <string name="label_welcome">Benvido/a</string>
-    <string name="description_intro_contact">Non dubides en contactar comigo se tes algunha cuestión ou idea sobre unha nova funcionalidade.</string>
-    <string name="label_translation">Tradución</string>
-    <string name="description_help_translate">Axúdame a facer dispoñible esta aplicación noutros idiomas.</string>
     <string name="label_device_speaker">Altofalante do dispositivo</string>
-    <string name="label_keyevent_playpause">Reproducir-deter</string>
-    <string name="label_keyevent_play">Reproducir</string>
-    <string name="label_keyevent_next">Seguinte</string>
-    <string name="label_install_id">ID de instalación</string>
     <string name="message_copied_to_clipboard">Copiado ao portapapeis</string>
-    <string name="label_thanks">Grazas</string>
-    <string name="label_licenses">Licenzas</string>
-    <string name="description_ring_volume_additional_permission">Cómpren permisos adicionais para cambiar o volume do ton.</string>
-    <string name="label_missing_permissions">Permisos pendentes</string>
-    <string name="action_grant">Conceder</string>
-    <string name="label_advanced">Avanzadas</string>
-    <string name="label_exclude_health">Excluír os perfís de saúde</string>
-    <string name="description_exclude_health">Algúns dispositivos Android bloquéanse ao buscar perfís bluetooth de \&quot;Dispositivos de saúde\&quot; (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Excluír perfís de servidor GATT</string>
-    <string name="label_exclude_gatt">Excluír perfís GATT</string>
-    <string name="description_exclude_gattserver">Non consulta perfís bluetooth do tipo \&quot;Atributo xenérico\&quot; (GATT).</string>
-    <string name="description_exclude_gatt">Non consulta perfís bluetooth de clientes do tipo \&quot;Atributo xenérico\&quot; (GATT).</string>
-    <string name="description_waiting_for_devicex">Agardando por %s para completar a conexión</string>
-    <string name="action_undo">Desfacer</string>
-    <string name="action_show">Mostrar</string>
     <string name="action_dismiss">Pechar</string>
-    <string name="action_fix">Arranxar</string>
-    <string name="battery_optimizations_issue_description">As optimizacións da batería están activadas para esta aplicación e poden impedir que reciba eventos Bluetooth. Considera desactivalas se experimentas problemas.</string>
     <string name="label_bluetooth_settings">Configuración de Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 restrinxe como as aplicacións poden iniciarse en segundo plano. Para permitir a apertura de aplicacións ao conectarse un dispositivo Bluetooth, concede o permiso &quot;Mostrar sobre outras aplicacións&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Código fonte</string>
-    <string name="android13_notification_permission_description">Concede a esta aplicación permiso para publicar notificacións. Isto permite mostrar unha notificación cando a aplicación está activa e se realizan axustes de volume.</string>
-    <string name="privacy_policy_label">Política de privacidade</string>
     <string name="managed_devices_empty_message">Non hai dispositivos Bluetooth configurados.\nToca o botón + para engadir o teu primeiro dispositivo.</string>
     <string name="label_pro_feature">Función premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Valorar</string>
     <string name="review_app_dismiss_action">Quizais máis tarde</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Compra cancelada</string>
-    <string name="error_iap_unavailable_message">As compras dentro da aplicación non están dispoñibles</string>
-    <string name="error_generic_message">Produciuse un erro. Téntao de novo.</string>
-    <string name="error_iap_owned_message">Xa tes este artigo</string>
     <string name="label_no_devices_title">Sen dispositivos</string>
     <string name="bluemusic_mascot_description">Icona da aplicación</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Seleccionar Aplicacións</string>
     <string name="devices_app_selection_search_hint">Buscar aplicacións…</string>
-    <string name="devices_app_selection_currently_selected">Seleccionado actualmente</string>
     <string name="devices_app_selection_selected_count">%d aplicacións seleccionadas</string>
     <string name="general_navigate_back_action">Navegar atrás</string>
     <string name="general_reset_action">Restablecer</string>
     <string name="general_clear_action">Limpar</string>
-    <string name="general_save_action">Gardar</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Bloqueo</string>
     <string name="devices_indicator_awake">Activo</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Límite</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Aumento</string>
-    <string name="devices_indicator_launch">Lanzar</string>
     <string name="devices_indicator_home">Inicio</string>
     <string name="devices_indicator_dnd">NM</string>
     <string name="devices_indicator_alert">Alerta</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">इस अपडेट के दौरान कुछ डिवाइस सेटिंग्स रीसेट हो गई होंगी। कृपया अपने डिवाइस कॉन्फिगरेशन की जांच करें।</string>
     <string name="onboarding_rewrite_action">जारी रखें</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">कोई अप्रबंधित डिवाइस नहीं मिला</string>
     <string name="discover_all_devices_managed_msg">आपके सभी पेयर्ड डिवाइस प्रबंधित हैं! एक नया चाहिए?</string>
     <string name="discover_pair_new_device_action">नया डिवाइस पेयर करें</string>
     <string name="discover_device_speaker_desc">इस फोन का अपना स्पीकर। इसकी वॉल्यूम तब लागू होती है जब ऑडियो फोन पर वापस स्विच हो, जैसे आपके Bluetooth डिवाइस के डिस्कनेक्ट होने के बाद।</string>
     <!-- Devices -->
     <string name="devices_device_config_label">डिवाइस कॉन्फिगरेशन</string>
-    <string name="devices_device_config_section_general_label">सामान्य</string>
     <string name="devices_device_config_remove_device_label">डिवाइस भूल जाएं</string>
-    <string name="devices_device_config_remove_device_desc">इस ऐप से डिवाइस को भूल जाता है और इसका कॉन्फिगरेशन डिलीट कर देता है। यह डिवाइस को अनपेयर नहीं करता।</string>
     <string name="devices_device_config_remove_device_action">भूल जाएं</string>
     <string name="devices_device_config_remove_device_confirmation">प्रबंधित डिवाइस से %s को भूल जाएं?</string>
-    <string name="devices_device_config_rename_device_label">डिवाइस का नाम बदलें</string>
-    <string name="devices_device_config_rename_device_desc">इस ऐप में इस डिवाइस का नाम बदलें, और यदि संभव हो तो सिस्टम में भी।</string>
     <string name="devices_device_config_rename_device_action">नाम बदलें</string>
     <string name="devices_device_config_enabled_label">सक्षम</string>
     <string name="devices_device_config_enabled_desc">कनेक्ट होने पर इस डिवाइस पर प्रतिक्रिया करें</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">ऑटोप्ले कमांड</string>
     <string name="devices_device_config_autoplay_keycodes_order">कमांड क्रम</string>
     <string name="devices_device_config_autoplay_keycodes_label">कमांड</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">कॉन्फ़िगर करें कि कौन सी कमांड भेजनी हैं और किस क्रम में</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">कोई कमांड कॉन्फ़िगर नहीं है</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">कमांड जोड़ें</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">अधिकतम %1$d कमांड</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">ओपर ले जाएं</string>
     <string name="cd_autoplay_keycode_move_down">नीचे ले जाएं</string>
     <string name="cd_autoplay_keycode_remove">हटाएं</string>
-    <string name="devices_device_config_section_volumes_label">ध्वनि</string>
     <string name="devices_device_config_section_volume_label">वॉल्यूम</string>
     <string name="devices_device_config_alarm_volume_label">अलार्म वॉल्यूम</string>
     <string name="devices_device_config_alarm_volume_desc">कुछ अलार्म ऐप इसके बजाय म्यूजिक वॉल्यूम का उपयोग करते हैं।</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">रिंग</string>
     <string name="devices_audio_stream_notification_label">अधिसूचना</string>
     <string name="devices_audio_stream_alarm_label">अलार्म</string>
-    <string name="devices_neverseen_label">कभी नहीं देखा</string>
-    <string name="devices_state_connected_label">जुड गया</string>
     <string name="devices_last_connected_label">आखिरी बार जुड़ा: %s</string>
     <string name="devices_currently_connected_label">फिलहाल जुड़ा है</string>
     <string name="devices_device_disabled_label">डिवाइस अक्षम</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">वह सेटिंग्स जो सभी प्रबंधित डिवाइस को प्रभावित करती हैं।</string>
     <string name="label_app_enabled">ऐप्प्स सक्षम किया गया</string>
     <string name="description_app_enabled">वॉल्यूम और ब्लूटूथ ईवेंट पर प्रतिक्रिया करने के लिए ऐप्प की क्षमता को टॉगल करें</string>
-    <string name="label_visible_volume_adjustments">दृश्यमान समायोजन</string>
-    <string name="description_visible_volume_adjustments">इस ऐप्प को समायोजन करने के दौरान सिस्टम की वॉल्यूम विंडो दिखाएं।</string>
     <string name="label_volume_listener">परिवर्तनों को देखें</string>
-    <string name="description_volume_listener">डिवाइस जुड़े होने दौरान सक्रिय रहें और ध्वनि परिवर्तन सहेजे, जो इस ऐप के कारण नहीं हुए हैं।</string>
     <string name="label_boot_restore">बूट पर पुनर्स्थापित करें</string>
     <string name="description_boot_restore">यदि कोई ब्लूटूथ डिवाइस कनेक्टेड है, तो बूटिंग/रीबूट करने के बाद वॉल्यूम पुनर्स्थापित करें ।</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM का प्रभावी रूप से उपयोग करना सीखें</string>
     <string name="settings_support_issue_tracker_description">बग रिपोर्ट्स और फीचर रिक्वेस्ट के लिए एक पब्लिक इश्यू ट्रैकर।</string>
     <string name="settings_support_issue_tracker_label">इश्यू ट्रैकर</string>
-    <string name="settings_support_debuglog_label">डिबग लॉग</string>
     <string name="settings_support_debuglog_desc">इस आप की हर गतिविधि को उस टेक्स्ट फाइल में रिकार्ड करें जिसे आप साझा कर सकते हैं।</string>
-    <string name="settings_support_debuglog_recording_desc">फिलहाल डिबग जानकारी रिकार्ड हो रही है। रिकार्डिंग बंद करने के लिए टैप करें।</string>
-    <string name="settings_support_debuglog_path">लॉग पाथ: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">बहुत छोटी रिकॉर्डिंग</string>
     <string name="settings_support_debuglog_short_recording_msg">यह एक बहुत छोटी रिकॉर्डिंग थी। डिबग लॉग रिकॉर्डिंग हैं, स्नैपशॉट नहीं — रिकॉर्डिंग सक्रिय रहते हुए समस्या को दोहराएं ताकि लॉग उपयोगी हो।</string>
     <string name="settings_support_debuglog_short_recording_continue">रिकॉर्डिंग जारी रखें</string>
     <string name="settings_support_debuglog_short_recording_stop">फिर भी रोकें</string>
-    <string name="settings_support_debuglog_folder_label">डिबग लॉग फोल्डर</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d सत्र, %2$s उपयोग कर रहा है</item>
-        <item quantity="other">%1$d सत्र, %2$s उपयोग कर रहे हैं</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">कोई डिबग लॉग संग्रहीत नहीं</string>
-    <string name="settings_support_debuglog_folder_delete_title">सभी डिबग लॉग हटाएं?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">यह सभी संग्रहीत डिबग लॉग सत्रों को स्थायी रूप से हटा देगा।</string>
     <string name="settings_support_discord_label">डिस्कॉर्ड</string>
     <string name="settings_support_discord_description">मिलने-जुलने और प्रश्न पूछने की जगह।</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">अनुवाद</string>
     <string name="settings_acks_translators_title">अनुवादक</string>
     <string name="settings_acks_translators_people">व्यक्ति1;व्यक्ति2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM का अनुवाद करें</string>
-    <string name="settings_acks_translate_desc">BVM को आपकी भाषा में अनुवाद करने में सहायता करें</string>
     <string name="settings_acks_thanks_header">धन्यवाद</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">ओपन-सोर्स प्रोजेक्ट्स के अनुवाद का समर्थन करने के लिए</string>
     <string name="settings_licenses_label">लाइसेंस</string>
     <string name="settings_translation_label">अनुवाद</string>
     <string name="settings_translation_desc">ऐप को अपनी पसंदीदा भाषा में अनुवाद करने में मदद करें</string>
-    <string name="settings_sponsor_development_title">विकास को स्पॉन्सर करें</string>
-    <string name="settings_sponsor_development_summary">एक पेट्रन बनें और निरंतर विकास को संभव बनाएं।</string>
     <string name="settings_privacy_policy_label">प्राइवेसी पालिसी</string>
     <string name="settings_privacy_policy_desc">डेटा को जिम्मेदारी से हैंडल करना।</string>
     <string name="changelog_label">बदलाव लॉग</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">रिस्टोर पूर्ण — %1$d डिवाइस रिस्टोर हुए, %2$d छोड़े गए।</string>
     <string name="backup_restore_version_warning">यह बैकअप वर्शन %1$s से बनाया गया था। आप %2$s चला रहे हैं। कुछ सेटिंग्स सही तरह से रिस्टोर नहीं हो सकती हैं।</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">डिबग अधिसूचनाएं</string>
     <string name="debug_log_consent_title">डिबग लॉग</string>
     <string name="debug_log_consent_explanation">यह फीचर आप की सभी गतिविधियों को एक साझा करने योग्य फाइल में रिकॉर्ड करता है। जेनरेट की गई फाइल में संवेदनशील जानकारी (जैसे फाइल नाम और इंस्टॉल किए गए आप) शामिल हैं। इसे केवल भरोसेमंद पार्टियों (जैसे समस्या का हल खोज रहे डेवलपर) के साथ साझा करें।</string>
-    <string name="debug_log_recording_progress">डिबग लॉग रिकॉर्ड हो रहा है</string>
     <string name="debug_log_record_action">रिकॉर्ड</string>
     <string name="debug_log_stop_action">रिकॉर्डिंग बंद करें</string>
     <string name="debug_log_screen_title">डिबग लॉग रिकॉर्डर</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">रद्द करें</string>
     <string name="debug_log_screen_keep_action">रखें</string>
-    <string name="debug_log_compressing_label">संपीड़ित हो रहा है…</string>
     <string name="debug_log_file_label">रिकॉर्ड की गई लॉग फाइल</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">लॉग भेजा गया?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">अपना सवाल विस्तार से बताएं।</string>
     <string name="contact_category_section_label">श्रेणी</string>
     <string name="contact_debug_log_label">डिबग लॉग</string>
-    <string name="contact_debug_log_select_hint">संलग्न करने के लिए डिबग लॉग चुनें</string>
     <string name="contact_debug_log_picker_hint">समस्या को तेज़ी से निदान करने में मदद के लिए डिबग लॉग संलग्न करें।</string>
     <string name="contact_debug_log_picker_empty">कोई डिबग लॉग उपलब्ध नहीं। पहले एक रिकॉर्ड करें।</string>
     <string name="contact_expected_behavior_label">अपेक्षित व्यवहार</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">मैं हर संदेश खुद पढ़ता हूं और जवाब देने की पूरी कोशिश करता हूं, लेकिन चूंकि मैं अकेले काम करता हूं, इसमें थोड़ा समय लग सकता है। आपकी धैर्यता के लिए धन्यवाद।</string>
     <string name="contact_footer_msg">आपका संदेश ईमेल के ज़रिए भेजा जाएगा। डिवाइस और सेटअप की जानकारी स्वचालित रूप से संलग्न होती है।</string>
     <string name="contact_no_email_app_msg">इस डिवाइस पर कोई ईमेल ऐप नहीं मिला।</string>
-    <string name="contact_attachment_missing_msg">डिबग लॉग फ़ाइल अब मौजूद नहीं है</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">संग्रहीत डिबग लॉग</string>
     <string name="settings_support_stored_logs_desc">%1$d सत्र (%2$s)</string>
     <string name="settings_support_stored_logs_empty">कोई संग्रहीत डिबग लॉग नहीं</string>
-    <string name="settings_support_stored_logs_delete_title">संग्रहीत लॉग हटाएं?</string>
-    <string name="settings_support_stored_logs_delete_msg">यह सभी %1$d संग्रहीत डिबग लॉग सत्रों को हटा देगा।</string>
-    <string name="settings_support_stored_logs_deleted_msg">संग्रहीत डिबग लॉग हटाए गए</string>
-    <string name="label_bug_reports">त्रुटि विवरण</string>
-    <string name="description_bug_reports">स्वचालित त्रुटि और क्रैश विवरणी।</string>
     <string name="label_add_device">डिवाइस जोड़ें</string>
-    <string name="label_just_a_moment_please">कृपया, एक पल रुके</string>
     <string name="label_notification_channel_status">स्थिति</string>
     <string name="label_notification_channel_setup">सेटअप आवश्यक</string>
     <string name="monitor_notification_starting">शुरुआत हो रही है…</string>
     <string name="action_set">सेट</string>
     <string name="action_cancel">रद्द</string>
-    <string name="label_invalid_input">अमान्य इनपुट</string>
     <string name="action_reset">रिसेट</string>
     <string name="label_no_connected_devices">कोई डिवाइस जुडी हुई नहीं है</string>
-    <string name="label_status_idle">स्थिर/निष्क्रिय</string>
-    <string name="label_status_adjusting_volumes">वॉल्यूम समायोजन</string>
-    <string name="label_premium_version">प्रीमियम संस्करण</string>
     <string name="general_upgrade_action">अपग्रेड</string>
     <string name="common_upgrade_required_label">अपग्रेड आवश्यक है</string>
-    <string name="label_premium_version_required">प्रीमियम संस्करण की आवश्यकता है</string>
-    <string name="description_intro_purpose">यह ऐप आपके एंड्रॉइड डिवाइस को विभिन्न ब्लूटूथ उपकरणों की मात्रा याद रखने की अनुमति देता है।</string>
-    <string name="upgrade_benefit_unlimited_devices">असीमित डिवाइस प्रोफ़ाइल</string>
-    <string name="upgrade_benefit_connection_actions">ऑटोप्ले, ऐप लॉन्च और कनेक्शन अलर्ट</string>
-    <string name="upgrade_benefit_theme_customization">थीम, स्टाइल और रंग कस्टमाइज़ेशन</string>
-    <string name="upgrade_benefit_power_controls">वॉल्यूम लॉक और रेट लिमिटिंग</string>
-    <string name="upgrade_benefit_support">स्वतंत्र विकास का समर्थन करें</string>
     <string name="upgrade_benefit_equalizer">• प्रति-डिवाइस इक्वलाइज़र (सिस्टम इक्वलाइज़र सपोर्ट वाले म्यूज़िक ऐप्स के लिए)</string>
-    <string name="description_intro_tap_the_button">अपना पहला डिवाइस जोड़कर प्रारंभ करें।</string>
     <string name="description_bluetooth_is_disabled">ब्लूटूथ अक्षम है।</string>
     <string name="title_bluetooth_is_off">ब्लूटूथ बंद है</string>
     <string name="action_enable_bluetooth">ब्लूटूथ सक्षम करें</string>
     <string name="title_bluetooth_permission_required">ब्लूटूथ अनुमति आवश्यक</string>
     <string name="description_bluetooth_permission_required">इस आप को आपके डिवाइस वॉल्यूम को मैनेज करने के लिए ब्लूटूथ अनुमति की आवश्यकता है।</string>
     <string name="action_grant_permission">अनुमति दें</string>
-    <string name="label_status_listening_for_changes">वॉल्यूम परिवर्तन के लिए सुन रहा है</string>
     <string name="action_exit">निकास</string>
-    <string name="action_start">प्रारंभ करें</string>
-    <string name="label_welcome">स्वागत है</string>
-    <string name="description_intro_contact">यदि आपके पास कोई प्रश्न या कोई नई सुविधा के लिए कोई विचार है तो मुझसे संपर्क करने में संकोच न करें।</string>
-    <string name="label_translation">अनुवाद</string>
-    <string name="description_help_translate">इस ऐप को अन्य भाषाओं में उपलब्ध कराने में मेरी सहायता करें।</string>
     <string name="label_device_speaker">डिवाइस स्पीकर</string>
-    <string name="label_keyevent_playpause">चालू करें-रोके</string>
-    <string name="label_keyevent_play">चलाएँ</string>
-    <string name="label_keyevent_next">आगे</string>
-    <string name="label_install_id">इनस्टॉल आईडी</string>
     <string name="message_copied_to_clipboard">क्लिपबोर्ड पर प्रतिलिपि बनाई गई</string>
-    <string name="label_thanks">धन्यवाद</string>
-    <string name="label_licenses">अनुज्ञप्ति</string>
-    <string name="description_ring_volume_additional_permission">रिंग की ध्वनि को बदलने के लिए अतिरिक्त अनुमतियां आवश्यक हैं।</string>
-    <string name="label_missing_permissions">अनुमतियां अनुपस्थित है</string>
-    <string name="action_grant">स्‍वीकृत</string>
-    <string name="label_advanced">उन्नत</string>
-    <string name="label_exclude_health">स्वास्थ्य प्रोफाइल को वर्जित करें</string>
-    <string name="description_exclude_health">\'हेल्थ डिवाइस\' ब्लूटूथ प्रोफाइल (एचडीपी, 0x1400) को देखते समय कुछ एंड्रॉइड डिवाइस हैंग होते हैं।</string>
-    <string name="label_exclude_gattserver">GATT सर्वर प्रोफाइल को वर्जित करें</string>
-    <string name="label_exclude_gatt">जीएटीटी प्रोफाइल बहिष्कृत करें</string>
-    <string name="description_exclude_gattserver">\'जेनेरिक एट्रिब्यूट\' (जीएटीटी) सर्वर के प्रकार के ब्लूटूथ प्रोफाइल से पूछताछ न करें।</string>
-    <string name="description_exclude_gatt">\'जेनेरिक एट्रिब्यूट\' (जीएटीटी) क्लाइंट के प्रकार के ब्लूटूथ प्रोफाइल से पूछताछ न करें</string>
-    <string name="description_waiting_for_devicex">कनेक्शन को पूरा करने के लिए %s की प्रतीक्षा कर रहा है</string>
-    <string name="action_undo">पूर्ववत्</string>
-    <string name="action_show">दिखाएँ</string>
     <string name="action_dismiss">खारिज करें</string>
-    <string name="action_fix">ठीक करें</string>
-    <string name="battery_optimizations_issue_description">बैटरी अनुकूलन इस एप्लिकेशन के लिए सक्षम हैं और ब्लूटूथ घटनाओं प्राप्त करने से इसे रोक सकते हैं । यदि आप समस्याओं का सामना कर रहे हैं, तो ऑप्टिमाइज़ेशन अक्षम करने पर विचार करें ।</string>
     <string name="label_bluetooth_settings">ब्लूटूथ सेटिंग्स</string>
-    <string name="android10_applaunch_issue_description">एंड्रॉइड 10 बताता है कि पृष्ठभूमि से एप्लिकेशन कैसे लॉन्च किए जा सकते हैं। ब्लूटूथ डिवाइस कनेक्ट होने पर एप्लिकेशन खोलने की अनुमति देने के लिए, \&quot;अन्य एप्लिकेशन पर प्रदर्शन\&quot; (SYSTEM_ALERT_WINDOW) की अनुमति दें।</string>
-    <string name="label_opensource">सोर्स कोड</string>
-    <string name="android13_notification_permission_description">इस आप को अधिसूचना पोस्ट करने की अनुमति दें। यह एक अधिसूचना दिखाने को सक्षम करता है जब यह आप सक्रिय हो और वॉल्यूम समायोजन किए जा रहे हों।</string>
-    <string name="privacy_policy_label">प्राइवेसी पालिसी</string>
     <string name="managed_devices_empty_message">कोई ब्लूटूथ डिवाइस कॉन्फिगर नहीं किया गया।\nअपना पहला डिवाइस जोड़ने के लिए + बटन पर टैप करें।</string>
     <string name="label_pro_feature">प्रीमियम फीचर</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">समीक्षा करें</string>
     <string name="review_app_dismiss_action">शायद बाद में</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">खरीदारी रद्द</string>
-    <string name="error_iap_unavailable_message">इन-आप खरीदारी उपलब्ध नहीं</string>
-    <string name="error_generic_message">एक त्रुटि आई। कृपया पुनः प्रयास करें।</string>
-    <string name="error_iap_owned_message">आपके पास यह आइटम पहले से है</string>
     <string name="label_no_devices_title">कोई डिवाइस नहीं</string>
     <string name="bluemusic_mascot_description">आप आइकन</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">ऐप्स चुनें</string>
     <string name="devices_app_selection_search_hint">ऐप्स खोजें…</string>
-    <string name="devices_app_selection_currently_selected">वर्तमान में चयनित</string>
     <string name="devices_app_selection_selected_count">%d ऐप्स चयनित</string>
     <string name="general_navigate_back_action">वापस नेविगेट करें</string>
     <string name="general_reset_action">रीसेट करें</string>
     <string name="general_clear_action">साफ करें</string>
-    <string name="general_save_action">सेव करें</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">लॉक</string>
     <string name="devices_indicator_awake">जागृत</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">सीमा</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">बूस्ट</string>
-    <string name="devices_indicator_launch">लॉन्च</string>
     <string name="devices_indicator_home">होम</string>
     <string name="devices_indicator_dnd">परेशान न करें</string>
     <string name="devices_indicator_alert">अलर्ट</string>

--- a/app/src/main/res/values-hr/strings.xml
+++ b/app/src/main/res/values-hr/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Neke postavke uređaja mogu biti resetirane tijekom ovog ažuriranja. Molimo provjerite konfiguracije svojih uređaja.</string>
     <string name="onboarding_rewrite_action">Nastavi</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nisu pronađeni neupravljani uređaji</string>
     <string name="discover_all_devices_managed_msg">Svi vaši upareni uređaji su upravljani! Trebate novi?</string>
     <string name="discover_pair_new_device_action">Upari novi uređaj</string>
     <string name="discover_device_speaker_desc">Vlastiti zvučnik telefona. Njegove razine glasnoće primjenjuju se kada se zvuk prebaci natrag na telefon, npr. nakon što se vaš Bluetooth uređaj isključi.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfiguracija uređaja</string>
-    <string name="devices_device_config_section_general_label">Općenito</string>
     <string name="devices_device_config_remove_device_label">Zaboravi uređaj</string>
-    <string name="devices_device_config_remove_device_desc">Zaboravlja uređaj iz ove aplikacije i briše njegovu konfiguraciju. Ovo ne uklanja uparivanje uređaja.</string>
     <string name="devices_device_config_remove_device_action">Zaboravi</string>
     <string name="devices_device_config_remove_device_confirmation">Zaboraviti %s iz upravljanih uređaja?</string>
-    <string name="devices_device_config_rename_device_label">Preimenuj uređaj</string>
-    <string name="devices_device_config_rename_device_desc">Preimenuj ovaj uređaj unutar ove aplikacije, i ako je moguće, unutar sustava.</string>
     <string name="devices_device_config_rename_device_action">Preimenuj</string>
     <string name="devices_device_config_enabled_label">Omogućeno</string>
     <string name="devices_device_config_enabled_desc">Reagiraj na ovaj uređaj kada se poveže</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Naredbe automatskog reproduciranja</string>
     <string name="devices_device_config_autoplay_keycodes_order">Redoslijed naredbi</string>
     <string name="devices_device_config_autoplay_keycodes_label">Naredbe</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Konfiguriraj koje naredbe slati i kojim redoslijedom</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nema konfiguriranih naredbi</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Dodaj naredbu</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimalno %1$d naredbi</string>
@@ -122,7 +116,6 @@
     <string name="cd_autoplay_keycode_move_up">Pomakni gore</string>
     <string name="cd_autoplay_keycode_move_down">Pomakni dolje</string>
     <string name="cd_autoplay_keycode_remove">Ukloni</string>
-    <string name="devices_device_config_section_volumes_label">Glasnoća</string>
     <string name="devices_device_config_section_volume_label">Glasnoća</string>
     <string name="devices_device_config_alarm_volume_label">Glasnoća alarma</string>
     <string name="devices_device_config_alarm_volume_desc">Neke aplikacije za alarm koriste glasnoću glazbe umjesto toga.</string>
@@ -156,8 +149,6 @@
     <string name="devices_audio_stream_ring_label">Zvono</string>
     <string name="devices_audio_stream_notification_label">Obavijest</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Nikad viđen</string>
-    <string name="devices_state_connected_label">Povezano</string>
     <string name="devices_last_connected_label">Posljednji put povezan: %s</string>
     <string name="devices_currently_connected_label">Trenutno povezan</string>
     <string name="devices_device_disabled_label">Uređaj onemogućen</string>
@@ -192,10 +183,7 @@
     <string name="devices_settings_desc">Postavke koje utječu na sve upravljane uređaje.</string>
     <string name="label_app_enabled">Aplikacija je omogućena</string>
     <string name="description_app_enabled">Uključuje/isključuje sposobnost aplikacije da reagira na glasnoću i Bluetooth događaje.</string>
-    <string name="label_visible_volume_adjustments">Vidljive prilagodbe</string>
-    <string name="description_visible_volume_adjustments">Prikažite prozor glasnoće sustava dok ova aplikacija izvršava izmjene.</string>
     <string name="label_volume_listener">Promatraj promjene</string>
-    <string name="description_volume_listener">Ostaje aktivan dok je uređaj povezan i sprema promjene glasnoće koje nisu uzrokovane ovom aplikacijom.</string>
     <string name="label_boot_restore">Vrati na ponovnom pokretanju</string>
     <string name="description_boot_restore">Vrati glasnoću nakon ponovnog pokretanja ako je Bluetooth uređaj povezan.</string>
     <!-- Settings/Support-->
@@ -205,23 +193,11 @@
     <string name="settings_support_wiki_description">Naučite kako učinkovito koristiti BVM</string>
     <string name="settings_support_issue_tracker_description">Javni sustav praćenja problema za prijave bugova i zahtjeve za značajkama.</string>
     <string name="settings_support_issue_tracker_label">Praćenje problema</string>
-    <string name="settings_support_debuglog_label">Zapisnik za otklanjanje pogrešaka</string>
     <string name="settings_support_debuglog_desc">Snimite sve što aplikacija radi u tekstualnu datoteku koju možete dijeliti.</string>
-    <string name="settings_support_debuglog_recording_desc">Trenutno se snimaju debug informacije. Dodirnite za zaustavljanje snimanja.</string>
-    <string name="settings_support_debuglog_path">Put do loga: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Vrlo kratko snimanje</string>
     <string name="settings_support_debuglog_short_recording_msg">To je bilo vrlo kratko snimanje. Debug logovi su snimke, ne snimke stanja — reproducirajte problem dok je snimanje aktivno da bi log bio koristan.</string>
     <string name="settings_support_debuglog_short_recording_continue">Nastavi snimanje</string>
     <string name="settings_support_debuglog_short_recording_stop">Zaustavi svejedno</string>
-    <string name="settings_support_debuglog_folder_label">Mapa debug logova</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sesija koristi %2$s</item>
-        <item quantity="few">%1$d sesije koriste %2$s</item>
-        <item quantity="other">%1$d sesija koristi %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nema pohranjenih debug logova</string>
-    <string name="settings_support_debuglog_folder_delete_title">Obrisati sve debug logove?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Ovo će trajno obrisati sve pohranjene debug log sesije.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Mjesto za druženje i postavljanje pitanja.</string>
     <!-- Settings/Acks-->
@@ -230,16 +206,12 @@
     <string name="settings_acks_translation_header">Prijevod</string>
     <string name="settings_acks_translators_title">Prevoditelji</string>
     <string name="settings_acks_translators_people">Tarik Hadžirović (tarik.hadzirovic.official@gmail.com);MatijaThe245th</string>
-    <string name="settings_acks_translate_title">Prevedi BVM</string>
-    <string name="settings_acks_translate_desc">Pomozite prevesti BVM na vaš jezik</string>
     <string name="settings_acks_thanks_header">Zahvale</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Za podršku prevođenja projekata otvorenog koda</string>
     <string name="settings_licenses_label">Licence</string>
     <string name="settings_translation_label">Prijevod</string>
     <string name="settings_translation_desc">Pomozite prevesti aplikaciju na svoj omiljeni jezik</string>
-    <string name="settings_sponsor_development_title">Sponzoriraj razvoj</string>
-    <string name="settings_sponsor_development_summary">Postanite pokrovitelj i omogućite nastavak razvoja.</string>
     <string name="settings_privacy_policy_label">Pravila privatnosti</string>
     <string name="settings_privacy_policy_desc">Odgovorno rukovanje podacima.</string>
     <string name="changelog_label">Dnevnik promjena</string>
@@ -261,10 +233,8 @@
     <string name="backup_restore_success_restore">Obnavljanje završeno — %1$d uređaja obnovljeno, %2$d preskočeno.</string>
     <string name="backup_restore_version_warning">Ova sigurnosna kopija kreirana je s verzijom %1$s. Trenutno koristite %2$s. Neke postavke možda neće biti pravilno obnovljene.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Debug obavijesti</string>
     <string name="debug_log_consent_title">Zapisnik za otklanjanje pogrešaka</string>
     <string name="debug_log_consent_explanation">Ova značajka snima sve što aplikacija radi u datoteku koja se može dijeliti. Generirana datoteka sadrži osjetljive informacije (npr. nazive datoteka i instalirane aplikacije). Dijelite je samo s pouzdanim stranama (npr. programerom koji rješava problem).</string>
-    <string name="debug_log_recording_progress">Snimanje debug loga</string>
     <string name="debug_log_record_action">Snimi</string>
     <string name="debug_log_stop_action">Zaustavi snimanje</string>
     <string name="debug_log_screen_title">Snimač debug loga</string>
@@ -280,7 +250,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Odbaci</string>
     <string name="debug_log_screen_keep_action">Zadrži</string>
-    <string name="debug_log_compressing_label">Komprimiranje…</string>
     <string name="debug_log_file_label">Snimljena log datoteka</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log poslan?</string>
@@ -308,7 +277,6 @@
     <string name="contact_description_question_hint">Opišite svoje pitanje detaljno.</string>
     <string name="contact_category_section_label">Kategorija</string>
     <string name="contact_debug_log_label">Zapisnik za otklanjanje pogrešaka</string>
-    <string name="contact_debug_log_select_hint">Odaberi debug log za prilaganje</string>
     <string name="contact_debug_log_picker_hint">Priložite debug log za brže dijagnosticiranje problema.</string>
     <string name="contact_debug_log_picker_empty">Nema dostupnih debug logova. Najprije snimite jedan.</string>
     <string name="contact_expected_behavior_label">Očekivano ponašanje</string>
@@ -323,82 +291,32 @@
     <string name="contact_welcome_msg">Svaku poruku čitam osobno i dajem sve od sebe da odgovorim, ali budući da radim sam, to može potrajati. Hvala na strpljenju.</string>
     <string name="contact_footer_msg">Vaša poruka bit će poslana e-mailom. Informacije o uređaju i postavkama priložene su automatski.</string>
     <string name="contact_no_email_app_msg">Na ovom uređaju nije pronađena aplikacija za e-mail.</string>
-    <string name="contact_attachment_missing_msg">Debug log datoteka više ne postoji</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Pohranjeni debug logovi</string>
     <string name="settings_support_stored_logs_desc">%1$d sesija (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Nema pohranjenih debug logova</string>
-    <string name="settings_support_stored_logs_delete_title">Obrisati pohranjene logove?</string>
-    <string name="settings_support_stored_logs_delete_msg">Ovo će obrisati svih %1$d pohranjenih debug log sesija.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Pohranjeni debug logovi obrisani</string>
-    <string name="label_bug_reports">Izvješća o pogreškama</string>
-    <string name="description_bug_reports">Automatsko izvješćivanje o pogreškama i padovima.</string>
     <string name="label_add_device">Dodaj uređaj</string>
-    <string name="label_just_a_moment_please">Samo trenutak.</string>
     <string name="label_notification_channel_status">Stanje</string>
     <string name="label_notification_channel_setup">Potrebno je postavljanje</string>
     <string name="monitor_notification_starting">Pokretanje…</string>
     <string name="action_set">Postavi</string>
     <string name="action_cancel">Odustani</string>
-    <string name="label_invalid_input">Pogrešan unos</string>
     <string name="action_reset">Ponovno postavi</string>
     <string name="label_no_connected_devices">Nema povezanih uređaja</string>
-    <string name="label_status_idle">Mirovanje</string>
-    <string name="label_status_adjusting_volumes">Podešavanje glasnoća</string>
-    <string name="label_premium_version">Premium verzija</string>
     <string name="general_upgrade_action">Nadogradi</string>
     <string name="common_upgrade_required_label">Nadogradnja potrebna</string>
-    <string name="label_premium_version_required">Potrebna je premium verzija</string>
-    <string name="description_intro_purpose">Ova aplikacija dopušta Vašem Android uređaju da zapamti glasnoću različitih Bluetooth uređaja.</string>
-    <string name="upgrade_benefit_unlimited_devices">Neograničeni profili uređaja</string>
-    <string name="upgrade_benefit_connection_actions">Automatska reprodukcija, pokretanje aplikacije i obavijesti o spajanju</string>
-    <string name="upgrade_benefit_theme_customization">Prilagodba teme, stila i boja</string>
-    <string name="upgrade_benefit_power_controls">Zaključavanje glasnoće i ograničenje brzine</string>
-    <string name="upgrade_benefit_support">Podržite neovisni razvoj</string>
     <string name="upgrade_benefit_equalizer">• Ekvilajzer po uređaju (za glazbene aplikacije s podrškom za sustavni ekvilajzer)</string>
-    <string name="description_intro_tap_the_button">Započnite dodavanjem svog prvog uređaja.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth je onemogućen.</string>
     <string name="title_bluetooth_is_off">Bluetooth je isključen</string>
     <string name="action_enable_bluetooth">Uključi Bluetooth</string>
     <string name="title_bluetooth_permission_required">Potrebno je dopuštenje za Bluetooth</string>
     <string name="description_bluetooth_permission_required">Ova aplikacija treba dopuštenje za Bluetooth za upravljanje glasnoćama uređaja.</string>
     <string name="action_grant_permission">Daj dopuštenje</string>
-    <string name="label_status_listening_for_changes">Slušanje promjena glasnoće</string>
     <string name="action_exit">Izlaz</string>
-    <string name="action_start">Započni</string>
-    <string name="label_welcome">Dobrodošli</string>
-    <string name="description_intro_contact">Nemojte se ustručavati, kontaktirajte me ako imate pitanja ili čak ideja za nove značajke.</string>
-    <string name="label_translation">Prijevod</string>
-    <string name="description_help_translate">Pomozite mi prevesti ovu aplikaciju na druge jezike.</string>
     <string name="label_device_speaker">Zvučnik uređaja</string>
-    <string name="label_keyevent_playpause">Reprodukcija-pauza</string>
-    <string name="label_keyevent_play">Reprodukcija</string>
-    <string name="label_keyevent_next">Sljedeće</string>
-    <string name="label_install_id">ID instalacije</string>
     <string name="message_copied_to_clipboard">Kopirano u međuspremnik</string>
-    <string name="label_thanks">Hvala</string>
-    <string name="label_licenses">Licence</string>
-    <string name="description_ring_volume_additional_permission">Dodatna dopuštenja su potrebne za promjenu glasnoće zvona.</string>
-    <string name="label_missing_permissions">Dopuštenja koja nedostaju</string>
-    <string name="action_grant">Dopusti</string>
-    <string name="label_advanced">Napredno</string>
-    <string name="label_exclude_health">Izuzmi zdravstvene profile</string>
-    <string name="description_exclude_health">Neki Android uređaji se smrznu prilikom pretraživanja Bluetooth profila \&quot;Health Device\&quot; (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Izuzmi profile GATT poslužitelja</string>
-    <string name="label_exclude_gatt">Izuzmi GATT profile</string>
-    <string name="description_exclude_gattserver">Nemoj tražiti Bluetooth profile vrste \&quot;Generic Attribute\&quot; (GATT) poslužitelj.</string>
-    <string name="description_exclude_gatt">Nemoj tražiti Bluetooth profile vrste \&quot;Generic Attribute\&quot; (GATT) klijent.</string>
-    <string name="description_waiting_for_devicex">Čekanje na %s za dovršetak veze</string>
-    <string name="action_undo">Poništi</string>
-    <string name="action_show">Prikaži</string>
     <string name="action_dismiss">Odbaci</string>
-    <string name="action_fix">Popravi</string>
-    <string name="battery_optimizations_issue_description">Optimizacija baterije je omogućena za ovu aplikaciju i može ju spriječiti u primanju Bluetooth događaja. Razmislite o onemogućavanju ako imate problema.</string>
     <string name="label_bluetooth_settings">Bluetooth postavke</string>
-    <string name="android10_applaunch_issue_description">Android 10 ograničava način pokretanja aplikacija iz pozadine. Da biste omogućili otvaranje aplikacija kada se Bluetooth uređaj poveže, dozvolite dopuštenje \&quot;Prikazivanje preko drugih aplikacija\&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Izvorni kod</string>
-    <string name="android13_notification_permission_description">Dajte ovoj aplikaciji dopuštenje za slanje obavijesti. To omogućuje prikazivanje obavijesti kada je aplikacija aktivna i vrše se prilagodbe glasnoće.</string>
-    <string name="privacy_policy_label">Pravila privatnosti</string>
     <string name="managed_devices_empty_message">Nije konfiguriran nijedan Bluetooth uređaj.\nDodirnite gumb + za dodavanje prvog uređaja.</string>
     <string name="label_pro_feature">Premium značajka</string>
     <plurals name="discover_device_limit_banner">
@@ -430,21 +348,15 @@
     <string name="review_app_review_action">Ocijeni</string>
     <string name="review_app_dismiss_action">Možda kasnije</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Kupnja otkazana</string>
-    <string name="error_iap_unavailable_message">Kupnje unutar aplikacije nisu dostupne</string>
-    <string name="error_generic_message">Došlo je do pogreške. Molimo pokušajte ponovo.</string>
-    <string name="error_iap_owned_message">Već posjedujete ovu stavku</string>
     <string name="label_no_devices_title">Nema uređaja</string>
     <string name="bluemusic_mascot_description">Ikona aplikacije</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Odaberi aplikacije</string>
     <string name="devices_app_selection_search_hint">Pretraži aplikacije…</string>
-    <string name="devices_app_selection_currently_selected">Trenutno odabrano</string>
     <string name="devices_app_selection_selected_count">%d aplikacija odabrano</string>
     <string name="general_navigate_back_action">Vrati se natrag</string>
     <string name="general_reset_action">Resetiraj</string>
     <string name="general_clear_action">Obriši</string>
-    <string name="general_save_action">Spremi</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Zaključaj</string>
     <string name="devices_indicator_awake">Budno</string>
@@ -454,7 +366,6 @@
     <string name="devices_indicator_limit">Ograničenje</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Pojačanje</string>
-    <string name="devices_indicator_launch">Pokretanje</string>
     <string name="devices_indicator_home">Početna</string>
     <string name="devices_indicator_dnd">NEM</string>
     <string name="devices_indicator_alert">Upozorenje</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Néhány eszközbeállítás visszaállítódhatott a frissítés során. Kérlek ellenőrizd az eszközkonfigurációkat.</string>
     <string name="onboarding_rewrite_action">Folytatás</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nem találhatók nem kezelt eszközök</string>
     <string name="discover_all_devices_managed_msg">Minden párosított eszközöd kezelt! Kell egy új?</string>
     <string name="discover_pair_new_device_action">Új eszköz párosítása</string>
     <string name="discover_device_speaker_desc">A telefon beépített hangszórója. Hangereje akkor érvényesül, amikor a hang visszakapcsolódik a telefonra, például a Bluetooth-eszköz lecsatlakozása után.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Eszköz beállítása</string>
-    <string name="devices_device_config_section_general_label">Általános</string>
     <string name="devices_device_config_remove_device_label">Eszköz elfelejtése</string>
-    <string name="devices_device_config_remove_device_desc">Elfelejti az eszközt ebből az alkalmazásból és törli annak beállításait. Ez nem szünteti meg az eszköz Bluetooth párosítását.</string>
     <string name="devices_device_config_remove_device_action">Elfelejt</string>
     <string name="devices_device_config_remove_device_confirmation">Elfelejted a(z) %s eszközt a kezelt eszközök közül?</string>
-    <string name="devices_device_config_rename_device_label">Eszköz átnevezése</string>
-    <string name="devices_device_config_rename_device_desc">Nevezd át ezt az eszközt az alkalmazáson belül, és ha lehetséges, a rendszer szintjén is.</string>
     <string name="devices_device_config_rename_device_action">Átnevezés</string>
     <string name="devices_device_config_enabled_label">Engedélyezve</string>
     <string name="devices_device_config_enabled_desc">Reagáljon erre az eszközre, amikor csatlakozik</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Automatikus lejátszási parancsok</string>
     <string name="devices_device_config_autoplay_keycodes_order">Parancssorozat</string>
     <string name="devices_device_config_autoplay_keycodes_label">Parancsok</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Beállíthatod, hogy mely parancsokat küldje el és milyen sorrendben</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nincs beállított parancs</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Parancs hozzáadása</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximum %1$d parancs</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Fel</string>
     <string name="cd_autoplay_keycode_move_down">Le</string>
     <string name="cd_autoplay_keycode_remove">Eltávolítás</string>
-    <string name="devices_device_config_section_volumes_label">Hangerő</string>
     <string name="devices_device_config_section_volume_label">Hangerő</string>
     <string name="devices_device_config_alarm_volume_label">Ébresztő hangereje</string>
     <string name="devices_device_config_alarm_volume_desc">Néhány ébresztő alkalmazás a zene hangerőt használja helyette.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Csengő</string>
     <string name="devices_audio_stream_notification_label">Értesítés</string>
     <string name="devices_audio_stream_alarm_label">Ébresztő</string>
-    <string name="devices_neverseen_label">Soha nem látott</string>
-    <string name="devices_state_connected_label">Csatlakozva</string>
     <string name="devices_last_connected_label">Utoljára csatlakozva: %s</string>
     <string name="devices_currently_connected_label">Jelenleg csatlakozva</string>
     <string name="devices_device_disabled_label">Eszköz letiltva</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Beállítások, amelyek az összes kezelt eszközre hatnak.</string>
     <string name="label_app_enabled">Alkalmazás engedélyezve</string>
     <string name="description_app_enabled">Az alkalmazás reagálási képességét kapcsolja be a hangerő és a Bluetooth eseményekre.</string>
-    <string name="label_visible_volume_adjustments">Látható beállítások</string>
-    <string name="description_visible_volume_adjustments">Jelenítsd meg a rendszer hangerő ablakát, miközben az alkalmazás hangerőbeállításokat végez.</string>
     <string name="label_volume_listener">Változások megfigyelése</string>
-    <string name="description_volume_listener">Az alkalmazás maradjon aktív, miközben az eszköz csatlakoztatva van, és mentse a hangerőváltozásokat, amelyeket az alkalmazás nem okozott.</string>
     <string name="label_boot_restore">Rendszer indulásakor visszaállít</string>
     <string name="description_boot_restore">A hangerő visszaállítása újraindítás után, ha egy Bluetooth eszköz csatlakozik.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Tanuld meg, hogyan használd hatékonyan a BVM-et</string>
     <string name="settings_support_issue_tracker_description">Nyilvános hibajelentő rendszer hibák és funkciókérések számára.</string>
     <string name="settings_support_issue_tracker_label">Hibajelentő rendszer</string>
-    <string name="settings_support_debuglog_label">Hibakeresési napló</string>
     <string name="settings_support_debuglog_desc">Rögzítsd mindent, amit az alkalmazás csinál egy szöveges fájlba, amit meg tudsz osztani.</string>
-    <string name="settings_support_debuglog_recording_desc">Jelenleg hibakeresési információkat rögzít. Koppints a rögzítés leállításához.</string>
-    <string name="settings_support_debuglog_path">Napló útvonala: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Nagyon rövid felvétel</string>
     <string name="settings_support_debuglog_short_recording_msg">Ez egy nagyon rövid felvétel volt. A hibakeresési naplók felvételek, nem pillanatképek — reprodukáld a problémát felvétel közben, hogy a napló hasznos legyen.</string>
     <string name="settings_support_debuglog_short_recording_continue">Felvétel folytatása</string>
     <string name="settings_support_debuglog_short_recording_stop">Leállítás mindenképpen</string>
-    <string name="settings_support_debuglog_folder_label">Hibakeresési napló mappa</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d munkamenet, %2$s használatával</item>
-        <item quantity="other">%1$d munkamenet, %2$s használatával</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nincsenek tárolt hibakeresési naplók</string>
-    <string name="settings_support_debuglog_folder_delete_title">Törli az összes hibakeresési naplót?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Ez véglegesen törli az összes tárolt hibakeresési napló munkamenetet.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Egy hely, ahol lógni és kérdéseket feltenni lehet.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Fordítás</string>
     <string name="settings_acks_translators_title">Fordítók</string>
     <string name="settings_acks_translators_people">Személy1;Személy2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM fordítása</string>
-    <string name="settings_acks_translate_desc">Segíts lefordítani a BVM-et a te nyelvedre</string>
     <string name="settings_acks_thanks_header">Köszönet</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">A nyílt forráskódú projektek fordításának támogatásáért</string>
     <string name="settings_licenses_label">Licencek</string>
     <string name="settings_translation_label">Fordítás</string>
     <string name="settings_translation_desc">Segítsd az alkalmazás lefordítását a kedvenc nyelvedre</string>
-    <string name="settings_sponsor_development_title">Fejlesztés támogatása</string>
-    <string name="settings_sponsor_development_summary">Válj támogatóvá és tedd lehetővé a folyamatos fejlesztést.</string>
     <string name="settings_privacy_policy_label">Adatvédelmi irányelvek</string>
     <string name="settings_privacy_policy_desc">Adatok felelősségteljes kezelése.</string>
     <string name="changelog_label">Változásnapló</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Visszaállítás kész – %1$d eszköz visszaállítva, %2$d kihagyva.</string>
     <string name="backup_restore_version_warning">Ez a mentés a(z) %1$s verzióval készült. Jelenleg a(z) %2$s fut. Néhány beállítás esetleg nem áll vissza megfelelően.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Hibakeresési értesítések</string>
     <string name="debug_log_consent_title">Hibakeresési napló</string>
     <string name="debug_log_consent_explanation">Ez a funkció mindent rögzít, amit az alkalmazás csinál egy megosztható fájlba. A létrehozott fájl érzékeny információkat tartalmaz (pl. fájlnevek és telepített alkalmazások). Csak megbízható felekkel oszd meg (pl. egy fejlesztővel, aki hibaelhárítást végz).</string>
-    <string name="debug_log_recording_progress">Hibakeresési napló rögzítése</string>
     <string name="debug_log_record_action">Rögzítés</string>
     <string name="debug_log_stop_action">Rögzítés leállítása</string>
     <string name="debug_log_screen_title">Hibakeresési napló rögzítő</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Eldobás</string>
     <string name="debug_log_screen_keep_action">Megtartás</string>
-    <string name="debug_log_compressing_label">Tömörítés…</string>
     <string name="debug_log_file_label">Rögzített naplófájl</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Napló elküldve?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Írd le részletesen a kérdésedet.</string>
     <string name="contact_category_section_label">Kategória</string>
     <string name="contact_debug_log_label">Hibakeresési napló</string>
-    <string name="contact_debug_log_select_hint">Válassz hibakeresési naplót a csatoláshoz</string>
     <string name="contact_debug_log_picker_hint">Csatolj hibakeresési naplót, hogy gyorsabban lehessen diagnosztizálni a problémát.</string>
     <string name="contact_debug_log_picker_empty">Nincs elérhető hibakeresési napló. Először rögzíts egyet.</string>
     <string name="contact_expected_behavior_label">Várt viselkedés</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Minden üzenetet személyesen olvasok el és mindent megteszek, hogy válaszoljak, de mivel egyedül dolgozom, ez eltarthat egy kicsit. Köszönöm a türelmedet.</string>
     <string name="contact_footer_msg">Az üzeneted e-mailben kerül elküldésre. Az eszköz és beállítási adatok automatikusan csatolva lesznek.</string>
     <string name="contact_no_email_app_msg">Ezen az eszközön nem található e-mail alkalmazás.</string>
-    <string name="contact_attachment_missing_msg">A hibakeresési napló fájl már nem létezik</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Tárolt hibakeresési naplók</string>
     <string name="settings_support_stored_logs_desc">%1$d munkamenet (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Nincsenek tárolt hibakeresési naplók</string>
-    <string name="settings_support_stored_logs_delete_title">Törli a tárolt naplókat?</string>
-    <string name="settings_support_stored_logs_delete_msg">Ez törli az összes %1$d tárolt hibakeresési napló munkamenetet.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Tárolt hibakeresési naplók törölve</string>
-    <string name="label_bug_reports">Hibajelentés</string>
-    <string name="description_bug_reports">Automatikus hiba- és összeomlás jelentés.</string>
     <string name="label_add_device">Eszköz hozzáadása</string>
-    <string name="label_just_a_moment_please">Egy pillanat, kérlek.</string>
     <string name="label_notification_channel_status">Állapot</string>
     <string name="label_notification_channel_setup">Beállítás szükséges</string>
     <string name="monitor_notification_starting">Indítás…</string>
     <string name="action_set">Beállítás</string>
     <string name="action_cancel">Mégse</string>
-    <string name="label_invalid_input">Érvénytelen adat</string>
     <string name="action_reset">Visszaállítás</string>
     <string name="label_no_connected_devices">Nincs csatlakoztatott eszköz</string>
-    <string name="label_status_idle">Üresjárat</string>
-    <string name="label_status_adjusting_volumes">Hangerő beállítása</string>
-    <string name="label_premium_version">Prémium verzió</string>
     <string name="general_upgrade_action">Frissítés</string>
     <string name="common_upgrade_required_label">Frissítés szükséges</string>
-    <string name="label_premium_version_required">Prémium verzió szükséges</string>
-    <string name="description_intro_purpose">Ez az alkalmazás lehetővé teszi, hogy az Android készüléked emlékezzen a különböző Bluetooth-eszközök hangerejére.</string>
-    <string name="upgrade_benefit_unlimited_devices">Korlátlan eszközprofilok</string>
-    <string name="upgrade_benefit_connection_actions">Automatikus lejátszás, alkalmazásindítás és kapcsolódási értesítések</string>
-    <string name="upgrade_benefit_theme_customization">Téma, stílus és szín testreszabása</string>
-    <string name="upgrade_benefit_power_controls">Hangerőzár és sebességkorlátozás</string>
-    <string name="upgrade_benefit_support">Független fejlesztés támogatása</string>
     <string name="upgrade_benefit_equalizer">• Eszközönkénti hangszínszabályzó (zenealkalmazások rendszer-hangszínszabályzó-támogatása esetén)</string>
-    <string name="description_intro_tap_the_button">Kezdéshez adj hozzá az első eszközt.</string>
     <string name="description_bluetooth_is_disabled">A Bluetooth ki van kapcsolva.</string>
     <string name="title_bluetooth_is_off">A Bluetooth ki van kapcsolva</string>
     <string name="action_enable_bluetooth">Bluetooth bekapcsolása</string>
     <string name="title_bluetooth_permission_required">Bluetooth engedély szükséges</string>
     <string name="description_bluetooth_permission_required">Ez az alkalmazás Bluetooth engedélyt igényel az eszközök hangerőszintjének kezeléséhez.</string>
     <string name="action_grant_permission">Engedély megadása</string>
-    <string name="label_status_listening_for_changes">Figyeli a hangerőszabályzást</string>
     <string name="action_exit">Kilépés</string>
-    <string name="action_start">Indítás</string>
-    <string name="label_welcome">Üdvözlet</string>
-    <string name="description_intro_contact">Ne habozz kapcsolatba lépni velem, ha kérdésed van vagy egy új funkcióra van ötleted.</string>
-    <string name="label_translation">Fordítás</string>
-    <string name="description_help_translate">Segíts, hogy ezt az alkalmazást más nyelveken is elérhetővé tegyük.</string>
     <string name="label_device_speaker">Készülék hangszóró</string>
-    <string name="label_keyevent_playpause">Lejátszás/szünet</string>
-    <string name="label_keyevent_play">Lejátszás</string>
-    <string name="label_keyevent_next">Következő</string>
-    <string name="label_install_id">Telepítési azonosító</string>
     <string name="message_copied_to_clipboard">Vágólapra másolva</string>
-    <string name="label_thanks">Köszönet</string>
-    <string name="label_licenses">Licencek</string>
-    <string name="description_ring_volume_additional_permission">További engedélyek szükségesek a csengetési hangerő megváltoztatásához.</string>
-    <string name="label_missing_permissions">Hiányzó engedélyek</string>
-    <string name="action_grant">Engedélyez</string>
-    <string name="label_advanced">Haladó</string>
-    <string name="label_exclude_health">Egészségügyi profilok kizárása</string>
-    <string name="description_exclude_health">Néhány Android-eszköz lefagy, amikor felkeresi az \&quot;Egészségügyi eszköz\&quot; Bluetooth-profilokat (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">GATT szerver profilok kizárása</string>
-    <string name="label_exclude_gatt">GATT profilok kizárása</string>
-    <string name="description_exclude_gattserver">Ne lekérdezze a \"Generic Attribute\" (GATT) szerver típusú Bluetooth profilokat.</string>
-    <string name="description_exclude_gatt">Ne lekérdezze a \"Generic Attribute\" (GATT) kliens típusú Bluetooth profilokat.</string>
-    <string name="description_waiting_for_devicex">Várakozás a(z) %s kapcsolat befejezésére</string>
-    <string name="action_undo">Visszavonás</string>
-    <string name="action_show">Mutatás</string>
     <string name="action_dismiss">Bezárás</string>
-    <string name="action_fix">Javítás</string>
-    <string name="battery_optimizations_issue_description">Az akkumulátor optimalizálás engedélyezett ennél az alkalmazásnál és megakadályozhatja a Bluetooth események fogadását. Fontold meg az optimalizálás letiltását, ha problémákat tapasztalsz.</string>
     <string name="label_bluetooth_settings">Bluetooth beállítások</string>
-    <string name="android10_applaunch_issue_description">Az Android 10 korlátozza, hogyan indíthatók el alkalmazások a háttérből. Az alkalmazások megnyitásának engedélyezéséhez Bluetooth eszköz csatlakozásakor add meg a &quot;Megjelenítés más alkalmazások felett&quot; engedélyt (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Forráskód</string>
-    <string name="android13_notification_permission_description">Add meg ennek az alkalmazásnak az értesítések küldéséhez szükséges engedélyt. Ez lehetővé teszi az értesítés megjelenítését, amikor az alkalmazás aktív és hangerőbeállításokat végez.</string>
-    <string name="privacy_policy_label">Adatvédelmi irányelvek</string>
     <string name="managed_devices_empty_message">Nincsenek Bluetooth eszközök konfigurálva.\nKoppints a + gombra az első eszköz hozzáadásához.</string>
     <string name="label_pro_feature">Prémium funkció</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Áttekintés</string>
     <string name="review_app_dismiss_action">Talán később</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Vásárlás megszakítva</string>
-    <string name="error_iap_unavailable_message">Az alkalmazáson belüli vásárlások nem elérhetőek</string>
-    <string name="error_generic_message">Hiba történt. Kérlek próbáld újra.</string>
-    <string name="error_iap_owned_message">Már birtoklod ezt a tételt</string>
     <string name="label_no_devices_title">Nincsenek eszközök</string>
     <string name="bluemusic_mascot_description">Alkalmazás ikon</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Alkalmazások kiválasztása</string>
     <string name="devices_app_selection_search_hint">Alkalmazások keresése…</string>
-    <string name="devices_app_selection_currently_selected">Jelenleg kiválasztott</string>
     <string name="devices_app_selection_selected_count">%d alkalmazás kiválasztva</string>
     <string name="general_navigate_back_action">Visszanavigálás</string>
     <string name="general_reset_action">Visszaállítás</string>
     <string name="general_clear_action">Törlés</string>
-    <string name="general_save_action">Mentés</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Zárolás</string>
     <string name="devices_indicator_awake">Ébren</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Korlát</string>
     <string name="devices_indicator_eq">Hangszín</string>
     <string name="devices_indicator_boost">Fokozás</string>
-    <string name="devices_indicator_launch">Indítás</string>
     <string name="devices_indicator_home">Főképernyő</string>
     <string name="devices_indicator_dnd">NZ</string>
     <string name="devices_indicator_alert">Értesítés</string>

--- a/app/src/main/res/values-hy-rAM/strings.xml
+++ b/app/src/main/res/values-hy-rAM/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Թարմացման ընթացքում որոշ հնարավորություններ փոխվել են: Խնդրում ենք ստուգել ձեր սարքի կարգավորումները՝ համոզվելու, որ ամեն ինչ ճիշտ է կարգաբերված:</string>
     <string name="onboarding_rewrite_action">Շարունակել</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Կառավարելիք սարքեր չեն գտնվել</string>
     <string name="discover_all_devices_managed_msg">Ձեր բոլոր զուգակցված սարքերը կառավարվում են: Ուզո՞ւմ եք ավելացնել նոր:</string>
     <string name="discover_pair_new_device_action">Զուգակցել նոր սարք</string>
     <string name="discover_device_speaker_desc">Այս հեռախոսի սեփական բարձրախոս։ Դրա ծավալները կիրառվում են, երբ աուդիոն վերադառնում է հեռախոսին, օր.՞ Bluetooth սարքի անջատվելուց հետո։</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Սարքի կարգաբերում</string>
-    <string name="devices_device_config_section_general_label">Ընդհանուր</string>
     <string name="devices_device_config_remove_device_label">Մոռանալ սարքը</string>
-    <string name="devices_device_config_remove_device_desc">Մոռանում է սարքը այս հավելվածից և ջնջում նրա կարգավորումը: Սա չի լուծում սարքի զուգակցությունը:</string>
     <string name="devices_device_config_remove_device_action">Մոռանալ</string>
     <string name="devices_device_config_remove_device_confirmation">Մոռանա՞լ %s-ին կառավարվող սարքերից:</string>
-    <string name="devices_device_config_rename_device_label">Վերանվանել սարքը</string>
-    <string name="devices_device_config_rename_device_desc">Վերանվանել այս սարքը այս հավելվածի շրջանակում և, հնարավորության դեպքում, համակարգում:</string>
     <string name="devices_device_config_rename_device_action">Վերանվանել</string>
     <string name="devices_device_config_enabled_label">Ակտիվացված</string>
     <string name="devices_device_config_enabled_desc">Արձագանքել այս սարքին կապակցվելիս</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Ավտոմատ նվագարկման հրամաններ</string>
     <string name="devices_device_config_autoplay_keycodes_order">Հրամանների հաջորդականություն</string>
     <string name="devices_device_config_autoplay_keycodes_label">Հրամաններ</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Կարգաբերեք, թե որ հրամաններն ուղարկել և ինչ հերթականությամբ</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Հրամաններ չեն կարգաբերվել</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Ավելացնել հրաման</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Առավելագույնը %1$d հրաման</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Տեղաշարժել վեր</string>
     <string name="cd_autoplay_keycode_move_down">Տեղաշարժել վար</string>
     <string name="cd_autoplay_keycode_remove">Հեռացնել</string>
-    <string name="devices_device_config_section_volumes_label">Ծավալներ</string>
     <string name="devices_device_config_section_volume_label">Ծավալ</string>
     <string name="devices_device_config_alarm_volume_label">Քլարմի ծավալ</string>
     <string name="devices_device_config_alarm_volume_desc">Քլարմի սպա հավելվածները երաժժական ծավալն ևն կիրառության ոգտագորխում են ոգտագորխում:</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">զանգակոց</string>
     <string name="devices_audio_stream_notification_label">Ծակուցություն</string>
     <string name="devices_audio_stream_alarm_label">Ռլարմ</string>
-    <string name="devices_neverseen_label">Արտասակ չի կապված</string>
-    <string name="devices_state_connected_label">Կապակցված</string>
     <string name="devices_last_connected_label">վերջին կապակցությունը: %s</string>
     <string name="devices_currently_connected_label">Ալի կապակցված</string>
     <string name="devices_device_disabled_label">Սարքը անկալժացված է</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Կարգավորումներ, որոնք ազդեցնում ևն բոլոր կառավարվող սարքերին:</string>
     <string name="label_app_enabled">Հավելվածը ակտիվացված է</string>
     <string name="description_app_enabled">Լլազարկում և հավելվածի կարողությունը արձագանքել ծավալի և Bluetooth իրադարիչներին:</string>
-    <string name="label_visible_volume_adjustments">Տեսանելի ճշգրտումներ</string>
-    <string name="description_visible_volume_adjustments">Ցուցադրել կարգաբերի ծավալի պատուհանը, երբ հավելվածն ճշգրտումներ և կատարում:</string>
     <string name="label_volume_listener">Դիտել փոփոխությունները</string>
-    <string name="description_volume_listener">Ակտիվ մնալ, մինչ սարք կապակցված և, և պահպանել ծավալի փոփոխությունները:</string>
     <string name="label_boot_restore">վերկնել բեռնակկից հետո</string>
     <string name="description_boot_restore">վերկնել ծավալը բեռնակկից հետո, եթև Bluetooth սարք կապակցված և:</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Իանել, թև արդյունականորևն կիրառել BVM-ը</string>
     <string name="settings_support_issue_tracker_description">Հանրային խնդիրնևրի հասկիչ սխալների և կարիքների համար:</string>
     <string name="settings_support_issue_tracker_label">Խնդիրների հետագծիչ</string>
-    <string name="settings_support_debuglog_label">Կարգաբերման մատյան</string>
     <string name="settings_support_debuglog_desc">Գրանցեք այն ամենը, ինչ անում է հավելվածը տեքստային ֆայլում, որը կարող եք կիսվել։</string>
-    <string name="settings_support_debuglog_recording_desc">Ալի կատարվում և սկզբական տևղեկագրությունը: Շոխեք կանգնելու:</string>
-    <string name="settings_support_debuglog_path">Գրանցի ողին: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">շատ կարճ գրանություն</string>
     <string name="settings_support_debuglog_short_recording_msg">Սա շատ կարճ գրանություն իր: Սկզբական լկերը գրանություններ ևն:</string>
     <string name="settings_support_debuglog_short_recording_continue">Շարունակել գրանցությունը</string>
     <string name="settings_support_debuglog_short_recording_stop">Այնուանկալծ կանգնել</string>
-    <string name="settings_support_debuglog_folder_label">Սկզբական լկի հապկիչ</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d նիստերկ հաշվառկությամբ %2$s</item>
-        <item quantity="other">%1$d նիստերկ հաշվառկությամբ %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Սկզբական լկեր չկա</string>
-    <string name="settings_support_debuglog_folder_delete_title">Ալիվականաբար բոլոր Սկզբական լկերը:</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Սա ալիվականաբար կծի բոլոր սկզբական լկի նիստերնևրը:</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Ժամանցի և հարցեր տալու վայր։</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Թարգմանություն</string>
     <string name="settings_acks_translators_title">Թարգմանիչներ</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Թարգմանել BVM-ը</string>
-    <string name="settings_acks_translate_desc">օգնել BVM-ի թարգմանությանը ձեր լևզվից</string>
     <string name="settings_acks_thanks_header">Շնորհակալություն</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Բաց կոդ-կան ծնդլայնումնևրի թարգմանությանը ապահովելու համար</string>
     <string name="settings_licenses_label">Լիցենզիաներ</string>
     <string name="settings_translation_label">Թարգմանություն</string>
     <string name="settings_translation_desc">Ողնել տարգմանել ծրագիրե ձեր սիրական լեզուով</string>
-    <string name="settings_sponsor_development_title">Հովանավորել զարգացումը</string>
-    <string name="settings_sponsor_development_summary">Դարձեք հովանավոր և հնարավորեցրեք շարունակ զարգացումն։</string>
     <string name="settings_privacy_policy_label">Գաղտնիության քաղաքականություն</string>
     <string name="settings_privacy_policy_desc">Տվյալների պատասխանատու մշակում։</string>
     <string name="changelog_label">Փոփոխությունների մատյան</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Վերականգնումն ավարտված է — վերականգնված է %1$d սարք, բաց թողնված՝ %2$d:</string>
     <string name="backup_restore_version_warning">Այս կրկնօրինակը ստեղծվել է %1$s տարբերակով: Դուք օգտագործում եք %2$s: Որոշ կարգավորումներ կարող են ճիշտ չվերականգնվել:</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Վրիպազերծման ծանուցումներ</string>
     <string name="debug_log_consent_title">Կարգաբերման մատյան</string>
     <string name="debug_log_consent_explanation">Այս հատկությունը գրանցում է հավելվածի բոլոր գործողությունները կիսվող ֆայլում: Ստեղծված ֆայլը պարունակում է կարևոր տեղեկություններ (օր. ֆայլերի անուններ և տեղադրված հավելվածներ): Կիսվեք միայն վստահելի կողմերի հետ (օր. խնդիր լուծող մշակողի հետ):</string>
-    <string name="debug_log_recording_progress">Գրանցվում է վրիպազերծման մատյանը</string>
     <string name="debug_log_record_action">Գրանցել</string>
     <string name="debug_log_stop_action">Կանգնացնել գրանցումը</string>
     <string name="debug_log_screen_title">Սկզբական լկի գրանծագրիչ</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Հեռացնել</string>
     <string name="debug_log_screen_keep_action">Պահել</string>
-    <string name="debug_log_compressing_label">սեղադրվում և...</string>
     <string name="debug_log_file_label">Գրանցված մատյանի ֆայլ</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Լկը ուկված և:</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Նկարագրեք դզեր հարցը մանրամասնուտյամբ։</string>
     <string name="contact_category_section_label">Կատеgория</string>
     <string name="contact_debug_log_label">Կարգաբերման մատյան</string>
-    <string name="contact_debug_log_select_hint">Ըրբեք վրիպակագրուտյուն կցկապնդելու համար</string>
     <string name="contact_debug_log_picker_hint">Կցկապնդեք վրիպակագրուտյուն խնդիրն ավելի արագ բացահայտելու համար։</string>
     <string name="contact_debug_log_picker_empty">Վրիպակագրուտյուններ բացակային չեն։ Նախ գրանցեք մեկե։</string>
     <string name="contact_expected_behavior_label">Նախատեսված վարքե</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Ես կարդում եմ բոլոր հաղորդագրությունները ինքնուրույն և լավագույն ամն անում եմ պատասխանելու համար, բայց քանի որ մենակ եմ աշխատում, կարող է մի փոքր ժամանակ տևել։ Ձեր համբերության համար շնորհակալ եմ։</string>
     <string name="contact_footer_msg">Ձեր հաղորդագրությունը կուղարկվի էլ. փոստով։ Սարքի և կարգավորումների տեղեկությունները ավտոմատ կցվում են։</string>
     <string name="contact_no_email_app_msg">Այս սարքում էլ. փոստի հավելված չկա</string>
-    <string name="contact_attachment_missing_msg">Կարգաբերման մատյանի ֆայլն այլևս գոյություն չունի</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Պահված կարգաբերման մատյաններ</string>
     <string name="settings_support_stored_logs_desc">%1$d նիստ (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Պահված կարգաբերման մատյաններ չկան</string>
-    <string name="settings_support_stored_logs_delete_title">Ջնջե՞լ պահված մատյանները</string>
-    <string name="settings_support_stored_logs_delete_msg">Սա կջծի բոլոր %1$d պահված կարգաբերման գլխի նիստերը։</string>
-    <string name="settings_support_stored_logs_deleted_msg">Պահված կարգաբերման մատյաններն ջնջվեցին</string>
-    <string name="label_bug_reports">Սխալների հաշվետվություններ</string>
-    <string name="description_bug_reports">Լրիր սխալի և խզիրի ավտոմատ հաշվետվություն</string>
     <string name="label_add_device">Ավելացնել սարք</string>
-    <string name="label_just_a_moment_please">Մի վայրկյան, խնդրում եմ:</string>
     <string name="label_notification_channel_status">Կարգավիճակ</string>
     <string name="label_notification_channel_setup">Անհրաժեշտ է կարգավորում</string>
     <string name="monitor_notification_starting">Մեկնարկում է…</string>
     <string name="action_set">Սահմանել</string>
     <string name="action_cancel">Չեղարկել</string>
-    <string name="label_invalid_input">Անվավեր մուտք</string>
     <string name="action_reset">Վերագործարկել</string>
     <string name="label_no_connected_devices">Կապակցված սարքեր չկան</string>
-    <string name="label_status_idle">Անգործուն</string>
-    <string name="label_status_adjusting_volumes">Բազմաչափ ձայները</string>
-    <string name="label_premium_version">Պրեմիում տարբերակ</string>
     <string name="general_upgrade_action">Թարմացնել</string>
     <string name="common_upgrade_required_label">Անհրաժեշտ է բարելավում</string>
-    <string name="label_premium_version_required">Պահանջվում է պրեմիում տարբերակ</string>
-    <string name="description_intro_purpose">Այս հավելվածը թույլ է տալիս ձեր Android սարքին հիշել տարբեր Bluetooth սարքերի ձայնի մակարդակը։</string>
-    <string name="upgrade_benefit_unlimited_devices">Անսահմանափակ սարքի պրոֆիլներ</string>
-    <string name="upgrade_benefit_connection_actions">Ավտոնվագարկում, հավելվածի գործարկում և կապի ծանուցումներ</string>
-    <string name="upgrade_benefit_theme_customization">Թեմայի, ոճի և գույնի հարմարեցում</string>
-    <string name="upgrade_benefit_power_controls">Ձայնի կողպեք և արագության սահմանափակում</string>
-    <string name="upgrade_benefit_support">Աջակցել անկախ մշակմանը</string>
     <string name="upgrade_benefit_equalizer">• Առանձին էկվալայզեր յուրաքանչյուր սարքի համար (երաժշտական հավելվածների համար, որոնք աջակցում են համակարգային էկվալայզերին)</string>
-    <string name="description_intro_tap_the_button">Սկսեք՝ ավելացնելով ձեր առաջին սարքը։</string>
     <string name="description_bluetooth_is_disabled">Bluetooth-ն անջատված է.</string>
     <string name="title_bluetooth_is_off">Bluetooth-ն անձատված է</string>
     <string name="action_enable_bluetooth">Միացնել Bluetooth</string>
     <string name="title_bluetooth_permission_required">Bluetooth-ի թույլտվություն է պահանջվում</string>
     <string name="description_bluetooth_permission_required">Այս հավելվախին կառիք ունի Bluetooth-ի թույլտվության ձեր սառքի ձայնեռը կառավառելու համառ։</string>
     <string name="action_grant_permission">Տրամադրել թույլտվություն</string>
-    <string name="label_status_listening_for_changes">Հետևում է ձայնի փոփոխություննեռին</string>
     <string name="action_exit">Ելք</string>
-    <string name="action_start">Սկսել</string>
-    <string name="label_welcome">Բարի գալուստ</string>
-    <string name="description_intro_contact">Հառցեռ կամ գաղափառնեռ ունե՞ք նոռ հնառավոռության մասին։ Մի հապաղեք կապ հաստատել ինձ հետ։</string>
-    <string name="label_translation">Թարգմանություն</string>
-    <string name="description_help_translate">Օգնել ինձ այս հավելվախը հաշանելի դառձնել այլ լեզունեռով։</string>
     <string name="label_device_speaker">Սարքի խոսափող</string>
-    <string name="label_keyevent_playpause">Նվագել/Դադարեցնել</string>
-    <string name="label_keyevent_play">Նվագել</string>
-    <string name="label_keyevent_next">Հաջորդ</string>
-    <string name="label_install_id">Տեղադրման ID</string>
     <string name="message_copied_to_clipboard">Պատկենվածն բուֆեր բերված է</string>
-    <string name="label_thanks">Շնորհակալություն</string>
-    <string name="label_licenses">Լիցենզիաներ</string>
-    <string name="description_ring_volume_additional_permission">Բառաբարկի ձայնը փոխելու համար լրացութիգ թույլտվություններ են անհրաժելի։</string>
-    <string name="label_missing_permissions">Բացկական թույլտվություններ</string>
-    <string name="action_grant">Տրամադրել</string>
-    <string name="label_advanced">Առննացված</string>
-    <string name="label_exclude_health">Բացառկել առողջական պրոֆիլները</string>
-    <string name="description_exclude_health">Անդրոիդի որինը սարքեր կախվածության են ունենալ Bluetooth-ի \"Health Device\" պրոֆիլների հարցում (HDP, 0x1400)։</string>
-    <string name="label_exclude_gattserver">Բացառկել GATT սերվերի պրոֆիլները</string>
-    <string name="label_exclude_gatt">Բացառկել GATT պրոֆիլները</string>
-    <string name="description_exclude_gattserver">Generic Attribute (GATT) սերվեր տիպի Bluetooth պրոֆիլներին չդիմել։</string>
-    <string name="description_exclude_gatt">Generic Attribute (GATT) կլիենտ տիպի Bluetooth պրոֆիլներին չդիմել։</string>
-    <string name="description_waiting_for_devicex">Սպասում է %s-ի կապակցության ավարտացության համար</string>
-    <string name="action_undo">Հետ դարձնել</string>
-    <string name="action_show">Ցուցադրել</string>
     <string name="action_dismiss">Մերժել</string>
-    <string name="action_fix">Ուղղել</string>
-    <string name="battery_optimizations_issue_description">Այս հավելվածի համար մարտկոցի օպտիմալացումները ակտիվ են և կարող են խոչինդոտել Bluetooth-ի իրադարձությունների ստացմանը։ Եթև խնդիրներ ունեք, մտածեք օպտիմալացումները անձատելու մասին։</string>
     <string name="label_bluetooth_settings">Bluetooth կարգավորումներ</string>
-    <string name="android10_applaunch_issue_description">Android 10-ը սահմանափակում է կիրառությունների բացկգրաունդից գորկելու հնարավորությունները։ Bluetooth սարքի կապակցության բացակկիրառությունների բացելու համար տրամադրել «Display over other apps» (SYSTEM_ALERT_WINDOW) թույլտվությունը։</string>
-    <string name="label_opensource">Սկզբնական կոդ</string>
-    <string name="android13_notification_permission_description">Տրամադրել այս հավելվախին ծաբելություններ ուղարկելու թույլտվությունը։ Սա հնարավորություն կ տալիս բանալիս ծաբելություն, երբ հավելվածը ակտիվ է և ձայնի կարգավորումներ կատարվում են։</string>
-    <string name="privacy_policy_label">Գաղտնիության քաղաքականություն</string>
     <string name="managed_devices_empty_message">Bluetooth սարքեր կարգավայրված չկան։\nՍեխմեկ + կնոպը առաջին սարքը ավելացնելու համար։</string>
     <string name="label_pro_feature">Ռազմավար գործալիթյուն</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Գնահատական</string>
     <string name="review_app_dismiss_action">Գուցե ավելի ուշ</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Գնումն չեղյալ է</string>
-    <string name="error_iap_unavailable_message">Լրացկի գնումները հասանելի չեն</string>
-    <string name="error_generic_message">Սխալ առաջացավորություն։ Խնդրում կրկնել։</string>
-    <string name="error_iap_owned_message">Արդեն այս ինքը կունեք</string>
     <string name="label_no_devices_title">Սարքեր չկան</string>
     <string name="bluemusic_mascot_description">Հավելվախի պատկեր</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Ընտրել կիրառություններ</string>
     <string name="devices_app_selection_search_hint">Գտնել կիրառություններ…</string>
-    <string name="devices_app_selection_currently_selected">Լռկիբս ընտրված</string>
     <string name="devices_app_selection_selected_count">Ընտրված է %d կիրառություն</string>
     <string name="general_navigate_back_action">Նախագնալ հետ</string>
     <string name="general_reset_action">Վերագործարկել</string>
     <string name="general_clear_action">Մաքրել</string>
-    <string name="general_save_action">Պահպանել</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Կողէլ</string>
     <string name="devices_indicator_awake">Արթնաբած</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Սահման</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Ուժեղացում</string>
-    <string name="devices_indicator_launch">Գորկարկել</string>
     <string name="devices_indicator_home">Գլխագլխ</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Ծանություն</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Beberapa pengaturan perangkat mungkin telah direset selama pembaruan ini. Tolong periksa konfigurasi perangkatmu.</string>
     <string name="onboarding_rewrite_action">Lanjutkan</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Tidak ada perangkat yang belum dikelola</string>
     <string name="discover_all_devices_managed_msg">Semua perangkat yang dipasangkan sudah dikelola! Butuh yang baru?</string>
     <string name="discover_pair_new_device_action">Pasangkan perangkat baru</string>
     <string name="discover_device_speaker_desc">Pelantang ponsel ini sendiri. Volume-nya diterapkan saat audio beralih kembali ke ponsel, misalnya setelah perangkat Bluetooth Anda terputus.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfigurasi perangkat</string>
-    <string name="devices_device_config_section_general_label">Umum</string>
     <string name="devices_device_config_remove_device_label">Lupakan perangkat</string>
-    <string name="devices_device_config_remove_device_desc">Melupakan perangkat dari aplikasi ini dan menghapus konfigurasinya. Ini tidak akan memutus pasangan perangkat.</string>
     <string name="devices_device_config_remove_device_action">Lupakan</string>
     <string name="devices_device_config_remove_device_confirmation">Lupakan %s dari perangkat yang dikelola?</string>
-    <string name="devices_device_config_rename_device_label">Ubah nama perangkat</string>
-    <string name="devices_device_config_rename_device_desc">Ubah nama perangkat ini di dalam aplikasi, dan jika memungkinkan, di dalam sistem.</string>
     <string name="devices_device_config_rename_device_action">Ubah nama</string>
     <string name="devices_device_config_enabled_label">Diaktifkan</string>
     <string name="devices_device_config_enabled_desc">Bereaksi terhadap perangkat ini saat terhubung</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Perintah putar otomatis</string>
     <string name="devices_device_config_autoplay_keycodes_order">Urutan perintah</string>
     <string name="devices_device_config_autoplay_keycodes_label">Perintah</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Konfigurasi perintah yang akan dikirim dan urutannya</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Tidak ada perintah yang dikonfigurasi</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Tambah perintah</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimum %1$d perintah</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">Pindah ke atas</string>
     <string name="cd_autoplay_keycode_move_down">Pindah ke bawah</string>
     <string name="cd_autoplay_keycode_remove">Hapus</string>
-    <string name="devices_device_config_section_volumes_label">Volume</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
     <string name="devices_device_config_alarm_volume_label">Volume alarm</string>
     <string name="devices_device_config_alarm_volume_desc">Beberapa aplikasi alarm menggunakan volume musik sebagai gantinya.</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">Dering</string>
     <string name="devices_audio_stream_notification_label">Pemberitahuan</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Tak pernah terlihat</string>
-    <string name="devices_state_connected_label">Terhubung</string>
     <string name="devices_last_connected_label">Terakhir terhubung: %s</string>
     <string name="devices_currently_connected_label">Sedang terhubung</string>
     <string name="devices_device_disabled_label">Perangkat dinonaktifkan</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">Pengaturan yang mempengaruhi semua perangkat yang dikelola.</string>
     <string name="label_app_enabled">Aplikasi diaktifkan</string>
     <string name="description_app_enabled">Kendalikan tombol aplikasi untuk dapat mengatur perubahan volume dan Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Penyesuaian tampilan</string>
-    <string name="description_visible_volume_adjustments">Menampilkan jendela volume sistem saat aplikasi membuat penyesuaian.</string>
     <string name="label_volume_listener">Mengamati perubahan</string>
-    <string name="description_volume_listener">Tetap aktif saat perangkat terhubung dan menyimpan perubahan volume yang tidak disebabkan oleh aplikasi.</string>
     <string name="label_boot_restore">Kembalikan saat dinyalakan</string>
     <string name="description_boot_restore">Kembalikan volume saat dinyalakan bila terdapat perangkat Bluetooth terhubung.</string>
     <!-- Settings/Support-->
@@ -203,21 +191,11 @@
     <string name="settings_support_wiki_description">Pelajari cara menggunakan BVM secara efektif</string>
     <string name="settings_support_issue_tracker_description">Pelacak masalah publik untuk laporan bug dan permintaan fitur.</string>
     <string name="settings_support_issue_tracker_label">Pelacak masalah</string>
-    <string name="settings_support_debuglog_label">Log debug</string>
     <string name="settings_support_debuglog_desc">Rekam semua yang dilakukan aplikasi ke dalam file teks yang bisa kamu bagikan.</string>
-    <string name="settings_support_debuglog_recording_desc">Sedang merekam informasi debug. Ketuk untuk berhenti merekam.</string>
-    <string name="settings_support_debuglog_path">Jalur log: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Rekaman sangat singkat</string>
     <string name="settings_support_debuglog_short_recording_msg">Itu adalah rekaman yang sangat singkat. Log debug adalah rekaman, bukan snapshot — reproduksi masalah saat perekaman aktif agar log berguna.</string>
     <string name="settings_support_debuglog_short_recording_continue">Lanjutkan rekaman</string>
     <string name="settings_support_debuglog_short_recording_stop">Hentikan tetap saja</string>
-    <string name="settings_support_debuglog_folder_label">Folder log debug</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d sesi menggunakan %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Tidak ada log debug yang tersimpan</string>
-    <string name="settings_support_debuglog_folder_delete_title">Hapus semua log debug?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Ini akan menghapus semua sesi log debug yang tersimpan secara permanen.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Tempat untuk nongkrong dan bertanya.</string>
     <!-- Settings/Acks-->
@@ -226,16 +204,12 @@
     <string name="settings_acks_translation_header">Terjemahan</string>
     <string name="settings_acks_translators_title">Penerjemah</string>
     <string name="settings_acks_translators_people">Orang1;Orang2(opsional@email.com)</string>
-    <string name="settings_acks_translate_title">Terjemahkan BVM</string>
-    <string name="settings_acks_translate_desc">Bantu terjemahkan BVM ke dalam bahasamu</string>
     <string name="settings_acks_thanks_header">Terima kasih</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Karena mendukung terjemahan proyek open-source</string>
     <string name="settings_licenses_label">Lisensi</string>
     <string name="settings_translation_label">Alih Bahasa</string>
     <string name="settings_translation_desc">Bantu terjemahkan aplikasi ini ke bahasa favorit Anda</string>
-    <string name="settings_sponsor_development_title">Sponsor pengembangan</string>
-    <string name="settings_sponsor_development_summary">Jadilah patron dan buat pengembangan berkelanjutan menjadi mungkin.</string>
     <string name="settings_privacy_policy_label">Kebijakan privasi</string>
     <string name="settings_privacy_policy_desc">Menangani data dengan bertanggung jawab.</string>
     <string name="changelog_label">Log perubahan</string>
@@ -257,10 +231,8 @@
     <string name="backup_restore_success_restore">Pemulihan selesai — %1$d perangkat dipulihkan, %2$d dilewati.</string>
     <string name="backup_restore_version_warning">Cadangan ini dibuat dengan versi %1$s. Kamu menjalankan %2$s. Beberapa pengaturan mungkin tidak dipulihkan dengan benar.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notifikasi debug</string>
     <string name="debug_log_consent_title">Log debug</string>
     <string name="debug_log_consent_explanation">Fitur ini merekam semua yang dilakukan aplikasi ke dalam file yang bisa dibagikan. File yang dihasilkan berisi informasi sensitif (misalnya nama file dan aplikasi yang terinstal). Hanya bagikan dengan pihak terpercaya (misalnya developer yang menyelesaikan masalah).</string>
-    <string name="debug_log_recording_progress">Merekam log debug</string>
     <string name="debug_log_record_action">Rekam</string>
     <string name="debug_log_stop_action">Berhenti merekam</string>
     <string name="debug_log_screen_title">Perekam Log Debug</string>
@@ -274,7 +246,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Buang</string>
     <string name="debug_log_screen_keep_action">Simpan</string>
-    <string name="debug_log_compressing_label">Mengompres…</string>
     <string name="debug_log_file_label">File log yang direkam</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log sudah dikirim?</string>
@@ -302,7 +273,6 @@
     <string name="contact_description_question_hint">Jelaskan pertanyaanmu secara detail.</string>
     <string name="contact_category_section_label">Kategori</string>
     <string name="contact_debug_log_label">Log debug</string>
-    <string name="contact_debug_log_select_hint">Pilih log debug untuk dilampirkan</string>
     <string name="contact_debug_log_picker_hint">Lampirkan log debug untuk membantu mendiagnosis masalah lebih cepat.</string>
     <string name="contact_debug_log_picker_empty">Tidak ada log debug tersedia. Rekam satu terlebih dahulu.</string>
     <string name="contact_expected_behavior_label">Perilaku yang diharapkan</string>
@@ -315,82 +285,32 @@
     <string name="contact_welcome_msg">Saya membaca setiap pesan sendiri dan berusaha sebaik mungkin untuk membalas, tapi karena saya bekerja sendiri, mungkin butuh sedikit waktu. Terima kasih atas kesabaranmu.</string>
     <string name="contact_footer_msg">Pesanmu akan dikirim melalui email. Informasi perangkat dan pengaturan dilampirkan secara otomatis.</string>
     <string name="contact_no_email_app_msg">Tidak ada aplikasi email yang ditemukan di perangkat ini.</string>
-    <string name="contact_attachment_missing_msg">File log debug sudah tidak ada</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Log debug tersimpan</string>
     <string name="settings_support_stored_logs_desc">%1$d sesi (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Tidak ada log debug tersimpan</string>
-    <string name="settings_support_stored_logs_delete_title">Hapus log tersimpan?</string>
-    <string name="settings_support_stored_logs_delete_msg">Ini akan menghapus semua %1$d sesi log debug yang tersimpan.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Log debug tersimpan dihapus</string>
-    <string name="label_bug_reports">Pelaporan Masalah</string>
-    <string name="description_bug_reports">Kirim permasalahan dan kerusakan secara otomatis.</string>
     <string name="label_add_device">Tambah perangkat</string>
-    <string name="label_just_a_moment_please">Mohon tunggu.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Pengaturan diperlukan</string>
     <string name="monitor_notification_starting">Memulai…</string>
     <string name="action_set">Atur</string>
     <string name="action_cancel">Batal</string>
-    <string name="label_invalid_input">Masukan tak sahih</string>
     <string name="action_reset">Atur Ulang</string>
     <string name="label_no_connected_devices">Tidak ada perangkat terhubung</string>
-    <string name="label_status_idle">Menganggur</string>
-    <string name="label_status_adjusting_volumes">Menyesuaikan volume</string>
-    <string name="label_premium_version">Versi premium</string>
     <string name="general_upgrade_action">Tingkatkan</string>
     <string name="common_upgrade_required_label">Upgrade diperlukan</string>
-    <string name="label_premium_version_required">Versi premium dibutuhkan</string>
-    <string name="description_intro_purpose">Aplikasi ini memungkinkan perangkat Android mengingat volume suara untuk perangkat Bluetooth berbeda.</string>
-    <string name="upgrade_benefit_unlimited_devices">Profil perangkat tak terbatas</string>
-    <string name="upgrade_benefit_connection_actions">Putar otomatis, peluncuran aplikasi, dan notifikasi koneksi</string>
-    <string name="upgrade_benefit_theme_customization">Kustomisasi tema, gaya, dan warna</string>
-    <string name="upgrade_benefit_power_controls">Kunci volume dan pembatasan laju</string>
-    <string name="upgrade_benefit_support">Dukung pengembangan independen</string>
     <string name="upgrade_benefit_equalizer">• Ekualisir per perangkat (untuk aplikasi musik dengan dukungan ekualisir sistem)</string>
-    <string name="description_intro_tap_the_button">Mulai dengan menambah perangkat pertama Anda.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth dimatikan.</string>
     <string name="title_bluetooth_is_off">Bluetooth Mati</string>
     <string name="action_enable_bluetooth">Aktifkan Bluetooth</string>
     <string name="title_bluetooth_permission_required">Izin Bluetooth Diperlukan</string>
     <string name="description_bluetooth_permission_required">Aplikasi ini memerlukan izin Bluetooth untuk mengelola volume perangkatmu.</string>
     <string name="action_grant_permission">Berikan Izin</string>
-    <string name="label_status_listening_for_changes">Menunggu perubahan volume</string>
     <string name="action_exit">Keluar</string>
-    <string name="action_start">Mulai</string>
-    <string name="label_welcome">Selamat Datang</string>
-    <string name="description_intro_contact">Jangan ragu untuk menghubungi saya bila Anda memiliki pertanyaan atau bahkan gagasan fitur baru.</string>
-    <string name="label_translation">Alih Bahasa</string>
-    <string name="description_help_translate">Bantu saya membuat aplikasi ini tersedia dalam bahasa lain.</string>
     <string name="label_device_speaker">Pelantang perangkat</string>
-    <string name="label_keyevent_playpause">Putar-Jeda</string>
-    <string name="label_keyevent_play">Putar</string>
-    <string name="label_keyevent_next">Berikutnya</string>
-    <string name="label_install_id">ID Pemasangan</string>
     <string name="message_copied_to_clipboard">Salin ke Papan Klip</string>
-    <string name="label_thanks">Terima kasih</string>
-    <string name="label_licenses">Lisensi</string>
-    <string name="description_ring_volume_additional_permission">Diperlukan izin tambahan untuk mengubah volume dering.</string>
-    <string name="label_missing_permissions">Perizinan kurang</string>
-    <string name="action_grant">Diizinkan</string>
-    <string name="label_advanced">Lanjutan</string>
-    <string name="label_exclude_health">Kecualikan profil kesehatan</string>
-    <string name="description_exclude_health">Beberapa perangkat Android membeku saat mencari profil \'Kesehatan Perangkat\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Kecualikan profil peladen GATT</string>
-    <string name="label_exclude_gatt">Kecualikan profil GATT</string>
-    <string name="description_exclude_gattserver">Jangan kirim permintaan profil Bluetooth berjenis peladen Generic Attribute (GATT).</string>
-    <string name="description_exclude_gatt">Jangan kirim permintaan profil Bluetooth berjenis klien Generic Attribute (GATT).</string>
-    <string name="description_waiting_for_devicex">Menunggu %s untuk menyelesaikan sambungan</string>
-    <string name="action_undo">Urungkan</string>
-    <string name="action_show">Tampil</string>
     <string name="action_dismiss">Singkirkan</string>
-    <string name="action_fix">Perbaiki</string>
-    <string name="battery_optimizations_issue_description">Optimasi baterai diaktifkan untuk aplikasi ini dan dapat mencegah menerima peristiwa Bluetooth. Pertimbangkan mematikan optimasi bila Anda mengalami suatu kendala.</string>
     <string name="label_bluetooth_settings">Pengaturan bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 membatasi cara aplikasi dapat diluncurkan dari latar belakang. Untuk mengizinkan pembukaan aplikasi saat perangkat Bluetooth terhubung, berikan izin &quot;Tampilkan di atas aplikasi lain&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Kode sumber</string>
-    <string name="android13_notification_permission_description">Berikan izin aplikasi ini untuk mengirim notifikasi. Ini memungkinkan menampilkan notifikasi saat aplikasi ini aktif dan penyesuaian volume sedang dilakukan.</string>
-    <string name="privacy_policy_label">Kebijakan privasi</string>
     <string name="managed_devices_empty_message">Tidak ada perangkat Bluetooth yang dikonfigurasi.\nKetuk tombol + untuk menambahkan perangkat pertamamu.</string>
     <string name="label_pro_feature">Fitur premium</string>
     <plurals name="discover_device_limit_banner">
@@ -420,21 +340,15 @@
     <string name="review_app_review_action">Ulasan</string>
     <string name="review_app_dismiss_action">Lain kali</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Pembelian dibatalkan</string>
-    <string name="error_iap_unavailable_message">Pembelian dalam aplikasi tidak tersedia</string>
-    <string name="error_generic_message">Terjadi kesalahan. Silakan coba lagi.</string>
-    <string name="error_iap_owned_message">Kamu sudah memiliki item ini</string>
     <string name="label_no_devices_title">Tidak Ada Perangkat</string>
     <string name="bluemusic_mascot_description">Ikon Aplikasi</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Pilih Aplikasi</string>
     <string name="devices_app_selection_search_hint">Cari aplikasi…</string>
-    <string name="devices_app_selection_currently_selected">Sedang dipilih</string>
     <string name="devices_app_selection_selected_count">%d aplikasi dipilih</string>
     <string name="general_navigate_back_action">Navigasi kembali</string>
     <string name="general_reset_action">Mengatur ulang</string>
     <string name="general_clear_action">Hapus</string>
-    <string name="general_save_action">Simpan</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Kunci</string>
     <string name="devices_indicator_awake">Terjaga</string>
@@ -444,7 +358,6 @@
     <string name="devices_indicator_limit">Batas</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Penguatan</string>
-    <string name="devices_indicator_launch">Buka</string>
     <string name="devices_indicator_home">Beranda</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Peringatan</string>

--- a/app/src/main/res/values-is/strings.xml
+++ b/app/src/main/res/values-is/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Sumir eiginleikar hafa breyst við uppfærsluna. Vinsamlegast athugaðu stillingar tækisins til að tryggja að allt sé rétt stillt.</string>
     <string name="onboarding_rewrite_action">Halda áfram</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Engin óstýrð tæki fundust</string>
     <string name="discover_all_devices_managed_msg">Öll pöruð tæki þín eru stýrð! Þarftu nýtt?</string>
     <string name="discover_pair_new_device_action">Para nýtt tæki</string>
     <string name="discover_device_speaker_desc">Eigin hátalari þessa sími. Hljóðstyrk hans er notaður þegar hljóð skiptir aftur til símans, t.d. eftir að Bluetooth tækinu þínu er aftengst.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Tækjastillingar</string>
-    <string name="devices_device_config_section_general_label">Almennt</string>
     <string name="devices_device_config_remove_device_label">Gleyma tæki</string>
-    <string name="devices_device_config_remove_device_desc">Gleymir tækinu í þessu forriti og eyðir stillingum þess. Þetta afparar ekki tækið.</string>
     <string name="devices_device_config_remove_device_action">Gleyma</string>
     <string name="devices_device_config_remove_device_confirmation">Gleyma %s úr stýrðum tækjum?</string>
-    <string name="devices_device_config_rename_device_label">Endurnefna tæki</string>
-    <string name="devices_device_config_rename_device_desc">Endurnefnir þetta tæki í þessu forriti og ef mögulegt er, í kerfinu.</string>
     <string name="devices_device_config_rename_device_action">Endurnefna</string>
     <string name="devices_device_config_enabled_label">Virkt</string>
     <string name="devices_device_config_enabled_desc">Bregaðast við þessu tæki þegar það er tengt</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Sjálfvirk spilun skipanir</string>
     <string name="devices_device_config_autoplay_keycodes_order">Skipanaroð</string>
     <string name="devices_device_config_autoplay_keycodes_label">Skipanir</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Stilltu hvaða skipanir á að senda og í hvaða röð</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Engar skipanir stilltar</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Bæta við skipun</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Hámark %1$d skipanir</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Færa upp</string>
     <string name="cd_autoplay_keycode_move_down">Færa niður</string>
     <string name="cd_autoplay_keycode_remove">Fjarlægja</string>
-    <string name="devices_device_config_section_volumes_label">Hljóðstyrkar</string>
     <string name="devices_device_config_section_volume_label">Hljóðstyrk</string>
     <string name="devices_device_config_alarm_volume_label">Viðvöruhljóðstyrk</string>
     <string name="devices_device_config_alarm_volume_desc">Sum viðvöruforrit nota hljóðstyrk tónlistar í staðinn.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Hringja</string>
     <string name="devices_audio_stream_notification_label">Tilkynning</string>
     <string name="devices_audio_stream_alarm_label">Viðvörun</string>
-    <string name="devices_neverseen_label">Aldrei séð</string>
-    <string name="devices_state_connected_label">Tengt</string>
     <string name="devices_last_connected_label">Síðast tengt: %s</string>
     <string name="devices_currently_connected_label">Tengt núna</string>
     <string name="devices_device_disabled_label">Tæki óvirkt</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Stillingar sem hafa áhrif á öll stýrð tæki.</string>
     <string name="label_app_enabled">Forrit virkt</string>
     <string name="description_app_enabled">Kveikir/slekkur á getu forritsins til að bregaðast við hljóðstyrks- og Bluetooth-atburðum.</string>
-    <string name="label_visible_volume_adjustments">Sýnilegar leiðréttingar</string>
-    <string name="description_visible_volume_adjustments">Sýndu hljóðstyrkglugga kerfisins á meðan þetta forrit gerðir leiðréttingar.</string>
     <string name="label_volume_listener">Fylgjast með breytingum</string>
-    <string name="description_volume_listener">Vera virkur á meðan tæki er tengt og vista hljóðstyrkbreytingar sem þetta forrit olli ekki.</string>
     <string name="label_boot_restore">Endurheimta við ræsingu</string>
     <string name="description_boot_restore">Endurheimta hljóðstyrk eftir ræsingu/endurræsingu ef Bluetooth tæki er tengt.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Lærðu hvernig á að nota BVM á skilvirkan hátt</string>
     <string name="settings_support_issue_tracker_description">Opinber vandamálasafnari fyrir villtilkynningar og beiðnir um eiginleika.</string>
     <string name="settings_support_issue_tracker_label">Vandamálarakning</string>
-    <string name="settings_support_debuglog_label">Villuleitarskrá</string>
     <string name="settings_support_debuglog_desc">Skráðu allt sem forritið gerir í textaskrá sem þú getur deilt.</string>
-    <string name="settings_support_debuglog_recording_desc">Skrái nú villuletaruplýsingar. Ýttu til að stöðva skráningu.</string>
-    <string name="settings_support_debuglog_path">Skráarslað: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Mjög stutt skráning</string>
     <string name="settings_support_debuglog_short_recording_msg">Þetta var mjög stutt skráning. Villuletarskrár eru skráningar, ekki skyndimyndir — endurskapa vandamálið á meðan skráning er virk til að skráin sé gagnleg.</string>
     <string name="settings_support_debuglog_short_recording_continue">Halda áfram að skrá</string>
     <string name="settings_support_debuglog_short_recording_stop">Stöðva samt</string>
-    <string name="settings_support_debuglog_folder_label">Mappa villuletarskrár</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d lota með %2$s</item>
-        <item quantity="other">%1$d lotur með %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Engar villuletarskrár geymdar</string>
-    <string name="settings_support_debuglog_folder_delete_title">Eyða öllum villuletarskrám?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Þetta mun eyða endanlega öllum geymdum villuletarskráningum.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Staður til að hanga og spyrja spurninga.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Þýðing</string>
     <string name="settings_acks_translators_title">Þýðendur</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Þýða BVM</string>
-    <string name="settings_acks_translate_desc">Hjálpaðu við þýðingu á BVM yfir á þitt tungumál</string>
     <string name="settings_acks_thanks_header">Takk</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Fyrir stuðning við þýðingar á opnum hugbúnaðarverkefnum</string>
     <string name="settings_licenses_label">Leyfi</string>
     <string name="settings_translation_label">Þýðing</string>
     <string name="settings_translation_desc">Hjálpaðu við að þýða forritið yfir á uppáhaldstungumálið þitt</string>
-    <string name="settings_sponsor_development_title">Styrkja þróun</string>
-    <string name="settings_sponsor_development_summary">Verðu styrktarmaður og gera áframhaldandi þroðun mögulega.</string>
     <string name="settings_privacy_policy_label">Persónuverndarstefna</string>
     <string name="settings_privacy_policy_desc">Meðhöndlun gagna á ábyrgan hátt.</string>
     <string name="changelog_label">Breytingaskrá</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Endurheimting lokið — %1$d tæki endurheimt, %2$d sleppt.</string>
     <string name="backup_restore_version_warning">Þetta öryggisafrit var búð til með útgáfu %1$s. Þú ert að keyra %2$s. Sumar stillingar gætu ekki endurheimt rétt.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Villuleit tilkynningar</string>
     <string name="debug_log_consent_title">Villuleitarskrá</string>
     <string name="debug_log_consent_explanation">Þessi eiginleiki skráir allt sem forritið gerir í deilanlega skrá. Skráin inniheldur viðkvæmar upplýsingar (t.d. skráarnöfn og uppsett forrit). Deildu henni aðeins með traustum aðilum (t.d. þróunaraðila sem er að leysa vandamál).</string>
-    <string name="debug_log_recording_progress">Skrái villuleitarannál</string>
     <string name="debug_log_record_action">Skrá</string>
     <string name="debug_log_stop_action">Stoppa upptöku</string>
     <string name="debug_log_screen_title">Villuletarskráningartaeki</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Henda</string>
     <string name="debug_log_screen_keep_action">Geyma</string>
-    <string name="debug_log_compressing_label">ÞJappa…</string>
     <string name="debug_log_file_label">Skráð villuleitarskrá</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Skrá send?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Lýstu spurningunni þinni nákvæmlega.</string>
     <string name="contact_category_section_label">Flokkur</string>
     <string name="contact_debug_log_label">Villuleitarskrá</string>
-    <string name="contact_debug_log_select_hint">Veldu villuletarskrá til að hengja við</string>
     <string name="contact_debug_log_picker_hint">Hengdu við villuletarskrá til að hjálpa við greiningu vandamálsins hraðar.</string>
     <string name="contact_debug_log_picker_empty">Engar villuletarskrár tiltækar. Skráðu fyrst eina.</string>
     <string name="contact_expected_behavior_label">Vænt hegðun</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Ég les hvert skilaboð sjálfur og geri mitt besta til að svara, en þar sem ég vinn að þessu einn, getur tekið svolítinn tíma. Þakka þér fyrir þolinmæðina.</string>
     <string name="contact_footer_msg">Skilaboðin þín verða send með tölvupósti. Upplýsingar um tæki og uppsetningu eru hlutlagðar sjálfkrafa.</string>
     <string name="contact_no_email_app_msg">Ekkert tölvupóstforrit fannst á þessu tæki.</string>
-    <string name="contact_attachment_missing_msg">Villuletarskrá er ekki lengur til</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Geymdar villuletarskrár</string>
     <string name="settings_support_stored_logs_desc">%1$d lotur (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Engar geymdar villuletarskrár</string>
-    <string name="settings_support_stored_logs_delete_title">Eyða geymdum skrám?</string>
-    <string name="settings_support_stored_logs_delete_msg">Þetta mun eyða öllum %1$d geymdum villuletarskráningum.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Geymdum villuletarskrám eyðt</string>
-    <string name="label_bug_reports">Villutilkynningar</string>
-    <string name="description_bug_reports">Sjálfvirk villa- og hrunstilkynning.</string>
     <string name="label_add_device">Bæta við tæki</string>
-    <string name="label_just_a_moment_please">Augnablik, takk.</string>
     <string name="label_notification_channel_status">Staða</string>
     <string name="label_notification_channel_setup">Uppsetning nauðsynleg</string>
     <string name="monitor_notification_starting">Ræsir…</string>
     <string name="action_set">Stilla</string>
     <string name="action_cancel">Hætta við</string>
-    <string name="label_invalid_input">Ógilt inntak</string>
     <string name="action_reset">Endurstilla</string>
     <string name="label_no_connected_devices">Engin tæki tengd</string>
-    <string name="label_status_idle">Aðgerðarlægur</string>
-    <string name="label_status_adjusting_volumes">Stillir hljóðstyrka</string>
-    <string name="label_premium_version">Íbuðarútgáfa</string>
     <string name="general_upgrade_action">Uppfæra</string>
     <string name="common_upgrade_required_label">Uppfærsla nauðsynleg</string>
-    <string name="label_premium_version_required">Íbuðarútgáfa nauðsynleg</string>
-    <string name="description_intro_purpose">Þetta forrit leyfir Android tækinu þínu að muna hljóðstyrk mismunandi Bluetooth tækja.</string>
-    <string name="upgrade_benefit_unlimited_devices">Ótakmarkaðar tækjasniðmát</string>
-    <string name="upgrade_benefit_connection_actions">Sjálfvirk spilun, ræsing forrits og tengingartilkynningar</string>
-    <string name="upgrade_benefit_theme_customization">Þma, stíll og litabreyting</string>
-    <string name="upgrade_benefit_power_controls">Hljóðstyrkslás og takmarkanir á hraða</string>
-    <string name="upgrade_benefit_support">Stuðja óháða þrróun</string>
     <string name="upgrade_benefit_equalizer">• Tónjafnari fyrir hvert tæki (fyrir tónlistarforrit með stuðning við kerfistónjafnara)</string>
-    <string name="description_intro_tap_the_button">Byrjaðu á þeim að bæta við fyrsta tækinu þinnu.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth er óvirkt.</string>
     <string name="title_bluetooth_is_off">Bluetooth er slökkt</string>
     <string name="action_enable_bluetooth">Kveikja á Bluetooth</string>
     <string name="title_bluetooth_permission_required">Bluetooth leyfi nauðsynlegt</string>
     <string name="description_bluetooth_permission_required">Þetta forrit þarf Bluetooth leyfi til að stjórna hljóðstyrkum tækisins þíns.</string>
     <string name="action_grant_permission">Veita leyfi</string>
-    <string name="label_status_listening_for_changes">Hlustar á hljóðstyrkbreytingar</string>
     <string name="action_exit">Hætta</string>
-    <string name="action_start">Byrja</string>
-    <string name="label_welcome">Velkomin</string>
-    <string name="description_intro_contact">Ekki hika við að hafa samband ef þú hefur spurningar eða jafnvel hugmynd að nýj um eiginleika.</string>
-    <string name="label_translation">Þýðing</string>
-    <string name="description_help_translate">Hjálpaðu mér við að gera þetta forrit tiltækt á öðrum tungumálum.</string>
     <string name="label_device_speaker">Hátalari tækis</string>
-    <string name="label_keyevent_playpause">Spila-hlé</string>
-    <string name="label_keyevent_play">Spila</string>
-    <string name="label_keyevent_next">Næsta</string>
-    <string name="label_install_id">Uppsetningarauðkenni</string>
     <string name="message_copied_to_clipboard">Afritað á klippiborgð</string>
-    <string name="label_thanks">Takk</string>
-    <string name="label_licenses">Leyfi</string>
-    <string name="description_ring_volume_additional_permission">Viðbótar leyfi eru nauðsynleg til að breyta hringihljóðstyrk.</string>
-    <string name="label_missing_permissions">Vantar leyfi</string>
-    <string name="action_grant">Veita</string>
-    <string name="label_advanced">Ítarlegt</string>
-    <string name="label_exclude_health">Útiloka heilsupróflíkur</string>
-    <string name="description_exclude_health">Sum Android tæki frjósa þgar þau leita upp \'Heilsutæki\' Bluetooth prófílar (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Útiloka GATT þjónar prófílar</string>
-    <string name="label_exclude_gatt">Útiloka GATT prófílar</string>
-    <string name="description_exclude_gattserver">Ekki senda fyrirspurn um Bluetooth prófílar af gerðinni \'Generic Attribute\' (GATT) þjónn.</string>
-    <string name="description_exclude_gatt">Ekki senda fyrirspurn um Bluetooth prófílar af gerðinni \'Generic Attribute\' (GATT) biðlari.</string>
-    <string name="description_waiting_for_devicex">Bíð eftir %s að ljúka tengingu</string>
-    <string name="action_undo">Afturkalla</string>
-    <string name="action_show">Sýna</string>
     <string name="action_dismiss">Hafna</string>
-    <string name="action_fix">Laga</string>
-    <string name="battery_optimizations_issue_description">Rafhlöðufínstillingar eru virkar fyrir þetta forrit og geta komið í veg fyrir að það fái Bluetooth atburði. Íhugið að slökkva á fínstillingum ef þú ert með vandamál.</string>
     <string name="label_bluetooth_settings">Bluetooth stillingar</string>
-    <string name="android10_applaunch_issue_description">Android 10 takmarkar hvernig forrit geta verið ræst í bakgrunni. Til að leyfa opnun forrita þgar Bluetooth tæki tengist, veittu leyfin \"Útbirta yfir önnur forrit\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Frumkóði</string>
-    <string name="android13_notification_permission_description">Veittu þessu forriti leyfi til að birta tilkynningar. Þetta gerir kleift að birta tilkynningu þgar þetta forrit er virkt og hljóðstyrksleiðréttingar eru gerðar.</string>
-    <string name="privacy_policy_label">Persónuverndarstefna</string>
     <string name="managed_devices_empty_message">Engin Bluetooth tæki stillt.\nYttu á + hnappin til að bæta við fyrsta tækinu þinnu.</string>
     <string name="label_pro_feature">Íbuðar eiginleiki</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Umsögn</string>
     <string name="review_app_dismiss_action">Kannski síðar</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Kaup afturkallað</string>
-    <string name="error_iap_unavailable_message">Kaup í forriti eru ekki tiltæk</string>
-    <string name="error_generic_message">Villa kom upp. Vinsamlegast reyndu aftur.</string>
-    <string name="error_iap_owned_message">Þú eignað þér þessa vöru nú þgar</string>
     <string name="label_no_devices_title">Engin tæki</string>
     <string name="bluemusic_mascot_description">Forritsmerki</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Velja forrit</string>
     <string name="devices_app_selection_search_hint">Leita í forritum…</string>
-    <string name="devices_app_selection_currently_selected">Valið núna</string>
     <string name="devices_app_selection_selected_count">%d forrit valin</string>
     <string name="general_navigate_back_action">Fara til baka</string>
     <string name="general_reset_action">Endurstilla</string>
     <string name="general_clear_action">Hreinsa</string>
-    <string name="general_save_action">Vista</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Lás</string>
     <string name="devices_indicator_awake">Vakandi</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Takmarka</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Aukning</string>
-    <string name="devices_indicator_launch">Ræsa</string>
     <string name="devices_indicator_home">Heim</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Viðvörun</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Alcune impostazioni dei dispositivi potrebbero essere state reimpostate durante questo aggiornamento. Si prega di controllare le configurazioni dei dispositivi.</string>
     <string name="onboarding_rewrite_action">Continua</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nessun dispositivo non gestito trovato</string>
     <string name="discover_all_devices_managed_msg">Tutti i tuoi dispositivi accoppiati sono gestiti! Te ne serve uno nuovo?</string>
     <string name="discover_pair_new_device_action">Accoppia nuovo dispositivo</string>
     <string name="discover_device_speaker_desc">L\'altoparlante del telefono stesso. I suoi volumi vengono applicati quando l\'audio torna al telefono, ad es. dopo che il dispositivo Bluetooth si disconnette.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configurazione dispositivo</string>
-    <string name="devices_device_config_section_general_label">Generale</string>
     <string name="devices_device_config_remove_device_label">Dimentica dispositivo</string>
-    <string name="devices_device_config_remove_device_desc">Dimentica il dispositivo da questa app ed elimina la sua configurazione. Non disaccoppia il dispositivo.</string>
     <string name="devices_device_config_remove_device_action">Dimentica</string>
     <string name="devices_device_config_remove_device_confirmation">Dimenticare %s dai dispositivi gestiti?</string>
-    <string name="devices_device_config_rename_device_label">Rinomina dispositivo</string>
-    <string name="devices_device_config_rename_device_desc">Rinomina questo dispositivo all\'interno di questa app e, se possibile, nel sistema.</string>
     <string name="devices_device_config_rename_device_action">Rinomina</string>
     <string name="devices_device_config_enabled_label">Abilitato</string>
     <string name="devices_device_config_enabled_desc">Reagisci a questo dispositivo quando è connesso</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Comandi autoplay</string>
     <string name="devices_device_config_autoplay_keycodes_order">Sequenza di comandi</string>
     <string name="devices_device_config_autoplay_keycodes_label">Comandi</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configura quali comandi inviare e in quale ordine</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nessun comando configurato</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Aggiungi comando</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Massimo %1$d comandi</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Sposta su</string>
     <string name="cd_autoplay_keycode_move_down">Sposta giu</string>
     <string name="cd_autoplay_keycode_remove">Elimina</string>
-    <string name="devices_device_config_section_volumes_label">Volumi</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
     <string name="devices_device_config_alarm_volume_label">Volume sveglia</string>
     <string name="devices_device_config_alarm_volume_desc">Alcune app per sveglie usano invece il volume della musica.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Suoneria</string>
     <string name="devices_audio_stream_notification_label">Notifica</string>
     <string name="devices_audio_stream_alarm_label">Sveglia</string>
-    <string name="devices_neverseen_label">Mai visto</string>
-    <string name="devices_state_connected_label">Connesso</string>
     <string name="devices_last_connected_label">Ultima connessione: %s</string>
     <string name="devices_currently_connected_label">Attualmente connesso</string>
     <string name="devices_device_disabled_label">Dispositivo disabilitato</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Impostazioni che influenzano tutti i dispositivi gestiti.</string>
     <string name="label_app_enabled">Attivazione app</string>
     <string name="description_app_enabled">Attiva o disattiva la possibilità dell\'app di reagire agli eventi relativi al volume e al Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Regolazioni visibili</string>
-    <string name="description_visible_volume_adjustments">Mostra la finestra di sistema dei volumi mentre quest\'app apporta delle regolazioni.</string>
     <string name="label_volume_listener">Rilevamento modifiche</string>
-    <string name="description_volume_listener">Resta attivo mentre un dispositivo è connesso e salva le modifiche ai volumi non applicate da quest\'app.</string>
     <string name="label_boot_restore">Ripristino all\'avvio</string>
     <string name="description_boot_restore">Ripristina i volumi dopo un avvio o un riavvio se un dispositivo Bluetooth è connesso.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Impara come usare BVM efficacemente</string>
     <string name="settings_support_issue_tracker_description">Un tracker pubblico per segnalazioni di bug e richieste di funzionalità.</string>
     <string name="settings_support_issue_tracker_label">Tracker problemi</string>
-    <string name="settings_support_debuglog_label">Log di debug</string>
     <string name="settings_support_debuglog_desc">Registra tutto quello che fa l\'app in un file di testo che puoi condividere.</string>
-    <string name="settings_support_debuglog_recording_desc">Attualmente registrando informazioni di debug. Tocca per interrompere la registrazione.</string>
-    <string name="settings_support_debuglog_path">Percorso log: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Registrazione molto breve</string>
     <string name="settings_support_debuglog_short_recording_msg">È stata una registrazione molto breve. I log di debug sono registrazioni, non istantanee — riproduci il problema mentre la registrazione è attiva affinché il log sia utile.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continua a registrare</string>
     <string name="settings_support_debuglog_short_recording_stop">Ferma comunque</string>
-    <string name="settings_support_debuglog_folder_label">Cartella log di debug</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sessione che usa %2$s</item>
-        <item quantity="other">%1$d sessioni che usano %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nessun log di debug salvato</string>
-    <string name="settings_support_debuglog_folder_delete_title">Eliminare tutti i log di debug?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Tutte le sessioni di log di debug salvate verranno eliminate definitivamente.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Un posto dove stare insieme e fare domande.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Traduzione</string>
     <string name="settings_acks_translators_title">Traduttori</string>
     <string name="settings_acks_translators_people">Filippo Lolli (IG: @lolli_filippo)</string>
-    <string name="settings_acks_translate_title">Traduci BVM</string>
-    <string name="settings_acks_translate_desc">Aiuta a tradurre BVM nella tua lingua</string>
     <string name="settings_acks_thanks_header">Ringraziamenti</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Per supportare la traduzione di progetti open-source</string>
     <string name="settings_licenses_label">Licenze</string>
     <string name="settings_translation_label">Traduzione</string>
     <string name="settings_translation_desc">Aiuta a tradurre l’app nella tua lingua preferita</string>
-    <string name="settings_sponsor_development_title">Sponsorizza lo sviluppo</string>
-    <string name="settings_sponsor_development_summary">Diventa un mecenate e rendi possibile lo sviluppo continuo.</string>
     <string name="settings_privacy_policy_label">Informativa sulla privacy</string>
     <string name="settings_privacy_policy_desc">Gestire i dati responsabilmente.</string>
     <string name="changelog_label">Registro modifiche</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Ripristino completato — %1$d dispositivi ripristinati, %2$d saltati.</string>
     <string name="backup_restore_version_warning">Questo backup è stato creato con la versione %1$s. Stai usando la versione %2$s. Alcune impostazioni potrebbero non essere ripristinate correttamente.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notifiche debug</string>
     <string name="debug_log_consent_title">Log debug</string>
     <string name="debug_log_consent_explanation">Questa funzione registra tutto quello che fa l\'app in un file condivisibile. Il file generato contiene informazioni sensibili (es. nomi file e app installate). Condividilo solo con parti fidate (es. uno sviluppatore che risolve un problema).</string>
-    <string name="debug_log_recording_progress">Registrando log debug</string>
     <string name="debug_log_record_action">Registra</string>
     <string name="debug_log_stop_action">Interrompi registrazione</string>
     <string name="debug_log_screen_title">Registratore Log Debug</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Scarta</string>
     <string name="debug_log_screen_keep_action">Conserva</string>
-    <string name="debug_log_compressing_label">Compressione in corso…</string>
     <string name="debug_log_file_label">File log registrato</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log inviato?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Descrivi la tua domanda nel dettaglio.</string>
     <string name="contact_category_section_label">Categoria</string>
     <string name="contact_debug_log_label">Log di debug</string>
-    <string name="contact_debug_log_select_hint">Seleziona un log di debug da allegare</string>
     <string name="contact_debug_log_picker_hint">Allega un log di debug per aiutare a diagnosticare il problema più velocemente.</string>
     <string name="contact_debug_log_picker_empty">Nessun log di debug disponibile. Registrane uno prima.</string>
     <string name="contact_expected_behavior_label">Comportamento atteso</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Leggo ogni messaggio personalmente e cerco di rispondere nel miglior modo possibile, ma dato che lavoro da solo, potrebbe volerci un po\'. Grazie per la pazienza.</string>
     <string name="contact_footer_msg">Il tuo messaggio sarà inviato tramite email. Le informazioni sul dispositivo e sulla configurazione vengono allegate automaticamente.</string>
     <string name="contact_no_email_app_msg">Nessuna app email trovata su questo dispositivo.</string>
-    <string name="contact_attachment_missing_msg">Il file di log di debug non esiste più</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Log di debug salvati</string>
     <string name="settings_support_stored_logs_desc">%1$d sessioni (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Nessun log di debug salvato</string>
-    <string name="settings_support_stored_logs_delete_title">Eliminare i log salvati?</string>
-    <string name="settings_support_stored_logs_delete_msg">Verranno eliminate tutte le %1$d sessioni di log di debug salvate.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Log di debug salvati eliminati</string>
-    <string name="label_bug_reports">Segnalazione bug</string>
-    <string name="description_bug_reports">Riporta automaticamente bug e crash.</string>
     <string name="label_add_device">Aggiungi un dispositivo</string>
-    <string name="label_just_a_moment_please">Solo un momento, per favore.</string>
     <string name="label_notification_channel_status">Stato</string>
     <string name="label_notification_channel_setup">Configurazione richiesta</string>
     <string name="monitor_notification_starting">Avvio in corso…</string>
     <string name="action_set">Imposta</string>
     <string name="action_cancel">Annulla</string>
-    <string name="label_invalid_input">Input non valido</string>
     <string name="action_reset">Ripristina</string>
     <string name="label_no_connected_devices">Nessun dispositivo connesso</string>
-    <string name="label_status_idle">Inattivo</string>
-    <string name="label_status_adjusting_volumes">Regolazione volumi</string>
-    <string name="label_premium_version">Versione premium</string>
     <string name="general_upgrade_action">Aggiorna</string>
     <string name="common_upgrade_required_label">Aggiornamento richiesto</string>
-    <string name="label_premium_version_required">È richiesta la versione premium</string>
-    <string name="description_intro_purpose">Quest\'app consente al tuo dispositivo Android di ricordare il volume di ogni dispositivo Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Profili dispositivo illimitati</string>
-    <string name="upgrade_benefit_connection_actions">Riproduzione automatica, avvio app e avvisi di connessione</string>
-    <string name="upgrade_benefit_theme_customization">Personalizzazione di tema, stile e colori</string>
-    <string name="upgrade_benefit_power_controls">Blocco volume e limitazione della frequenza</string>
-    <string name="upgrade_benefit_support">Supporta lo sviluppo indipendente</string>
     <string name="upgrade_benefit_equalizer">• Equalizzatore per dispositivo (per app musicali con supporto all\'equalizzatore di sistema)</string>
-    <string name="description_intro_tap_the_button">Inizia aggiungendo il tuo primo dispositivo.</string>
     <string name="description_bluetooth_is_disabled">Il Bluetooth è disattivato.</string>
     <string name="title_bluetooth_is_off">Bluetooth è spento</string>
     <string name="action_enable_bluetooth">Abilita Bluetooth</string>
     <string name="title_bluetooth_permission_required">Permesso Bluetooth richiesto</string>
     <string name="description_bluetooth_permission_required">Questa app ha bisogno del permesso Bluetooth per gestire i volumi dei tuoi dispositivi.</string>
     <string name="action_grant_permission">Concedi permesso</string>
-    <string name="label_status_listening_for_changes">In ascolto per modifiche dei volumi</string>
     <string name="action_exit">Esci</string>
-    <string name="action_start">Inizia</string>
-    <string name="label_welcome">Benvenuto</string>
-    <string name="description_intro_contact">Non esitare a contattarmi se hai una domanda o un\'idea per una nuova funzione.</string>
-    <string name="label_translation">Traduzione</string>
-    <string name="description_help_translate">Aiutami a rendere quest\'app disponibile in altre lingue.</string>
     <string name="label_device_speaker">Altoparlante del dispositivo</string>
-    <string name="label_keyevent_playpause">Riproduci-Metti in pausa</string>
-    <string name="label_keyevent_play">Riproduci</string>
-    <string name="label_keyevent_next">Avanti</string>
-    <string name="label_install_id">Installa ID</string>
     <string name="message_copied_to_clipboard">Copiato negli appunti</string>
-    <string name="label_thanks">Ringraziamenti</string>
-    <string name="label_licenses">Licenze</string>
-    <string name="description_ring_volume_additional_permission">Sono necessari ulteriori autorizzazioni per modificare il volume della suoneria.</string>
-    <string name="label_missing_permissions">Autorizzazioni mancanti</string>
-    <string name="action_grant">Consenti</string>
-    <string name="label_advanced">Avanzate</string>
-    <string name="label_exclude_health">Escludi i profili sanitari</string>
-    <string name="description_exclude_health">Alcuni dispositivi Android si bloccano quando cercano i profili Bluetooth di dispositivi sanitari (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Escludi i profili server GATT</string>
-    <string name="label_exclude_gatt">Escludi i profili GATT</string>
-    <string name="description_exclude_gattserver">Non ricercare i profili Bluetooth di tipo server di \'Attributo Generico\' (GATT).</string>
-    <string name="description_exclude_gatt">Non ricercare i profili Bluetooth di tipo client di \'Attributo Generico\' (GATT).</string>
-    <string name="description_waiting_for_devicex">In attesa di %s per completare la connessione</string>
-    <string name="action_undo">Annulla</string>
-    <string name="action_show">Mostra</string>
     <string name="action_dismiss">Annulla</string>
-    <string name="action_fix">Correggi</string>
-    <string name="battery_optimizations_issue_description">Le ottimizzazioni della batteria sono attivate per quest\'app e questo potrebbe impedire la ricezione degli eventi Bluetooth. Prova a disattivare le ottimizzazioni se riscontri problemi.</string>
     <string name="label_bluetooth_settings">Impostazioni Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 limita il modo in cui le app possono essere avviate in background. Per consentire l\'apertura di app quando un dispositivo Bluetooth si connette, concedi il permesso &quot;Visualizza sopra altre app&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Codice sorgente</string>
-    <string name="android13_notification_permission_description">Concedi a questa app il permesso di pubblicare notifiche. Questo abilita la visualizzazione di una notifica quando l\'app è attiva e vengono fatte regolazioni del volume.</string>
-    <string name="privacy_policy_label">Informativa sulla privacy</string>
     <string name="managed_devices_empty_message">Nessun dispositivo Bluetooth configurato.\nTocca il pulsante + per aggiungere il tuo primo dispositivo.</string>
     <string name="label_pro_feature">Funzionalità premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Recensione</string>
     <string name="review_app_dismiss_action">Forse più tardi</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Acquisto annullato</string>
-    <string name="error_iap_unavailable_message">Gli acquisti in-app non sono disponibili</string>
-    <string name="error_generic_message">Si è verificato un errore. Riprova.</string>
-    <string name="error_iap_owned_message">Possiedi già questo articolo</string>
     <string name="label_no_devices_title">Nessun dispositivo</string>
     <string name="bluemusic_mascot_description">Icona App</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Seleziona App</string>
     <string name="devices_app_selection_search_hint">Cerca app…</string>
-    <string name="devices_app_selection_currently_selected">Attualmente selezionate</string>
     <string name="devices_app_selection_selected_count">%d app selezionate</string>
     <string name="general_navigate_back_action">Torna indietro</string>
     <string name="general_reset_action">Ripristina</string>
     <string name="general_clear_action">Cancella</string>
-    <string name="general_save_action">Salva</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Blocco</string>
     <string name="devices_indicator_awake">Attivo</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Limite</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Boost</string>
-    <string name="devices_indicator_launch">Avvia</string>
     <string name="devices_indicator_home">Home</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Avviso</string>

--- a/app/src/main/res/values-iw/strings.xml
+++ b/app/src/main/res/values-iw/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">חלק מהגדרות המכשיר עשויות להיאנץ במהלך העדכון. אנא בדקו את תצורות המכשירים שלכם.</string>
     <string name="onboarding_rewrite_action">המשך</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">לא נמצאו מכשירים לא מנוהלים</string>
     <string name="discover_all_devices_managed_msg">כל המכשירים המצומדים שלכם מנוהלים! צריכים חדש?</string>
     <string name="discover_pair_new_device_action">צמד מכשיר חדש</string>
     <string name="discover_device_speaker_desc">הרמקול של הטלפון הזה. עוצמות הקול שלו מוחלות כאשר האודיו חוזר לטלפון, למשל לאחר ניתוק מכשיר ה-Bluetooth שלך.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">תצורת מכשיר</string>
-    <string name="devices_device_config_section_general_label">כללי</string>
     <string name="devices_device_config_remove_device_label">שכח מכשיר</string>
-    <string name="devices_device_config_remove_device_desc">משכיח את המכשיר מהאפליקציה ומוחק את התצורה שלו. זה לא מנתק את הצימוד למכשיר.</string>
     <string name="devices_device_config_remove_device_action">שכח</string>
     <string name="devices_device_config_remove_device_confirmation">לשכוח את %s מהמכשירים המנוהלים?</string>
-    <string name="devices_device_config_rename_device_label">שנה שם מכשיר</string>
-    <string name="devices_device_config_rename_device_desc">שנה את שם המכשיר באפליקציה זו, ואם אפשר, במערכת.</string>
     <string name="devices_device_config_rename_device_action">שנה שם</string>
     <string name="devices_device_config_enabled_label">מופעל</string>
     <string name="devices_device_config_enabled_desc">הגב למכשיר זה כאשר הוא מחובר</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">פקודות ניגון אוטומטי</string>
     <string name="devices_device_config_autoplay_keycodes_order">רצף פקודות</string>
     <string name="devices_device_config_autoplay_keycodes_label">פקודות</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">הגדר אילו פקודות לשלוח ובאיזה סדר</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">לא הוגדרו פקודות</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">הוסף פקודה</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">מקסימום %1$d פקודות</string>
@@ -122,7 +116,6 @@
     <string name="cd_autoplay_keycode_move_up">הזז למעלה</string>
     <string name="cd_autoplay_keycode_move_down">הזז למטה</string>
     <string name="cd_autoplay_keycode_remove">הסרה</string>
-    <string name="devices_device_config_section_volumes_label">עוצמות</string>
     <string name="devices_device_config_section_volume_label">עוצמה</string>
     <string name="devices_device_config_alarm_volume_label">עוצמת התראה</string>
     <string name="devices_device_config_alarm_volume_desc">חלק מאפליקציות התראה משתמשות בעוצמת המוזיקה במקום.</string>
@@ -156,8 +149,6 @@
     <string name="devices_audio_stream_ring_label">צלצול</string>
     <string name="devices_audio_stream_notification_label">התראה</string>
     <string name="devices_audio_stream_alarm_label">התראה</string>
-    <string name="devices_neverseen_label">לא נראה מעולם</string>
-    <string name="devices_state_connected_label">מחובר</string>
     <string name="devices_last_connected_label">חיבור אחרון: %s</string>
     <string name="devices_currently_connected_label">מחובר כעת</string>
     <string name="devices_device_disabled_label">המכשיר מנוטרל</string>
@@ -192,10 +183,7 @@
     <string name="devices_settings_desc">הגדרות המשפיעות על כל המכשירים המנוהלים.</string>
     <string name="label_app_enabled">אפליקצייה מאופשרת</string>
     <string name="description_app_enabled">שינוי יכולת האפליקציה להגיב לאירועי ווליום ו-Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">התאמות נראות</string>
-    <string name="description_visible_volume_adjustments">הצגת חלון ווליום של המערכת כאשר ההתאמות נעשות על ידי אפליקציה זו.</string>
     <string name="label_volume_listener">צפייה בשינויים</string>
-    <string name="description_volume_listener">להשאיר פעיל כאשר התקן מחובר ושמירת שינויי ווליום שלא נגרמו על ידי אפליקציה זו.</string>
     <string name="label_boot_restore">שחזור באתחול</string>
     <string name="description_boot_restore">שחזר עוצמת קול לאחר אתחול/אתחול מחדש אם מכשיר בלוטוס מחובר.</string>
     <!-- Settings/Support-->
@@ -205,23 +193,11 @@
     <string name="settings_support_wiki_description">למד איך להשתמש ב-BVM באופן יעיל</string>
     <string name="settings_support_issue_tracker_description">מעקב בעיות ציבורי לדיווחים על באגים ובקשות לתכונות.</string>
     <string name="settings_support_issue_tracker_label">מעקב בעיות</string>
-    <string name="settings_support_debuglog_label">לוג ניפוי באגים</string>
     <string name="settings_support_debuglog_desc">הקלט כל מה שהאפליקציה עושה לקובץ טקסט שאפשר לשתף.</string>
-    <string name="settings_support_debuglog_recording_desc">מקליט כרגע מידע ניפוי באגים. לחץ כדי להפסיק הקלטה.</string>
-    <string name="settings_support_debuglog_path">נתיב לוג: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">הקלטה קצרה מאוד</string>
     <string name="settings_support_debuglog_short_recording_msg">זו הייתה הקלטה קצרה מאוד. לוגי ניפוי באגים הם הקלטות, לא תמונות מצב — שחזר את הבעיה בזמן שההקלטה פעילה כדי שהלוג יהיה שימושי.</string>
     <string name="settings_support_debuglog_short_recording_continue">המשך הקלטה</string>
     <string name="settings_support_debuglog_short_recording_stop">עצור בכל זאת</string>
-    <string name="settings_support_debuglog_folder_label">תיקיית לוג ניפוי באגים</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d סשן בשימוש %2$s</item>
-        <item quantity="two">%1$d סשנים בשימוש %2$s</item>
-        <item quantity="other">%1$d סשנים בשימוש %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">אין לוגי ניפוי באגים שמורים</string>
-    <string name="settings_support_debuglog_folder_delete_title">למחוק את כל לוגי ניפוי הבאגים?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">כל סשני לוג ניפוי הבאגים השמורים יימחקו לצמיתות.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">מקום לבלות ולשאול שאלות.</string>
     <!-- Settings/Acks-->
@@ -230,16 +206,12 @@
     <string name="settings_acks_translation_header">תרגום</string>
     <string name="settings_acks_translators_title">מתרגמים</string>
     <string name="settings_acks_translators_people">אדם1;אדם2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">תרגם את BVM</string>
-    <string name="settings_acks_translate_desc">עזור לתרגם את BVM לשפתך</string>
     <string name="settings_acks_thanks_header">תודות</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">על תמיכה בתרגום פרויקטים קוד פתוח</string>
     <string name="settings_licenses_label">רישיונות</string>
     <string name="settings_translation_label">תרגום</string>
     <string name="settings_translation_desc">עזור לתרגם את האפליקציה לשפה המועדפת עליך</string>
-    <string name="settings_sponsor_development_title">חסות פיתוח</string>
-    <string name="settings_sponsor_development_summary">היה פטרון ואפשר המשכת פיתוח.</string>
     <string name="settings_privacy_policy_label">מדיניות פרטיות</string>
     <string name="settings_privacy_policy_desc">טיפול במידע באחריות.</string>
     <string name="changelog_label">לוג שינויים</string>
@@ -261,10 +233,8 @@
     <string name="backup_restore_success_restore">השחזור הושלם — %1$d מכשירים שוחזרו, %2$d דולגו.</string>
     <string name="backup_restore_version_warning">גיבוי זה נוצר עם גרסה %1$s. אתה מריץ %2$s. ייתכן שחלק מההגדרות לא ישוחזרו כראוי.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">התראות ניפוי באגים</string>
     <string name="debug_log_consent_title">לוג ניפוי באגים</string>
     <string name="debug_log_consent_explanation">תכונה זו מקליטה כל מה שהאפליקציה עושה לקובץ שניתן לשתף. הקובץ הנוצר מכיל מידע רגיש (למשל שמות קבצים ואפליקציות מותקנות). שתפו אותו רק עם גורמים מועמדים (למשל מפתח הפותר בעיה).</string>
-    <string name="debug_log_recording_progress">מקליט לוג ניפוי באגים</string>
     <string name="debug_log_record_action">הקלט</string>
     <string name="debug_log_stop_action">הפסק הקלטה</string>
     <string name="debug_log_screen_title">מקליט לוג ניפוי באגים</string>
@@ -280,7 +250,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">ותר</string>
     <string name="debug_log_screen_keep_action">שמור</string>
-    <string name="debug_log_compressing_label">דחיסה…</string>
     <string name="debug_log_file_label">קובץ לוג מוקלט</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">הלוג נשלח?</string>
@@ -308,7 +277,6 @@
     <string name="contact_description_question_hint">תאר את שאלתך בפירוט.</string>
     <string name="contact_category_section_label">קטגוריה</string>
     <string name="contact_debug_log_label">לוג ניפוי באגים</string>
-    <string name="contact_debug_log_select_hint">בחר לוג ניפוי באגים לצירוף</string>
     <string name="contact_debug_log_picker_hint">צרף לוג ניפוי באגים לאבחון מהיר יותר של הבעיה.</string>
     <string name="contact_debug_log_picker_empty">אין לוגי ניפוי באגים זמינים. הקלט אחד תחילה.</string>
     <string name="contact_expected_behavior_label">התנהגות צפויה</string>
@@ -323,82 +291,32 @@
     <string name="contact_welcome_msg">אני קורא כל הודעה בעצמי ועושה כמיטב יכולתי להשיב, אך מכיוון שאני עובד לבד, זה עשוי לקחת קצת זמן. תודה על הסבלנות.</string>
     <string name="contact_footer_msg">ההודעה שלך תישלח באימייל. מידע על המכשיר וההגדרות מצורף אוטומטית.</string>
     <string name="contact_no_email_app_msg">לא נמצאה אפליקציית אימייל במכשיר זה.</string>
-    <string name="contact_attachment_missing_msg">קובץ לוג ניפוי הבאגים אינו קיים עוד</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">לוגי ניפוי באגים שמורים</string>
     <string name="settings_support_stored_logs_desc">%1$d סשנים (%2$s)</string>
     <string name="settings_support_stored_logs_empty">אין לוגי ניפוי באגים שמורים</string>
-    <string name="settings_support_stored_logs_delete_title">למחוק לוגים שמורים?</string>
-    <string name="settings_support_stored_logs_delete_msg">כל %1$d סשני לוג ניפוי הבאגים השמורים יימחקו.</string>
-    <string name="settings_support_stored_logs_deleted_msg">לוגי ניפוי הבאגים השמורים נמחקו</string>
-    <string name="label_bug_reports">דיווח באגים</string>
-    <string name="description_bug_reports">דיווח באגים וקריסות אוטומטי.</string>
     <string name="label_add_device">הוספת התקן</string>
-    <string name="label_just_a_moment_please">אנא המתינו.</string>
     <string name="label_notification_channel_status">מצב</string>
     <string name="label_notification_channel_setup">נדרשת הגדרה</string>
     <string name="monitor_notification_starting">מתחיל…</string>
     <string name="action_set">קביעה</string>
     <string name="action_cancel">ביטול</string>
-    <string name="label_invalid_input">קלט לא תקין</string>
     <string name="action_reset">איפוס</string>
     <string name="label_no_connected_devices">אין התקנים מחוברים</string>
-    <string name="label_status_idle">לא פעיל</string>
-    <string name="label_status_adjusting_volumes">התאמת ווליום</string>
-    <string name="label_premium_version">גרסת פרימיום</string>
     <string name="general_upgrade_action">שדרוג</string>
     <string name="common_upgrade_required_label">נדרש שדרוג</string>
-    <string name="label_premium_version_required">נדרשת גרסת פרימיום</string>
-    <string name="description_intro_purpose">אפליקציה זו מאפשרת למכשיר האנדרואיד שלכם לזכור רמות ווליום של מכשירי Bluetooth שונים.</string>
-    <string name="upgrade_benefit_unlimited_devices">פרופילי מכשיר ללא הגבלה</string>
-    <string name="upgrade_benefit_connection_actions">ניגון אוטומטי, הפעלת אפליקציה והתראות חיבור</string>
-    <string name="upgrade_benefit_theme_customization">התאמה אישית של ערכת נושא, סגנון וצבע</string>
-    <string name="upgrade_benefit_power_controls">נעילת עוצמת קול והגבלת קצב</string>
-    <string name="upgrade_benefit_support">תמוך בפיתוח עצמאי</string>
     <string name="upgrade_benefit_equalizer">• אקולייזר לכל מכשיר (עבור אפליקציות מוזיקה עם תמיכה באקולייזר מערכת)</string>
-    <string name="description_intro_tap_the_button">התחילו על ידי הוספת המכשיר הראשון שלכם.</string>
     <string name="description_bluetooth_is_disabled">בלוטות\' מנוטרל.</string>
     <string name="title_bluetooth_is_off">בלוטוס כבוי</string>
     <string name="action_enable_bluetooth">אפשר בלוטוס</string>
     <string name="title_bluetooth_permission_required">נדרשת הרשאת בלוטוס</string>
     <string name="description_bluetooth_permission_required">האפליקציה צריכה הרשאת בלוטוס כדי לנהל את עוצמות המכשירים שלך.</string>
     <string name="action_grant_permission">הענק הרשאה</string>
-    <string name="label_status_listening_for_changes">האזנה לשינויים בווליום</string>
     <string name="action_exit">יציאה</string>
-    <string name="action_start">התחלה</string>
-    <string name="label_welcome">ברוך הבא</string>
-    <string name="description_intro_contact">אל תהססו לפנות אלי אם יש לכם שאלות או אפילו רעיון לתכונה חדשה.</string>
-    <string name="label_translation">תרגום</string>
-    <string name="description_help_translate">עזרו לי להפוך אפליקציה זו לזמינה בשפות אחרות.</string>
     <string name="label_device_speaker">רמקול מכשיר</string>
-    <string name="label_keyevent_playpause">ניגון-עצירה</string>
-    <string name="label_keyevent_play">ניגון</string>
-    <string name="label_keyevent_next">הבא</string>
-    <string name="label_install_id">מזהה התקנה</string>
     <string name="message_copied_to_clipboard">הועתק ללוח הגזירות</string>
-    <string name="label_thanks">תודות</string>
-    <string name="label_licenses">רשיונות</string>
-    <string name="description_ring_volume_additional_permission">נדרשות הרשאות נוספות כדי לשנות את עוצמת הצלצול.</string>
-    <string name="label_missing_permissions">הרשאות חסרות</string>
-    <string name="action_grant">הענק</string>
-    <string name="label_advanced">מתקדם</string>
-    <string name="label_exclude_health">החרג פרופילי בריאות</string>
-    <string name="description_exclude_health">חלק ממכשירי אנדרואיד תוקעים כאשר מחפשים פרופילי בלוטוס של \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">החרג פרופילי GATT server</string>
-    <string name="label_exclude_gatt">החרג פרופילי GATT</string>
-    <string name="description_exclude_gattserver">אל תשאל פרופילי בלוטוס מסוג \'Generic Attribute\' (GATT) server.</string>
-    <string name="description_exclude_gatt">אל תשאל פרופילי בלוטוס מסוג \'Generic Attribute\' (GATT) client.</string>
-    <string name="description_waiting_for_devicex">ממתין ש%s ישלים חיבור</string>
-    <string name="action_undo">בטל</string>
-    <string name="action_show">הצג</string>
     <string name="action_dismiss">דחה</string>
-    <string name="action_fix">תקן</string>
-    <string name="battery_optimizations_issue_description">אימוצי סוללה מופעלים עבור האפליקציה ועלולים למנוע ממנה לקבל אירועי בלוטוס. שקלו להשבית אימוצים אם אתם חווים בעיות.</string>
     <string name="label_bluetooth_settings">הגדרות בלוטוס</string>
-    <string name="android10_applaunch_issue_description">אנדרואיד 10 מגביל איך ניתן להפעיל אפליקציות מהרקע. כדי לאפשר פתיחת אפליקציות כאשר מכשיר בלוטוס מתחבר, העניקו את ההרשאה &quot;הצג מעל אפליקציות אחרות&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">קוד מקור</string>
-    <string name="android13_notification_permission_description">העניקו לאפליקציה הרשאה לפרסם התראות. זה מאפשר הצגת התראה כאשר האפליקציה פעילה ומבצעות התאמות עוצמה.</string>
-    <string name="privacy_policy_label">מדיניות פרטיות</string>
     <string name="managed_devices_empty_message">לא הוגדרו מכשירי בלוטוס.\nלחץ על כפתור + כדי להוסיף את המכשיר הראשון.</string>
     <string name="label_pro_feature">תכונה פרימיום</string>
     <plurals name="discover_device_limit_banner">
@@ -430,21 +348,15 @@
     <string name="review_app_review_action">סקירה</string>
     <string name="review_app_dismiss_action">אולי מאוחר יותר</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">רכישה בוטלה</string>
-    <string name="error_iap_unavailable_message">רכישות בתוך האפליקציה לא זמינות</string>
-    <string name="error_generic_message">אירעה שגיאה. אנא נסו שוב.</string>
-    <string name="error_iap_owned_message">אתם כבר בעלים של פריט זה</string>
     <string name="label_no_devices_title">אין מכשירים</string>
     <string name="bluemusic_mascot_description">איקון אפליקציה</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">בחר אפליקציות</string>
     <string name="devices_app_selection_search_hint">חפש אפליקציות…</string>
-    <string name="devices_app_selection_currently_selected">נבחר כעת</string>
     <string name="devices_app_selection_selected_count">%d אפליקציות נבחרו</string>
     <string name="general_navigate_back_action">נווט אחורה</string>
     <string name="general_reset_action">איפוס</string>
     <string name="general_clear_action">נקה</string>
-    <string name="general_save_action">שמור</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">נעילה</string>
     <string name="devices_indicator_awake">ער</string>
@@ -454,7 +366,6 @@
     <string name="devices_indicator_limit">הגבלה</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">הגברה</string>
-    <string name="devices_indicator_launch">הפעלה</string>
     <string name="devices_indicator_home">בית</string>
     <string name="devices_indicator_dnd">נא לא להפריע</string>
     <string name="devices_indicator_alert">התראה</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">このアップデート中に一部のデバイス設定がリセットされた可能性があります。デバイスの設定を確認してください。</string>
     <string name="onboarding_rewrite_action">続ける</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">管理されていないデバイスが見つかりません</string>
     <string name="discover_all_devices_managed_msg">ペアリングされたデバイスはすべて管理されています！新しいのが必要ですか？</string>
     <string name="discover_pair_new_device_action">新しいデバイスをペアリング</string>
     <string name="discover_device_speaker_desc">この電話自体のスピーカー。Bluetooth デバイスが切断された後など、オーディオが電話に戻されるとき、そのボリュームが適用されます。</string>
     <!-- Devices -->
     <string name="devices_device_config_label">デバイス設定</string>
-    <string name="devices_device_config_section_general_label">一般</string>
     <string name="devices_device_config_remove_device_label">デバイスを忘れる</string>
-    <string name="devices_device_config_remove_device_desc">このアプリからデバイスを忘れ、その設定を削除します。これはデバイスのペアリングを解除しません。</string>
     <string name="devices_device_config_remove_device_action">忘れる</string>
     <string name="devices_device_config_remove_device_confirmation">管理デバイスから%sを忘れますか？</string>
-    <string name="devices_device_config_rename_device_label">デバイス名を変更</string>
-    <string name="devices_device_config_rename_device_desc">このアプリ内で、可能であればシステム内でも、このデバイスの名前を変更します。</string>
     <string name="devices_device_config_rename_device_action">名前変更</string>
     <string name="devices_device_config_enabled_label">有効</string>
     <string name="devices_device_config_enabled_desc">接続時にこのデバイスに反応する</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">自動再生コマンド</string>
     <string name="devices_device_config_autoplay_keycodes_order">コマンドシーケンス</string>
     <string name="devices_device_config_autoplay_keycodes_label">コマンド</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">送信するコマンドとその順序を設定します</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">コマンドが設定されていません</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">コマンドを追加</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">最大 %1$d コマンド</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">上へ移動</string>
     <string name="cd_autoplay_keycode_move_down">下へ移動</string>
     <string name="cd_autoplay_keycode_remove">削除</string>
-    <string name="devices_device_config_section_volumes_label">音量</string>
     <string name="devices_device_config_section_volume_label">音量</string>
     <string name="devices_device_config_alarm_volume_label">アラームの音量</string>
     <string name="devices_device_config_alarm_volume_desc">アラームアプリによっては、音楽の音量を使用するものもあります。</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">着信</string>
     <string name="devices_audio_stream_notification_label">通知</string>
     <string name="devices_audio_stream_alarm_label">アラーム</string>
-    <string name="devices_neverseen_label">接続履歴なし</string>
-    <string name="devices_state_connected_label">接続済み</string>
     <string name="devices_last_connected_label">最後の接続: %s</string>
     <string name="devices_currently_connected_label">現在接続中</string>
     <string name="devices_device_disabled_label">デバイス無効</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">すべての管理デバイスに影響する設定。</string>
     <string name="label_app_enabled">アプリの有効化</string>
     <string name="description_app_enabled">アプリが音量とBluetoothのイベントに反応するかどうかを切り替えます。</string>
-    <string name="label_visible_volume_adjustments">調整の可視化</string>
-    <string name="description_visible_volume_adjustments">このアプリが音量を調節する際に、システムの音量ウィンドウを表示します。</string>
     <string name="label_volume_listener">変更の監視</string>
-    <string name="description_volume_listener">デバイスが接続されている間はアプリを常駐させて、このアプリ以外による音量の変更を保存します。</string>
     <string name="label_boot_restore">起動時に復元</string>
     <string name="description_boot_restore">Bluetoothデバイスが接続されている場合、起動/再起動後に音量を復元します。</string>
     <!-- Settings/Support-->
@@ -203,21 +191,11 @@
     <string name="settings_support_wiki_description">BVMを効果的に使用する方法を学ぶ</string>
     <string name="settings_support_issue_tracker_description">バグ報告と機能リクエストのための公開問題トラッカー。</string>
     <string name="settings_support_issue_tracker_label">問題トラッカー</string>
-    <string name="settings_support_debuglog_label">デバッグログ</string>
     <string name="settings_support_debuglog_desc">アプリが行っているすべてをテキストファイルに記録して共有できます。</string>
-    <string name="settings_support_debuglog_recording_desc">現在デバッグ情報を記録中です。タップして記録を停止します。</string>
-    <string name="settings_support_debuglog_path">ログパス: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">非常に短い録音</string>
     <string name="settings_support_debuglog_short_recording_msg">非常に短い録音でした。デバッグログは録音であり、スナップショットではありません — ログを有用にするには、録音中に問題を再現してください。</string>
     <string name="settings_support_debuglog_short_recording_continue">録音を続ける</string>
     <string name="settings_support_debuglog_short_recording_stop">それでも停止する</string>
-    <string name="settings_support_debuglog_folder_label">デバッグログフォルダ</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d セッション、%2$s 使用</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">保存されたデバッグログなし</string>
-    <string name="settings_support_debuglog_folder_delete_title">すべてのデバッグログを削除しますか？</string>
-    <string name="settings_support_debuglog_folder_delete_msg">保存されたデバッグログセッションをすべて完全に削除します。</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">雑談や質問ができる場所。</string>
     <!-- Settings/Acks-->
@@ -226,16 +204,12 @@
     <string name="settings_acks_translation_header">翻訳</string>
     <string name="settings_acks_translators_title">翻訳者</string>
     <string name="settings_acks_translators_people">Estel Freesia;Re*Index.(ot_inc)</string>
-    <string name="settings_acks_translate_title">BVMを翻訳</string>
-    <string name="settings_acks_translate_desc">BVMをあなたの言語に翻訳するのを手伝ってください</string>
     <string name="settings_acks_thanks_header">謝辞</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">オープンソースプロジェクトの翻訳をサポートしてくださりありがとうございます</string>
     <string name="settings_licenses_label">ライセンス</string>
     <string name="settings_translation_label">翻訳</string>
     <string name="settings_translation_desc">このアプリをあなたの好きな言語に翻訳するのを手伝ってください</string>
-    <string name="settings_sponsor_development_title">開発をスポンサー</string>
-    <string name="settings_sponsor_development_summary">パトロンになって継続的な開発を可能にしてください。</string>
     <string name="settings_privacy_policy_label">プライバシーポリシー</string>
     <string name="settings_privacy_policy_desc">データを責任を持って処理します。</string>
     <string name="changelog_label">変更ログ</string>
@@ -257,10 +231,8 @@
     <string name="backup_restore_success_restore">復元完了—%1$d台のデバイスを復元し、%2$d台をスキップしました。</string>
     <string name="backup_restore_version_warning">このバックアップはバージョン%1$sで作成されました。現在%2$sを実行中です。一部の設定が正しく復元されない場合があります。</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">デバッグ通知</string>
     <string name="debug_log_consent_title">デバッグログ</string>
     <string name="debug_log_consent_explanation">この機能はアプリが行っているすべてを共有可能なファイルに記録します。生成されるファイルには機密情報（例：ファイル名やインストール済みアプリ）が含まれています。信頼できる相手（例：問題をトラブルシューティングしている開発者）とのみ共有してください。</string>
-    <string name="debug_log_recording_progress">デバッグログを記録中</string>
     <string name="debug_log_record_action">記録</string>
     <string name="debug_log_stop_action">記録停止</string>
     <string name="debug_log_screen_title">デバッグログレコーダー</string>
@@ -274,7 +246,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">破棄</string>
     <string name="debug_log_screen_keep_action">保持</string>
-    <string name="debug_log_compressing_label">圧縮中…</string>
     <string name="debug_log_file_label">記録されたログファイル</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">ログは送信しましたか？</string>
@@ -302,7 +273,6 @@
     <string name="contact_description_question_hint">質問を詳しく説明してください。</string>
     <string name="contact_category_section_label">カテゴリ</string>
     <string name="contact_debug_log_label">デバッグログ</string>
-    <string name="contact_debug_log_select_hint">添付するデバッグログを選択</string>
     <string name="contact_debug_log_picker_hint">デバッグログを添付すると問題の診断が早くなります。</string>
     <string name="contact_debug_log_picker_empty">デバッグログがありません。先に録音してください。</string>
     <string name="contact_expected_behavior_label">期待される動作</string>
@@ -315,82 +285,32 @@
     <string name="contact_welcome_msg">すべてのメッセージを自分で読み、できる限り返信しますが、一人で作業しているため少し時間がかかる場合があります。ご辛抱ください。</string>
     <string name="contact_footer_msg">メッセージはメールで送信されます。デバイスと設定情報は自動的に添付されます。</string>
     <string name="contact_no_email_app_msg">このデバイスにメールアプリが見つかりません。</string>
-    <string name="contact_attachment_missing_msg">デバッグログファイルが見つかりません</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">保存されたデバッグログ</string>
     <string name="settings_support_stored_logs_desc">%1$d セッション (%2$s)</string>
     <string name="settings_support_stored_logs_empty">保存されたデバッグログなし</string>
-    <string name="settings_support_stored_logs_delete_title">保存されたログを削除しますか？</string>
-    <string name="settings_support_stored_logs_delete_msg">保存されたデバッグログセッション %1$d 件をすべて削除します。</string>
-    <string name="settings_support_stored_logs_deleted_msg">保存されたデバッグログを削除しました</string>
-    <string name="label_bug_reports">バグ報告</string>
-    <string name="description_bug_reports">バグとクラッシュの自動報告。</string>
     <string name="label_add_device">デバイスを追加</string>
-    <string name="label_just_a_moment_please">少々お待ちください。</string>
     <string name="label_notification_channel_status">状態</string>
     <string name="label_notification_channel_setup">設定が必要です</string>
     <string name="monitor_notification_starting">起動中…</string>
     <string name="action_set">セット</string>
     <string name="action_cancel">キャンセル</string>
-    <string name="label_invalid_input">無効な入力</string>
     <string name="action_reset">リセット</string>
     <string name="label_no_connected_devices">デバイスが接続されていません</string>
-    <string name="label_status_idle">待機中</string>
-    <string name="label_status_adjusting_volumes">音量調整中</string>
-    <string name="label_premium_version">プレミアム版</string>
     <string name="general_upgrade_action">アップグレード</string>
     <string name="common_upgrade_required_label">アップグレードが必要</string>
-    <string name="label_premium_version_required">プレミアム版が必要です</string>
-    <string name="description_intro_purpose">このアプリは、Android端末がBluetoothデバイスごとに音量を記憶できるようにします。</string>
-    <string name="upgrade_benefit_unlimited_devices">無制限のデバイスプロファイル</string>
-    <string name="upgrade_benefit_connection_actions">自動再生、アプリ起動、接続通知</string>
-    <string name="upgrade_benefit_theme_customization">テーマ、スタイル、カラーのカスタマイズ</string>
-    <string name="upgrade_benefit_power_controls">ボリュームロックとレート制限</string>
-    <string name="upgrade_benefit_support">独立開発をサポート</string>
     <string name="upgrade_benefit_equalizer">・デバイスごとのイコライザー(システムイコライザー対応の音楽アプリ用)</string>
-    <string name="description_intro_tap_the_button">まずあなたの最初のデバイスを追加します。</string>
     <string name="description_bluetooth_is_disabled">Bluetoothが無効です。</string>
     <string name="title_bluetooth_is_off">Bluetoothがオフです</string>
     <string name="action_enable_bluetooth">Bluetoothを有効にする</string>
     <string name="title_bluetooth_permission_required">Bluetooth許可が必要です</string>
     <string name="description_bluetooth_permission_required">このアプリはデバイスの音量を管理するためにBluetooth許可が必要です。</string>
     <string name="action_grant_permission">許可を与える</string>
-    <string name="label_status_listening_for_changes">音量変更を監視中</string>
     <string name="action_exit">終了</string>
-    <string name="action_start">開始</string>
-    <string name="label_welcome">ようこそ</string>
-    <string name="description_intro_contact">質問や新たな機能のアイデアがございましたらお気軽にご連絡ください。</string>
-    <string name="label_translation">翻訳</string>
-    <string name="description_help_translate">このアプリを他の言語で利用できるようにするために力を貸してください。</string>
     <string name="label_device_speaker">端末スピーカー</string>
-    <string name="label_keyevent_playpause">再生 / 一時停止</string>
-    <string name="label_keyevent_play">再生</string>
-    <string name="label_keyevent_next">次へ</string>
-    <string name="label_install_id">インストールID</string>
     <string name="message_copied_to_clipboard">クリップボードにコピーしました</string>
-    <string name="label_thanks">ありがとうございます</string>
-    <string name="label_licenses">ライセンス</string>
-    <string name="description_ring_volume_additional_permission">着信音量を変更するには、追加の権限が必要です。</string>
-    <string name="label_missing_permissions">権限がありません</string>
-    <string name="action_grant">許可</string>
-    <string name="label_advanced">高度な設定</string>
-    <string name="label_exclude_health">Healthプロファイルを除外</string>
-    <string name="description_exclude_health">一部のAndroid端末は、\&quot;Health Device\&quot; Bluetoothプロファイル(HDP、0x1400) を検索中にハングアップします。</string>
-    <string name="label_exclude_gattserver">GATTサーバプロファイルを除外</string>
-    <string name="label_exclude_gatt">GATTプロファイルを除外</string>
-    <string name="description_exclude_gattserver">\'Generic Attribute\' (GATT) サーバプロファイルを問い合わせません。</string>
-    <string name="description_exclude_gatt">\'Generic Attribute\' (GATT) プロファイルを問い合わせません。</string>
-    <string name="description_waiting_for_devicex">%s の接続完了待機中</string>
-    <string name="action_undo">元に戻す</string>
-    <string name="action_show">表示</string>
     <string name="action_dismiss">閉じる</string>
-    <string name="action_fix">修正</string>
-    <string name="battery_optimizations_issue_description">このアプリでバッテリーの最適化が有効になっており、Bluetoothイベントの受信を妨げる可能性があります。問題が発生している場合は最適化を無効にしてください。</string>
     <string name="label_bluetooth_settings">Bluetooth 設定</string>
-    <string name="android10_applaunch_issue_description">Android 10では、バックグラウンドからのアプリ起動が制限されています。 Bluetoothデバイスが接続されたときにアプリを開くことを許可するには、\&quot;他のアプリ上に表示\&quot; (SYSTEM_ALERT_WINDOW) 権限を許可します。</string>
-    <string name="label_opensource">ソースコード</string>
-    <string name="android13_notification_permission_description">このアプリに通知を投稿する許可を与えてください。これにより、このアプリがアクティブで音量調整が行われている時に通知を表示できるようになります。</string>
-    <string name="privacy_policy_label">プライバシーポリシー</string>
     <string name="managed_devices_empty_message">Bluetoothデバイスが設定されていません。\n+ボタンをタップして最初のデバイスを追加してください。</string>
     <string name="label_pro_feature">プレミアム機能</string>
     <plurals name="discover_device_limit_banner">
@@ -420,21 +340,15 @@
     <string name="review_app_review_action">レビュー</string>
     <string name="review_app_dismiss_action">また後で</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">購入がキャンセルされました</string>
-    <string name="error_iap_unavailable_message">アプリ内購入が利用できません</string>
-    <string name="error_generic_message">エラーが発生しました。再度お試しください。</string>
-    <string name="error_iap_owned_message">このアイテムは既に所有しています</string>
     <string name="label_no_devices_title">デバイスなし</string>
     <string name="bluemusic_mascot_description">アプリアイコン</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">アプリを選択</string>
     <string name="devices_app_selection_search_hint">アプリを検索...</string>
-    <string name="devices_app_selection_currently_selected">現在選択中</string>
     <string name="devices_app_selection_selected_count">%d個のアプリが選択されています</string>
     <string name="general_navigate_back_action">戻る</string>
     <string name="general_reset_action">リセット</string>
     <string name="general_clear_action">クリア</string>
-    <string name="general_save_action">保存</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">ロック</string>
     <string name="devices_indicator_awake">スリープ無効</string>
@@ -444,7 +358,6 @@
     <string name="devices_indicator_limit">制限</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">ブースト</string>
-    <string name="devices_indicator_launch">起動</string>
     <string name="devices_indicator_home">ホーム</string>
     <string name="devices_indicator_dnd">おやすみ</string>
     <string name="devices_indicator_alert">アラート</string>

--- a/app/src/main/res/values-ka-rGE/strings.xml
+++ b/app/src/main/res/values-ka-rGE/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">განახლების დროს ზოგიერთი ფუნქცია შეიცვალა. გთხოვთ შეამოწმოთ მოწყობილობის პარამეტრები, რათა დარწმუნდეთ, რომ ყველაფერი სწორად არის კონფიგურირებული.</string>
     <string name="onboarding_rewrite_action">გაგრძელება</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">მართვის გარეშე მოწყობილობები ვერ მოიძებნა</string>
     <string name="discover_all_devices_managed_msg">ყველა თქვენი დაწყვილებული მოწყობილობა მართვის ქვეშაა! გჭირდებათ ახალი?</string>
     <string name="discover_pair_new_device_action">ახალი მოწყობილობის დაწყვილება</string>
     <string name="discover_device_speaker_desc">ამ ტელეფონის საკუთარი სპიკერი. მისი ხმის დონე გამოიყენება, როდესაც აუდიო ტელეფონზე დაბრუნდება, მაგ., თქვენი Bluetooth მოწყობილობის გათიშვის შემდეგ.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">მოწყობილობის კონფიგურაცია</string>
-    <string name="devices_device_config_section_general_label">ზოგადი</string>
     <string name="devices_device_config_remove_device_label">მოწყობილობის დავიწყება</string>
-    <string name="devices_device_config_remove_device_desc">ავიწყებს მოწყობილობას ამ აპიდან და შლის მის კონფიგურაციას. ეს არ აუქმებს მოწყობილობის დაწყვილებას.</string>
     <string name="devices_device_config_remove_device_action">დავიწყება</string>
     <string name="devices_device_config_remove_device_confirmation">დავიწყოთ %s მართვადი მოწყობილობებიდან?</string>
-    <string name="devices_device_config_rename_device_label">მოწყობილობის გადარქმევა</string>
-    <string name="devices_device_config_rename_device_desc">გადარქვათ ამ მოწყობილობას სახელი ამ აპში, და თუ შესაძლებელია, სისტემაშიც.</string>
     <string name="devices_device_config_rename_device_action">გადარქმევა</string>
     <string name="devices_device_config_enabled_label">ჩართული</string>
     <string name="devices_device_config_enabled_desc">რეაგირება ამ მოწყობილობაზე დაკავშირებისას</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">ავტოდაკვრის ბრძანებები</string>
     <string name="devices_device_config_autoplay_keycodes_order">ბრძანებების თანმიმდევრობა</string>
     <string name="devices_device_config_autoplay_keycodes_label">ბრძანებები</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">კონფიგურაცია, თუ რომელი ბრძანებები გაიგზავნოს და რა თანმიმდევრობით</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">ბრძანებები არ არის კონფიგურირებული</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">ბრძანების დამატება</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">მაქსიმუმ %1$d ბრძანება</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">ზემოთ გადატანა</string>
     <string name="cd_autoplay_keycode_move_down">ქვემოთ გადატანა</string>
     <string name="cd_autoplay_keycode_remove">ამოშლა</string>
-    <string name="devices_device_config_section_volumes_label">ხმები</string>
     <string name="devices_device_config_section_volume_label">ხმა</string>
     <string name="devices_device_config_alarm_volume_label">მაღვიძარის ხმა</string>
     <string name="devices_device_config_alarm_volume_desc">ზოგიერთი მაღვიძარა-აპი სამაგიეროდ მუსიკის ხმას იყენებს.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">ზარის მელოდია</string>
     <string name="devices_audio_stream_notification_label">შეტყობინება</string>
     <string name="devices_audio_stream_alarm_label">მაღვიძარა</string>
-    <string name="devices_neverseen_label">არასდროს დანახული</string>
-    <string name="devices_state_connected_label">დაკავშირებული</string>
     <string name="devices_last_connected_label">ბოლოს დაკავშირება: %s</string>
     <string name="devices_currently_connected_label">ამჯამად დაკავშირებული</string>
     <string name="devices_device_disabled_label">მოწყობილობა გამორთულია</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">პარამეტრები, რომლებიც ყველა მართვად მოწყობილობაზე მოქმედებს.</string>
     <string name="label_app_enabled">აპი ჩართულია</string>
     <string name="description_app_enabled">ჩართავს/გამორთავს აპის ხმასთან და Bluetooth მოვლენებთან რეაგირების შესაძლებლობას.</string>
-    <string name="label_visible_volume_adjustments">ხილული რეგულირებები</string>
-    <string name="description_visible_volume_adjustments">ამ აპის მიერ რეგულირებების გაკეთებისას სისტემის ხმის ფანჯრის ჩვენება.</string>
     <string name="label_volume_listener">ცვლილებების დაკვირვება</string>
-    <string name="description_volume_listener">დარჩე აქტიური სანამ მოწყობილობა დაკავშირებულია და შეინახე ხმის ცვლილებები, რომლებიც ამ აპს არ გამოუწვევია.</string>
     <string name="label_boot_restore">ჩართვისას აღდგენა</string>
     <string name="description_boot_restore">ხმის აღდგენა ჩართვის/გადაჩართვის შემდეგ თუ Bluetooth მოწყობილობა დაკავშირებულია.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">ისწავლე BVM-ის ეფექტური გამოყენება</string>
     <string name="settings_support_issue_tracker_description">საჯარო საკითხების ტრეკერი შეცდომების შესახებ მოხსენებებისა და მახასიათებლების მოთხოვნებისთვის.</string>
     <string name="settings_support_issue_tracker_label">შეცდომის ტრეკერი</string>
-    <string name="settings_support_debuglog_label">გამართვის ჟურნალი</string>
     <string name="settings_support_debuglog_desc">ჩაწერეთ ყველაფერი, რასაც აპლიკაცია აკეთებს ტექსტურ ფაილში, რომლის გაზიარებაც შეგიძლიათ.</string>
-    <string name="settings_support_debuglog_recording_desc">ამჯამად ჩაიწერება debug ინფორმაცია. შეეხეთ ჩაწერის შეჩერებისთვის.</string>
-    <string name="settings_support_debuglog_path">ლოგის გზა: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">ძალიან მოკლე ჩაწერა</string>
     <string name="settings_support_debuglog_short_recording_msg">ეს ძალიან მოკლე ჩაწერა იყო. Debug ლოგები ჩაწერებია, არა სნეფშოტები — გამეორეთ პრობლემა ჩაწერის დროს, რომ ლოგი სასარგებლო იყოს.</string>
     <string name="settings_support_debuglog_short_recording_continue">ჩაწერის გაგრძელება</string>
     <string name="settings_support_debuglog_short_recording_stop">მაინც შეჩერება</string>
-    <string name="settings_support_debuglog_folder_label">Debug ლოგის საქაღალდე</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d სესია %2$s-ის გამოყენებით</item>
-        <item quantity="other">%1$d სესია %2$s-ის გამოყენებით</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Debug ლოგები შენახული არ არის</string>
-    <string name="settings_support_debuglog_folder_delete_title">წაიშალოს ყველა debug ლოგი?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">ეს სამუდამოდ წაშლის ყველა შენახულ debug ლოგის სესიას.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">ადგილი დასასვენებლად და კითხვების დასმისთვის.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">თარგმანი</string>
     <string name="settings_acks_translators_title">მთარგმნელები</string>
     <string name="settings_acks_translators_people">პირი1;პირი2(სურვილისამებრ@email.com)</string>
-    <string name="settings_acks_translate_title">BVM-ის თარგმნა</string>
-    <string name="settings_acks_translate_desc">დაეხმარე BVM-ის შენს ენაზე თარგმნაში</string>
     <string name="settings_acks_thanks_header">მადლობა</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">ღია კოდის პროექტების თარგმანის მხარდაჭერისთვის</string>
     <string name="settings_licenses_label">ლიცენზიები</string>
     <string name="settings_translation_label">თარგმანი</string>
     <string name="settings_translation_desc">დაეხმარე აპის შენს საყვარელ ენაზე თარგმნაში</string>
-    <string name="settings_sponsor_development_title">სპონსორის განვითარება</string>
-    <string name="settings_sponsor_development_summary">გახდი მფარველი და განაგრძე განვითარება შესაძლებელი.</string>
     <string name="settings_privacy_policy_label">Კონფიდენციალურობის პოლიტიკა</string>
     <string name="settings_privacy_policy_desc">მონაცემების პასუხისმგებლობით დამუშავება.</string>
     <string name="changelog_label">ცვლილებების ჟურნალი</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">აღდგენა დასრულდა — %1$d მოწყობილობა აღდგენილია, %2$d გამოტოვებულია.</string>
     <string name="backup_restore_version_warning">ეს სარეზერვო ასლი შეიქმნა ვერსიით %1$s. თქვენ იყენებთ %2$s. ზოგიერთერი პარამეტრი შეიძლება სწორად ვერ აღდგეს.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">გამართვის შეტყობინებები</string>
     <string name="debug_log_consent_title">გამართვის ჟურნალი</string>
     <string name="debug_log_consent_explanation">ეს ფუნქცია ჩაწერს ყველაფერს, რასაც აპი აკეთებს გასაზიარებელ ფაილში. გენერირებული ფაილი შეიცავს სენსიტიურ ინფორმაციას (მაგ. ფაილების სახელები და დაინსტალირებული აპები). გაუზიარეთ ის მხოლოდ სანდო მხარეებს (მაგ. დეველოპერს, რომელიც პრობლემას აგვარებს).</string>
-    <string name="debug_log_recording_progress">გამართვის ჟურნალის ჩაწერა</string>
     <string name="debug_log_record_action">ჩაწერა</string>
     <string name="debug_log_stop_action">ჩაწერის შეჩერება</string>
     <string name="debug_log_screen_title">Debug ლოგის ჩამწერი</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">უარყოფა</string>
     <string name="debug_log_screen_keep_action">შენარჩუნება</string>
-    <string name="debug_log_compressing_label">შეკუმშვა…</string>
     <string name="debug_log_file_label">ჩაწერილი ჟურნალის ფაილი</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">ლოგი გაიგზავნა?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">დეტალურად აღწერეთ თქვენი კითხვა.</string>
     <string name="contact_category_section_label">კატეგორია</string>
     <string name="contact_debug_log_label">გამართვის ჟურნალი</string>
-    <string name="contact_debug_log_select_hint">აირჩიეთ debug ლოგი მისამაგრებლად</string>
     <string name="contact_debug_log_picker_hint">მიამაგრეთ debug ლოგი პრობლემის უფრო სწრაფი დიაგნოზისთვის.</string>
     <string name="contact_debug_log_picker_empty">Debug ლოგები ხელმისაწვდომი არ არის. ჯერ ჩაწერეთ ერთი.</string>
     <string name="contact_expected_behavior_label">მოსალოდნელი ქცევა</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">მე თვითონ ვკითხულობ ყველა შეტყობინებას და ვცდილობ პასუხი გავცე, მაგრამ ვინაიდან ამ პროექტზე მარტო ვმუშაობ, შეიძლება ცოტა დრო დასჭირდეს. გმადლობთ მოთმინებისთვის.</string>
     <string name="contact_footer_msg">თქვენი შეტყობინება ელ-ფოსტით გაიგზავნება. მოწყობილობისა და კონფიგურაციის ინფორმაცია ავტომატურად ემაგრება.</string>
     <string name="contact_no_email_app_msg">ამ მოწყობილობაზე ელ-ფოსტის აპი ვერ მოიძებნა.</string>
-    <string name="contact_attachment_missing_msg">Debug ლოგის ფაილი აღარ არსებობს</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">შენახული debug ლოგები</string>
     <string name="settings_support_stored_logs_desc">%1$d სესია (%2$s)</string>
     <string name="settings_support_stored_logs_empty">შენახული debug ლოგები არ არის</string>
-    <string name="settings_support_stored_logs_delete_title">წაიშალოს შენახული ლოგები?</string>
-    <string name="settings_support_stored_logs_delete_msg">ეს წაშლის ყველა %1$d შენახულ debug ლოგის სესიას.</string>
-    <string name="settings_support_stored_logs_deleted_msg">შენახული debug ლოგები წაიშალა</string>
-    <string name="label_bug_reports">შეცდომების ანგარიშები</string>
-    <string name="description_bug_reports">ავტომატური შეცდომების და კრეშის ანგარიში.</string>
     <string name="label_add_device">მოწყობილობის დამატება</string>
-    <string name="label_just_a_moment_please">ერთი წუთი, გთხოვთ.</string>
     <string name="label_notification_channel_status">სტატუსი</string>
     <string name="label_notification_channel_setup">დაყენება აუცილებელია</string>
     <string name="monitor_notification_starting">იწყება…</string>
     <string name="action_set">დაყენება</string>
     <string name="action_cancel">გაუქმება</string>
-    <string name="label_invalid_input">არასწორი შეყვანა</string>
     <string name="action_reset">გადატვირთვა</string>
     <string name="label_no_connected_devices">მოწყობილობები არ არის დაკავშირებული</string>
-    <string name="label_status_idle">უქმი</string>
-    <string name="label_status_adjusting_volumes">ხმების რეგულირება</string>
-    <string name="label_premium_version">პრემიუმ ვერსია</string>
     <string name="general_upgrade_action">გარემონტება</string>
     <string name="common_upgrade_required_label">საჭიროა განახლება</string>
-    <string name="label_premium_version_required">საჭიროა პრემიუმ ვერსია</string>
-    <string name="description_intro_purpose">ეს აპი საშუალებას აძლევს თქვენს Android მოწყობილობას დაიმახსოვროს სხვადასხვა Bluetooth მოწყობილობის ხმა.</string>
-    <string name="upgrade_benefit_unlimited_devices">შეუზღუდავი მოწყობილობის პროფილები</string>
-    <string name="upgrade_benefit_connection_actions">ავტომატური დაკვრა, აპის გაშვება და კავშირის შეტყობინებები</string>
-    <string name="upgrade_benefit_theme_customization">თემის, სტილისა და ფერის მორგება</string>
-    <string name="upgrade_benefit_power_controls">ხმის დაბლოკვა და სიჩქარის შეზღუდვა</string>
-    <string name="upgrade_benefit_support">დამოუკიდებელი განვითარების მხარდაჭერა</string>
     <string name="upgrade_benefit_equalizer">• მოწყობილობაზე თითოეული ეკვალაიზერი (სისტემის ეკვალაიზერი მხარდამჭერი მუსიკის აპებისთვის)</string>
-    <string name="description_intro_tap_the_button">დაიწყეთ პირველი მოწყობილობის დამატებით.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth გათიშულია.</string>
     <string name="title_bluetooth_is_off">Bluetooth გამორთულია</string>
     <string name="action_enable_bluetooth">Bluetooth-ის ჩართვა</string>
     <string name="title_bluetooth_permission_required">საჭიროა Bluetooth-ის ნებართვა</string>
     <string name="description_bluetooth_permission_required">ამ აპს სჭირდება Bluetooth-ის ნებართვა თქვენი მოწყობილობის ხმების სამართავად.</string>
     <string name="action_grant_permission">ნებართვის მიცემა</string>
-    <string name="label_status_listening_for_changes">ხმის ცვლილებების მოსმენა</string>
     <string name="action_exit">გამოსვლა</string>
-    <string name="action_start">დაწყება</string>
-    <string name="label_welcome">მოგესალმებით</string>
-    <string name="description_intro_contact">ნუ მოგერიდებათ ჩემი დაკავშირება თუ გაქვთ კითხვები ან თუნდაც ახალი ფუნქციის იდეა.</string>
-    <string name="label_translation">თარგმანი</string>
-    <string name="description_help_translate">დამეხმარე ეს აპი სხვა ენებზე ხელმისაწვდომი გავხადო.</string>
     <string name="label_device_speaker">მოწყობილობის დინამიკი</string>
-    <string name="label_keyevent_playpause">დაკვრა-პაუზა</string>
-    <string name="label_keyevent_play">დაკვრა</string>
-    <string name="label_keyevent_next">შემდეგი</string>
-    <string name="label_install_id">დააინსტალირების ID</string>
     <string name="message_copied_to_clipboard">ბუფერში დაკოპირდა</string>
-    <string name="label_thanks">მადლობა</string>
-    <string name="label_licenses">ლიცენზიები</string>
-    <string name="description_ring_volume_additional_permission">ზარის ხმის შეცვლისთვის საჭიროა დამატებითი ნებართვები.</string>
-    <string name="label_missing_permissions">ნებართვები არ არის</string>
-    <string name="action_grant">მიცემა</string>
-    <string name="label_advanced">გაფართოებული</string>
-    <string name="label_exclude_health">ჯანმრთელობის პროფილების გამორიცხვა</string>
-    <string name="description_exclude_health">ზოგიერთი Android მოწყობილობა იყინება \'Health Device\' Bluetooth პროფილების (HDP, 0x1400) ძიებისას.</string>
-    <string name="label_exclude_gattserver">GATT სერვერის პროფილების გამორიცხვა</string>
-    <string name="label_exclude_gatt">GATT პროფილების გამორიცხვა</string>
-    <string name="description_exclude_gattserver">არ მოიძიოს \'Generic Attribute\' (GATT) სერვერის ტიპის Bluetooth პროფილები.</string>
-    <string name="description_exclude_gatt">არ მოიძიოს \'Generic Attribute\' (GATT) კლიენტის ტიპის Bluetooth პროფილები.</string>
-    <string name="description_waiting_for_devicex">ველოდება %s-ის კავშირის დასრულებას</string>
-    <string name="action_undo">დაბრუნება</string>
-    <string name="action_show">ჩვენება</string>
     <string name="action_dismiss">გაუქმება</string>
-    <string name="action_fix">შეკეთება</string>
-    <string name="battery_optimizations_issue_description">ბატარეის ოპტიმიზაციები ჩართულია ამ აპისთვის და შეიძლება ხელი შეუშალოს Bluetooth მოვლენების მიღებას. განიხილეთ ოპტიმიზაციების გამორთვა პრობლემების შემთხვევაში.</string>
     <string name="label_bluetooth_settings">Bluetooth-ის პარამეტრები</string>
-    <string name="android10_applaunch_issue_description">Android 10 ზღუდავს როგორ შეიძლება გაეშვას აპები ფონიდან. Bluetooth მოწყობილობის დაკავშირებისას აპების გახსნის დასაშვებლად, მიეცით ნებართვა \"სხვა აპებზე ჩვენება\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">წყაროს კოდი</string>
-    <string name="android13_notification_permission_description">მიეცით ამ აპს ნებართვა შეტყობინებების გამოსაქვეყნებლად. ეს საშუალებას იძლევს შეტყობინება ჩაჩვენდეს როცა ეს აპი აქტიურია და ხმის რეგულირება ხდება.</string>
-    <string name="privacy_policy_label">Კონფიდენციალურობის პოლიტიკა</string>
     <string name="managed_devices_empty_message">Bluetooth მოწყობილობები კონფიგურირებული არ არის.\nშეეხეთ + ღილაკს პირველი მოწყობილობის დასამატებლად.</string>
     <string name="label_pro_feature">პრემიუმ ფუნქცია</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">მიმოხილვა</string>
     <string name="review_app_dismiss_action">შესაძლოა მოგვიანებით</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">შეძენა გაუქმდა</string>
-    <string name="error_iap_unavailable_message">აპში შეძენა ხელმისაწვდომი არ არის</string>
-    <string name="error_generic_message">შეცდომა მოხდა. გთხოვთ, სცადეთ თავიდან.</string>
-    <string name="error_iap_owned_message">ეს ელემენტი უკვე გაქვთ</string>
     <string name="label_no_devices_title">მოწყობილობები არ არის</string>
     <string name="bluemusic_mascot_description">აპის ხატულა</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">აპების არჩევა</string>
     <string name="devices_app_selection_search_hint">აპების ძებნა…</string>
-    <string name="devices_app_selection_currently_selected">ამჟამად არჩეული</string>
     <string name="devices_app_selection_selected_count">არჩეულია %d აპი</string>
     <string name="general_navigate_back_action">უკან გადასვლა</string>
     <string name="general_reset_action">გადატვირთვა</string>
     <string name="general_clear_action">გასუფთავება</string>
-    <string name="general_save_action">შენახვა</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">დაბლოკვა</string>
     <string name="devices_indicator_awake">გაღვიძებული</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">ლიმიტი</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">გაძლიერება</string>
-    <string name="devices_indicator_launch">გაშვება</string>
     <string name="devices_indicator_home">მთავარი</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">გაფრთხილება</string>

--- a/app/src/main/res/values-km-rKH/strings.xml
+++ b/app/src/main/res/values-km-rKH/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">មុខងារខ្លះបានផ្លាស់ប្តូរក្នុងអំឡុងពេលធ្វើបច្ចុប្បន្នភាព។ សូមពិនិត្យការកំណត់ឧបករណ៍របស់អ្នក ដើម្បីធានាថាអ្វីៗទាំងអស់ត្រូវបានកំណត់យ៉ាងត្រឹមត្រូវ។</string>
     <string name="onboarding_rewrite_action">បន្ត</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">រកមិនឃើញឧបករណ៍ដែលមិនបានគ្រប់គ្រង</string>
     <string name="discover_all_devices_managed_msg">ឧបករណ៍ដែលបានផ្សារភ្ជាប់ទាំងអស់របស់អ្នកត្រូវបានគ្រប់គ្រង! ត្រូវការឧបករណ៍ថ្មីទេ?</string>
     <string name="discover_pair_new_device_action">ផ្សារភ្ជាប់ឧបករណ៍ថ្មី</string>
     <string name="discover_device_speaker_desc">ស្ពីករ​របស់​ទូរស័ព្ទ។ កម្រិត​សម្លេង​របស់វា​ត្រូវ​បាន​ប្រើ​នៅ​ពេល​សម្លេង​ប្តូរ​ត្រឡប់​ទៅ​ទូរស័ព្ទ ដូច​ជា​បន្ទាប់​ពី​ឧបករណ៍​ប៊ុលធូស​របស់​អ្នក​ផ្ដាច់។</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ការកំណត់ឧបករណ៍</string>
-    <string name="devices_device_config_section_general_label">ជាទូទៅ</string>
     <string name="devices_device_config_remove_device_label">ភ្លេចឧបករណ៍</string>
-    <string name="devices_device_config_remove_device_desc">ភ្លេចឧបករណ៍ពីកម្មវិធីនេះ ហើយលប់ការកំណត់រចនាសម្ព័ន្ធរបស់វា។ វាមិនដកការផ្សារភ្ជាប់ឧបករណ៍ទេ។</string>
     <string name="devices_device_config_remove_device_action">ភ្លេច</string>
     <string name="devices_device_config_remove_device_confirmation">ភ្លេច %s ពីឧបករណ៍ដែលបានគ្រប់គ្រង?</string>
-    <string name="devices_device_config_rename_device_label">ប្តូរឈ្មោះឧបករណ៍</string>
-    <string name="devices_device_config_rename_device_desc">ប្តូរឈ្មោះឧបករណ៍នេះក្នុងកម្មវិធីនេះ និងប្រសិនបើអាចធ្វើទៅបាន ក្នុងប្រព័ន្ធផងដែរ។</string>
     <string name="devices_device_config_rename_device_action">ប្តូរឈ្មោះ</string>
     <string name="devices_device_config_enabled_label">បានបើក</string>
     <string name="devices_device_config_enabled_desc">ប្រតិកម្មទៅកាន់ឧបករណ៍នេះពេលភ្ជាប់</string>
@@ -93,7 +88,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">ពាក្យបញ្ជារៀបចំបន្លឺ</string>
     <string name="devices_device_config_autoplay_keycodes_order">លំដាប់ពាក្យបញ្ជា</string>
     <string name="devices_device_config_autoplay_keycodes_label">ពាក្យបញ្ជា</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">កំណត់ពាក្យបញ្ជាណាដើម្បីផ្ញើ និងតាមលំដាប់អ្វី</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">មិនមានពាក្យបញ្ជាដែលបានកំណត់</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">បន្ថែមពាក្យបញ្ជា</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">ពាក្យបញ្ជាអតិបរមា %1$d</string>
@@ -119,7 +113,6 @@
     <string name="cd_autoplay_keycode_move_up">ផ្លាស់តី១ើលើ</string>
     <string name="cd_autoplay_keycode_move_down">ផ្លាស់តីចុះក្រោម</string>
     <string name="cd_autoplay_keycode_remove">លុបចេញ</string>
-    <string name="devices_device_config_section_volumes_label">កម្រិតសំឡេង</string>
     <string name="devices_device_config_section_volume_label">កម្រិតសំឡេង</string>
     <string name="devices_device_config_alarm_volume_label">កម្រិតសំឡេងរោត៍</string>
     <string name="devices_device_config_alarm_volume_desc">កម្មវិធីរោត៍ខ្លះប្រើកម្រិតសំឡេងតន្ត្រីជំនួសវិញ។</string>
@@ -153,8 +146,6 @@
     <string name="devices_audio_stream_ring_label">រោត៍</string>
     <string name="devices_audio_stream_notification_label">ការជូនដំណឹង</string>
     <string name="devices_audio_stream_alarm_label">រោត៍ភ្ញាក</string>
-    <string name="devices_neverseen_label">មិនធ្លាបឃើញ</string>
-    <string name="devices_state_connected_label">បានភ្ជាប់</string>
     <string name="devices_last_connected_label">ភ្ជាប់ចុងក្រោយ: %s</string>
     <string name="devices_currently_connected_label">កំពុងភ្ជាប់</string>
     <string name="devices_device_disabled_label">ឧបករណ៍ត្រូវបានបិត</string>
@@ -189,10 +180,7 @@
     <string name="devices_settings_desc">ការកំណត់ដែលប័តិផលដល់ឧបករណ៍ដែលបានគ្រប់គ្រងតាំងអស់។</string>
     <string name="label_app_enabled">កម្មវិធីបានបើក</string>
     <string name="description_app_enabled">បង្វិលសមត្ថភាពរបស់កម្មវិធីក្នុងការប្រតិកម្មតៅកាន់ព័ត្តិការណ៍កម្រិតសំឡេង និង Bluetooth។</string>
-    <string name="label_visible_volume_adjustments">ការកែតម្រូវដែលអាចមើលឃើញ</string>
-    <string name="description_visible_volume_adjustments">បង្ហាញបង្ហួជកម្រិតសំឡេងរបស់ប្រព័ន្ធពេលកម្មវិធីនេះកំពុងធ្វើការកែតម្រូវ។</string>
     <string name="label_volume_listener">ត្រួតពិនិត្យការផ្លាស់ប្តូរ</string>
-    <string name="description_volume_listener">នៅសក្មពេលឧបករណ៍ភ្ជាប់ ហើយរក្សាតុកការផ្លាស់ប្តូរកម្រិតសំឡេងដែលមិនត្រូវបានបង្កើតឡើងដោយកម្មវិធីនេះ។</string>
     <string name="label_boot_restore">ស្តារពេលចាប់ផ្តើម</string>
     <string name="description_boot_restore">ស្តារកម្រិតសំឡេងបន្តាប់ពីចាប់ផ្តើម/ចាប់ផ្តើមឡើងវិញ ប្រសិនបើឧបករណ៍ Bluetooth ភ្ជាប់។</string>
     <!-- Settings/Support-->
@@ -202,21 +190,11 @@
     <string name="settings_support_wiki_description">ស្វែងយល់ពីរបើបប្រើ BVM ប្រកបដោយប្រសិត្ធភាព</string>
     <string name="settings_support_issue_tracker_description">ឧបករណ៍តាមដានបញ្ហាសាធារណ៍សម្រាប់របាយការណ៍កំហុស និងសំណើមុខងារ។</string>
     <string name="settings_support_issue_tracker_label">កម្មវិធីតាមដានបញ្ហា</string>
-    <string name="settings_support_debuglog_label">កំណត់ហេតុកំហុស</string>
     <string name="settings_support_debuglog_desc">កត់ត្រាគ្រប់យ៉ាងនៃកម្មវិធីគឺជាការធ្វើទៅជាឯកសារអត្ថបទដែលអ្នកអាចចែករំលែកបាន។</string>
-    <string name="settings_support_debuglog_recording_desc">កំពុងកត់ត្រាព័ត្តមានបំបាត់កំហុស។ ចុចដើម្បីឨបកត់ត្រា។</string>
-    <string name="settings_support_debuglog_path">ផ្លូវកំណត់ហេតុ: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">ការកត់ត្រាខ្លីខ្លំងពេក</string>
     <string name="settings_support_debuglog_short_recording_msg">ការកត់ត្រានោះខ្លីណាស។ កំណត់ហេតុបំបាត់កំហុសគឹជាការកត់ត្រា មិនម្មែនការថតស្ថានភាពទេ — សូមបង្ហាញបញ្ហាឡើងវិញពេលការកត់ត្រានៅដំណើរការ ដើម្បីហោឡឹកំណត់ហេតុមានប្រយោជន់។</string>
     <string name="settings_support_debuglog_short_recording_continue">បន្តការកត់ត្រា</string>
     <string name="settings_support_debuglog_short_recording_stop">ឨបត្តោះជាយ៉ាងណា</string>
-    <string name="settings_support_debuglog_folder_label">ថតឯកសារកំណត់ហេតុបំបាត់កំហុស</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d វគ្គកំពុងប្រើ %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">គ្មានកំណត់ហេតុបំបាត់កំហុសដែលបានរក្សាតុក</string>
-    <string name="settings_support_debuglog_folder_delete_title">លប់កំណត់ហេតុបំបាត់កំហុសតាំងអស់?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">វានឹងលប់ជាអចិន្ត្រ័យ៍នូវគ្កំណត់ហេតុបំបាត់កំហុសដែលបានរក្សាតុកតាំងអស់។</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">កន្លែងសម្រាប់ជជែកកំសាន្ត និងសួរសំណួរ។</string>
     <!-- Settings/Acks-->
@@ -225,16 +203,12 @@
     <string name="settings_acks_translation_header">ការបកប្រែ</string>
     <string name="settings_acks_translators_title">អ្នកបកប្រែ</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">បកប្រែ BVM</string>
-    <string name="settings_acks_translate_desc">ជួយបកប្រែ BVM ជាភាសារបស់អ្នក</string>
     <string name="settings_acks_thanks_header">អរគុណ</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">ដើម្បីគាំត្រការបកប្រែគម្រោងកូដប្រភពបើកចំហ</string>
     <string name="settings_licenses_label">អាជ្ញាប័ណ្ណ</string>
     <string name="settings_translation_label">ការបកប្រែ</string>
     <string name="settings_translation_desc">ជួយបកប្រែកម្មវិធីជាភាសាដែលអ្នកចូលចិត្ត</string>
-    <string name="settings_sponsor_development_title">ឧបត្ថម្ភការអភិវឌ្ឍន៍</string>
-    <string name="settings_sponsor_development_summary">ក្លាយជាអ្នកឧបត្ថម្ភ ហើយធ្វើឡើយការអភិវឌ្ញន៍ជាបន្តបន្តាប់ទៅជាការពិត។</string>
     <string name="settings_privacy_policy_label">គោលការណ៍ឯកជនភាព</string>
     <string name="settings_privacy_policy_desc">ការដោះស្រាយទិន្នន័យដោយមានការទទួលខុសត្រូវ។</string>
     <string name="changelog_label">កំណត់ហេតុផ្លាស់ប្ដូរ</string>
@@ -256,10 +230,8 @@
     <string name="backup_restore_success_restore">ការស្តារបានបញ្ចប់ — ឧបករណ៍ %1$d ត្រូវបានស្តារ, %2$d ត្រូវបានរំលង។</string>
     <string name="backup_restore_version_warning">ការបម្រុងទុកនេះត្រូវបានបង្កើតជាមួយកំណែ %1$s។ អ្នកកំពុងដំណើរការ %2$s។ ការកំណត់ខ្លះអាចមិនស្តារបានត្រឹមត្រូវ។</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">ការជូនដំណឹងកែកំហុស</string>
     <string name="debug_log_consent_title">កំណត់ហេតុកំហុស</string>
     <string name="debug_log_consent_explanation">លក្ខណៈពិសេសនេះកត់ត្រារាល់អ្វីដែលកម្មវិធីកំពុងធ្វើទៅក្នុងឯកសារដែលអាចចែករំលែកបាន។ ឯកសារដែលបានបង្កើតមានព័ត៌មានរសើប (ឧ. ឈ្មោះឯកសារ និងកម្មវិធីដែលបានដំឡើង)។ សូមចែករំលែកជាមួយភាគីដែលអាចជឿទុកចិត្តបានតែប៉ុណ្ណោះ (ឧ. អ្នកអភិវឌ្ឍន៍ដែលកំពុងដោះស្រាយបញ្ហា)។</string>
-    <string name="debug_log_recording_progress">កំពុងកត់ត្រាកំណត់ហេតុកែកំហុស</string>
     <string name="debug_log_record_action">កត់ត្រា</string>
     <string name="debug_log_stop_action">បញ្ឈប់ការកត់ត្រា</string>
     <string name="debug_log_screen_title">ម័ស៊ីនថតកំណត់ហេតុបំបាត់កំហុស</string>
@@ -273,7 +245,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">លះបង់</string>
     <string name="debug_log_screen_keep_action">រក្សា</string>
-    <string name="debug_log_compressing_label">កំពុងបង្ហាប់…</string>
     <string name="debug_log_file_label">ឯកសារកំណត់ហេតុដែលត្រូវបានកត់ត្រា</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">កំណត់ហេតុបានផ្ញើរ?</string>
@@ -301,7 +272,6 @@
     <string name="contact_description_question_hint">ពិពណ៍នាសំណួររបស់អ្នកលម្ហិត។</string>
     <string name="contact_category_section_label">ប្រភេត</string>
     <string name="contact_debug_log_label">កំណត់ហេតុកំហុស</string>
-    <string name="contact_debug_log_select_hint">ជ្រើសរើសកំណត់ហេតុបំបាត់កំហុសដើម្បីភ្ជាប់</string>
     <string name="contact_debug_log_picker_hint">ភ្ជាប់កំណត់ហេតុបំបាត់កំហុសដើម្បីជួយធ្វើការវិនិច្ឆ័យបញ្ហាបានលើនជាងមុន។</string>
     <string name="contact_debug_log_picker_empty">គ្មានកំណត់ហេតុបំបាត់កំហុសដែលអាចប្រើបាន។ ថតមួយជាមុនសិន។</string>
     <string name="contact_expected_behavior_label">អាកប្បកិរិយាដែលរំពឹង</string>
@@ -314,82 +284,32 @@
     <string name="contact_welcome_msg">ខ្ញុំអានសារជាច្រើននោះខ្លួនឯង ហើយព្យាយាមឆ្លើយឡើយអស់ពិលត្ធភាព ប័ះន្តែចាប់ពីខ្ញុំធ្វើការម្នាក់ឯង វាអាចចំណាយពេលបន្តិច។ សូមអរគុណចំពោះការអត់ធ្មត់របស់អ្នក។</string>
     <string name="contact_footer_msg">សាររបស់អ្នកនឹងត្រូវបានផ្ញើរតាមរយៈអឺម័ល។ ព័ត្តមានឧបករណ៍ និងការតំលើងត្រូវបានភ្ជាប់ស័យប្រវត្តិ។</string>
     <string name="contact_no_email_app_msg">រកមិនឃើញកម្មវិធីអឺម័លលើឧបករណ៍នេះ។</string>
-    <string name="contact_attachment_missing_msg">ឯកសារកំណត់ហេតុបំបាត់កំហុសលែងមាន</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">កំណត់ហេតុបំបាត់កំហុសដែលបានរក្សាតុក</string>
     <string name="settings_support_stored_logs_desc">%1$d វគ្គ (%2$s)</string>
     <string name="settings_support_stored_logs_empty">គ្មានកំណត់ហេតុបំបាត់កំហុសដែលបានរក្សាតុក</string>
-    <string name="settings_support_stored_logs_delete_title">លប់កំណត់ហេតុដែលបានរក្សាតុក?</string>
-    <string name="settings_support_stored_logs_delete_msg">វានឹងលប់វគ្គកំណត់ហេតុបំបាត់កំហុសដែលបានរក្សាតុកចំនួន %1$d តាំងអស់។</string>
-    <string name="settings_support_stored_logs_deleted_msg">កំណត់ហេតុបំបាត់កំហុសដែលបានរក្សាតុកត្រូវបានលប់</string>
-    <string name="label_bug_reports">របាយការណ៍កំហុស</string>
-    <string name="description_bug_reports">ការរាយការណ៍ស័យប្រវត្តិនូវកំហុស និងការគាំង។</string>
     <string name="label_add_device">បន្ថែមឧបករណ៍</string>
-    <string name="label_just_a_moment_please">សូមរង់ចាំបន្តិច។</string>
     <string name="label_notification_channel_status">ស្ថានភាព</string>
     <string name="label_notification_channel_setup">ត្រូវការការរៀបចំ</string>
     <string name="monitor_notification_starting">កំពុងចាប់ផ្តើម…</string>
     <string name="action_set">កំណត់</string>
     <string name="action_cancel">បោះបង់</string>
-    <string name="label_invalid_input">ធាតុបញ្ចូលមិនត្រឹមត្រូវ</string>
     <string name="action_reset">កំណត់ឡើងវិញ</string>
     <string name="label_no_connected_devices">មិនមានឧបករណ៍ភ្ជាប់</string>
-    <string name="label_status_idle">ស្ងប់ស្ងាត់</string>
-    <string name="label_status_adjusting_volumes">កំពុងកែតម្រូវកម្រិតសំឡេង</string>
-    <string name="label_premium_version">កំណែពិសេស</string>
     <string name="general_upgrade_action">វិសិដ្ឋកម្ម</string>
     <string name="common_upgrade_required_label">តម្រូវការធ្វើឱ្យប្រសើរ</string>
-    <string name="label_premium_version_required">ត្រូវការកំណែពិសេស</string>
-    <string name="description_intro_purpose">កម្មវិធីនេះអនុញ្ញាតឱ្យឧបករណ៍ Android របស់អ្នកចងចាំកម្រិតសំឡេងនៃឧបករណ៍ Bluetooth ផ្សើៗ។</string>
-    <string name="upgrade_benefit_unlimited_devices">ប្រវត្តិរូបឧបករណ៍គ្មានដែនកំណត់</string>
-    <string name="upgrade_benefit_connection_actions">ចាកស្វ័យប្រវត្តិ, ការចាប្តើមកម្មវិធី និងការជូនដំណឹងការតភ្ជាប់</string>
-    <string name="upgrade_benefit_theme_customization">ការប្តូររូបរាង, រចនាប័ត្ម និងពណ៍</string>
-    <string name="upgrade_benefit_power_controls">ការចាកសោសំឡេង និងការកំណត់ល្បើន</string>
-    <string name="upgrade_benefit_support">គាំត្រការអភិវដ្ឌន៍ឥសរាជ្យ</string>
     <string name="upgrade_benefit_equalizer">• Equalizer សម្រាប់ឧបករណ៍នីមួយៗ (សម្រាប់កម្មវិធីតន្ត្រីដែលគាំទ្រ equalizer ប្រព័ន្ធ)</string>
-    <string name="description_intro_tap_the_button">ចាប់ផ្តើមដោយបន្ថែមឧបករណ៍ដំបូងរបស់អ្នក។</string>
     <string name="description_bluetooth_is_disabled">ប៊្លូធូសត្រូវបានបិទ.</string>
     <string name="title_bluetooth_is_off">Bluetooth ត្រូវបានបិត</string>
     <string name="action_enable_bluetooth">បើក Bluetooth</string>
     <string name="title_bluetooth_permission_required">តម្រូវការអនុញ្ញាត Bluetooth</string>
     <string name="description_bluetooth_permission_required">កម្មវិធីនេះត្រូវការអនុញ្ញាត Bluetooth ដើម្បីគ្រប់គ្រងកម្រិតសំឡេងឧបករណ៍របស់អ្នក។</string>
     <string name="action_grant_permission">ផ្តល់ការអនុញ្ញាត</string>
-    <string name="label_status_listening_for_changes">ស្តាបការផ្លាស់ប្តូរកម្រិតសំឡេង</string>
     <string name="action_exit">ចាកចេញ</string>
-    <string name="action_start">ចាប់ផ្តើម</string>
-    <string name="label_welcome">សូមស្វាគមន៍</string>
-    <string name="description_intro_contact">សូមមិនត្រូវស្តាក់ស្តើរក្នុងការតំនាក់តំនងខ្ញុំ ប្រសិនបើអ្នកមានសំណួរ ហើយសូម្បីតែគំនិតសម្រាប់មុខងារថ្មី។</string>
-    <string name="label_translation">ការបកប្រែ</string>
-    <string name="description_help_translate">ជួយខ្ញុំធ្វើឡើយកម្មវិធីនេះអាចប្រើបានជាភាសាផ្សើ។</string>
     <string name="label_device_speaker">ស្ពីករឧបករណ៍</string>
-    <string name="label_keyevent_playpause">លើង-ផ្ហាក</string>
-    <string name="label_keyevent_play">លើង</string>
-    <string name="label_keyevent_next">បន្តាប់</string>
-    <string name="label_install_id">ID ដំឡើង</string>
     <string name="message_copied_to_clipboard">បានចម្លងតៅក្តារតម្បឹតខ្តាស់</string>
-    <string name="label_thanks">អរគុណ</string>
-    <string name="label_licenses">អាជ្ញាបណ្ណ</string>
-    <string name="description_ring_volume_additional_permission">ការអនុញ្ញាតបន្ថែមចាំបាចដើម្បីផ្លាស់ប្តូរកម្រិតសំឡេងរោត៍។</string>
-    <string name="label_missing_permissions">ការអនុញ្ញាតបាត់</string>
-    <string name="action_grant">ផ្តល់</string>
-    <string name="label_advanced">កម្រិតខ្ពស់</string>
-    <string name="label_exclude_health">មិនរាប់បញ្ចូលតម្រង់សុខភាព</string>
-    <string name="description_exclude_health">ឧបករណ៍ Android ខ្លះគាំពេលស្វែងរកតម្រង់ Bluetooth \'Health Device\' (HDP, 0x1400)។</string>
-    <string name="label_exclude_gattserver">មិនរាប់បញ្ចូលតម្រង់ម័ស៊ីនបម្រើ GATT</string>
-    <string name="label_exclude_gatt">មិនរាប់បញ្ចូលតម្រង់ GATT</string>
-    <string name="description_exclude_gattserver">កុំស្នើសុំតម្រង់ Bluetooth ប្រភេត \'Generic Attribute\' (GATT) ម័ស៊ីនបម្រើ។</string>
-    <string name="description_exclude_gatt">កុំស្នើសុំតម្រង់ Bluetooth ប្រភេត \'Generic Attribute\' (GATT) ភ្ញឹវ។</string>
-    <string name="description_waiting_for_devicex">កំពុងរង់ចាំ %s ដើម្បីបញ្ចប់ការភ្ជាប់</string>
-    <string name="action_undo">អាន់ឌូ</string>
-    <string name="action_show">បង្ហាញ</string>
     <string name="action_dismiss">បដិសេធ</string>
-    <string name="action_fix">ជួសជុល</string>
-    <string name="battery_optimizations_issue_description">ការធ្វើឡើយប្រសើរថ្មីត្រូវបានបើកសម្រាប់កម្មវិធីនេះ ហើយអាចការពារវាពីការត្រស័យព័ត្តិការណ៍ Bluetooth។ សូមពិចារណាបិតការធ្វើឡើយប្រសើរ ប្រសិនបើអ្នកជួបបញ្ហា។</string>
     <string name="label_bluetooth_settings">ការកំណត់ Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 កំណត់ការដំណើរការកម្មវិធីពីផ្តាឆលងខាងក្រោយ។ ដើម្បីអនុញ្ញាតបើកកម្មវិធីពេលឧបករណ៍ Bluetooth ភ្ជាប់ ផ្តល់ការអនុញ្ញាត \"បង្ហាញលើកម្មវិធីផ្សើ\" (SYSTEM_ALERT_WINDOW)។</string>
-    <string name="label_opensource">កូដប្រភព</string>
-    <string name="android13_notification_permission_description">ផ្តល់ការអនុញ្ញាតឡើយកម្មវិធីនេះបង្ហាញការជូនដំណឹង។ វានឹងបើកការបង្ហាញការជូនដំណឹងពេលកម្មវិធីនេះដំណើរការ ហើយការកែតម្រូវកម្រិតសំឡេងកំពុងត្រូវបានធ្វើ។</string>
-    <string name="privacy_policy_label">គោលការណ៍ឯកជនភាព</string>
     <string name="managed_devices_empty_message">គ្មានឧបករណ៍ Bluetooth ត្រូវបានកំណត់។\nចុចប៊ួតុង + ដើម្បីបន្ថែមឧបករណ៍ដំបូងរបស់អ្នក។</string>
     <string name="label_pro_feature">មុខងារពិសេស</string>
     <plurals name="discover_device_limit_banner">
@@ -419,21 +339,15 @@
     <string name="review_app_review_action">វាយតម្លៃ</string>
     <string name="review_app_dismiss_action">ប្រហែលពេលក្រោយ</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">ការទិញត្រូវបានបោះបង់</string>
-    <string name="error_iap_unavailable_message">ការទិញក្នុងកម្មវិធីមិនអាចប្រើបានទេ</string>
-    <string name="error_generic_message">មានបញ្ហាកើតឡើង។ សូមព្យាយាមម្ដងទៀត។</string>
-    <string name="error_iap_owned_message">អ្នកមានវត្ថុនេះរួចហើយ</string>
     <string name="label_no_devices_title">គ្មានឧបករណ៍</string>
     <string name="bluemusic_mascot_description">រូបតំណាងកម្មវិធី</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">ជ្រើសរើសកម្មវិធី</string>
     <string name="devices_app_selection_search_hint">ស្វែងរកកម្មវិធី…</string>
-    <string name="devices_app_selection_currently_selected">ត្រូវបានជ្រើសរើសសព្វថ្ងៃ</string>
     <string name="devices_app_selection_selected_count">បានជ្រើសរើស %d កម្មវិធី</string>
     <string name="general_navigate_back_action">ត្រឡប់ក្រោយ</string>
     <string name="general_reset_action">កំណត់ឡើងវិញ</string>
     <string name="general_clear_action">សម្អាត</string>
-    <string name="general_save_action">រក្សាទុក</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">ចាក់សោ</string>
     <string name="devices_indicator_awake">តើក</string>
@@ -443,7 +357,6 @@
     <string name="devices_indicator_limit">កម្រិត</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">បង្កើន</string>
-    <string name="devices_indicator_launch">បើក</string>
     <string name="devices_indicator_home">ទ័ពត្រឹម</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">ជូនដំណឹង</string>

--- a/app/src/main/res/values-kmr-rTR/strings.xml
+++ b/app/src/main/res/values-kmr-rTR/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Hin taybetmendî di dema nûvekirinê de guherîne. Ji kerema xwe mîhengên cîhaza xwe kontrol bikin da ku her tişt rast hatibe mîheng kirin.</string>
     <string name="onboarding_rewrite_action">Berdewam bike</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Ti cîhazên nebirêvebir nehatin dîtin</string>
     <string name="discover_all_devices_managed_msg">Hemû cîhazên weya hevbestekirî tên birêvebirin! Ji nûvekiyek hewce dike?</string>
     <string name="discover_pair_new_device_action">Cîhazekî nû hevbeste bike</string>
     <string name="discover_device_speaker_desc">Bipêjek xwe ya vê telefon. Helûskên wê dema deng vegerê telefon di sepandin, mînakî piştî ku amûra Bluetooth-a te veqetiya.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Mîhengkarîn cîhazê</string>
-    <string name="devices_device_config_section_general_label">Gishtgir</string>
     <string name="devices_device_config_remove_device_label">Cîhazê ji bîr bike</string>
-    <string name="devices_device_config_remove_device_desc">Cîhazê ji vê bernameê ji bîr dike û mîhengkarîn wê jê dike. Ev cîhaz ji hevbestê bernabide.</string>
     <string name="devices_device_config_remove_device_action">Ji bîr bike</string>
     <string name="devices_device_config_remove_device_confirmation">%s ji cîhazên birêvebirî jê bibin?</string>
-    <string name="devices_device_config_rename_device_label">Cîhazê biguheze</string>
-    <string name="devices_device_config_rename_device_desc">Navê vê cîhazê di vê bernameê de, û heger gengaz be, di sîstemê de biguherîne.</string>
     <string name="devices_device_config_rename_device_action">Biguheze</string>
     <string name="devices_device_config_enabled_label">Aktif</string>
     <string name="devices_device_config_enabled_desc">Dema ev cîhaz bi hestek bibe bersivê bide</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Fermanên lîstina xweser</string>
     <string name="devices_device_config_autoplay_keycodes_order">Rêza fermanan</string>
     <string name="devices_device_config_autoplay_keycodes_label">Ferman</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Mîheng bike ku kîjan ferman bişîne û bi çi rêzê</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Hîç ferman nehatiye mîhengkirin</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Fermanê zêde bike</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Herî zêde %1$d ferman</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Bibe jor</string>
     <string name="cd_autoplay_keycode_move_down">Bibe xwar</string>
     <string name="cd_autoplay_keycode_remove">Rake</string>
-    <string name="devices_device_config_section_volumes_label">Deng</string>
     <string name="devices_device_config_section_volume_label">Deng</string>
     <string name="devices_device_config_alarm_volume_label">Dengê alarmê</string>
     <string name="devices_device_config_alarm_volume_desc">Hin bernamên alarmê dengê mûzikê li xwe diguheranin.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Zengil</string>
     <string name="devices_audio_stream_notification_label">Agahdarî</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Hên nehatî dîtin</string>
-    <string name="devices_state_connected_label">Bi hestek</string>
     <string name="devices_last_connected_label">Dawiya hevbestê: %s</string>
     <string name="devices_currently_connected_label">Niha bi hestek e</string>
     <string name="devices_device_disabled_label">Cîhaz neaktîf</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Mîhengên ku hemû cîhazên birêvebir tê de bandor dikin.</string>
     <string name="label_app_enabled">Bername aktif</string>
     <string name="description_app_enabled">Kamala bersivê bernameê ji rûyderîn deng û Bluetooth sûk dike.</string>
-    <string name="label_visible_volume_adjustments">Rastkarîn diyar</string>
-    <string name="description_visible_volume_adjustments">Pencereya dengê sîstemê nîşan bide dema vê bernameê rastkarîn dike.</string>
     <string name="label_volume_listener">Guherînên bihîstin</string>
-    <string name="description_volume_listener">Aktif bimîne dema cîhazek bi hestek be û guherînên dengê ku ne ji vê bernameê ne hatine parastin bike.</string>
     <string name="label_boot_restore">Piştî bootê vegerîne</string>
     <string name="description_boot_restore">Dengê piştî bootkirinê vegerîne heger cîhazek Bluetooth bi hestek be.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Fam bikin ka BVM bi bandorî çawa bikarîne</string>
     <string name="settings_support_issue_tracker_description">Nivîskar pirsgirêkan a gelîrî ji bo raportên bug û daxwazên taybetmendê.</string>
     <string name="settings_support_issue_tracker_label">Şopînera pirsgirêkan</string>
-    <string name="settings_support_debuglog_label">Tomara çareserkirinê</string>
     <string name="settings_support_debuglog_desc">Her tiştê ku sepan dike di pelek nivîskî de tomar bike ku hûn dikarin parve bikin.</string>
-    <string name="settings_support_debuglog_recording_desc">Niha agahdarîna debugê tê tomarkirin. Jî bikînin da were sekinandin.</string>
-    <string name="settings_support_debuglog_path">Riya tomare: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Tomarkirina pir kin</string>
     <string name="settings_support_debuglog_short_recording_msg">Ev tomarkirinek pir kin bû. Pirsgirêk di dema tomarkirinê de ji nû ve hilberînin da ku tomar karêdek be.</string>
     <string name="settings_support_debuglog_short_recording_continue">Tomarkirina berdewam bike</string>
     <string name="settings_support_debuglog_short_recording_stop">Were sekinandin</string>
-    <string name="settings_support_debuglog_folder_label">Pergala tomarên debug</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d danistin bi %2$s</item>
-        <item quantity="other">%1$d danistin bi %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Ti tomarên debug ne hatine hilandin</string>
-    <string name="settings_support_debuglog_folder_delete_title">Hemû tomarên debug jê bibin?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Ev hemû danistinên tomarên debug yên hilandi bi domî jê dike.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Cîhek ji bo hevdîtin û pirsînê.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Werger</string>
     <string name="settings_acks_translators_title">Wergêr</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM wergerîne</string>
-    <string name="settings_acks_translate_desc">BVM wergertina zimana xwe bikin</string>
     <string name="settings_acks_thanks_header">Spas</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Ji bo pishtgirîna wergertina projeyanê çavkaniya vekirî</string>
     <string name="settings_licenses_label">Lîsans</string>
     <string name="settings_translation_label">Werger</string>
     <string name="settings_translation_desc">Aliyarîna wergertina bernameê bo zimana xwe ya bijartî bikin</string>
-    <string name="settings_sponsor_development_title">Perkeftîna perkîfîtkirinê</string>
-    <string name="settings_sponsor_development_summary">Bibin patron û perkeftîna berdewam gengaz bikin.</string>
     <string name="settings_privacy_policy_label">Polîtîkaya nepenîtiyê</string>
     <string name="settings_privacy_policy_desc">Bi berpirsiyarî daneyan bi rêve bibin.</string>
     <string name="changelog_label">Tomara guhertinan</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Vegerandin qediya — %1$d cîhaz hat vegerandin, %2$d hat derbaskirin.</string>
     <string name="backup_restore_version_warning">Ev backup bi guhertoya %1$s hat çêkirin. Tu %2$s xebitandî. Hin mîheng dibe ku rast neyên vegerandin.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Agahdariyên çareserkirinê</string>
     <string name="debug_log_consent_title">Tomara çareserkirinê</string>
     <string name="debug_log_consent_explanation">Ev taybetmend hemû tishtên bernameê têrî dike li dosyeyek parvekirbar tomar dike. Dosyeya hatiyê jidaykirin agahdarîyên hesas dihewine. Tenê bi aliyanê mîbawer re biparize.</string>
-    <string name="debug_log_recording_progress">Tomara çareserkirinê tê tomarkirin</string>
     <string name="debug_log_record_action">Tomar bike</string>
     <string name="debug_log_stop_action">Tomarkirinê rawestîne</string>
     <string name="debug_log_screen_title">Tomarkarê Tomarên Debug</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Avêtin</string>
     <string name="debug_log_screen_keep_action">Bimîne</string>
-    <string name="debug_log_compressing_label">Zav dike...</string>
     <string name="debug_log_file_label">Pela tomara tomarkirî</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Tomar hatîşandin?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Pirsiyara xwe bi huzurmend rave bikin.</string>
     <string name="contact_category_section_label">Kategoriyê</string>
     <string name="contact_debug_log_label">Tomara çareserkirinê</string>
-    <string name="contact_debug_log_select_hint">Tomara debugê pir vekêr hilbijerin</string>
     <string name="contact_debug_log_picker_hint">Tomara debugê pir vek bikin da pirsgirêk zútir were tê bigihastin.</string>
     <string name="contact_debug_log_picker_empty">Ti tomarên debug tune ne. Yekemî tomar bikin.</string>
     <string name="contact_expected_behavior_label">Tevgera jê hatî hevîn</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Ez her peyam dixwenim. Spas.</string>
     <string name="contact_footer_msg">Peyama we bi posta elektronikî têşandin. Agahdarîyên cîhaz bixweber dibin.</string>
     <string name="contact_no_email_app_msg">Li vê cîhazê ti bername posta elektronikî nehate dîtin.</string>
-    <string name="contact_attachment_missing_msg">Dosyeya tomara debug tune</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Tomarên debug hilandî</string>
     <string name="settings_support_stored_logs_desc">%1$d danistin (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Ti tomar debug ne hilandî</string>
-    <string name="settings_support_stored_logs_delete_title">Tomarên hilandî jê bibin?</string>
-    <string name="settings_support_stored_logs_delete_msg">Ev hemû %1$d danistinên tomar debugê hilandî jê dike.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Tomarên debug hilandî hatin jê kirin</string>
-    <string name="label_bug_reports">Raportên bug</string>
-    <string name="description_bug_reports">Tomarkirinê bixweber a bug û xirap bûnê.</string>
     <string name="label_add_device">Cîhazê bizêde bike</string>
-    <string name="label_just_a_moment_please">Wax bikin, ji kerema xwe.</string>
     <string name="label_notification_channel_status">Dema niha</string>
     <string name="label_notification_channel_setup">Sazkirin pêwîst e</string>
     <string name="monitor_notification_starting">Vegu tê de…</string>
     <string name="action_set">Saz bike</string>
     <string name="action_cancel">Betal bike</string>
-    <string name="label_invalid_input">Ketina ne derbasdar</string>
     <string name="action_reset">Ji nû ve saz bike</string>
     <string name="label_no_connected_devices">Ti cîhaz bi hestek ninin</string>
-    <string name="label_status_idle">Betal</string>
-    <string name="label_status_adjusting_volumes">Dengê tê rastkar kirin</string>
-    <string name="label_premium_version">Guhertoya premium</string>
     <string name="general_upgrade_action">Nûjen bike</string>
     <string name="common_upgrade_required_label">Bilindkirina pêdivî ye</string>
-    <string name="label_premium_version_required">Guhertoya premium hewce ye</string>
-    <string name="description_intro_purpose">Ev bername dihêle cîhaza Android-a we astên dengê cîhazên Bluetooth ji bîr bike.</string>
-    <string name="upgrade_benefit_unlimited_devices">Profîlên cîhazê yên bêsînor</string>
-    <string name="upgrade_benefit_connection_actions">Otomatîkî lêdan, vekirin a sepanê û hişyariyên girêdanê</string>
-    <string name="upgrade_benefit_theme_customization">Xweşkirina tema, stil û rengî</string>
-    <string name="upgrade_benefit_power_controls">Kilîda dengbêjiyê û sînorkirina rêjeyê</string>
-    <string name="upgrade_benefit_support">Piştgirî ji pêşvebrina serbixwe re bike</string>
     <string name="upgrade_benefit_equalizer">• Hevsengkerê taybet ji bo her amûrê (ji bo sepanên muzîkê yên bi piştgiriya hevsengkera pergalê)</string>
-    <string name="description_intro_tap_the_button">Bi zêdekirina cîhaza xwe ya yekemî dest pê bikin.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth neçalak e.</string>
     <string name="title_bluetooth_is_off">Bluetooth neaktîf e</string>
     <string name="action_enable_bluetooth">Bluetooth aktif bike</string>
     <string name="title_bluetooth_permission_required">Destvîrîna Bluetooth Hewce Ye</string>
     <string name="description_bluetooth_permission_required">Ev bername destvîrîna Bluetooth hewce dike da astên dengê cîhazên we birêve bike.</string>
     <string name="action_grant_permission">Destvîrî bide</string>
-    <string name="label_status_listening_for_changes">Li guherînên dengê guh didin</string>
     <string name="action_exit">Derketin</string>
-    <string name="action_start">Dest pê bike</string>
-    <string name="label_welcome">Bi xêr hatî</string>
-    <string name="description_intro_contact">Heger pirsiyar hebin, ji kerema xwe pêwendî bikin.</string>
-    <string name="label_translation">Werger</string>
-    <string name="description_help_translate">Aliyarîna min bikin da bername di zimanên din de berdest be.</string>
     <string name="label_device_speaker">Bilindkera cîhazê</string>
-    <string name="label_keyevent_playpause">Lêdan-Sekinandin</string>
-    <string name="label_keyevent_play">Lêdan</string>
-    <string name="label_keyevent_next">Berdewam</string>
-    <string name="label_install_id">Nasnameya sazkirinê</string>
     <string name="message_copied_to_clipboard">Ji panberê hate kop kirin</string>
-    <string name="label_thanks">Spas</string>
-    <string name="label_licenses">Lîsans</string>
-    <string name="description_ring_volume_additional_permission">Destvîrîn zedê ji bo guhertin dengê zengilê hewce ne.</string>
-    <string name="label_missing_permissions">Destvîrîn kêm</string>
-    <string name="action_grant">Bide</string>
-    <string name="label_advanced">Pêştir</string>
-    <string name="label_exclude_health">Profil tenduristî ji nav bibe</string>
-    <string name="description_exclude_health">Hin cîhaz Android dema profil Bluetooth ya Tenduristî (HDP, 0x1400) têşander kirin, dixêwin.</string>
-    <string name="label_exclude_gattserver">Profil server GATT ji nav bibe</string>
-    <string name="label_exclude_gatt">Profil GATT ji nav bibe</string>
-    <string name="description_exclude_gattserver">Profil Bluetooth ya tipa GATT server têşander nake.</string>
-    <string name="description_exclude_gatt">Profil Bluetooth ya tipa GATT mûverî têşander nake.</string>
-    <string name="description_waiting_for_devicex">Sekinandina %s da hevbest tê xelas kirin</string>
-    <string name="action_undo">Vegerîne</string>
-    <string name="action_show">Nîşan bide</string>
     <string name="action_dismiss">Berde</string>
-    <string name="action_fix">Sax bike</string>
-    <string name="battery_optimizations_issue_description">Optimîzasyona battery aktif e û dibe ku wergirtina rûdaner Bluetooth asteng bike. Optimîzasyona bitebitandin heger pirsgirêk hês dibin.</string>
     <string name="label_bluetooth_settings">Mîhengên Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 sînor dide ser destpêkirina bername ji pavenkê. Da bernameyan biweke dema cîhazek Bluetooth bi hestek dibe, destvîrîna \'Nîşan li ser bernameên din\' bide.</string>
-    <string name="label_opensource">Koda çavkaniê</string>
-    <string name="android13_notification_permission_description">Destvîrîna vê bernameê bide da agahdar birste.</string>
-    <string name="privacy_policy_label">Polîtîkaya nepenîtiyê</string>
     <string name="managed_devices_empty_message">Ti cîhaz Bluetooth nehatîn mîheng kirin.</string>
     <string name="label_pro_feature">Taybetmenda premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Pîrsguhek</string>
     <string name="review_app_dismiss_action">Paşê dibe</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Kirîn hatî betal kirin</string>
-    <string name="error_iap_unavailable_message">Kirêna di bernameê de berdest nîne</string>
-    <string name="error_generic_message">Xeletîyeke peyda bû. Ji kerema xwe dîsa biceribinin.</string>
-    <string name="error_iap_owned_message">Ev tiştanek we jixwe xwedîê</string>
     <string name="label_no_devices_title">Ti Cîhaz</string>
     <string name="bluemusic_mascot_description">Nîşana Bernameê</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Bernameyan Hilbijerin</string>
     <string name="devices_app_selection_search_hint">Bernameyan bigerin…</string>
-    <string name="devices_app_selection_currently_selected">Niha hatîn hilbijartin</string>
     <string name="devices_app_selection_selected_count">%d bername hatîn hilbijartin</string>
     <string name="general_navigate_back_action">Ber bi paş ve here</string>
     <string name="general_reset_action">Ji nû ve saz bike</string>
     <string name="general_clear_action">Pªk bike</string>
-    <string name="general_save_action">Tomar bike</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Kilîd</string>
     <string name="devices_indicator_awake">Hişyar</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Sînor</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Bilindkirin</string>
-    <string name="devices_indicator_launch">Bixebite</string>
     <string name="devices_indicator_home">Ekrana Malê</string>
     <string name="devices_indicator_dnd">NXW</string>
     <string name="devices_indicator_alert">Agahdarî</string>

--- a/app/src/main/res/values-kn-rIN/strings.xml
+++ b/app/src/main/res/values-kn-rIN/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">ಅಪ್‌ಡೇಟ್ ಸಮಯದಲ್ಲಿ ಕೆಲವು ವೈಶಿಷ್ಟ್ಯಗಳು ಬದಲಾಗಿವೆ. ಎಲ್ಲವೂ ಸರಿಯಾಗಿ ಹೊಂದಿಸಲಾಗಿದೆ ಎಂದು ಖಚಿತಪಡಿಸಿಕೊಳ್ಳಲು ನಿಮ್ಮ ಸಾಧನದ ಸೆಟ್ಟಿಂಗ್‌ಗಳನ್ನು ಪರಿಶೀಲಿಸಿ.</string>
     <string name="onboarding_rewrite_action">ಮುಂದುವರಿಸಿ</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">ನಿರ್ವಹಿಸದ ಸಾಧನಗಳು ಕಂಡುಬಂದಿಲ್ಲ</string>
     <string name="discover_all_devices_managed_msg">ನಿಮ್ಮ ಎಲ್ಲಾ ಜೋಡಿಯಾದ ಸಾಧನಗಳು ನಿರ್ವಹಿಸಲ್ಪಡುತ್ತಿವೆ! ಹೊಸದು ಬೇಕೇ?</string>
     <string name="discover_pair_new_device_action">ಹೊಸ ಸಾಧನ ಜೋಡಿಸಿ</string>
     <string name="discover_device_speaker_desc">ಈ ಫೋನ್‌ನ ಸ್ವಂತ ಸ್ಪೀಕರ್. ಆಡಿಯೋ ಫೋನ್‌ಗೆ ಮತ್ತೆ ಬದಲಾಗಿದಾಗ ಅದರ ವಾಲ್ಯೂಮ್‌ಗಳನ್ನು ಅನ್ವಯ ಮಾಡಲಾಗುತ್ತದೆ, ಉದಾ. ನಿಮ್ಮ Bluetooth ಸಾಧನ ಸಂಪರ್ಕ ಕಡಿತವಾದ ನಂತರ.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ಸಾಧನ ಅನುಸ್ಥಾಪನೆ</string>
-    <string name="devices_device_config_section_general_label">ಸಾಮಾನ್ಯ</string>
     <string name="devices_device_config_remove_device_label">ಸಾಧನ ಮರೆಯಿ</string>
-    <string name="devices_device_config_remove_device_desc">ಈ ಅಪ್ಲಿಕೇಶನ್‌ನಿಂದ ಸಾಧನವನ್ನು ಮರೆತು ಅದರ ಅನುಸ್ಥಾಪನೆ ಅಳಿಸುತ್ತದೆ. ಇದು ಸಾಧನವನ್ನು ಜೋಡಿ ತೆಗೆದುಕೊಳ್ಳಲಾರದು.</string>
     <string name="devices_device_config_remove_device_action">ಮರೆಯಿ</string>
     <string name="devices_device_config_remove_device_confirmation">ನಿರ್ವಹಿತ ಸಾಧನಗಳಿಂದ %s ಅನ್ನು ಮರೆಯಬೇಕೇ?</string>
-    <string name="devices_device_config_rename_device_label">ಸಾಧನ ಮರುನಾಮಕರಣ</string>
-    <string name="devices_device_config_rename_device_desc">ಈ ಅಪ್ಲಿಕೇಶನ್‌ನಲ್ಲಿ ಈ ಸಾಧನವನ್ನು ಮರುನಾಮಕರಿಸಿ, ಮತ್ತು ಸಾಧ್ಯವಿದ್ದಲ್ಲಿ ಸಿಸ್ಟಮ್‌ನಲ್ಲಿಯೂ ಮರುನಾಮಕರಿಸಿ.</string>
     <string name="devices_device_config_rename_device_action">ಮರುನಾಮಕರಿಸಿ</string>
     <string name="devices_device_config_enabled_label">ಸಕ್ರಿಯವಾಗಿದೆ</string>
     <string name="devices_device_config_enabled_desc">ಜೋಡಿಗೊಂಡಾಗ ಈ ಸಾಧನಕ್ಕೆ ಪ್ರತಿಕ್ರಿಯಿಸಿ</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">ಆಟೋಪ್ಲೇ ಆಜ್ಞೆಗಳು</string>
     <string name="devices_device_config_autoplay_keycodes_order">ಆಜ್ಞೆ ಅನುಕ್ರಮ</string>
     <string name="devices_device_config_autoplay_keycodes_label">ಆಜ್ಞೆಗಳು</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">ಯಾವ ಆಜ್ಞೆಗಳನ್ನು ಕಳುಹಿಸಬೇಕು ಮತ್ತು ಯಾವ ಕ್ರಮದಲ್ಲಿ ಎಂದು ಕಾನ್ಫಿಗರ್ ಮಾಡಿ</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">ಯಾವುದೇ ಆಜ್ಞೆಗಳು ಕಾನ್ಫಿಗರ್ ಆಗಿಲ್ಲ</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">ಆಜ್ಞೆ ಸೇರಿಸಿ</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">ಗರಿಷ್ಠ %1$d ಆಜ್ಞೆಗಳು</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">ಮೇಲೆ ಸರಿಸಿ</string>
     <string name="cd_autoplay_keycode_move_down">ಕೆಳಗೆ ಸರಿಸಿ</string>
     <string name="cd_autoplay_keycode_remove">ತೆಗೆದುಹಾಕಿ</string>
-    <string name="devices_device_config_section_volumes_label">ವಾಲ್ಯೂಮ್ಗಳು</string>
     <string name="devices_device_config_section_volume_label">ವಾಲ್ಯೂಮ್</string>
     <string name="devices_device_config_alarm_volume_label">ಅಲಾರ್ಮ್ ವಾಲ್ಯೂಮ್</string>
     <string name="devices_device_config_alarm_volume_desc">ಕೆಲವು ಅಲಾರ್ಮ್ ಅಪ್ಲಿಗಳು ಬದಲಾಗಿ ಮ್ಯೂಸಿಕ್ ವಾಲ್ಯೂಮ್ ಬಳಸುತ್ತವೆ.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">ರಿಂಗ್</string>
     <string name="devices_audio_stream_notification_label">ಅಧಿಸೂಚನೆ</string>
     <string name="devices_audio_stream_alarm_label">ಅಲಾರ್ಮ್</string>
-    <string name="devices_neverseen_label">ಎಂದೂ ಕಂಡಿಲ್ಲ</string>
-    <string name="devices_state_connected_label">ಜೋಡಿಗೊಂಡಿದೆ</string>
     <string name="devices_last_connected_label">ಕೊನೆಯಾಗಿ ಜೋಡಿಗೊಂಡದ್ದು: %s</string>
     <string name="devices_currently_connected_label">ಪ್ರಸ್ತುತ ಜೋಡಿಗೊಂಡಿದೆ</string>
     <string name="devices_device_disabled_label">ಸಾಧನ ನಿಷ್ಕ್ರಿಯ</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">ಎಲ್ಲಾ ನಿರ್ವಹಿತ ಸಾಧನಗಳನ್ನು ಪರಿಣಾಮಿಸುವ ಸೆಟ್ಟಿಂಗ್‌ಗಳು.</string>
     <string name="label_app_enabled">ಅಪ್ ಸಕ್ರಿಯ</string>
     <string name="description_app_enabled">ವಾಲ್ಯೂಮ್ ಮತ್ತು Bluetooth ಘಟನೆಗಳಕ್ಕೆ ಪ್ರತಿಕ್ರಿಯಿಸುವ ಅಪ್ನ ಸಾಮರ್ಥ್ಯವನ್ನು ಟೊಗ್‌ಗ್ ಮಾಡುತ್ತದೆ.</string>
-    <string name="label_visible_volume_adjustments">ದೃಶ್ಯ ಸರಿಹೊಂದಿಕೆಗಳು</string>
-    <string name="description_visible_volume_adjustments">ಈ ಅಪ್ಲಿಕೇಶನ್ ಸರಿಹೊಂದಿಕೆ ಮಾಡುವಾಗ ಸಿಸ್ಟಮ್ನ ವಾಲ್ಯೂಮ್ ವಿಂಡೋ ತೋರಿಸಿ.</string>
     <string name="label_volume_listener">ಬದಲಾವಣೆಗಳನ್ನು ಗಮನಿಸಿ</string>
-    <string name="description_volume_listener">ಎಂದಾದರೂ ಸಾಧನ ಜೋಡಿಗೊಂಡಿರುವಾಗ ಸಕ್ರಿಯವಾಗಿರಿ ಮತ್ತು ಈ ಅಪ್ಲಿಕೇಶನ್ ಮಾಡ್ಯದ ವಾಲ್ಯೂಮ್ ಬದಲಾವಣೆಗಳನ್ನು ಉಳಿಸಿಕೊಳ್ಳಿ.</string>
     <string name="label_boot_restore">ಬೂಟ್ ಮೇಲೆ ಪುನರ್ಸ್ಥಾಪಿಸಿ</string>
     <string name="description_boot_restore">Bluetooth ಸಾಧನ ಜೋಡಿಗೊಂಡಿದ್ದರೆ ಬೂಟ್/ರಿಬೂಟ್ ನಂತರ ವಾಲ್ಯೂಮ್ ಪುನರ್ಸ್ಥಾಪಿಸಿ.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM ಅನ್ನು ಪರಿಣಾಮಕಾರಿಯಾಗಿ ಬಳಸುವುದು ಹೇಗೆ ಎಂದು ತಿಳಿಯಿ</string>
     <string name="settings_support_issue_tracker_description">ಬಗ್ ವರದಿಗಳು ಮತ್ತು ಫೀಚರ್ ವಿನಂತಿಗಳಗಾಗಿ ಸಾರ್ವಜನಿಕ ಸಮಸ್ಯೆ ನಿರ್ವಾಹಕ.</string>
     <string name="settings_support_issue_tracker_label">ಸಮಸ್ಯೆ ಟ್ರ್ಯಾಕರ್</string>
-    <string name="settings_support_debuglog_label">ಡೀಬಗ್ ಲಾಗ್</string>
     <string name="settings_support_debuglog_desc">ಅಪ್ಲಿಕೇಶನ್ ಮಾಡುವ ಎಲ್ಲವನ್ನೂ ನೀವು ಹಂಚಿಕೊಳ್ಳಬಹುದಾದ ಪಠ್ಯ ಫೈಲ್‌ನಲ್ಲಿ ರೆಕಾರ್ಡ್ ಮಾಡಿ.</string>
-    <string name="settings_support_debuglog_recording_desc">ಪ್ರಸ್ತುತ ಡಿಬಗ್ ಮಾಹಿತಿ ರೆಕಾರ್ಡಿಂಗ್ ಮಾಡುತ್ತಿದೆ. ರೆಕಾರ್ಡಿಂಗ್ ನಿಲ್ಲಿಸಲು ತಾಟಿ.</string>
-    <string name="settings_support_debuglog_path">ಲಾಗ್ ಮಾರ್ಗ: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">ತುಂಬಾ ಕಿರು ರೆಕಾರ್ಡಿಂಗ್</string>
     <string name="settings_support_debuglog_short_recording_msg">ಅದು ತುಂಬಾ ಕಿರು ರೆಕಾರ್ಡಿಂಗ್ ಆಗಿತ್ತು. ಡಿಬಗ್ ಲಾಗ್ಗಳು ರೆಕಾರ್ಡಿಂಗ್ಗಳು, ಸ್ನ್ಯಾಪ್ಶರ್ಗಳಲ್ಲ - ರೆಕಾರ್ಡಿಂಗ್ ಸಕ್ರಿಯವಾಗಿರುವಾಗ ಸಮಸ್ಯೆ ಪುನರ್ ಉತ್ಪನ್ನಿಸಿ ಲಾಗ್ ಬಳಕಕ್ಕೆ ಬರಲಿ.</string>
     <string name="settings_support_debuglog_short_recording_continue">ರೆಕಾರ್ಡಿಂಗ್ ಮುಂದುವರಿಸಿ</string>
     <string name="settings_support_debuglog_short_recording_stop">ಹಾಗೆಯೇ ನಿಲ್ಲಿಸಿ</string>
-    <string name="settings_support_debuglog_folder_label">ಡಿಬಗ್ ಲಮಮು</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d ಸೆಷನ್ %2$s ಬಳಸಕೆ</item>
-        <item quantity="other">%1$d ಸೆಷನ್ಗಳು %2$s ಬಳಸಕೆ</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">ಯಾವುದೇ ಡಿಬಗ್ ಲಾಗ್ ಸಂಗ್ರಿಸಲಾಗಿಲ್ಲ</string>
-    <string name="settings_support_debuglog_folder_delete_title">ಎಲ್ಲಾ ಡಿಬಗ್ ಲಾಗ್ಗಳನ್ನು ಅಳಿಸಬೇಕೇ?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">ಇದು ಎಲ್ಲಾ ಸಂಗ್ರಿಸಲಾದ ಡಿಬಗ್ ಲಾಗ್ ಸೆಷನ್ಗಳನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸುತ್ತದೆ.</string>
     <string name="settings_support_discord_label">ಡಿಸ್ಕಾರ್ಡ್</string>
     <string name="settings_support_discord_description">ಹ್ಯಾಂಗ್ ಔಟ್ ಮಾಡಲು ಮತ್ತು ಪ್ರಶ್ನೆಗಳನ್ನು ಕೇಳಲು ಒಂದು ಸ್ಥಳ.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">ಅನುವಾದ</string>
     <string name="settings_acks_translators_title">ಅನುವಾದಕರು</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM ತರ್ಜುಮೆ ಮಾಡಿ</string>
-    <string name="settings_acks_translate_desc">BVM ಅನ್ನು ನಿಮ್ಮ ಭಾಷೆಗೆ ತರ್ಜುಮೆ ಮಾಡಲು ಸಹಾಯಿಸಿ</string>
     <string name="settings_acks_thanks_header">ಧನ್ಯವಾದ</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">ಓಪನ್-ಸೋರ್ಸ್ ಯೋಜನೆಗಳ ತರ್ಜುಮೆ ಬೆಂಬಲಿಸಿದಕ್ಕಾಗಿ</string>
     <string name="settings_licenses_label">ಪರವಾನಗಿಗಳು</string>
     <string name="settings_translation_label">ಅನುವಾದ</string>
     <string name="settings_translation_desc">ಅಪ್ಅನ್ನು ನಿಮ್ಮ ಪ್ರಿಯ ಭಾಷೆಗೆ ತರ್ಜುಮೆ ಮಾಡಲು ಸಹಾಯಿಸಿ</string>
-    <string name="settings_sponsor_development_title">ಅಭಿವೃದ್ಧಿ ಪ್ರಾಯೋಜಕ</string>
-    <string name="settings_sponsor_development_summary">ಪೃಷ್ಟ೛ಪೋಷಕರಾಗಿ ಸೇರಿ ನಿರಂತರ ಅಭಿವೃದ್ಧಿ ಸಾಧ್ಯವಾಗಿಸಿ.</string>
     <string name="settings_privacy_policy_label">ಗೌಪ್ಯತೆ ನೀತಿ</string>
     <string name="settings_privacy_policy_desc">ಡೇಟಾವನ್ನು ಜವಾಬ್ದಾರಿಯುತವಾಗಿ ನಿರ್ವಹಿಸುವುದು.</string>
     <string name="changelog_label">ಬದಲಾವಣೆ ಲಾಗ್</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">ಮರುಸ್ಥಾಪನೆ ಪೂರ್ಣಗೊಂಡಿದೆ — %1$d ಸಾಧನಗಳು ಮರುಸ್ಥಾಪಿಸಲಾಗಿದೆ, %2$d ಬಿಟ್ಟುಬಿಡಲಾಗಿದೆ.</string>
     <string name="backup_restore_version_warning">ಈ ಬ್ಯಾಕಪ್ ಆವೃತ್ತಿ %1$s ನೊಂದಿಗೆ ರಚಿಸಲಾಗಿದೆ. ನೀವು %2$s ಚಾಲಿಸುತ್ತಿದ್ದೀರಿ. ಕೆಲವು ಸೆಟ್ಟಿಂಗ್‌ಗಳು ಸರಿಯಾಗಿ ಮರುಸ್ಥಾಪನೆ ಆಗದಿರಬಹುದು.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">ಡೀಬಗ್ ಅಧಿಸೂಚನೆಗಳು</string>
     <string name="debug_log_consent_title">ಡೀಬಗ್ ಲಾಗ್</string>
     <string name="debug_log_consent_explanation">ಈ ವೈಶಿಷ್ಟ್ಯ ಅಪ್ಲಿಕೇಶನ್ ಮಾಡುತ್ತಿರುವ ಪ್ರತಿಯನ್ನು ಹಂಚಿಕೊಳ್ಳಲಾಗುವ ಫೈಲಿಗೆ ರೆಕಾರ್ಡ್ ಮಾಡುತ್ತದೆ. ಉತ್ಪನ್ನವಾದ ಫೈಲು ಸಂವೇದನಶೀಲ ಮಾಹಿತಿಯನ್ನು ಹೊಂದಿಸಿದೆ (ಉದಾ. ಫೈಲ್ ಹೆಸರುಗಳು ಮತ್ತು ಸ್ಥಾಪಿಸಲಾದ ಅಪ್ಲಿಗಳು). ಇದನ್ನು ವಿಶ್ವಾಸಾರ್ಹ ಪಕ್ಷಗಳೊಂದಿಗೆ ಮಾತ್ರ ಹಂಚಿಕೊಳ್ಳಿ.</string>
-    <string name="debug_log_recording_progress">ಡೀಬಗ್ ಲಾಗ್ ರೆಕಾರ್ಡ್ ಮಾಡಲಾಗುತ್ತಿದೆ</string>
     <string name="debug_log_record_action">ರೆಕಾರ್ಡ್</string>
     <string name="debug_log_stop_action">ರೆಕಾರ್ಡಿಂಗ್ ನಿಲ್ಲಿಸಿ</string>
     <string name="debug_log_screen_title">ಡಿಬಗ್ ಲಾಗ್ ರೆಕಾರ್ಡರ್</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">ಬಿಟಿ</string>
     <string name="debug_log_screen_keep_action">ಇಟ್ಟುಕೊ</string>
-    <string name="debug_log_compressing_label">ಸಂಕುಚಿಸಲಾಗುತ್ತಿದೆ…</string>
     <string name="debug_log_file_label">ರೆಕಾರ್ಡ್ ಮಾಡಿದ ಲಾಗ್ ಫೈಲ್</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">ಲಾಗ್ ಕಳುಹಿಸಲಾಯಿತೇ?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">ನಿಮ್ಮ ಪ್ರಶ್ನೆಯನ್ನು ವಿಸ್ತೌರವಾಗಿ ವಿವರಿಸಿ.</string>
     <string name="contact_category_section_label">ವರ್ಗ</string>
     <string name="contact_debug_log_label">ಡೀಬಗ್ ಲಾಗ್</string>
-    <string name="contact_debug_log_select_hint">ಲಗತ್ತಿಸಲು ಡಿಬಗ್ ಲಾಗ್ ಆಯ್ಕೆ ಮಾಡಿ</string>
     <string name="contact_debug_log_picker_hint">ಸಮಸ್ಯೆ ವೇಗವಾಗಿ ಪತ್ತೆಹಚ್ಚಲು ಡಿಬಗ್ ಲಾಗ್ ಲಗತ್ತಿಸಿ.</string>
     <string name="contact_debug_log_picker_empty">ಯಾವುದೇ ಡಿಬಗ್ ಲಾಗ್ ಲಭ್ಯವಿಲ್ಲ. ಮೊದಲು ಒಂದನ್ನು ರೆಕಾರ್ಡ್ ಮಾಡಿ.</string>
     <string name="contact_expected_behavior_label">ಎಂದು ನಿರೀಕ್ಷಿಸಲಾಗಿತ್ತು</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">ಪ್ರತಿಯೊಂದು ಸಂದೇಶವನ್ನು ನಾನು ಸ್ವಯಂ ಓದುತ್ತೇನೆ ಮತ್ತು ಪ್ರತಿಕ್ರಿಯಿಸಲು ಪ್ರಯತ್ನಿಸುತ್ತೇನೆ, ಆದರೆ ಏಕಲಾ ಕೆಲಸ ಮಾಡುವುದರಿಂದ ಸ್ವಲ್ಪ ಸಮಯ ಕಳೆಯಬಹುದು. ತಾಳ್ಮೆಗಾಗಿ ಧನ್ಯವಾದ.</string>
     <string name="contact_footer_msg">ನಿಮ್ಮ ಸಂದೇಶ ಇಮೇಲ್ ಮೂಲಕ ಕಳುಹಿಸಲಾಗುತ್ತದೆ. ಸಾಧನ ಮತ್ತು ಸೆಟ್ಟಪ್ ಮಾಹಿತಿ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಲಗತ್ತಿಸಲಾಗುತ್ತದೆ.</string>
     <string name="contact_no_email_app_msg">ಈ ಸಾಧನದಲ್ಲಿ ಇಮೇಲ್ ಅಪ್ ಕಂಡುಬಂದಿಲ್ಲ.</string>
-    <string name="contact_attachment_missing_msg">ಡಿಬಗ್ ಲಮಮು ಫೈಲು ಇನ್ನು ಅಸ್ತಿತ್ವದಲ್ಲಿಲ್ಲ</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">ಸಂಗ್ರಿಸಲಾದ ಡಿಬಗ್ ಲಾಗ್ಗಳು</string>
     <string name="settings_support_stored_logs_desc">%1$d ಸೆಷನ್ಗಳು (%2$s)</string>
     <string name="settings_support_stored_logs_empty">ಸಂಗ್ರಿಸಲಾದ ಡಿಬಗ್ ಲಾಗ್ಗಳಿಲ್ಲ</string>
-    <string name="settings_support_stored_logs_delete_title">ಸಂಗ್ರಿಸಲಾದ ಲಮಾಮುಗಳನ್ನು ಅಳಿಸಬೇಕೇ?</string>
-    <string name="settings_support_stored_logs_delete_msg">ಇದು ಎಲ್ಲಾ %1$d ಸಂಗ್ರಿಸಲಾದ ಡಿಬಗ್ ಲಮಾಮು ಸೆಷನ್ಗಳನ್ನು ಅಳಿಸುತ್ತದೆ.</string>
-    <string name="settings_support_stored_logs_deleted_msg">ಸಂಗ್ರಿಸಲಾದ ಡಿಬಗ್ ಲಮಾಮುಗಳು ಅಳಿಸಲಾಯಿತು</string>
-    <string name="label_bug_reports">ಬಗ್ ವರದಿಗಳು</string>
-    <string name="description_bug_reports">ಸ್ವಯಂಚಾಲಿತ ಬಗ್ ಮತ್ತು ಕ್ರ್ಯಾಶ್ ವರದಿ.</string>
     <string name="label_add_device">ಸಾಧನ ಸೇರಿಸಿ</string>
-    <string name="label_just_a_moment_please">ಒಂದು ಕ್ಷಣ, ದಯವಿಟ್ಟು.</string>
     <string name="label_notification_channel_status">ಸ್ಥಿತಿ</string>
     <string name="label_notification_channel_setup">ಸೆಟಪ್ ಅಗತ್ಯ</string>
     <string name="monitor_notification_starting">ಪ್ರಾರಂಭಿಸುತ್ತಿದೆ…</string>
     <string name="action_set">ಹೊಂದಿಸಿ</string>
     <string name="action_cancel">ರದ್ದುಮಾಡಿ</string>
-    <string name="label_invalid_input">ಅಮಾನ್ಯ ಇನ್ಪುಟ್</string>
     <string name="action_reset">ಮರುಹೊಂದಿಸಿ</string>
     <string name="label_no_connected_devices">ಯಾವುದೇ ಸಾಧನ ಜೋಡಿಗೊಂಡಿಲ್ಲ</string>
-    <string name="label_status_idle">ನಿಷ್ಕ್ರಿಯ</string>
-    <string name="label_status_adjusting_volumes">ವಾಲ್ಯೂಮ್ ಸರಿಹೊಂದಿಸಲಾಗುತ್ತಿದೆ</string>
-    <string name="label_premium_version">ಪ್ರಿಮಿಯಮ್ ಆವೃತ್ತಿ</string>
     <string name="general_upgrade_action">ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ</string>
     <string name="common_upgrade_required_label">ಅಪ್‌ಗ್ರೇಡ್ ಅಗತ್ಯವಿದೆ</string>
-    <string name="label_premium_version_required">ಪ್ರಿಮಿಯಮ್ ಆವೃತ್ತಿ ಅಗತ್ಯ</string>
-    <string name="description_intro_purpose">ಈ ಅಪ್ಲಿಕೇಶನ್ ನಿಮ್ಮ Android ಸಾಧನಕ್ಕೆ ವಿವಿಧ Bluetooth ಸಾಧನಗಳ ವಾಲ್ಯೂಮ್ ನೆನಪಿಟ್ಟುಕೊಳ್ಳಲು ಅನುಮತಿಸುತ್ತದೆ.</string>
-    <string name="upgrade_benefit_unlimited_devices">ಅಪರಿಮಿತ ಸಾಧನ ಪ್ರೊಫೈಲ್‌ಗಳು</string>
-    <string name="upgrade_benefit_connection_actions">ಸ್ವಯಂಪ್ಲೇ, ಅಪ್ಲಿಕೇಶನ್ ಲಾಂಚ್ ಮತ್ತು ಸಂಪರ್ಕ ಎಚ್ಚರಿಕೆಗಳು</string>
-    <string name="upgrade_benefit_theme_customization">ಥೀಮ್, ಶೈಲಿ ಮತ್ತು ಬಣ್ಣ ಕಸ್ಟಮೈಸೇಶನ್</string>
-    <string name="upgrade_benefit_power_controls">ವಾಲ್ಯೂಮ್ ಲಾಕ್ ಮತ್ತು ದರ ಮಿತಿ</string>
-    <string name="upgrade_benefit_support">ಸ್ವತಂತ್ರ ಅಭಿವೃದ್ಧಿಯನ್ನು ಬೆಂಬಲಿಸಿ</string>
     <string name="upgrade_benefit_equalizer">• ಪ್ರತಿ-ಸಾಧನ ಸಮಾನಕಾರೀ (ವ್ಯವಸ್ಥೆಯ ಸಮಾನಕಾರೀ ಬೆಂಬಲದೊಂದಿಗೆ ಸಂಗೀತ ಅಪ್ಲಿಕೇಶನ್‌ಗಳಿಗೆ)</string>
-    <string name="description_intro_tap_the_button">ನಿಮ್ಮ ಮೊದಲ ಸಾಧನ ಸೇರಿಸುವೊದರಿಂದ ಪ್ರಾರಂಭಿಸಿ.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth ನಿಷ್ಕ್ರಿಯಗೊಳಿಸಲಾಗಿದೆ.</string>
     <string name="title_bluetooth_is_off">Bluetooth ಆಫ್ ಆಗಿದೆ</string>
     <string name="action_enable_bluetooth">Bluetooth ಸಕ್ರಿಯಮಾಡಿ</string>
     <string name="title_bluetooth_permission_required">Bluetooth ಅನುಮತಿ ಅಗತ್ಯ</string>
     <string name="description_bluetooth_permission_required">ನಿಮ್ಮ ಸಾಧನ ವಾಲ್ಯೂಮ್ ನಿರ್ವಹಿಸಲು ಈ ಅಪ್ಗೆ Bluetooth ಅನುಮತಿ ಬೇಕು.</string>
     <string name="action_grant_permission">ಅನುಮತಿ ನೀಡಿ</string>
-    <string name="label_status_listening_for_changes">ವಾಲ್ಯೂಮ್ ಬದಲಾವಣೆಗಳನ್ನು ಕೇಳುತ್ತಿದೆ</string>
     <string name="action_exit">ನಿಂಗಡಿ</string>
-    <string name="action_start">ಪ್ರಾರಂಭಿಸಿ</string>
-    <string name="label_welcome">ಸ್ವಾಗತ</string>
-    <string name="description_intro_contact">ನಿಮ್ಮಗೆ ಪ್ರಶ್ನೆಗಳು ಅಥವಾ ಹೊಸ ವೈಶಿಷ್ಟ್ಯಕ್ಕೆ ಆಲೋಚನೆ ಇದ್ದರೆ ನನ್ನನ್ನು ಸಂಪರ್ಕಿಸಲು ಹಿಂಜಿಕೊಳ್ಳಬೇಡಿ.</string>
-    <string name="label_translation">ಅನುವಾದ</string>
-    <string name="description_help_translate">ಈ ಅಪ್ಅನ್ನು ಇತರ ಭಾಷೆಗಳಲ್ಲಿ ಲಭ್ಯವಾಗಿಸಲು ನನಗೆ ಸಹಾಯಿಸಿ.</string>
     <string name="label_device_speaker">ಸಾಧನ ಸ್ಪೀಕರ್</string>
-    <string name="label_keyevent_playpause">ಪ್ಲೇ-ಪಾಸ್</string>
-    <string name="label_keyevent_play">ಪ್ಲೇ</string>
-    <string name="label_keyevent_next">ಮುಂದಿನದು</string>
-    <string name="label_install_id">ಇನ್‌ಸ್ಟಾಲ್ ಐಡಿ</string>
     <string name="message_copied_to_clipboard">ಕ್ಲಿಪ್ಬೋರ್ಡ್‌ಗೆ ನಕಲಿಸಲಾಯಿತು</string>
-    <string name="label_thanks">ಧನ್ಯವಾದ</string>
-    <string name="label_licenses">ಪರವಾನಗಿಗಳು</string>
-    <string name="description_ring_volume_additional_permission">ರಿಂಗ್ ವಾಲ್ಯೂಮ್ ಬದಲಾಯಿಸಲು ಹೆಚ್ಚಿನ ಅನುಮತಿಗಳು ಅಗತ್ಯ.</string>
-    <string name="label_missing_permissions">ಅನುಮತಿಗಳು ಇಲ್ಲ</string>
-    <string name="action_grant">ನೀಡಿ</string>
-    <string name="label_advanced">ಸುಧಾರಿತ</string>
-    <string name="label_exclude_health">ಆರೋಗ್ಯ ಪ್ರೋಫೈಲ್ಗಳನ್ನು ಹೋಳಿಸಿ</string>
-    <string name="description_exclude_health">ಕೆಲವು Android ಸಾಧನಗಳು \'Health Device\' Bluetooth ಪ್ರೋಫೈಲ್ಗಳನ್ನು (HDP, 0x1400) ಬೆದಕಿದಾಗ ನಿಲ್ಲಿಬಿಡುತ್ತವೆ.</string>
-    <string name="label_exclude_gattserver">GATT ಸರ್ವರ್ ಪ್ರೋಫೈಲ್ಗಳನ್ನು ಹೋಳಿಸಿ</string>
-    <string name="label_exclude_gatt">GATT ಪ್ರೋಫೈಲ್ಗಳನ್ನು ಹೋಳಿಸಿ</string>
-    <string name="description_exclude_gattserver">\'Generic Attribute\' (GATT) ಸರ್ವರ್ ಪ್ರಕಾರದ Bluetooth ಪ್ರೋಫೈಲ್ಗಳನ್ನು ಅನ್ವೇಷಿಸಬೇಡಿ.</string>
-    <string name="description_exclude_gatt">\'Generic Attribute\' (GATT) ಕ್ಲೈಂಟ್ ಪ್ರಕಾರದ Bluetooth ಪ್ರೋಫೈಲ್ಗಳನ್ನು ಅನ್ವೇಷಿಸಬೇಡಿ.</string>
-    <string name="description_waiting_for_devicex">%s ಸಂಪರ್ಕವನ್ನು ಪೂರ್ಣಗೊಳಿಸಲು ಕಾಯುತ್ತಿದೆ</string>
-    <string name="action_undo">ರದ್ದುಮಾಡು</string>
-    <string name="action_show">ತೋರಿಸು</string>
     <string name="action_dismiss">ವಜಾ ಮಾಡು</string>
-    <string name="action_fix">ಸರಿಪಡಿಸು</string>
-    <string name="battery_optimizations_issue_description">ಈ ಅಪ್ಲಿಕೇಶನ್‌ಗೆ ಬ್ಯಾಟರಿ ಆಪ್ಟಿಮೈಸೇಶನ್‌ಗಳು ಸಕ್ರಿಯವಾಗಿವೆ ಮತ್ತು ಇದು ಬ್ಲೂಟೂತ್ ಈವೆಂಟ್‌ಗಳನ್ನು ಸ್ವೀಕರಿಸುವುದರಿಂದ ತಡೆಯಬಹುದು</string>
     <string name="label_bluetooth_settings">ಬ್ಲೂಟೂತ್ ಸೆಟ್ಟಿಂಗ್‌ಗಳು</string>
-    <string name="android10_applaunch_issue_description">Android 10 ಅಪ್ಲಿಕೇಶನ್‌ಗಳನ್ನು ಹಿನ್ನೆಲೆಯಿಂದ ಹೇಗೆ ಪ್ರಾರಂಭಿಸಬಹುದು ಎಂಬುದನ್ನು ನಿರ್ಬಂಧಿಸುತ್ತದೆ</string>
-    <string name="label_opensource">ಮೂಲ ಕೋಡ್</string>
-    <string name="android13_notification_permission_description">ಅಧಿಸೂಚನೆಗಳನ್ನು ಪೋಸ್ಟ್ ಮಾಡಲು ಈ ಅಪ್ಲಿಕೇಶನ್‌ಗೆ ಅನುಮತಿ ನೀಡಿ</string>
-    <string name="privacy_policy_label">ಗೌಪ್ಯತೆ ನೀತಿ</string>
     <string name="managed_devices_empty_message">ಯಾವುದೇ ಬ್ಲೂಟೂತ್ ಸಾಧನಗಳು ಕಾನ್ಫಿಗರ್ ಮಾಡಾಗಿಲ್ಲ.
 ನಿಮ್ಮ ಮೊದಲ ಸಾಧನವನ್ನು ಸೇರಿಸಲು + ಬಟನನ್ನು ಟ್ಯಾಪ್ ಮಾಡಿ</string>
     <string name="label_pro_feature">ಪ್ರಿಮಿಯಂ ವೈಶಿಷ್ಟ್ಯ</string>
@@ -426,21 +345,15 @@
     <string name="review_app_review_action">ವಿಮರ್ಶೆ</string>
     <string name="review_app_dismiss_action">ಬೇಕಾದರೆ ನಂತರ</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">ಖರೀದು ರದ್ದಾಗಿದೆ</string>
-    <string name="error_iap_unavailable_message">ಅಪ್ ಒಳಗೆ ಖರೀದುಗಳು ಲಭ್ಯವಿಲ್ಲ</string>
-    <string name="error_generic_message">ದೋಷ ಸಂಭವಿಸಿದೆ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.</string>
-    <string name="error_iap_owned_message">ನೀವು ಈಗાಗಲೆ ಈ ವಸ್ತುವನ್ನು ಹೊಂದಿದ್ದೀರಿ</string>
     <string name="label_no_devices_title">ಸಾಧನಗಳಿಲ್ಲ</string>
     <string name="bluemusic_mascot_description">ಅಪ್ ಐಕಾನ್</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">ಅಪ್‌ಗಳನ್ನು ಆಯ್ಕೆಮಾಡಿ</string>
     <string name="devices_app_selection_search_hint">ಅಪ್‌ಗಳನ್ನು ಹುಡುಕಿರಿ…</string>
-    <string name="devices_app_selection_currently_selected">ಏಗાದರು ಆಯ್ಕೆಮಾಡಲಾಗಿದೆ</string>
     <string name="devices_app_selection_selected_count">%d ಅಪ್‌ಗಳು ಆಯ್ಕೆಮಾಡಲಾಗಿವೆ</string>
     <string name="general_navigate_back_action">ಹಿಂದೆ ತೆರಳಿ</string>
     <string name="general_reset_action">ಮರುಹೊಂದಿಸು</string>
     <string name="general_clear_action">ತೆರವುಮಾಡು</string>
-    <string name="general_save_action">ಉಳಿಸಿ</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">ಲಾಕ್</string>
     <string name="devices_indicator_awake">ಎಚ್ಚರವಾಗಿರು</string>
@@ -450,7 +363,6 @@
     <string name="devices_indicator_limit">ಮಿತಿ</string>
     <string name="devices_indicator_eq">ಸಮಾನ</string>
     <string name="devices_indicator_boost">ವರ್ಧನೆ</string>
-    <string name="devices_indicator_launch">ಪ್ರಾರಂಭಿಸು</string>
     <string name="devices_indicator_home">ಮುಖಪುಟ</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">ಎಚ್ಚರಿಕೆ</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">이번 업데이트로 인해 일부 디바이스 설정이 재설정되었을 수 있습니다. 디바이스 구성을 확인해 주세요.</string>
     <string name="onboarding_rewrite_action">계속</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">관리되지 않는 디바이스를 찾을 수 없습니다</string>
     <string name="discover_all_devices_managed_msg">모든 페어링된 기기가 이미 관리되고 있어요! 새로운 기기가 필요하신가요?</string>
     <string name="discover_pair_new_device_action">새 기기 페어링</string>
     <string name="discover_device_speaker_desc">이 휴대폰의 자체 스피커입니다. 오디오가 휴대폰으로 전환될 때(예: Bluetooth 기기 연결 해제 후) 음량이 적용됩니다.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">디바이스 설정</string>
-    <string name="devices_device_config_section_general_label">일반</string>
     <string name="devices_device_config_remove_device_label">디바이스 제거</string>
-    <string name="devices_device_config_remove_device_desc">이 앱에서 디바이스를 제거하고 설정을 삭제합니다. 블루투스 페어링은 해제되지 않습니다.</string>
     <string name="devices_device_config_remove_device_action">제거</string>
     <string name="devices_device_config_remove_device_confirmation">관리 디바이스에서 %s를 제거하시겠습니까?</string>
-    <string name="devices_device_config_rename_device_label">디바이스 이름 변경</string>
-    <string name="devices_device_config_rename_device_desc">이 앱 내에서, 그리고 가능하다면 시스템에서도 이 디바이스의 이름을 변경합니다.</string>
     <string name="devices_device_config_rename_device_action">이름 변경</string>
     <string name="devices_device_config_enabled_label">활성화됨</string>
     <string name="devices_device_config_enabled_desc">연결 시 이 기기에 반응</string>
@@ -93,7 +88,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">자동 재생 명령</string>
     <string name="devices_device_config_autoplay_keycodes_order">명령 순서</string>
     <string name="devices_device_config_autoplay_keycodes_label">명령</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">전송할 명령과 순서를 설정합니다</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">설정된 명령 없음</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">명령 추가</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">최대 %1$d개 명령</string>
@@ -119,7 +113,6 @@
     <string name="cd_autoplay_keycode_move_up">위로 이동</string>
     <string name="cd_autoplay_keycode_move_down">아래로 이동</string>
     <string name="cd_autoplay_keycode_remove">제거</string>
-    <string name="devices_device_config_section_volumes_label">볼륨</string>
     <string name="devices_device_config_section_volume_label">음량</string>
     <string name="devices_device_config_alarm_volume_label">알람 음량</string>
     <string name="devices_device_config_alarm_volume_desc">일부 알람 앱은 음악 음량을 사용합니다.</string>
@@ -153,8 +146,6 @@
     <string name="devices_audio_stream_ring_label">벨소리</string>
     <string name="devices_audio_stream_notification_label">알림</string>
     <string name="devices_audio_stream_alarm_label">알람</string>
-    <string name="devices_neverseen_label">마지막 연결 없음</string>
-    <string name="devices_state_connected_label">연결됨</string>
     <string name="devices_last_connected_label">마지막 연결: %s</string>
     <string name="devices_currently_connected_label">현재 연결됨</string>
     <string name="devices_device_disabled_label">기기 비활성화됨</string>
@@ -189,10 +180,7 @@
     <string name="devices_settings_desc">모든 관리 디바이스에 영향을 주는 설정입니다.</string>
     <string name="label_app_enabled">앱 켜짐</string>
     <string name="description_app_enabled">앱이 음량 및 블루투스 관련 이벤트에 반응하도록 켜거나 이를 끌 수 있습니다.</string>
-    <string name="label_visible_volume_adjustments">조절 보이기</string>
-    <string name="description_visible_volume_adjustments">이 앱이 설정을 변경할 때 시스템 음량 창을 표시합니다.</string>
     <string name="label_volume_listener">변경 관측</string>
-    <string name="description_volume_listener">이 앱이 행하지 않은 음량 변경 사항을 저장합니다. 디바이스가 연결되어 있을 때 이 앱이 계속 켜져 있게 됩니다.</string>
     <string name="label_boot_restore">부트 후 복구</string>
     <string name="description_boot_restore">안드로이드가 시작 또는 재시작된 뒤 블루투스 디바이스가 연결되어 있을 경우 음량을 복구합니다.</string>
     <!-- Settings/Support-->
@@ -202,21 +190,11 @@
     <string name="settings_support_wiki_description">BVM을 효과적으로 사용하는 방법을 만나보세요</string>
     <string name="settings_support_issue_tracker_description">버그 신고와 기능 요청을 위한 공개 이슈 추적기입니다.</string>
     <string name="settings_support_issue_tracker_label">이슈 추적기</string>
-    <string name="settings_support_debuglog_label">디버그 로그</string>
     <string name="settings_support_debuglog_desc">앱이 하고 있는 모든 작업을 공유할 수 있는 텍스트 파일로 기록합니다.</string>
-    <string name="settings_support_debuglog_recording_desc">현재 디버그 정보를 기록 중입니다. 기록을 중지하려면 탭하세요.</string>
-    <string name="settings_support_debuglog_path">로그 경로: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">매우 짧은 녹음</string>
     <string name="settings_support_debuglog_short_recording_msg">녹음이 매우 짧았습니다. 디버그 로그는 스냅샷이 아닌 녹음입니다 — 로그가 유용하려면 녹음 중에 문제를 재현하세요.</string>
     <string name="settings_support_debuglog_short_recording_continue">계속 녹음</string>
     <string name="settings_support_debuglog_short_recording_stop">그래도 중지</string>
-    <string name="settings_support_debuglog_folder_label">디버그 로그 폴더</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d 세션, %2$s 사용 중</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">저장된 디버그 로그 없음</string>
-    <string name="settings_support_debuglog_folder_delete_title">모든 디버그 로그를 삭제할까요?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">저장된 모든 디버그 로그 세션이 영구적으로 삭제됩니다.</string>
     <string name="settings_support_discord_label">디스코드</string>
     <string name="settings_support_discord_description">어울리고 질문을 할 수 있는 공간입니다.</string>
     <!-- Settings/Acks-->
@@ -225,16 +203,12 @@
     <string name="settings_acks_translation_header">번역</string>
     <string name="settings_acks_translators_title">번역자</string>
     <string name="settings_acks_translators_people">Annyeong1(yoon0421@hotmail.com)</string>
-    <string name="settings_acks_translate_title">BVM 번역</string>
-    <string name="settings_acks_translate_desc">BVM을 여러분의 언어로 번역하는데 도움을 주세요</string>
     <string name="settings_acks_thanks_header">감사</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">오픈소스 프로젝트의 번역을 지원해주어서</string>
     <string name="settings_licenses_label">라이센스</string>
     <string name="settings_translation_label">번역</string>
     <string name="settings_translation_desc">이 앱을 원하는 언어로 번역하는 데 도움을 주세요</string>
-    <string name="settings_sponsor_development_title">개발 후원</string>
-    <string name="settings_sponsor_development_summary">후원자가 되어 지속적인 개발을 가능하게 해주세요.</string>
     <string name="settings_privacy_policy_label">개인정보처리방침</string>
     <string name="settings_privacy_policy_desc">데이터를 책임감 있게 처리합니다.</string>
     <string name="changelog_label">변경 내역</string>
@@ -256,10 +230,8 @@
     <string name="backup_restore_success_restore">복원 완료 — %1$d개 기기가 복원되었고, %2$d개가 건너뛰어졌습니다.</string>
     <string name="backup_restore_version_warning">이 백업은 버전 %1$s에서 만들어졌습니다. 현재 버전은 %2$s입니다. 일부 설정이 올바르게 복원되지 않을 수 있습니다.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">디버그 알림</string>
     <string name="debug_log_consent_title">디버그 로그</string>
     <string name="debug_log_consent_explanation">이 기능은 앱이 하고 있는 모든 작업을 공유 가능한 파일로 기록합니다. 생성된 파일에는 민감한 정보(예: 파일 이름 및 설치된 앱)가 포함되어 있습니다. 신뢰할 수 있는 당사자(예: 문제를 해결하는 개발자)에게만 공유하세요.</string>
-    <string name="debug_log_recording_progress">디버그 로그 기록 중</string>
     <string name="debug_log_record_action">기록</string>
     <string name="debug_log_stop_action">기록 중지</string>
     <string name="debug_log_screen_title">디버그 로그 레코더</string>
@@ -273,7 +245,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">폐기</string>
     <string name="debug_log_screen_keep_action">보관</string>
-    <string name="debug_log_compressing_label">압축 중…</string>
     <string name="debug_log_file_label">기록된 로그 파일</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">로그를 전송했나요?</string>
@@ -301,7 +272,6 @@
     <string name="contact_description_question_hint">질문을 자세히 설명하세요.</string>
     <string name="contact_category_section_label">카테고리</string>
     <string name="contact_debug_log_label">디버그 로그</string>
-    <string name="contact_debug_log_select_hint">첨부할 디버그 로그 선택</string>
     <string name="contact_debug_log_picker_hint">디버그 로그를 첨부하면 문제를 더 빠르게 진단할 수 있습니다.</string>
     <string name="contact_debug_log_picker_empty">디버그 로그가 없습니다. 먼저 녹음하세요.</string>
     <string name="contact_expected_behavior_label">예상 동작</string>
@@ -314,82 +284,32 @@
     <string name="contact_welcome_msg">모든 메시지를 직접 읽고 최선을 다해 답변드리지만, 혼자 작업하기 때문에 시간이 좀 걸릴 수 있습니다. 기다려 주셔서 감사합니다.</string>
     <string name="contact_footer_msg">메시지는 이메일로 전송됩니다. 기기와 설정 정보가 자동으로 첨부됩니다.</string>
     <string name="contact_no_email_app_msg">이 기기에서 이메일 앱을 찾을 수 없습니다.</string>
-    <string name="contact_attachment_missing_msg">디버그 로그 파일이 더 이상 존재하지 않습니다</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">저장된 디버그 로그</string>
     <string name="settings_support_stored_logs_desc">%1$d 세션 (%2$s)</string>
     <string name="settings_support_stored_logs_empty">저장된 디버그 로그 없음</string>
-    <string name="settings_support_stored_logs_delete_title">저장된 로그를 삭제할까요?</string>
-    <string name="settings_support_stored_logs_delete_msg">저장된 디버그 로그 세션 %1$d개를 모두 삭제합니다.</string>
-    <string name="settings_support_stored_logs_deleted_msg">저장된 디버그 로그가 삭제되었습니다</string>
-    <string name="label_bug_reports">오류 보고</string>
-    <string name="description_bug_reports">오류 및 충돌 보고서를 자동으로 전송합니다.</string>
     <string name="label_add_device">디바이스 추가</string>
-    <string name="label_just_a_moment_please">잠시만 기다려주세요.</string>
     <string name="label_notification_channel_status">상태</string>
     <string name="label_notification_channel_setup">설정 필요</string>
     <string name="monitor_notification_starting">시작 중입니다…</string>
     <string name="action_set">설정</string>
     <string name="action_cancel">취소</string>
-    <string name="label_invalid_input">잘못된 입력</string>
     <string name="action_reset">초기화</string>
     <string name="label_no_connected_devices">연결된 디바이스 없음</string>
-    <string name="label_status_idle">유휴</string>
-    <string name="label_status_adjusting_volumes">음량 조절 중</string>
-    <string name="label_premium_version">프리미엄 버전</string>
     <string name="general_upgrade_action">업그레이드</string>
     <string name="common_upgrade_required_label">업그레이드 필요</string>
-    <string name="label_premium_version_required">프리미엄 버전 필요</string>
-    <string name="description_intro_purpose">이 앱은 안드로이드 디바이스가 각기 다른 블루투스 디바이스의 음량을 기억하도록 해줍니다.</string>
-    <string name="upgrade_benefit_unlimited_devices">무제한 기기 프로필</string>
-    <string name="upgrade_benefit_connection_actions">자동 재생, 앱 실행 및 연결 알림</string>
-    <string name="upgrade_benefit_theme_customization">테마, 스타일 및 색상 사용자 지정</string>
-    <string name="upgrade_benefit_power_controls">볼륨 잠금 및 속도 제한</string>
-    <string name="upgrade_benefit_support">독립 개발 지원</string>
     <string name="upgrade_benefit_equalizer">• 기기별 이퀄라이저 (시스템 이퀄라이저를 지원하는 음악 앱용)</string>
-    <string name="description_intro_tap_the_button">첫 번째 디바이스를 추가하세요.</string>
     <string name="description_bluetooth_is_disabled">블루투스가 꺼져 있습니다.</string>
     <string name="title_bluetooth_is_off">블루투스가 꺼져 있습니다</string>
     <string name="action_enable_bluetooth">블루투스 켜기</string>
     <string name="title_bluetooth_permission_required">블루투스 권한 필요</string>
     <string name="description_bluetooth_permission_required">이 앱은 디바이스 음량을 관리하기 위해 블루투스 권한이 필요합니다.</string>
     <string name="action_grant_permission">권한 허용</string>
-    <string name="label_status_listening_for_changes">음량 변경 감지 중</string>
     <string name="action_exit">나가기</string>
-    <string name="action_start">시작</string>
-    <string name="label_welcome">환영합니다</string>
-    <string name="description_intro_contact">질문 또는 새 기능 제안이 있을 경우 연락해주시기 바랍니다.</string>
-    <string name="label_translation">번역</string>
-    <string name="description_help_translate">이 앱이 다른 언어로도 쓰일 수 있도록 도와주세요.</string>
     <string name="label_device_speaker">디바이스 스피커</string>
-    <string name="label_keyevent_playpause">재생/일시정지</string>
-    <string name="label_keyevent_play">재생</string>
-    <string name="label_keyevent_next">다음</string>
-    <string name="label_install_id">설치 ID</string>
     <string name="message_copied_to_clipboard">클립보드로 복사됨</string>
-    <string name="label_thanks">감사</string>
-    <string name="label_licenses">라이선스</string>
-    <string name="description_ring_volume_additional_permission">벨소리의 음량을 조절하려면 추가 권한이 필요합니다.</string>
-    <string name="label_missing_permissions">권한 없음</string>
-    <string name="action_grant">허가</string>
-    <string name="label_advanced">고급</string>
-    <string name="label_exclude_health">헬스 프로파일 제외</string>
-    <string name="description_exclude_health">일부 안드로이드 디바이스의 경우 \'헬스 디바이스\' 블루투스 프로파일(HDP, 0x1400)을 검색할 때 오류가 발생할 수도 있습니다.</string>
-    <string name="label_exclude_gattserver">GATT 서버 프로파일 제외</string>
-    <string name="label_exclude_gatt">GATT 프로파일 제외</string>
-    <string name="description_exclude_gattserver">\'일반 속성(GATT)\' 서버의 블루투스 프로파일을 조회하지 않습니다.</string>
-    <string name="description_exclude_gatt">\'일반 속성(GATT)\' 클라이언트의 블루투스 프로파일을 조회하지 않습니다.</string>
-    <string name="description_waiting_for_devicex">%s 장치와의 연결이 완료될 때까지 기다리고 있습니다</string>
-    <string name="action_undo">실행 취소</string>
-    <string name="action_show">표시</string>
     <string name="action_dismiss">취소</string>
-    <string name="action_fix">수정</string>
-    <string name="battery_optimizations_issue_description">본 앱이 배터리 최적화에 포함되어 있으며, 블루투스 관련 이벤트를 놓쳐 문제가 발생할 수도 있습니다. 문제가 발생했을 경우 배터리 최적화에서 본 앱을 예외로 지정해보세요.</string>
     <string name="label_bluetooth_settings">블루투스 설정</string>
-    <string name="android10_applaunch_issue_description">안드로이드 10은 앱이 백그라운드에서 실행되는 것을 금지하고 있습니다. 블루투스 디바이스가 연결될 때 앱을 열려면 \&quot;앱 위에서 그리기\&quot; (SYSTEM_ALERT_WINDOW) 권한을 허용해주세요.</string>
-    <string name="label_opensource">소스 코드</string>
-    <string name="android13_notification_permission_description">이 앱에 알림 게시 권한을 허용하세요. 이렇게 하면 앱이 활성화되고 음량이 조정될 때 알림을 표시할 수 있습니다.</string>
-    <string name="privacy_policy_label">개인정보처리방침</string>
     <string name="managed_devices_empty_message">설정된 블루투스 디바이스가 없습니다.\n+ 버튼을 눌러 첫 번째 디바이스를 추가하세요.</string>
     <string name="label_pro_feature">프리미엄 기능</string>
     <plurals name="discover_device_limit_banner">
@@ -419,21 +339,15 @@
     <string name="review_app_review_action">리뷰</string>
     <string name="review_app_dismiss_action">다음에 해요</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">구매 취소됨</string>
-    <string name="error_iap_unavailable_message">인앱 구매를 이용할 수 없습니다</string>
-    <string name="error_generic_message">오류가 발생했습니다. 다시 시도해 주세요.</string>
-    <string name="error_iap_owned_message">이미 이 항목을 소유하고 있습니다</string>
     <string name="label_no_devices_title">디바이스 없음</string>
     <string name="bluemusic_mascot_description">앱 아이콘</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">앱 선택</string>
     <string name="devices_app_selection_search_hint">앱 검색…</string>
-    <string name="devices_app_selection_currently_selected">현재 선택됨</string>
     <string name="devices_app_selection_selected_count">%d개 앱 선택됨</string>
     <string name="general_navigate_back_action">뒤로 이동</string>
     <string name="general_reset_action">재설정</string>
     <string name="general_clear_action">지우기</string>
-    <string name="general_save_action">저장</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">잠금</string>
     <string name="devices_indicator_awake">깨어있음</string>
@@ -443,7 +357,6 @@
     <string name="devices_indicator_limit">제한</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">부스트</string>
-    <string name="devices_indicator_launch">실행</string>
     <string name="devices_indicator_home">홈</string>
     <string name="devices_indicator_dnd">방해금지</string>
     <string name="devices_indicator_alert">알림</string>

--- a/app/src/main/res/values-ky-rKG/strings.xml
+++ b/app/src/main/res/values-ky-rKG/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Жаңыртуу учурунда кээ бир функциялар өзгөрдү. Баардыгы туура конфигурацияланганын текшерүү үчүн түзмөктүн жөндөөлөрүн текшериңиз.</string>
     <string name="onboarding_rewrite_action">Улантуу</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Башкарылбаган түзмөктөр табылган жок</string>
     <string name="discover_all_devices_managed_msg">Бардык жупташтырылган түзмөктөрүңүз башкарылууда! Жаңы бирин кошосузбу?</string>
     <string name="discover_pair_new_device_action">Жаңы түзмөктү жупташтыруу</string>
     <string name="discover_device_speaker_desc">Телефондун өзүнүн докладчы. Анын үндөрү аудио телефонго артка кайтканда колдонулат, мисалы Bluetooth түзмөгүңүз ажыратылгандан кийин.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Түзмөктүн конфигурациясы</string>
-    <string name="devices_device_config_section_general_label">Жалпы</string>
     <string name="devices_device_config_remove_device_label">Түзмөктү унутуу</string>
-    <string name="devices_device_config_remove_device_desc">Бул колдонмодон түзмөктү унутат жана анын конфигурациясын жок кылат. Бул түзмөктү жуптан чыгарбайт.</string>
     <string name="devices_device_config_remove_device_action">Унутуу</string>
     <string name="devices_device_config_remove_device_confirmation">%s башкарылган түзмөктөрдөн унутуу керекпи?</string>
-    <string name="devices_device_config_rename_device_label">Түзмөктүн атын өзгөртүү</string>
-    <string name="devices_device_config_rename_device_desc">Бул колдонмода жана мүмкүн болсо, системада бул түзмөктүн атын өзгөртүңүз.</string>
     <string name="devices_device_config_rename_device_action">Атын өзгөртүү</string>
     <string name="devices_device_config_enabled_label">Иштетилген</string>
     <string name="devices_device_config_enabled_desc">Туташканда бул түзмөккө жооп берүү</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Автоойнотуу буйруктары</string>
     <string name="devices_device_config_autoplay_keycodes_order">Буйрук ырааттуулугу</string>
     <string name="devices_device_config_autoplay_keycodes_label">Буйруктар</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Кайсы буйруктарды жана кандай тартипте жөнөтүүнү конфигурациялаңыз</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Буйруктар конфигурацияланган жок</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Буйрук кошуу</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Максималдуу %1$d буйрук</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Жогору жылдыруу</string>
     <string name="cd_autoplay_keycode_move_down">Ылдый жылдыруу</string>
     <string name="cd_autoplay_keycode_remove">Жок кылуу</string>
-    <string name="devices_device_config_section_volumes_label">Үндөр</string>
     <string name="devices_device_config_section_volume_label">Үн</string>
     <string name="devices_device_config_alarm_volume_label">Ойготкуч үнү</string>
     <string name="devices_device_config_alarm_volume_desc">Кээ бир ойготкуч колдонмолор анын ордуна музыка үнүн колдонот.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Коңгуроо</string>
     <string name="devices_audio_stream_notification_label">Билдирме</string>
     <string name="devices_audio_stream_alarm_label">Ойготкуч</string>
-    <string name="devices_neverseen_label">Эч качан көрүлгөн жок</string>
-    <string name="devices_state_connected_label">Туташкан</string>
     <string name="devices_last_connected_label">Акыркы туташуу: %s</string>
     <string name="devices_currently_connected_label">Учурда туташкан</string>
     <string name="devices_device_disabled_label">Түзмөк өчүрүлгөн</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Бардык башкарылган түзмөктөргө таасир этүүчү жөндөөлөр.</string>
     <string name="label_app_enabled">Колдонмо иштетилген</string>
     <string name="description_app_enabled">Колдонмонун үн жана Bluetooth иш-чараларына жооп берүү жөндөмдүүлүгүн которот.</string>
-    <string name="label_visible_volume_adjustments">Көрүнүктүү тууралоолор</string>
-    <string name="description_visible_volume_adjustments">Бул колдонмо тууралоолор жасап жатканда системанын үн терезесин көрсөтүүгө.</string>
     <string name="label_volume_listener">Өзгөрүүлөрдү байкоо</string>
-    <string name="description_volume_listener">Түзмөк туташып турганда активдүү болуп, бул колдонмо жасабаган үн өзгөртүүлөрүн сактаңыз.</string>
     <string name="label_boot_restore">Жүктөөдө калыбына келтирүү</string>
     <string name="description_boot_restore">Bluetooth түзмөк туташкан болсо, жүктөп/кайра жүктөп алгандан кийин үндү калыбына келтирүү.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM-ди натыйлалуу колдонууну үйрөнүңүз</string>
     <string name="settings_support_issue_tracker_description">Мүчүлүштүктөр боюнча кабарлоолар жана функция суроо-талаптары үчүн коомдук маселе трекери.</string>
     <string name="settings_support_issue_tracker_label">Маселелерди көзөмөлдөгүч</string>
-    <string name="settings_support_debuglog_label">Мүчүлүштүктөрдү оңдоо журналы</string>
     <string name="settings_support_debuglog_desc">Колдонмо жасап жаткан бардык нерсени бөлүшө турган текст файлына жазыңыз.</string>
-    <string name="settings_support_debuglog_recording_desc">Учурда мүчүлүштүктөрдү оңдоо маалымат жазылып жатат. Жазуону токтотуу үчүн басыңыз.</string>
-    <string name="settings_support_debuglog_path">Журнал жолу: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Өтө кыска жазуу</string>
     <string name="settings_support_debuglog_short_recording_msg">Бул өтө кыска жазуу болду. Мүчүлүштүктөрдү оңдоо журналдар — сүрөт эмес, жазуулар — журнал пайдалуу болуш үчүн жазуу активдүү болгонда маселени кайра чыгарыңыз.</string>
     <string name="settings_support_debuglog_short_recording_continue">Жазууну улантуу</string>
     <string name="settings_support_debuglog_short_recording_stop">Баары бир токтотуу</string>
-    <string name="settings_support_debuglog_folder_label">Мүчүлүштүктөрдү оңдоо журналдарынын папкасы</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d сессия %2$s колдонуп</item>
-        <item quantity="other">%1$d сессия %2$s колдонуп</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Мүчүлүштүктөрдү оңдоо журналдары сакталган жок</string>
-    <string name="settings_support_debuglog_folder_delete_title">Бардык мүчүлүштүктөрдү оңдоо журналдарын жок кылуу керекпи?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Бул сакталган бардык мүчүлүштүктөрдү оңдоо журнал сессияларын биротоло жок кылат.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Эс алуу жана суроолорду берүү үчүн жай.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Котормо</string>
     <string name="settings_acks_translators_title">Котормочулар</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM котормосуна жардам берүү</string>
-    <string name="settings_acks_translate_desc">BVM-ди өз тилиңизге которууга жардам берүү</string>
     <string name="settings_acks_thanks_header">Ыракмат</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Ачык кодду колдонгон долбоорлордун котормосун колдоо үчүн</string>
     <string name="settings_licenses_label">Лицензиялар</string>
     <string name="settings_translation_label">Котормо</string>
     <string name="settings_translation_desc">Колдонмону сүйүктүү тилиңизге которууга жардам берүү</string>
-    <string name="settings_sponsor_development_title">Иштеп чыгууну колдоо</string>
-    <string name="settings_sponsor_development_summary">Патрон болуп, иштеп чыгуунун улануусуна мүмкүнчүлүк берүү.</string>
     <string name="settings_privacy_policy_label">Купуялык саясаты</string>
     <string name="settings_privacy_policy_desc">Маалыматтарды жоопкерчилик менен иштетүү.</string>
     <string name="changelog_label">Өзгөртүүлөр журналы</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Калыбына келтирүү аякталды — %1$d түзмөк калыбына келтирилди, %2$d өткөрүлдү.</string>
     <string name="backup_restore_version_warning">Бул камдык көчүрмө %1$s нүскасы менен жасалды. Сиз %2$s нүскасын колдонудасыз. Кэйбир жөндөөлөр туура калыбына келтирилбашы мүмкүн.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Мүчүлүштүктөрдү оңдоо билдирүүлөрү</string>
     <string name="debug_log_consent_title">Мүчүлүштүктөрдү оңдоо журналы</string>
     <string name="debug_log_consent_explanation">Бул функция колдонмонун жасап жаткан бардык нерсесин бөлүшүүгө болгон файлга жазып турат. Жаратылган файл купуя маалыматты камтыйт (мис., файл аттары жана орнотулган колдонмолор). Аны ишенимдүү тараптар менен гана бөлүшүңүз (мис., маселени чечүүчү иштеп чыгуучу).</string>
-    <string name="debug_log_recording_progress">Мүчүлүштүктөрдү оңдоо журналын жазуу</string>
     <string name="debug_log_record_action">Жазуу</string>
     <string name="debug_log_stop_action">Жаздырууну токтотуу</string>
     <string name="debug_log_screen_title">Мүчүлүштүктөрдү оңдоо журналы жаздыруучу</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Ыргытуу</string>
     <string name="debug_log_screen_keep_action">Сактоо</string>
-    <string name="debug_log_compressing_label">Кысылууда…</string>
     <string name="debug_log_file_label">Жазылган журнал файлы</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Журнал жөнөтүлдүбү?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Суроонузду толук сүрөттөңүз.</string>
     <string name="contact_category_section_label">Категория</string>
     <string name="contact_debug_log_label">Мүчүлүштүктөрдү оңдоо журналы</string>
-    <string name="contact_debug_log_select_hint">Тиркөө үчүн мүчүлүштүктөрдү оңдоо журналын тандаңыз</string>
     <string name="contact_debug_log_picker_hint">Маселени тезирээк аныктоога жардам берүү үчүн мүчүлүштүктөрдү оңдоо журналын тиркеңиз.</string>
     <string name="contact_debug_log_picker_empty">Мүчүлүштүктөрдү оңдоо журналдары жок. Алгач бирин жаздырыңыз.</string>
     <string name="contact_expected_behavior_label">Күтүлгөн жүрүм-туруму</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Ар бир билдирүүнү өзүм окуйм жана жооп берүүгө аракет кылам, бирок муну жалгыз жасагандыктан, бир аз убакыт кетиши мүмкүн. Чыдамкайлыгыңыз үчүн ыракмат.</string>
     <string name="contact_footer_msg">Билдирүүңүз электрондук кат аркылуу менен жөнөтүлөт. Түзмөк жана орнотуу маалыматы автоматтык түрдө тиркелет.</string>
     <string name="contact_no_email_app_msg">Бул түзмөктө электрондук почта колдонмосу табылган жок.</string>
-    <string name="contact_attachment_missing_msg">Мүчүлүштүктөрдү оңдоо журнал файлы мындан ары жок</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Сакталган мүчүлүштүктөрдү оңдоо журналдары</string>
     <string name="settings_support_stored_logs_desc">%1$d сессия (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Сакталган мүчүлүштүктөрдү оңдоо журналдары жок</string>
-    <string name="settings_support_stored_logs_delete_title">Сакталган журналдарды жок кылуу керекпи?</string>
-    <string name="settings_support_stored_logs_delete_msg">Бул сакталган бардык %1$d мүчүлүштүктөрдү оңдоо журнал сессияларын жок кылат.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Сакталган мүчүлүштүктөрдү оңдоо журналдары жок кылынды</string>
-    <string name="label_bug_reports">Мүчүлүштүктөр боюнча кабарлоолор</string>
-    <string name="description_bug_reports">Автоматтык мүчүлүштүктөр жана бузулуулар боюнча кабарлоо.</string>
     <string name="label_add_device">Түзмөк кошуу</string>
-    <string name="label_just_a_moment_please">Бир мүнөт, сураныч.</string>
     <string name="label_notification_channel_status">Абал</string>
     <string name="label_notification_channel_setup">Тууралоо талап кылынат</string>
     <string name="monitor_notification_starting">Иштелип жатат…</string>
     <string name="action_set">Коюуу</string>
     <string name="action_cancel">Жокко чыгаруу</string>
-    <string name="label_invalid_input">Жараксыз киргизүү</string>
     <string name="action_reset">Баштапкы абалга келтирүү</string>
     <string name="label_no_connected_devices">Туташкан түзмөктөр жок</string>
-    <string name="label_status_idle">Бош</string>
-    <string name="label_status_adjusting_volumes">Үндөрдү тууралап жатат</string>
-    <string name="label_premium_version">Премиум нускасы</string>
     <string name="general_upgrade_action">Жаңыртуу</string>
     <string name="common_upgrade_required_label">Жаңылануу кажет</string>
-    <string name="label_premium_version_required">Премиум нускасы талап кылынат</string>
-    <string name="description_intro_purpose">Бул колдонмо Android түзмөгүңҿзгө ар кандай Bluetooth түзмөктөрүнүн үн деңгээлдерин эстеп калууга мүмкүндүк берет.</string>
-    <string name="upgrade_benefit_unlimited_devices">Чексиз түзмөк профилдери</string>
-    <string name="upgrade_benefit_connection_actions">Автоойнотуу, колдонмо ишке жүгүртүү жана кошулуу ескертүүләри</string>
-    <string name="upgrade_benefit_theme_customization">Тема, стиль жана түс теңдеөлөө</string>
-    <string name="upgrade_benefit_power_controls">Үн кулпусу жана жылдамдык чектөө</string>
-    <string name="upgrade_benefit_support">Тәуэлсиз жаштаоону колдоо</string>
     <string name="upgrade_benefit_equalizer">• Ар бир түзмөк үчүн эквалайзер (системалык эквалайзерди колдогон музыка колдонмолору үчүн)</string>
-    <string name="description_intro_tap_the_button">Биринчи түзмөгүңүздү кошуудан баштаңыз.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth өчүрүлгөн.</string>
     <string name="title_bluetooth_is_off">Bluetooth өчүк</string>
     <string name="action_enable_bluetooth">Bluetooth иштетүү</string>
     <string name="title_bluetooth_permission_required">Bluetooth Уруксаты Талап Кылынат</string>
     <string name="description_bluetooth_permission_required">Бул колдонмо түзмөгүңүздүн үн деңгээлдерин башкаруу үчүн Bluetooth уруксатын талап кылат.</string>
     <string name="action_grant_permission">Уруксат берүү</string>
-    <string name="label_status_listening_for_changes">Үн өзгөртүүлөрдү угуп жатат</string>
     <string name="action_exit">Чыгуу</string>
-    <string name="action_start">Баштоо</string>
-    <string name="label_welcome">Кош келдиңиз</string>
-    <string name="description_intro_contact">Суроолоруңуз болсо же жаңы функция үчүн идея болсо, байланышуудан тартынбаңыз.</string>
-    <string name="label_translation">Котормо</string>
-    <string name="description_help_translate">Бул колдонмону башка тилдерде жеткиликтүү кылууга жардам бериңиз.</string>
     <string name="label_device_speaker">Түзмөктүн динамиги</string>
-    <string name="label_keyevent_playpause">Ойнотуу-Токтотуу</string>
-    <string name="label_keyevent_play">Ойнотуу</string>
-    <string name="label_keyevent_next">Кийинки</string>
-    <string name="label_install_id">Орнотуу ID</string>
     <string name="message_copied_to_clipboard">Алмашуу буферине көчүрүлдү</string>
-    <string name="label_thanks">Ыракмат</string>
-    <string name="label_licenses">Лицензиялар</string>
-    <string name="description_ring_volume_additional_permission">Коңгуроо үнүн өзгөртүү үчүн кошумча уруксаттар талап кылынат.</string>
-    <string name="label_missing_permissions">Жок уруксаттар</string>
-    <string name="action_grant">Берүү</string>
-    <string name="label_advanced">Өнүккөн</string>
-    <string name="label_exclude_health">Ден соолук профилдерин алып салуу</string>
-    <string name="description_exclude_health">Кээ бир Android түзмөктөр \'Health Device\' Bluetooth профилдерин (HDP, 0x1400) издегенде тоңуп калат.</string>
-    <string name="label_exclude_gattserver">GATT сервер профилдерин алып салуу</string>
-    <string name="label_exclude_gatt">GATT профилдерин алып салуу</string>
-    <string name="description_exclude_gattserver">\'Generic Attribute\' (GATT) серверинин Bluetooth профилдерине суроо жибербеңиз.</string>
-    <string name="description_exclude_gatt">\'Generic Attribute\' (GATT) клиентинин Bluetooth профилдерине суроо жибербеңиз.</string>
-    <string name="description_waiting_for_devicex">%s туташууну аяктаосун күтүп жатат</string>
-    <string name="action_undo">Кайтаруу</string>
-    <string name="action_show">Көрсөтүү</string>
     <string name="action_dismiss">Жабуу</string>
-    <string name="action_fix">Оңдоо</string>
-    <string name="battery_optimizations_issue_description">Бул колдонмо үчүн батарея оптимизациялары иштетилген жана Bluetooth окуяларын алуудан тоскоол болушу мүмкүн. Эгер көйгөйлөрдү башынан кечирип жатсаңыз, оптимизацияларды өчүрүп коюуну карап көрүңүз.</string>
     <string name="label_bluetooth_settings">Bluetooth жөндөөлөрү</string>
-    <string name="android10_applaunch_issue_description">Android 10 колдонмолордун фондон кантип иштетилишин чектейт. Bluetooth түзмөгү туташканда колдонмолорду ачууга уруксат берүү үчүн \"Башка колдонмолордун үстүндө көрсөтүү\" (SYSTEM_ALERT_WINDOW) уруксатын бериңиз.</string>
-    <string name="label_opensource">Баштапкы код</string>
-    <string name="android13_notification_permission_description">Бул колдонмого билдирмелерди жарыялоого уруксат бериңиз. Бул колдонмо активдүү болуп, үн деңгелин өзгөртүүлөр жасалып жатканда билдирме көрсөтүүгө мүмкүндүк берет.</string>
-    <string name="privacy_policy_label">Купуялык саясаты</string>
     <string name="managed_devices_empty_message">Bluetooth түзмөктөрү конфигурацияланган эмес.\n+ баскычын таптап, биринчи түзмөгүңүздү кошуңуз.</string>
     <string name="label_pro_feature">Премиум функция</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Рецензия</string>
     <string name="review_app_dismiss_action">Кийин</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Сатып алуу бекер кылынды</string>
-    <string name="error_iap_unavailable_message">Колдонмо ишинде сатып алуу мүмкүн эмес</string>
-    <string name="error_generic_message">Кате көйгөл чыкты. Кайра аракет көрүңүз.</string>
-    <string name="error_iap_owned_message">Бул зат сизде бар</string>
     <string name="label_no_devices_title">Түзмөктөр жок</string>
     <string name="bluemusic_mascot_description">Колдонмо сүрөтү</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Колдонмолорду тандоо</string>
     <string name="devices_app_selection_search_hint">Колдонмолорду издөө…</string>
-    <string name="devices_app_selection_currently_selected">Азыркы тандалган</string>
     <string name="devices_app_selection_selected_count">%d колдонмо тандалды</string>
     <string name="general_navigate_back_action">Артка кайтуу</string>
     <string name="general_reset_action">Баштан баштоо</string>
     <string name="general_clear_action">Тазалоо</string>
-    <string name="general_save_action">Сактоо</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Күлүп</string>
     <string name="devices_indicator_awake">Уюктанбай</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Чектөө</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Көтөрүү</string>
-    <string name="devices_indicator_launch">Ишке салуу</string>
     <string name="devices_indicator_home">Баш бет</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Деңгюул</string>

--- a/app/src/main/res/values-lo-rLA/strings.xml
+++ b/app/src/main/res/values-lo-rLA/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">ບາງຟີເຈີໄດ້ປ່ຽນແປງໃນລະຫວ່າງການອັບເດດ. ກະລຸນາກວດສອບການຕັ້ງຄ່າອຸປະກອນຂອງທ່ານເພື່ອໃຫ້ທຸກຢ່າງຖືກຕັ້ງຄ່າຢ່າງຖືກຕ້ອງ.</string>
     <string name="onboarding_rewrite_action">ສືບຕໍ່</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">ບໍ່ພົບອຸປະກອນທີ່ບໍ່ໄດ້ຈັດການ</string>
     <string name="discover_all_devices_managed_msg">ອຸປະກອນທີ່ຈັບຄູ່ທັງໝົດຂອງທ່ານຖືກຈັດການແລ້ວ! ຕ້ອງການໃໝ່ບໍ?</string>
     <string name="discover_pair_new_device_action">ຈັບຄູ່ອຸປະກອນໃໝ່</string>
     <string name="discover_device_speaker_desc">ລຳໂພງຂອງໂທລະສັບນີ້ເອງ. ລະດັບສຽງຂອງມັນຖືກໃຊ້ໃນເວລາທີ່ສຽງກັບຄືນສູ່ໂທລະສັບ, ຕົວຍ່າງ ໜຼັງຈາກທີ່ອຸປະກອນ Bluetooth ຂອງທ່ານຕັດການເຊື່ອມຕໍ່.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ການຕັ້ງຄ່າອຸປະກອນ</string>
-    <string name="devices_device_config_section_general_label">ທົ່ວໄປ</string>
     <string name="devices_device_config_remove_device_label">ລືມອຸປະກອນ</string>
-    <string name="devices_device_config_remove_device_desc">ລືມອຸປະກອນຈາກແອັບນີ້ ແລະລົບການຕັ້ງຄ່າຂອງມັນ. ການນີ້ບໍ່ໄດ້ຖອດການຈັບຄູ່ອຸປະກອນ.</string>
     <string name="devices_device_config_remove_device_action">ລືມ</string>
     <string name="devices_device_config_remove_device_confirmation">ລືມ %s ຈາກອຸປະກອນທີ່ຈັດການບໍ?</string>
-    <string name="devices_device_config_rename_device_label">ເປລີ່ຍຊື່ອຸປະກອນ</string>
-    <string name="devices_device_config_rename_device_desc">ເປລີ່ຍຊື່ອຸປະກອນນີ້ພາຍໃນແອັບນີ້ ແລະຖ້າເປັນໄປໄດ້ ເພື່ອໃນລະບົບດ້ວຍ.</string>
     <string name="devices_device_config_rename_device_action">ເປລີ່ຍຊື່</string>
     <string name="devices_device_config_enabled_label">ເອີນໃຊ້ງານ</string>
     <string name="devices_device_config_enabled_desc">ຕອບສນອງຕ່ອອຸປະກອນນີ້ເມື່ອຕ່ອ</string>
@@ -93,7 +88,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">ຄຳສັ່ງຫຼິ້ນອັດຕະໂນມັດ</string>
     <string name="devices_device_config_autoplay_keycodes_order">ລຳດັບຄຳສັ່ງ</string>
     <string name="devices_device_config_autoplay_keycodes_label">ຄຳສັ່ງ</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">ຕັ້ງຄ່າວ່າຈະສົ່ງຄຳສັ່ງໃດ ແລະ ລຳດັບໃດ</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">ຍັງບໍ່ໄດ້ຕັ້ງຄ່າຄຳສັ່ງ</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">ເພີ່ມຄຳສັ່ງ</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">ສູງສຸດ %1$d ຄຳສັ່ງ</string>
@@ -119,7 +113,6 @@
     <string name="cd_autoplay_keycode_move_up">ຍ້າຍຂຶ້ນ</string>
     <string name="cd_autoplay_keycode_move_down">ຍ້າຍລົງ</string>
     <string name="cd_autoplay_keycode_remove">ເອົາອອກ</string>
-    <string name="devices_device_config_section_volumes_label">ລະດັບສຽງ</string>
     <string name="devices_device_config_section_volume_label">ລະດັບສຽງ</string>
     <string name="devices_device_config_alarm_volume_label">ລະດັບສຽງເຕືອນ</string>
     <string name="devices_device_config_alarm_volume_desc">ແອັບເຕືອນບາງອັນໃຊ້ລະດັບສຽງດນຕຳແທນ.</string>
@@ -153,8 +146,6 @@
     <string name="devices_audio_stream_ring_label">ເວົ້າ</string>
     <string name="devices_audio_stream_notification_label">ການແຈ້ງ</string>
     <string name="devices_audio_stream_alarm_label">ເຕືອນ</string>
-    <string name="devices_neverseen_label">ບໍ່ເຄີຍພົບເຫັນ</string>
-    <string name="devices_state_connected_label">ຕ່ອອຍູ່</string>
     <string name="devices_last_connected_label">ຕ່ອລ່າສຸດ: %s</string>
     <string name="devices_currently_connected_label">ຕ່ອອຍູ່ໃນຂະນີ້</string>
     <string name="devices_device_disabled_label">ອຸປະກອນຖືກປິດໃຊ້ງານ</string>
@@ -189,10 +180,7 @@
     <string name="devices_settings_desc">ການຕັ້ງຄ່າທີ່ສ່ງຜລຕ່ອທຸກອຸປະກອນທີ່ຈັດການ.</string>
     <string name="label_app_enabled">ເອີນໃຊ້ງານແອັບ</string>
     <string name="description_app_enabled">ໂຕໂກ້ການຕອບສນອງຕ່ອລະດັບສຽງ ແລະເຫດການ Bluetooth ຂອງແອັບ.</string>
-    <string name="label_visible_volume_adjustments">ການປັບແບບແສດງຜລ</string>
-    <string name="description_visible_volume_adjustments">ແສດງຫນ້າຕ່າງລະດັບສຽງຂອງລະບົບໃນຂະທີ່ແອັບນີ້ປັບ.</string>
     <string name="label_volume_listener">ສັງເກດການປ່ຽນແປງ</string>
-    <string name="description_volume_listener">ສັກກະວະໃນຂະທີ່ອຸປະກອນຕ່ອ ແລະບັນທຶກການປ່ຽນແປງລະດັບສຽງທີ່ບໍ່ໄດ້ເກີດຈາກແອັບນີ້.</string>
     <string name="label_boot_restore">ຄືນຄ່າຕອນເປີດເຣືອນ</string>
     <string name="description_boot_restore">ຄືນຄ່າລະດັບສຽງຫລັງຈາກການເປີດເຣືອນ/ເປີດເຣືອນໃໝ່ ຖ້າອຸປະກອນ Bluetooth ຕ່ອອຍູ່.</string>
     <!-- Settings/Support-->
@@ -202,21 +190,11 @@
     <string name="settings_support_wiki_description">ເລີຍນຮູ້ການໃຊ້ BVM ຢ່າງມີປຶຜລ</string>
     <string name="settings_support_issue_tracker_description">ຕົວຕິດຕາມບັນຫາສາທາລະນະສໍາລັບການລາຍງານຂໍ້ຜິດພາດ ແລະ ການຮ້ອງຂໍ feature.</string>
     <string name="settings_support_issue_tracker_label">ຕົວຕິດຕາມບັນຫາ</string>
-    <string name="settings_support_debuglog_label">ບັນທຶກ debug</string>
     <string name="settings_support_debuglog_desc">ບັນທຶກທຸກສິ່ງທີ່ແອັບກໍາລັງເຮັດໃສ່ໄຟລ໌ຂໍ້ຄວາມທີ່ທ່ານສາມາດແບ່ງປັນໄດ້.</string>
-    <string name="settings_support_debuglog_recording_desc">ກຳລັງບັນທຶກຂໍ້ມູນການແກ້ບັດ. ກດເພື່ອຫຍຸດການບັນທຶກ.</string>
-    <string name="settings_support_debuglog_path">ເສ້ນທາງລຶກ: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">ການບັນທຶກສັ້ນຫລາຍ</string>
     <string name="settings_support_debuglog_short_recording_msg">ນັ້ນເປັນການບັນທຶກສັ້ນຫລາຍ. ລຶກການແກ້ບັດເປັນການບັນທຳ6ກ ບໍ່ໃຊ້ເປັນອີກພາບ ເພຳ7່ອໃຫ້ລຳ6ກມີປຳ6ຟລ ໃຫ້ສຳ6ບປັຍຫາຂະທຳ5່ການບັນທຳ6ກຍັງທຳງານຢູ່.</string>
     <string name="settings_support_debuglog_short_recording_continue">ບັນທຶກຕໍ່ໄປ</string>
     <string name="settings_support_debuglog_short_recording_stop">ຢຸດເທົ່ານັ້ນ</string>
-    <string name="settings_support_debuglog_folder_label">ໂຟລເດີລຶກ debug</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d ເຊດຊັ່ນ ໃຊ້ %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">ບໍ່ມີລຶກ debug ຖືກບັນທຶກໄວ້</string>
-    <string name="settings_support_debuglog_folder_delete_title">ລຶບລຶກ debug ທັງໝົດບໍ?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">ອັນນີ້ຈະລຶບລະບົບລຶກ debug ທີ່ຖືກບັນທຶກໄວ້ທັງໝົດຢ່າງຖາວອນ.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">ສະຖານທີ່ສໍາລັບພັກຜ່ອນແລະຖາມຄໍາຖາມ.</string>
     <!-- Settings/Acks-->
@@ -225,16 +203,12 @@
     <string name="settings_acks_translation_header">ການແປພາສາ</string>
     <string name="settings_acks_translators_title">ຜູ້ແປ</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">ແປວ BVM</string>
-    <string name="settings_acks_translate_desc">ຊ່ວຍແປວ BVM ໃຫ້ເປັນພາສາຂອງທ່ານ</string>
     <string name="settings_acks_thanks_header">ຂອບໃຈ</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">ສຳຫລັບການສນັບສະນູນການແປວ່2ຄງການພຶງດ້ວຍການໄ1ປວຂອງໄ2ຄງການພຶງ open-source</string>
     <string name="settings_licenses_label">ໃບອະນຸຍາດ</string>
     <string name="settings_translation_label">ການແປພາສາ</string>
     <string name="settings_translation_desc">ຊ່ວຍແປວແອັບໃຫ້ເປັນພາສາທີ່ທ່ານຊອບ</string>
-    <string name="settings_sponsor_development_title">ສະໜັບສະໜູນການພັດທະນາ</string>
-    <string name="settings_sponsor_development_summary">ເປັນຜູ້ອຸປະຖໍາແລະເຮັດໃຫ້ການພັດທະນາສືບຕໍ່ໄດ້.</string>
     <string name="settings_privacy_policy_label">ນະໂຍບາຍຄວາມເປັນສ່ວນຕົວ</string>
     <string name="settings_privacy_policy_desc">ການຈັດການຂໍ້ມູນຢ່າງມີຄວາມຮັບຜິດຊອບ.</string>
     <string name="changelog_label">ບັນຊີການປ່ຽນແປງ</string>
@@ -256,10 +230,8 @@
     <string name="backup_restore_success_restore">ກູ້ຄືນສຳເລັດ — ກູ້ %1$d ອຸປະກອນ, ຂ້າມ %2$d.</string>
     <string name="backup_restore_version_warning">ການສຳຮອງນີ້ຖືກສ້າງດ້ວຍເວີຊັນ %1$s. ທ່ານກຳລັງໃຊ້ %2$s. ການຕັ້ງຄ່າບາງຢ່າງອາດກູ້ຄືນໄດ້ບໍ່ຖືກຕ້ອງ.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">ການແຈ້ງເຕືອນດີບັກ</string>
     <string name="debug_log_consent_title">ບັນທຶກ debug</string>
     <string name="debug_log_consent_explanation">ຄຸນສົມບັດນີ້ບັນທຶກທຸກສິ່ງທີ່ແອັບກຳລັງເຮັດໃສ່ໄຟລ໌ທີ່ສາມາດແບ່ງປັນໄດ້. ໄຟລ໌ທີ່ສ້າງຂຶ້ນມີຂໍ້ມູນທີ່ລະອຽດອ່ອນ (ເຊັ່ນ: ຊື່ໄຟລ໌ ແລະ ແອັບທີ່ຕິດຕັ້ງ). ແບ່ງປັນກັບພາກສ່ວນທີ່ເຊື່ອຖືໄດ້ເທົ່ານັ້ນ (ເຊັ່ນ: ນັກພັດທະນາທີ່ແກ້ໄຂບັນຫາ).</string>
-    <string name="debug_log_recording_progress">ກຳລັງບັນທຶກບັນທຶກດີບັກ</string>
     <string name="debug_log_record_action">ບັນທຳ6ກ</string>
     <string name="debug_log_stop_action">ຢຸດການບັນທຶກ</string>
     <string name="debug_log_screen_title">ຕັວບັນທຳ6ກລຳ6ກ debug</string>
@@ -273,7 +245,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">ທິ້ງ</string>
     <string name="debug_log_screen_keep_action">ເກັບໄວ້</string>
-    <string name="debug_log_compressing_label">ກຳລັງອັດອານສຶປສຶບ...</string>
     <string name="debug_log_file_label">ໄຟລ໌ບັນທຶກທີ່ບັນທຶກໄວ້</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">ສ່ງລຳ6ກແລ້ວບໍ?</string>
@@ -301,7 +272,6 @@
     <string name="contact_description_question_hint">ອິບາຍຄຳຖາມຂອງທ່ານແບບລະອີຍດ.</string>
     <string name="contact_category_section_label">ຫມວດຫມູ່</string>
     <string name="contact_debug_log_label">ບັນທຶກ debug</string>
-    <string name="contact_debug_log_select_hint">ເລືອກລຳ6ກ debug ເພື່ອແນບ</string>
     <string name="contact_debug_log_picker_hint">ແນບລຳ6ກ debug ເພື່ອຊ່ວຍຕວຜນພ່ອງທີ່ໄວຂຶ້ນ.</string>
     <string name="contact_debug_log_picker_empty">ບໍ່ມີລຳ6ກ debug ພອ້ມ. ບັນທຳ6ກອັນໝຶ່ງກ່ອນ.</string>
     <string name="contact_expected_behavior_label">ພະຕິການທີ່ຄາດຫວັງ</string>
@@ -314,82 +284,32 @@
     <string name="contact_welcome_msg">ຂ້ອຍອ່ານທຸກຂໍ້ຄວາມດ້ວຍຕັວເອງ ແລະພະຍາຍຕອບສນອງເທົາທີ່ເປັນໄປໄດ້ ແຕ່เນື່ອງຂ້ອຍທຳງານຜູ້ເດີຍວ ມັນອາດໃຊ້ເວລາພອສມ. ຂອບຄຸນສଳຫລັບຄວາມເຂົ້າໃຈຂອງທ່ານ.</string>
     <string name="contact_footer_msg">ຂໍ້ຄວາມຂອງທ່ານຈະຖືກສ່ງຜ່ານອີເມລ. ຂໍ້ມູນອຸປະກອນແລະການຕັ້ງຄ່າຖືກແນບອັດຕາ.</string>
     <string name="contact_no_email_app_msg">ບໍ່ພົບແອັບອີເມລບນອຸປະກອນນີ້.</string>
-    <string name="contact_attachment_missing_msg">ໄຟລລຳ6ກ debug ບໍ່ມີອຍູ່ອີກເລີ່ຍ</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">ລຳ6ກ debug ทີ່ບັນທຳ6ກໄ4ວ້</string>
     <string name="settings_support_stored_logs_desc">%1$d ເຊດຊັ່ນ (%2$s)</string>
     <string name="settings_support_stored_logs_empty">ບໍ່ມີລຳ6ກ debug ທີ່ບັນທຳ6ກໄ4ວ້</string>
-    <string name="settings_support_stored_logs_delete_title">ລົບລຳ6ກທີ່ບັນທຳ6ກໄ4ວ້ບໍ?</string>
-    <string name="settings_support_stored_logs_delete_msg">ອັນນີ້ຈະລົບເຊດຊັ່ນລຳ6ກ debug ທີ່ບັນທຳ6ກໄ4ວ້ທັງ %1$d.</string>
-    <string name="settings_support_stored_logs_deleted_msg">ລຳ6ກ debug ทີ່ບັນທຳ6ກໄ4ວ້ຖືກລົບແລ້ວ</string>
-    <string name="label_bug_reports">ຣາຍງານຂໍ້ບົກພົບ</string>
-    <string name="description_bug_reports">ການຣາຍງານຂໍ້ບົກພົບແລະການກາກເຫລວອັດຕາ.</string>
     <string name="label_add_device">ເພີ່ມອຸປະກອນ</string>
-    <string name="label_just_a_moment_please">ສ଱ກຄູ່ ກະລຸນາ.</string>
     <string name="label_notification_channel_status">ສະຖານະ</string>
     <string name="label_notification_channel_setup">ຕ້ອງຕັ້ງຄ່າ</string>
     <string name="monitor_notification_starting">ກຳລັງເລີ່ມຕົ້ນ...</string>
     <string name="action_set">ຕັ້ງ</string>
     <string name="action_cancel">ຍົກເລີກ</string>
-    <string name="label_invalid_input">ຂໍ້ມູນທີ່ປ້ອນບໍ່ຖືກຕ້ອງ</string>
     <string name="action_reset">ຣີເຊັດ</string>
     <string name="label_no_connected_devices">ບໍ່ມີອຸປະກອນຕ່ອ</string>
-    <string name="label_status_idle">ວ່າງ</string>
-    <string name="label_status_adjusting_volumes">ກຳລັງປັບລະດັບສຽງ</string>
-    <string name="label_premium_version">ເວີຊັນພຣີເມີຍມ</string>
     <string name="general_upgrade_action">ອັບເກຣດ</string>
     <string name="common_upgrade_required_label">ຕ້ອງການອັບເກຣດ</string>
-    <string name="label_premium_version_required">ຕ້ອງການໄ0ວີຊັນພຣີໄ0ມີຍມ</string>
-    <string name="description_intro_purpose">ແອັບນີ້ອະນຸຍາດໃຫ້ອຸປະກອນ Android ຂອງທ່ານຈດຈຳລະດັບສຽງຂອງອຸປະກອນ Bluetooth ຕ່າງๆ</string>
-    <string name="upgrade_benefit_unlimited_devices">ໂປຣໄຟລ໌ອຸປະກອນບໍ່ຈຳກັດ</string>
-    <string name="upgrade_benefit_connection_actions">ຫຼິ້ນອັດຕະໂນມັດ, ເປີດແອັບ ແລະ ການແຈ້ງເຕືອນການເຊື່ອມຕໍ່</string>
-    <string name="upgrade_benefit_theme_customization">ການປັບແຕ່ໝົດໂຖກ, ສໄຕລ໌ ແລະ ສີ</string>
-    <string name="upgrade_benefit_power_controls">ການລັອກລະດັບສຽງ ແລະ ການຈຳກັດອັດຕະ</string>
-    <string name="upgrade_benefit_support">ສະໝັບສະໝູນການພັດທະນາອິດສະຫຼະ</string>
     <string name="upgrade_benefit_equalizer">• ອີຄິວອລາຍເຊີສະເພາະແຕ່ລະອຸປະກອນ (ສຳລັບແອັບເພງທີ່ຮອງຮັບອີຄິວອລາຍເຊີລະບົບ)</string>
-    <string name="description_intro_tap_the_button">ເລີ່ມດ້ວຍການໄ0ພີ່ມອຸປະກອນໄ1ລກຂອງທ່ານ.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth ຖືກປິດ.</string>
     <string name="title_bluetooth_is_off">Bluetooth ປິດອຍູ່</string>
     <string name="action_enable_bluetooth">ໄ0ອີນ Bluetooth</string>
     <string name="title_bluetooth_permission_required">ຕ້ອງການສິດທິ່ Bluetooth</string>
     <string name="description_bluetooth_permission_required">ແອັບນີ້ຕ້ອງການສິດທິ່ Bluetooth ໄ0ພື່ອຈັດການລະດັບສຽງຂອງອຸປະກອນຂອງທ່ານ.</string>
     <string name="action_grant_permission">ມອບສິດທິ່</string>
-    <string name="label_status_listening_for_changes">ກຳລັງ໺ັງການປ່ຽນແປງລະດັບສຽງ</string>
     <string name="action_exit">ອອກ</string>
-    <string name="action_start">ເລີ່ມ</string>
-    <string name="label_welcome">ຍິນດີຕ້ອນຮັບ</string>
-    <string name="description_intro_contact">ອຍ່າລັງເລ່ອມຕິດຕ່ອຂ້ອຍ ຖ້າທ່ານມີຄຳຖາມຫລືອໄ1ມ່ນໄອະອີບາຍໄ0ຜືອການຟີໄ0ຈີໃໝ່.</string>
-    <string name="label_translation">ການແປພາສາ</string>
-    <string name="description_help_translate">ຊ່ວຍຂ້ອຍໄ1ປວແອັບນີ້ໄ3ຫ້ໄ0ປັນພາສາອື່ນๆ.</string>
     <string name="label_device_speaker">ລຳໄ2ພງອຸປະກອນ</string>
-    <string name="label_keyevent_playpause">ໄ0ລຯນ-ຫຍຸດ</string>
-    <string name="label_keyevent_play">ໄ0ລຯນ</string>
-    <string name="label_keyevent_next">ຖັດໄປ</string>
-    <string name="label_install_id">ID ຕິດຕັ້ງ</string>
     <string name="message_copied_to_clipboard">ຄັດລອກໄ1ປ່ clipboard ໄ1ລ້ວ</string>
-    <string name="label_thanks">ຂອບໃຈ</string>
-    <string name="label_licenses">ໃບອະນຸຍາດ</string>
-    <string name="description_ring_volume_additional_permission">ຕ້ອງການສິດທິ່ໄ0ພິ່ມໄ0ຕີມໄ0ພື່ອໄ0ປລີ່ຍໄ1ປງລະດັບສຽງໄ0ວົ້າ.</string>
-    <string name="label_missing_permissions">ສິດທິ່ຫາຍໄ4ປ</string>
-    <string name="action_grant">ມອບສິດທິ່</string>
-    <string name="label_advanced">ໄ2ກນໄ1ກ່ນ</string>
-    <string name="label_exclude_health">ໄ1ລກປໄ2ຟລ Health</string>
-    <string name="description_exclude_health">ອຸປະກອນ Android ບານອັນຄໂນຕວ່າໄ0ງົ່ອງໄ0ມື່ອຄໂນປໄ2ຟລ Bluetooth \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">ໄ1ລກປໄ2ຟລໄ0ວີຊາ GATT server</string>
-    <string name="label_exclude_gatt">ໄ1ລກປໄ2ຟລ GATT</string>
-    <string name="description_exclude_gattserver">ບໍ່ສອບຖາມປໄ2ຟລ Bluetooth ປະໄ0ພດ \'Generic Attribute\' (GATT) server.</string>
-    <string name="description_exclude_gatt">ບໍ່ສອບຖາມປໄ2ຟລ Bluetooth ປະໄ0ພດ \'Generic Attribute\' (GATT) client.</string>
-    <string name="description_waiting_for_devicex">ກຳລັງຣອກອຍູ່ %s ໄ0ພື່ອສຳໄ0ລະການຕ່ອ</string>
-    <string name="action_undo">ຍົກເລີກ</string>
-    <string name="action_show">ໄ1ສດງ</string>
     <string name="action_dismiss">ປະຕິເສດ</string>
-    <string name="action_fix">ແກ້ໄຂ</string>
-    <string name="battery_optimizations_issue_description">ການອຫນຸໄ0ທບັດໄ0ຕຣີ່ມຖືກໄ0ອີນໃຊ້ງານສଳຫລັບໄ1ອັບນີ້ ໄ1ລະອາດໄ0ປີດກັ້ນໄ1ອັບຈາກການຮັບໄ0ຫດການ Bluetooth. ກະລຸນາປິດການອຫນຸໄ0ທບັດຖ້າທ່ານພົບປັຍຫາ.</string>
     <string name="label_bluetooth_settings">ການຕັ້ງຄ່າ Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 ຈຳກັດວິທີທີ່ໄ1ອັບສາມາຖໄ0ປີດຈາກພື້ນຫລັງ. ໄ0ພື່ອອະນຸຍາດໄ0ປີດໄ1ອັບໄ0ມື່ອອຸປະກອນ Bluetooth ຕ່ອ ໄ3ຫ້ມອບສິດທິ່ \"Display over other apps\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">ໄ2ຄດຕ້ນເຄິດ</string>
-    <string name="android13_notification_permission_description">ມອບສິດທິ່ສଳຫລັບໄ1ອັບນີ້ໄ3ຫ້ຂຽນການໄ1ຈ້ງ. ທີ່ໄ0ອີນໄ3ຫ້ໄ1ສດງການໄ1ຈ້ງໄ0ມື່ອໄ1ອັບໄ0ງິນໄ1ລະກຳລັງປັບລະດັບສຽງ.</string>
-    <string name="privacy_policy_label">ນະໂຍບາຍຄວາມເປັນສ່ວນຕົວ</string>
     <string name="managed_devices_empty_message">ບໍ່ມີອຸປະກອນ Bluetooth ຖືກຕັ້ງຄ່າ.\nກດປົ່ມ + ໄ0ພື່ອໄ0ພີ່ມອຸປະກອນໄ1ລກຂອງທ່ານ.</string>
     <string name="label_pro_feature">ຟີໄ0ຈີພຣີໄ0ມີຍມ</string>
     <plurals name="discover_device_limit_banner">
@@ -419,21 +339,15 @@
     <string name="review_app_review_action">ຄຳເຫັນ</string>
     <string name="review_app_dismiss_action">ບາງທີພາຍຫຼັງ</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">ການຊື້ຖືກຍກເລີກ</string>
-    <string name="error_iap_unavailable_message">ການຊື້ພາຍໃນແອັບບໍ່ພອ້ມໃຊ້ງານ</string>
-    <string name="error_generic_message">ເກີດຂໍ້ຜິດພຫລາດ. ກະລຸນາລອງໃໝ່ອີກຄັ້ງ.</string>
-    <string name="error_iap_owned_message">ທ່ານມີສິ່ງນີ້ໄ1ລ້ວ</string>
     <string name="label_no_devices_title">ບໍ່ມີອຸປະກອນ</string>
     <string name="bluemusic_mascot_description">ໄອຄອນແອັບ</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">ໄ0ລືອກໄ1ອັບ</string>
     <string name="devices_app_selection_search_hint">ຄ້ນຫາໄ1ອັບ...</string>
-    <string name="devices_app_selection_currently_selected">ໄ0ລືອກອຍູ່ປັຈຈຸບັນ</string>
     <string name="devices_app_selection_selected_count">ໄ0ລືອກ %d ໄ1ອັບໄ1ລ້ວ</string>
     <string name="general_navigate_back_action">ນຳທາງກັບຄືນ</string>
     <string name="general_reset_action">ຣີເຊັດ</string>
     <string name="general_clear_action">ລົບລ້າງ</string>
-    <string name="general_save_action">ບັນທຶກ</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">ຖົງ</string>
     <string name="devices_indicator_awake">ຕື່ນຕ຺ພົນ</string>
@@ -443,7 +357,6 @@
     <string name="devices_indicator_limit">ຈຳກັດ</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">ເພີ່ມສຽງ</string>
-    <string name="devices_indicator_launch">ເປີດ</string>
     <string name="devices_indicator_home">ຫນ້າຫລັກ</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">ການແຈ້ເຕືອນ</string>

--- a/app/src/main/res/values-lt/strings.xml
+++ b/app/src/main/res/values-lt/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Kai kurios funkcijos pasikeitė atnaujinimo metu. Patikrinkite įrenginių nustatymus ir įsitikinkite, kad viskas sukonfigūruota teisingai.</string>
     <string name="onboarding_rewrite_action">Tęsti</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nevaldomi įrenginiai nerasti</string>
     <string name="discover_all_devices_managed_msg">Visi suporuoti įrenginiai valdomi! Reikia naujo?</string>
     <string name="discover_pair_new_device_action">Suporuoti naują įrenginį</string>
     <string name="discover_device_speaker_desc">Jūsų telefono savasis garsiakalbis. Jo garsumai yra taikomi, kai garsas persijungia atgal į telefoną, pvz., po to, kai jūsų „Bluetooth“ įrenginys atsijungia.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Įrenginio konfigūracija</string>
-    <string name="devices_device_config_section_general_label">Bendra</string>
     <string name="devices_device_config_remove_device_label">Pamiršti įrenginį</string>
-    <string name="devices_device_config_remove_device_desc">Pašalina įrenginį iš šios programos ir ištrina jo konfigūraciją. Tai nenutraukia įrenginio suporavimo.</string>
     <string name="devices_device_config_remove_device_action">Pamiršti</string>
     <string name="devices_device_config_remove_device_confirmation">Pamiršti %s iš valdomų įrenginių?</string>
-    <string name="devices_device_config_rename_device_label">Pervadinti įrenginį</string>
-    <string name="devices_device_config_rename_device_desc">Pervadinti šį įrenginį šioje programoje ir, jei įmanoma, sistemoje.</string>
     <string name="devices_device_config_rename_device_action">Pervadinti</string>
     <string name="devices_device_config_enabled_label">Įjungta</string>
     <string name="devices_device_config_enabled_desc">Reaguoti į šį įrenginį kai jis prijungtas</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Automatinio paleidimo komandos</string>
     <string name="devices_device_config_autoplay_keycodes_order">Komandų seka</string>
     <string name="devices_device_config_autoplay_keycodes_label">Komandos</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Nustatyti, kurias komandas siųsti ir kokia tvarka</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nėra sukonfigūruotų komandų</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Pridėti komandą</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimaliai %1$d komandų</string>
@@ -123,7 +117,6 @@
     <string name="cd_autoplay_keycode_move_up">Perkelti aukštyn</string>
     <string name="cd_autoplay_keycode_move_down">Perkelti žemyn</string>
     <string name="cd_autoplay_keycode_remove">Pašalinti</string>
-    <string name="devices_device_config_section_volumes_label">Garsumai</string>
     <string name="devices_device_config_section_volume_label">Garsumas</string>
     <string name="devices_device_config_alarm_volume_label">Signalo garsumas</string>
     <string name="devices_device_config_alarm_volume_desc">Kai kurios signalo programos vietoj to naudoja muzikos garsumą.</string>
@@ -157,8 +150,6 @@
     <string name="devices_audio_stream_ring_label">Skambėjimas</string>
     <string name="devices_audio_stream_notification_label">Pranešimas</string>
     <string name="devices_audio_stream_alarm_label">Signalas</string>
-    <string name="devices_neverseen_label">Nematytas</string>
-    <string name="devices_state_connected_label">Prisijungta</string>
     <string name="devices_last_connected_label">Paskutinį kartą prisijungta: %s</string>
     <string name="devices_currently_connected_label">Šiuo metu prisijungta</string>
     <string name="devices_device_disabled_label">Įrenginys išjungtas</string>
@@ -193,10 +184,7 @@
     <string name="devices_settings_desc">Nustatymai, kurie veikia visus valdomus įrenginius.</string>
     <string name="label_app_enabled">Programa įjungta</string>
     <string name="description_app_enabled">Perjungia programos gebėjimą reaguoti į garsumo bei bluetooth veiksmus.</string>
-    <string name="label_visible_volume_adjustments">Matomas valdymas</string>
-    <string name="description_visible_volume_adjustments">Rodo sistemos garsumo panelės langą programai keičiant garsumą.</string>
     <string name="label_volume_listener">Stebėti pokyčius</string>
-    <string name="description_volume_listener">Laikyti aktyviu kai įrenginys prijungtas ir valdomas garsumas.</string>
     <string name="label_boot_restore">Atstatyti įjungiant</string>
     <string name="description_boot_restore">Atstato garsumą po įjungimo/perkrovimo jei Bluetooth įrenginys prijungtas.</string>
     <!-- Settings/Support-->
@@ -206,24 +194,11 @@
     <string name="settings_support_wiki_description">Sužinokite, kaip efektyviai naudoti BVM</string>
     <string name="settings_support_issue_tracker_description">Viešas problemų sekiklis klaidų pranešimams ir funkcijų užklausoms.</string>
     <string name="settings_support_issue_tracker_label">Problemų sekiklis</string>
-    <string name="settings_support_debuglog_label">Derinimo žurnalas</string>
     <string name="settings_support_debuglog_desc">Įrašykite viską, ką daro programa, į tekstinį failą, kurį galite bendrinti.</string>
-    <string name="settings_support_debuglog_recording_desc">Šiuo metu įrašoma derinimo informacija. Bakstelėkite, kad sustabdytumėte įrašymą.</string>
-    <string name="settings_support_debuglog_path">Žurnalo kelias: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Labai trumpas įrašas</string>
     <string name="settings_support_debuglog_short_recording_msg">Tai buvo labai trumpas įrašas. Derinimo žurnalai yra įrašai, o ne momentinės nuotraukos — atkurkite problemą įrašymo metu, kad žurnalas būtų naudingas.</string>
     <string name="settings_support_debuglog_short_recording_continue">Tęsti įrašymą</string>
     <string name="settings_support_debuglog_short_recording_stop">Sustabdyti vis tiek</string>
-    <string name="settings_support_debuglog_folder_label">Derinimo žurnalų aplankas</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sesija naudoja %2$s</item>
-        <item quantity="few">%1$d sesijos naudoja %2$s</item>
-        <item quantity="many">%1$d sesijos naudoja %2$s</item>
-        <item quantity="other">%1$d sesijų naudoja %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nėra išsaugotų derinimo žurnalų</string>
-    <string name="settings_support_debuglog_folder_delete_title">Ištrinti visus derinimo žurnalus?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Tai visam laikui ištrins visas išsaugotas derinimo žurnalų sesijas.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Vieta pabendrauti ir užduoti klausimus.</string>
     <!-- Settings/Acks-->
@@ -232,16 +207,12 @@
     <string name="settings_acks_translation_header">Vertimas</string>
     <string name="settings_acks_translators_title">Vertėjai</string>
     <string name="settings_acks_translators_people">Asmuo1;Asmuo2(neprivalomas@email.com)</string>
-    <string name="settings_acks_translate_title">Versti BVM</string>
-    <string name="settings_acks_translate_desc">Padėkite versti BVM į savo kalbą</string>
     <string name="settings_acks_thanks_header">Ačiū</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Už atvirojo kodo projektų vertimo palaikymą</string>
     <string name="settings_licenses_label">Licencijos</string>
     <string name="settings_translation_label">Vertimas</string>
     <string name="settings_translation_desc">Padėkite išversti programą į savo mėgstamą kalbą</string>
-    <string name="settings_sponsor_development_title">Remti kūrimą</string>
-    <string name="settings_sponsor_development_summary">Tapkite mecenatu ir padarykite tolesnį kūrimą įmanomą.</string>
     <string name="settings_privacy_policy_label">Privatumo politika</string>
     <string name="settings_privacy_policy_desc">Atsakingas duomenų tvarkymas.</string>
     <string name="changelog_label">Pakeitimų žurnalas</string>
@@ -263,10 +234,8 @@
     <string name="backup_restore_success_restore">Atkūrimas baigtas — %1$d įrenginių atkurta, %2$d praleista.</string>
     <string name="backup_restore_version_warning">Ši atsarginė kopija buvo sukurta su versija %1$s. Jūs naudojate %2$s. Kai kurie nustatymai gali būti atkurti neteisingai.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Derinimo pranešimai</string>
     <string name="debug_log_consent_title">Derinimo žurnalas</string>
     <string name="debug_log_consent_explanation">Ši funkcija įrašo viską, ką daro programa, į dalijamą failą. Sugeneruotas failas turi jautrią informaciją (pvz., failų pavadinimus ir įdiegtas programas). Dalinkitės tik su patikimais asmenimis (pvz., kūrėju, šalinančiu problemą).</string>
-    <string name="debug_log_recording_progress">Įrašomas derinimo žurnalas</string>
     <string name="debug_log_record_action">Įrašyti</string>
     <string name="debug_log_stop_action">Sustabdyti įrašymą</string>
     <string name="debug_log_screen_title">Derinimo žurnalo įrašiklis</string>
@@ -283,7 +252,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Atmesti</string>
     <string name="debug_log_screen_keep_action">Palikti</string>
-    <string name="debug_log_compressing_label">Glaudinamas…</string>
     <string name="debug_log_file_label">Įrašytas žurnalo failas</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Žurnalas išsiųstas?</string>
@@ -311,7 +279,6 @@
     <string name="contact_description_question_hint">Aprašykite savo klausimą išsamiai.</string>
     <string name="contact_category_section_label">Kategorija</string>
     <string name="contact_debug_log_label">Derinimo žurnalas</string>
-    <string name="contact_debug_log_select_hint">Pasirinkite derinimo žurnalą pridėti</string>
     <string name="contact_debug_log_picker_hint">Pridėkite derinimo žurnalą, kad padėtumėte greičiau diagnozuoti problemą.</string>
     <string name="contact_debug_log_picker_empty">Derinimo žurnalų nėra. Pirmiausia įrašykite vieną.</string>
     <string name="contact_expected_behavior_label">Laukiamas elgesys</string>
@@ -327,82 +294,32 @@
     <string name="contact_welcome_msg">Aš skaitau kiekvieną žinutę pats ir darau viską, kad atsakyčiau, tačiau kadangi dirbu vienas, tai gali šiek tiek užtrukti. Ačiū už kantrybę.</string>
     <string name="contact_footer_msg">Jūsų žinutė bus išsiųsta el. paštu. Įrenginio ir sąrankos informacija pridedama automatiškai.</string>
     <string name="contact_no_email_app_msg">Šiame įrenginyje nerasta el. pašto programa.</string>
-    <string name="contact_attachment_missing_msg">Derinimo žurnalo failas nebeegzistuoja</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Išsaugoti derinimo žurnalai</string>
     <string name="settings_support_stored_logs_desc">%1$d sesijos (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Nėra išsaugotų derinimo žurnalų</string>
-    <string name="settings_support_stored_logs_delete_title">Ištrinti išsaugotus žurnalus?</string>
-    <string name="settings_support_stored_logs_delete_msg">Bus ištrintos visos %1$d išsaugotos derinimo žurnalų sesijos.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Išsaugoti derinimo žurnalai ištrinti</string>
-    <string name="label_bug_reports">Pranešti apie klaidą</string>
-    <string name="description_bug_reports">Automatinis klaidų siuntimas.</string>
     <string name="label_add_device">Pridėti įrenginį</string>
-    <string name="label_just_a_moment_please">Luktelkite.</string>
     <string name="label_notification_channel_status">Būsena</string>
     <string name="label_notification_channel_setup">Reikalinga sąranka</string>
     <string name="monitor_notification_starting">Pradedama…</string>
     <string name="action_set">Nustatyti</string>
     <string name="action_cancel">Atšaukti</string>
-    <string name="label_invalid_input">Netinkama įvestis</string>
     <string name="action_reset">Atstatyti</string>
     <string name="label_no_connected_devices">Nėra prijungtų įrenginių</string>
-    <string name="label_status_idle">Laukiama</string>
-    <string name="label_status_adjusting_volumes">Garsumo valdymas</string>
-    <string name="label_premium_version">Premium versija</string>
     <string name="general_upgrade_action">Atnaujinti</string>
     <string name="common_upgrade_required_label">Reikalingas atnaujinimas</string>
-    <string name="label_premium_version_required">Būtina Premium versija</string>
-    <string name="description_intro_purpose">Ši programa leidžia jūsų Android įrenginiui prisiminti įvairių Bluetooth įrenginių garsumo nustatymus.</string>
-    <string name="upgrade_benefit_unlimited_devices">Neriboti įrenginių profiliai</string>
-    <string name="upgrade_benefit_connection_actions">Automatinis paleidimas, programų paleidimas ir prisijungimo pranešimai</string>
-    <string name="upgrade_benefit_theme_customization">Temos, stiliaus ir spalvų tinkinimas</string>
-    <string name="upgrade_benefit_power_controls">Garso užraktas ir greičio ribojimas</string>
-    <string name="upgrade_benefit_support">Palaikykite nepriklausomą kūrimą</string>
     <string name="upgrade_benefit_equalizer">• Ekvalaizeris kiekvienam įrenginiui (muzikos programėlėms, palaikančioms sistemos ekvalaizerį)</string>
-    <string name="description_intro_tap_the_button">Pradėkite pridėdami pirmą įrenginį.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth išjungtas.</string>
     <string name="title_bluetooth_is_off">Bluetooth išjungtas</string>
     <string name="action_enable_bluetooth">Įjungti Bluetooth</string>
     <string name="title_bluetooth_permission_required">Reikalingas Bluetooth leidimas</string>
     <string name="description_bluetooth_permission_required">Šiai programai reikalingas Bluetooth leidimas valdyti jūsų įrenginių garsumus.</string>
     <string name="action_grant_permission">Suteikti leidimą</string>
-    <string name="label_status_listening_for_changes">Stebi garsumo pasikeitimus</string>
     <string name="action_exit">Išeiti</string>
-    <string name="action_start">Pradėti</string>
-    <string name="label_welcome">Sveiki!</string>
-    <string name="description_intro_contact">Jei turite klausimų ar pasiūlymų nedvejodami susisiekite su manimi.</string>
-    <string name="label_translation">Vertimas</string>
-    <string name="description_help_translate">Padėkite man šią programą išversti į kitas kalbas.</string>
     <string name="label_device_speaker">Įrenginio garsiakalbis</string>
-    <string name="label_keyevent_playpause">Groti-Pauzė</string>
-    <string name="label_keyevent_play">Groti</string>
-    <string name="label_keyevent_next">Kitas</string>
-    <string name="label_install_id">Įdiegimo ID</string>
     <string name="message_copied_to_clipboard">Nukopijuota į iškarpinę</string>
-    <string name="label_thanks">Ačiū</string>
-    <string name="label_licenses">Licencijos</string>
-    <string name="description_ring_volume_additional_permission">Skambučio garsumo valdymui reikalingos papildomos teisės.</string>
-    <string name="label_missing_permissions">Trūksta leidimų</string>
-    <string name="action_grant">Suteikti</string>
-    <string name="label_advanced">Išplėstiniai</string>
-    <string name="label_exclude_health">Išskirti sveikatos profilius</string>
-    <string name="description_exclude_health">Kai kurie Android įrenginiai užstringa prijungus Bluetooth \'Sveikatingumo Įrenginį\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Išskirti GATT serverio profilius</string>
-    <string name="label_exclude_gatt">Išskirti GATT profilius</string>
-    <string name="description_exclude_gattserver">Neieškoti \'Generic Attribute\' (GATT) serverių Bluetooth profilių.</string>
-    <string name="description_exclude_gatt">Neieškoti \'Generic Attribute\' (GATT) klientų Bluetooth profilių.</string>
-    <string name="description_waiting_for_devicex">Laukiama kol %s užbaigs prisijungimą</string>
-    <string name="action_undo">Anuliuoti</string>
-    <string name="action_show">Rodyti</string>
     <string name="action_dismiss">Atmesti</string>
-    <string name="action_fix">Taisyti</string>
-    <string name="battery_optimizations_issue_description">Šiai programai įjungtas baterijos optimizavimas, tai gali paveikti programos veikimą. Jei pastebite programos veikimo problemas, išjunkite optimizavimą.</string>
     <string name="label_bluetooth_settings">Bluetooth nustatymai</string>
-    <string name="android10_applaunch_issue_description">Android 10 riboja, kaip programos gali būti paleidžiamos fone. Norėdami leisti atidaryti programas prisijungus Bluetooth įrenginiui, suteikite leidimą &quot;Rodyti virš kitų programų&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Išeities kodas</string>
-    <string name="android13_notification_permission_description">Suteikite šiai programai leidimą skelbti pranešimus. Tai leidžia rodyti pranešimą, kai programa yra aktyvi ir atliekami garsumo reguliavimai.</string>
-    <string name="privacy_policy_label">Privatumo politika</string>
     <string name="managed_devices_empty_message">Bluetooth įrenginiai nesukonfigūruoti.\nBakstelėkite mygtuką +, kad pridėtumėte pirmąjį įrenginį.</string>
     <string name="label_pro_feature">Premijinė funkcija</string>
     <plurals name="discover_device_limit_banner">
@@ -435,21 +352,15 @@
     <string name="review_app_review_action">Apžvalga</string>
     <string name="review_app_dismiss_action">Galbūt vėliau</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Pirkimas atšauktas</string>
-    <string name="error_iap_unavailable_message">Pirkimai programoje nepasiekiami</string>
-    <string name="error_generic_message">Įvyko klaida. Bandykite dar kartą.</string>
-    <string name="error_iap_owned_message">Jūs jau turite šį elementą</string>
     <string name="label_no_devices_title">Nėra įrenginių</string>
     <string name="bluemusic_mascot_description">Programos piktograma</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Pasirinkti programas</string>
     <string name="devices_app_selection_search_hint">Ieškoti programų…</string>
-    <string name="devices_app_selection_currently_selected">Šiuo metu pasirinkta</string>
     <string name="devices_app_selection_selected_count">Pasirinkta %d programų</string>
     <string name="general_navigate_back_action">Naviguoti atgal</string>
     <string name="general_reset_action">Atstatyti</string>
     <string name="general_clear_action">Išvalyti</string>
-    <string name="general_save_action">Išsaugoti</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Užraktas</string>
     <string name="devices_indicator_awake">Aktyvus</string>
@@ -459,7 +370,6 @@
     <string name="devices_indicator_limit">Limitas</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Padidinimas</string>
-    <string name="devices_indicator_launch">Paleidimas</string>
     <string name="devices_indicator_home">Pradžia</string>
     <string name="devices_indicator_dnd">NT</string>
     <string name="devices_indicator_alert">Įspėjimas</string>

--- a/app/src/main/res/values-lv/strings.xml
+++ b/app/src/main/res/values-lv/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Dažas funkcijas tika maintas atjaunināšanas laikā. Lūdzu pārbaudiet ierīces iestatījumus, lai pārliecinātos, ka viss ir pareizi konfigurēts.</string>
     <string name="onboarding_rewrite_action">Turpināt</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nav atrasts neviena nepārvalditā ierīce</string>
     <string name="discover_all_devices_managed_msg">Visas jūsu savienotās ierīces tiek pārvaldītas! Vajag jaunu?</string>
     <string name="discover_pair_new_device_action">Savienot jaunu ierīci</string>
     <string name="discover_device_speaker_desc">Tālruņa savs skaļrunis. Tā skaļumi tiek piemēroti, kad audio pārslēdzas atpakaļ uz tālruni, piemēram, pēc Bluetooth ierīces atvienošanas.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Ierīces konfigurācija</string>
-    <string name="devices_device_config_section_general_label">Vispārīgi</string>
     <string name="devices_device_config_remove_device_label">Aizmirst ierīci</string>
-    <string name="devices_device_config_remove_device_desc">Aizmirst šo ierīci no šīs lietotnes un dzēst tās konfigurāciju. Tas neatvieno ierīces pāri.</string>
     <string name="devices_device_config_remove_device_action">Aizmirst</string>
     <string name="devices_device_config_remove_device_confirmation">Aizmirst %s no pārvaldītajām ierīcēm?</string>
-    <string name="devices_device_config_rename_device_label">Pārdēvēt ierīci</string>
-    <string name="devices_device_config_rename_device_desc">Pārdēvēt šo ierīci šajā lietotnē un, ja iespējams, sistēmā.</string>
     <string name="devices_device_config_rename_device_action">Pārdēvēt</string>
     <string name="devices_device_config_enabled_label">Iespējots</string>
     <string name="devices_device_config_enabled_desc">Reģģēt uz šo ierīci, kad tā ir pievienota</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Automātiskās atskaņošanas komandas</string>
     <string name="devices_device_config_autoplay_keycodes_order">Komandu secība</string>
     <string name="devices_device_config_autoplay_keycodes_label">Komandas</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Konfigurēt, kuras komandas nosūtīt un kādā secībā</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nav konfigurētu komandu</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Pievienot komandu</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimums %1$d komandas</string>
@@ -122,7 +116,6 @@
     <string name="cd_autoplay_keycode_move_up">Pārvietot uz augšu</string>
     <string name="cd_autoplay_keycode_move_down">Pārvietot uz leju</string>
     <string name="cd_autoplay_keycode_remove">Noņemt</string>
-    <string name="devices_device_config_section_volumes_label">Skaļumi</string>
     <string name="devices_device_config_section_volume_label">Skaļums</string>
     <string name="devices_device_config_alarm_volume_label">Traċsigņāla skaļums</string>
     <string name="devices_device_config_alarm_volume_desc">Dažas traċsigņālu lietotnes tā vietā izmanto mūzikas skaļumu.</string>
@@ -156,8 +149,6 @@
     <string name="devices_audio_stream_ring_label">Zvanīšana</string>
     <string name="devices_audio_stream_notification_label">Paziņojums</string>
     <string name="devices_audio_stream_alarm_label">Trauksme</string>
-    <string name="devices_neverseen_label">Nekad nav redzets</string>
-    <string name="devices_state_connected_label">Pievienots</string>
     <string name="devices_last_connected_label">Pēdējā reize pievienots: %s</string>
     <string name="devices_currently_connected_label">Pašlaik pievienots</string>
     <string name="devices_device_disabled_label">Ierīce atspējota</string>
@@ -192,10 +183,7 @@
     <string name="devices_settings_desc">Iestatījumi, kas ietekmē visas pārvaldītās ierīces.</string>
     <string name="label_app_enabled">Lietotne iespējota</string>
     <string name="description_app_enabled">Pārslēdz lietotnes spēju reaģēt uz skaļuma un Bluetooth notikumiem.</string>
-    <string name="label_visible_volume_adjustments">Redzamas pielāgošanas</string>
-    <string name="description_visible_volume_adjustments">Rādīt sistēmas skaļuma logu, kamēr šī lietotne veic pielāgošanas.</string>
     <string name="label_volume_listener">Novērot izmaiņas</string>
-    <string name="description_volume_listener">Palikt aktīvam, kamēr ierīce ir pievienota, un saglabāt skaļuma izmaiņas, kas nav radusās no šīs lietotnes.</string>
     <string name="label_boot_restore">Atjaunot pēc startēšanas</string>
     <string name="description_boot_restore">Atjaunot skaļumu pēc ieslēgšanas/pārslēgšanas, ja ir pievienota Bluetooth ierīce.</string>
     <!-- Settings/Support-->
@@ -205,23 +193,11 @@
     <string name="settings_support_wiki_description">Uzziniet, kā efektīvi izmantot BSP</string>
     <string name="settings_support_issue_tracker_description">Publiskais problēmu izsekotājs kļūdu ziņojumiem un funkciju pieprasījumiem.</string>
     <string name="settings_support_issue_tracker_label">Problēmu izsekotājs</string>
-    <string name="settings_support_debuglog_label">Atkļūdošanas žurnāls</string>
     <string name="settings_support_debuglog_desc">Ierakstiet visu, ko lietotne dara, teksta failā, ko varat kopīgot.</string>
-    <string name="settings_support_debuglog_recording_desc">Pašlaik tiek reģistrēta atklājumā informācija. Pieskarieties, lai apturētu reģistrēšanu.</string>
-    <string name="settings_support_debuglog_path">Journala ceļs: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">ļoti īsa reģistrēšana</string>
     <string name="settings_support_debuglog_short_recording_msg">Tā bija ļoti īsa reģistrēšana. Atklājumu journali ir reģistrēšanas, nevis momentuzstādi - reproduciet problēmu reģistrēšanas laikā, lai journali būtu noderīgi.</string>
     <string name="settings_support_debuglog_short_recording_continue">Turpināt reģistrēšanu</string>
     <string name="settings_support_debuglog_short_recording_stop">Apturēt jebkurā gadījumā</string>
-    <string name="settings_support_debuglog_folder_label">Atklājumu log failu mape</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="zero">%1$d sesijas izmantojot %2$s</item>
-        <item quantity="one">%1$d sesija izmantojot %2$s</item>
-        <item quantity="other">%1$d sesijas izmantojot %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nav saglabātu atklājumu log failu</string>
-    <string name="settings_support_debuglog_folder_delete_title">Dzēst visus atklājumu logus?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Tās neatgriezeniski dzēs visas saglabātās atklājumu log sesijas.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Vieta, kur pavadīt laiku un uzdot jautājumus.</string>
     <!-- Settings/Acks-->
@@ -230,16 +206,12 @@
     <string name="settings_acks_translation_header">Tulkošana</string>
     <string name="settings_acks_translators_title">Tulkotāji</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Tulkot BSP</string>
-    <string name="settings_acks_translate_desc">Palīdzēt tulkot BSP jūsu valodā</string>
     <string name="settings_acks_thanks_header">Paldies</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Par atbalstu atvērtā pirmkoda projektu tulkošanai</string>
     <string name="settings_licenses_label">Licences</string>
     <string name="settings_translation_label">Tulkošana</string>
     <string name="settings_translation_desc">Palīdzēt tulkot lietotni jūsu mīlākajā valodā</string>
-    <string name="settings_sponsor_development_title">Sponsorēt izstrādi</string>
-    <string name="settings_sponsor_development_summary">Kļūstiet par patronu un padariet turpmāku izstrādi iespējamu.</string>
     <string name="settings_privacy_policy_label">Privātuma politika</string>
     <string name="settings_privacy_policy_desc">Atbildīga datu apstrāde.</string>
     <string name="changelog_label">Izmaiņu žurnāls</string>
@@ -261,10 +233,8 @@
     <string name="backup_restore_success_restore">Atjaunošana pabeigta — atjaunotas %1$d ierīces, izlaistas %2$d.</string>
     <string name="backup_restore_version_warning">Šis dublējums tika izveidots ar versiju %1$s. Jūs izmantojat %2$s. Daži iestatījumi var netikt atjaunoti pareizi.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Atkļūdošanas paziņojumi</string>
     <string name="debug_log_consent_title">Atkļūdošanas žurnāls</string>
     <string name="debug_log_consent_explanation">Šī funkcija ieraksta visu, ko lietotne dara, koplietojamā failā. Izveidotais fails satur sensitīvu informāciju (piem. failu nosaukumus un instalētās lietotnes). Dalieties tikai ar uzticamām pusēm (piem. izstrādātāju, kas risina problēmu).</string>
-    <string name="debug_log_recording_progress">Ieraksta atkļūdošanas žurnālu</string>
     <string name="debug_log_record_action">Reģistrēt</string>
     <string name="debug_log_stop_action">Apturēt ierakstīšanu</string>
     <string name="debug_log_screen_title">Atklājumu log reģistrētājs</string>
@@ -280,7 +250,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Atmest</string>
     <string name="debug_log_screen_keep_action">Saglabāt</string>
-    <string name="debug_log_compressing_label">Kompresē...</string>
     <string name="debug_log_file_label">Ierakstītais žurnāla fails</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Logs nosūtīts?</string>
@@ -308,7 +277,6 @@
     <string name="contact_description_question_hint">Aprakstiet savu jautājumu sīkāk.</string>
     <string name="contact_category_section_label">Kategorija</string>
     <string name="contact_debug_log_label">Atkļūdošanas žurnāls</string>
-    <string name="contact_debug_log_select_hint">Izvēlēties atklājumu log, ko pievienot</string>
     <string name="contact_debug_log_picker_hint">Pievienojiet atklājumu log, lai palīdzētu ātrāk diagnosticmēt problēmu.</string>
     <string name="contact_debug_log_picker_empty">Nav pieejamu atklājumu logu. Vispirms reģistrējiet vienu.</string>
     <string name="contact_expected_behavior_label">Gaidītā uzvedība</string>
@@ -323,82 +291,32 @@
     <string name="contact_welcome_msg">Es pats lasu katru ziņojumu un dari visu iespējamo, lai atbildetu, taču tkā es stradāju viens, tas var aizņemt nedēvedu laiku. Paldies par pacietbu!</string>
     <string name="contact_footer_msg">Jūsu ziņojums tiks nosūtīts pa e-pastu. Ierīces un iestatījumu informācija tiek pievienota automātiski.</string>
     <string name="contact_no_email_app_msg">Šajā ierīcē nav atrasts e-pasta klients.</string>
-    <string name="contact_attachment_missing_msg">Atklājumu log fails vairs nepastāv</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Saglabātie atklājumu logi</string>
     <string name="settings_support_stored_logs_desc">%1$d sesijas (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Nav saglabātu atklājumu logu</string>
-    <string name="settings_support_stored_logs_delete_title">Dzēst saglabātos logus?</string>
-    <string name="settings_support_stored_logs_delete_msg">Tās dzēs visas %1$d saglabātās atklājumu log sesijas.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Saglabātie atklājumu logi izdzēsti</string>
-    <string name="label_bug_reports">Kļūdu ziņojumi</string>
-    <string name="description_bug_reports">Automātiska kļūdu un avāriju ziņošana.</string>
     <string name="label_add_device">Pievienot ierīci</string>
-    <string name="label_just_a_moment_please">Uzgaņiet, lūdzu.</string>
     <string name="label_notification_channel_status">Stāvoklis</string>
     <string name="label_notification_channel_setup">Nepieciešama iestatīšana</string>
     <string name="monitor_notification_starting">Uzsāk...</string>
     <string name="action_set">Iestatīt</string>
     <string name="action_cancel">Atcelt</string>
-    <string name="label_invalid_input">Nederīga ievade</string>
     <string name="action_reset">Atiestatīt</string>
     <string name="label_no_connected_devices">Nav pievienotu ierīču</string>
-    <string name="label_status_idle">Gaida</string>
-    <string name="label_status_adjusting_volumes">Skaļumu pielāgošana</string>
-    <string name="label_premium_version">Premium versija</string>
     <string name="general_upgrade_action">Jaunināt</string>
     <string name="common_upgrade_required_label">Nepieciešams jauninājums</string>
-    <string name="label_premium_version_required">Nepieciešama premium versija</string>
-    <string name="description_intro_purpose">Šī lietotne ļauj jūsu Android ierīcei atcerēties dažādu Bluetooth ierīču skaļumus.</string>
-    <string name="upgrade_benefit_unlimited_devices">Neierobežots ierīcī profilu skaits</string>
-    <string name="upgrade_benefit_connection_actions">Automātiskā atskaņošana, lietotnes palaist un savienojuma brīdinājumi</string>
-    <string name="upgrade_benefit_theme_customization">Temāta, stila un krāsu pielāgošana</string>
-    <string name="upgrade_benefit_power_controls">Skaļuma bloķēšana un ātruma ierobežošana</string>
-    <string name="upgrade_benefit_support">Atbalstīt neatkarīgu izstrādi</string>
     <string name="upgrade_benefit_equalizer">• Katrai ierīcei individuāls ekvaizeris (mūzikas lietotnēm ar sistēmas ekvaizera atbalstu)</string>
-    <string name="description_intro_tap_the_button">Sāciet, pievienojot savu pirmo ierīci.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth ir atspējots.</string>
     <string name="title_bluetooth_is_off">Bluetooth ir izslēgts</string>
     <string name="action_enable_bluetooth">Ieslegt Bluetooth</string>
     <string name="title_bluetooth_permission_required">Nepieciešama Bluetooth atļauja</string>
     <string name="description_bluetooth_permission_required">Šai lietotnei nepieciešama Bluetooth atļauja, lai pārvaldītu jūsu ierīču skaļumus.</string>
     <string name="action_grant_permission">Piešķirt atļauju</string>
-    <string name="label_status_listening_for_changes">Uzklausā skaļuma izmaiņas</string>
     <string name="action_exit">Iziet</string>
-    <string name="action_start">Sākt</string>
-    <string name="label_welcome">Laipni lūdzam</string>
-    <string name="description_intro_contact">Nebaidieties sazināties ar mani, ja jums ir jautājumi vai pat jauna funkcija ideja.</string>
-    <string name="label_translation">Tulkošana</string>
-    <string name="description_help_translate">Palīdzējiet man padarīt šo lietotni pieejamu citās valodās.</string>
     <string name="label_device_speaker">Ierīces skairuņis</string>
-    <string name="label_keyevent_playpause">Atskanēt/Apturēt</string>
-    <string name="label_keyevent_play">Atskanēt</string>
-    <string name="label_keyevent_next">Nākamais</string>
-    <string name="label_install_id">Instalācijas ID</string>
     <string name="message_copied_to_clipboard">Kopēts starplīktnī</string>
-    <string name="label_thanks">Paldies</string>
-    <string name="label_licenses">Licences</string>
-    <string name="description_ring_volume_additional_permission">Lai mainītu zvanīšanas skaļumu, nepieciešamas papildu atļaujas.</string>
-    <string name="label_missing_permissions">Trūkstošas atļaujas</string>
-    <string name="action_grant">Piešķirt</string>
-    <string name="label_advanced">Papildu</string>
-    <string name="label_exclude_health">Izslēgt vesēlības profilus</string>
-    <string name="description_exclude_health">Dažas Android ierīces iestrēgst, meklējot Bluetooth profilus \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Izslēgt GATT servera profilus</string>
-    <string name="label_exclude_gatt">Izslēgt GATT profilus</string>
-    <string name="description_exclude_gattserver">Nevaicajāt \'Generic Attribute\' (GATT) servera tipa Bluetooth profilus.</string>
-    <string name="description_exclude_gatt">Nevaicajāt \'Generic Attribute\' (GATT) klienta tipa Bluetooth profilus.</string>
-    <string name="description_waiting_for_devicex">Gaida, līdz %s pabeig savienojumu</string>
-    <string name="action_undo">Atsaukt</string>
-    <string name="action_show">Rādīt</string>
     <string name="action_dismiss">Noraidīt</string>
-    <string name="action_fix">Labot</string>
-    <string name="battery_optimizations_issue_description">Šai lietotnei ir iespējotas akumlatora optimizācijas, kas var liegt tai saņemt Bluetooth notikumus. Apsveriet optimizāciju atspējošanu, ja radusies problēmas.</string>
     <string name="label_bluetooth_settings">Bluetooth iestatījumi</string>
-    <string name="android10_applaunch_issue_description">Android 10 ierobežo, kā lietotnes var tikt palaistas fonā. Lai atļautu lietotņu atvēršanu, kad pievienojas Bluetooth ierīce, piešķiriet atļauju \"Attēlošana virs citām lietotnēm\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Pirmkods</string>
-    <string name="android13_notification_permission_description">Piešķiriet šai lietotnei atļauju ievietot paziņojumus. Tas ļauj parādīt paziņojumu, kad šī lietotne ir aktīva un tiek veikta skaļuma pielāgošana.</string>
-    <string name="privacy_policy_label">Privātuma politika</string>
     <string name="managed_devices_empty_message">Nav konfigurētu Bluetooth ierīču.\nPieskarieties pogai +, lai pievienotu savu pirmo ierīci.</string>
     <string name="label_pro_feature">Maksas funkcija</string>
     <plurals name="discover_device_limit_banner">
@@ -430,21 +348,15 @@
     <string name="review_app_review_action">Atsauksme</string>
     <string name="review_app_dismiss_action">Varbūt vēlāk</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Pirkums atcelts</string>
-    <string name="error_iap_unavailable_message">Pirkumi lietotnē nav pieejami</string>
-    <string name="error_generic_message">Radusās kļūda. Lūdzu mēģiniet vēlreiz.</string>
-    <string name="error_iap_owned_message">Jums jau pieder šis elements</string>
     <string name="label_no_devices_title">Nav ierīču</string>
     <string name="bluemusic_mascot_description">Lietotnes ikona</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Izvēlēties lietotnes</string>
     <string name="devices_app_selection_search_hint">Meklēt lietotnes...</string>
-    <string name="devices_app_selection_currently_selected">Pašlaik izvēlēts</string>
     <string name="devices_app_selection_selected_count">Izvēlētas %d lietotnes</string>
     <string name="general_navigate_back_action">Pārvietoties atpakaļ</string>
     <string name="general_reset_action">Atiestatīt</string>
     <string name="general_clear_action">Notīrīt</string>
-    <string name="general_save_action">Saglabāt</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Bloktāze</string>
     <string name="devices_indicator_awake">Nomods</string>
@@ -454,7 +366,6 @@
     <string name="devices_indicator_limit">Ierobežot</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Pastiprinājums</string>
-    <string name="devices_indicator_launch">Palaist</string>
     <string name="devices_indicator_home">Sākums</string>
     <string name="devices_indicator_dnd">NTR</string>
     <string name="devices_indicator_alert">Brīdinājums</string>

--- a/app/src/main/res/values-mk-rMK/strings.xml
+++ b/app/src/main/res/values-mk-rMK/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Некои функции се промениле за време на ажурирањето. Провери ги поставките на уредот за да се осигураш дека сè е правилно конфигурирано.</string>
     <string name="onboarding_rewrite_action">Продолжи</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Нема пронајдено неуправувани уреди</string>
     <string name="discover_all_devices_managed_msg">Сите твои спарени уреди се управувани! Треба нов?</string>
     <string name="discover_pair_new_device_action">Спари нов уред</string>
     <string name="discover_device_speaker_desc">Вградениот звучник на телефонот. Неговите волумени се применуваат кога аудио се враќа на телефонот, нпр. откако се прекине вашиот Bluetooth уред.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Конфигурација на уредот</string>
-    <string name="devices_device_config_section_general_label">Генерално</string>
     <string name="devices_device_config_remove_device_label">Заборави уред</string>
-    <string name="devices_device_config_remove_device_desc">Го заборава уредот од оваа апликација и ја брише неговата конфигурација. Ова не го одспарува уредот.</string>
     <string name="devices_device_config_remove_device_action">Заборави</string>
     <string name="devices_device_config_remove_device_confirmation">Да се заборави %s од управуваните уреди?</string>
-    <string name="devices_device_config_rename_device_label">Преименувај уред</string>
-    <string name="devices_device_config_rename_device_desc">Преименувај го овој уред во оваа апликација, и ако е можно, и во системот.</string>
     <string name="devices_device_config_rename_device_action">Преименувај</string>
     <string name="devices_device_config_enabled_label">Овозможен</string>
     <string name="devices_device_config_enabled_desc">Реагирај на овој уред кога е поврзан</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Команди за автоматско пуштање</string>
     <string name="devices_device_config_autoplay_keycodes_order">Редослед на команди</string>
     <string name="devices_device_config_autoplay_keycodes_label">Команди</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Конфигурирај кои команди да се испратат и во кој редослед</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Нема конфигурирани команди</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Додај команда</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Максимум %1$d команди</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Помести горе</string>
     <string name="cd_autoplay_keycode_move_down">Помести долу</string>
     <string name="cd_autoplay_keycode_remove">Отстрани</string>
-    <string name="devices_device_config_section_volumes_label">Јачини на звук</string>
     <string name="devices_device_config_section_volume_label">Јачина на звук</string>
     <string name="devices_device_config_alarm_volume_label">Јачина на алармот</string>
     <string name="devices_device_config_alarm_volume_desc">Некои аларм апликации ја користат јачина на звук за музичка.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Ѕвонење</string>
     <string name="devices_audio_stream_notification_label">Известување</string>
     <string name="devices_audio_stream_alarm_label">Аларм</string>
-    <string name="devices_neverseen_label">Никогаш не виден</string>
-    <string name="devices_state_connected_label">Конектирано</string>
     <string name="devices_last_connected_label">Последно поврзано: %s</string>
     <string name="devices_currently_connected_label">Моментално поврзано</string>
     <string name="devices_device_disabled_label">Уредот е оневозможен</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Поставки кои влијаат на сите управувани уреди.</string>
     <string name="label_app_enabled">Апликацијата е овозможена</string>
     <string name="description_app_enabled">Ја проклопува способноста на апликацијата да реагира на волумен и Блутут настани.</string>
-    <string name="label_visible_volume_adjustments">Видливи прилагодувања</string>
-    <string name="description_visible_volume_adjustments">Прикажи го системскиот прозорец за јачина на звукот додека оваа апликација прави прилагодувања.</string>
     <string name="label_volume_listener">Надгледува на промени</string>
-    <string name="description_volume_listener">Останува активна додека е поврзан уредот и зачувај ги промените на звукот кои не се предизвикани од оваа апликација.</string>
     <string name="label_boot_restore">Врати на подигање</string>
     <string name="description_boot_restore">Враќање волумен по подигнување/рестартирање ако е поврзан уред со Блутут.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Научи да го користиш BVM ефикасно</string>
     <string name="settings_support_issue_tracker_description">Јавен тракер за пријавување грешки и барања за нови функции.</string>
     <string name="settings_support_issue_tracker_label">Тракер за проблеми</string>
-    <string name="settings_support_debuglog_label">Дебаг лог</string>
     <string name="settings_support_debuglog_desc">Сними сè што прави апликацијата во текстуална датотека која можеш да ја споделиш.</string>
-    <string name="settings_support_debuglog_recording_desc">Моментално се снима дебаг информацијата. Допри за да запреш со снимање.</string>
-    <string name="settings_support_debuglog_path">Патека на логот: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Многу кратко снимање</string>
     <string name="settings_support_debuglog_short_recording_msg">Тоа беше многу кратко снимање. Дебаг логовите се снимки, не снимки на состојбата — репродуцирај го проблемот додека снимањето е активно за логот да биде корисен.</string>
     <string name="settings_support_debuglog_short_recording_continue">Продолжи со снимање</string>
     <string name="settings_support_debuglog_short_recording_stop">Запри сепак</string>
-    <string name="settings_support_debuglog_folder_label">Папка за дебаг логови</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d сесија користи %2$s</item>
-        <item quantity="other">%1$d сесии користат %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Нема зачувани дебаг логови</string>
-    <string name="settings_support_debuglog_folder_delete_title">Да се избришат сите дебаг логови?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Ова трајно ќе ги избрише сите зачувани сесии на дебаг лог.</string>
     <string name="settings_support_discord_label">Раздор</string>
     <string name="settings_support_discord_description">Место каде можеш да се дружиш и да поставуваш прашања.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Превод</string>
     <string name="settings_acks_translators_title">Преведувачи</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Преведи BVM</string>
-    <string name="settings_acks_translate_desc">Помогни го преводот на BVM на твојот јазик</string>
     <string name="settings_acks_thanks_header">Благодарности</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">За поддршката на преводот на проекти со отворен код</string>
     <string name="settings_licenses_label">Лиценци</string>
     <string name="settings_translation_label">Превод</string>
     <string name="settings_translation_desc">Помогнете да ја преведете апликацијата на вашиот омилен јазик</string>
-    <string name="settings_sponsor_development_title">Спонзорирај развој</string>
-    <string name="settings_sponsor_development_summary">Стани патрон и овозможи продолжување на развојот.</string>
     <string name="settings_privacy_policy_label">Политика за приватност</string>
     <string name="settings_privacy_policy_desc">Одговорно ракување со податоците.</string>
     <string name="changelog_label">Историја на промени</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Враќањето е завршено — %1$d уреди вратени, %2$d прескокнати.</string>
     <string name="backup_restore_version_warning">Оваа резервна копија е создадена со верзија %1$s. Вие користите %2$s. Некои поставки може да не се вратат правилно.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Дебаг известувања</string>
     <string name="debug_log_consent_title">Дебаг лог</string>
     <string name="debug_log_consent_explanation">Оваа функција снима сè што прави апликацијата во датотека која може да се сподели. Генерираната датотека содржи чувствителни информации (на пр. имиња на датотеки и инсталирани апликации). Сподели ја само со доверливи страни (на пр. програмер кој решава проблем).</string>
-    <string name="debug_log_recording_progress">Снимање дебаг лог</string>
     <string name="debug_log_record_action">Сними</string>
     <string name="debug_log_stop_action">Запри со снимање</string>
     <string name="debug_log_screen_title">Снимач на дебаг лог</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Отфрли</string>
     <string name="debug_log_screen_keep_action">Задржи</string>
-    <string name="debug_log_compressing_label">Компресирање…</string>
     <string name="debug_log_file_label">Снимена лог датотека</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Логот е испратен?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Опиши го своето прашање детално.</string>
     <string name="contact_category_section_label">Категорија</string>
     <string name="contact_debug_log_label">Дебаг лог</string>
-    <string name="contact_debug_log_select_hint">Избери дебаг лог за прикачување</string>
     <string name="contact_debug_log_picker_hint">Прикачи дебаг лог за побрза дијагноза на проблемот.</string>
     <string name="contact_debug_log_picker_empty">Нема достапни дебаг логови. Прво сними еден.</string>
     <string name="contact_expected_behavior_label">Очекувано однесување</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Јас лично ги читам сите пораки и се трудам да одговорам, но бидејќи работам сам, тоа може да потрае малку. Благодарам на трпеливоста.</string>
     <string name="contact_footer_msg">Твојата порака ќе биде испратена преку е-пошта. Информациите за уредот и поставките се прикачуваат автоматски.</string>
     <string name="contact_no_email_app_msg">На овој уред нема апликација за е-пошта.</string>
-    <string name="contact_attachment_missing_msg">Датотеката со дебаг лог повеќе не постои</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Зачувани дебаг логови</string>
     <string name="settings_support_stored_logs_desc">%1$d сесии (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Нема зачувани дебаг логови</string>
-    <string name="settings_support_stored_logs_delete_title">Да се избришат зачуваните логови?</string>
-    <string name="settings_support_stored_logs_delete_msg">Ќе се избришат сите %1$d зачувани сесии на дебаг лог.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Зачуваните дебаг логови се избришани</string>
-    <string name="label_bug_reports">Пријави грешка</string>
-    <string name="description_bug_reports">Автоматско известување за грешки и падови.</string>
     <string name="label_add_device">Додај уред</string>
-    <string name="label_just_a_moment_please">Само еден момент, ве молиме.</string>
     <string name="label_notification_channel_status">Статус</string>
     <string name="label_notification_channel_setup">Потребно е поставување</string>
     <string name="monitor_notification_starting">Стартување…</string>
     <string name="action_set">Поставете</string>
     <string name="action_cancel">Откажи</string>
-    <string name="label_invalid_input">Невалиден внес</string>
     <string name="action_reset">Ресетирај</string>
     <string name="label_no_connected_devices">Нема поврзани уреди</string>
-    <string name="label_status_idle">Во мирување</string>
-    <string name="label_status_adjusting_volumes">Прилагодување на тон</string>
-    <string name="label_premium_version">Премиум верзија</string>
     <string name="general_upgrade_action">Надградба</string>
     <string name="common_upgrade_required_label">Потребна надградба</string>
-    <string name="label_premium_version_required">Потребна е премиум верзија</string>
-    <string name="description_intro_purpose">Оваа апликација дозволува вашиот Андроид уред го памети нивото на глас на различни Блутут уреди.</string>
-    <string name="upgrade_benefit_unlimited_devices">Неограничен број профили на уреди</string>
-    <string name="upgrade_benefit_connection_actions">Автоматско пуштање, стартување на апликација и известувања за поврзување</string>
-    <string name="upgrade_benefit_theme_customization">Прилагодување на тема, стил и боја</string>
-    <string name="upgrade_benefit_power_controls">Заклучување на јачина на звук и ограничување на стапка</string>
-    <string name="upgrade_benefit_support">Поддржи независен развој</string>
     <string name="upgrade_benefit_equalizer">• Еквилајзер по уред (за музички апликации со поддршка за системски еквилајзер)</string>
-    <string name="description_intro_tap_the_button">Започнете со додавање на вашиот прв уред.</string>
     <string name="description_bluetooth_is_disabled">Блутутот е исклучен.</string>
     <string name="title_bluetooth_is_off">Bluetooth е исклучен</string>
     <string name="action_enable_bluetooth">Вклучи Bluetooth</string>
     <string name="title_bluetooth_permission_required">Потребна е дозвола за Bluetooth</string>
     <string name="description_bluetooth_permission_required">Оваа апликација треба дозвола за Bluetooth за да управува со јачините на звукот на уредите.</string>
     <string name="action_grant_permission">Дај дозвола</string>
-    <string name="label_status_listening_for_changes">Слуша за промени јачината на звукот</string>
     <string name="action_exit">Излез</string>
-    <string name="action_start">Старт</string>
-    <string name="label_welcome">Добредојдовте</string>
-    <string name="description_intro_contact">Не двоумете се да ме контактирате ако имате прашања или дури и идеја за нова функција.</string>
-    <string name="label_translation">Превод</string>
-    <string name="description_help_translate">Помогнете ми да ја направам оваа апликација достапна и на други јазици.</string>
     <string name="label_device_speaker">Звучник на уредот</string>
-    <string name="label_keyevent_playpause">Старт-Пауза</string>
-    <string name="label_keyevent_play">Старт</string>
-    <string name="label_keyevent_next">Следно</string>
-    <string name="label_install_id">Инсталирај го ID</string>
     <string name="message_copied_to_clipboard">Копирано на таблата со исечоци</string>
-    <string name="label_thanks">Благодарам</string>
-    <string name="label_licenses">Лиценци</string>
-    <string name="description_ring_volume_additional_permission">Потребни се дополнителни дозволи за промена на јачината на ѕвонењето.</string>
-    <string name="label_missing_permissions">Недостасуваат дозволи</string>
-    <string name="action_grant">Додели</string>
-    <string name="label_advanced">Напредно</string>
-    <string name="label_exclude_health">Исклучи здравствени профили</string>
-    <string name="description_exclude_health">Некои уреди со Андрои висат кога бараат Блутут профили на \&quot;Здравствени Уреди\&quot; (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Исклучете ги профилите на GATT серверот</string>
-    <string name="label_exclude_gatt">Исклучете GATT профили</string>
-    <string name="description_exclude_gattserver">Не ги пребарувајте Блутут профилите од типот \'Генерички атрибут\' (GATT) сервер.</string>
-    <string name="description_exclude_gatt">Не ги пребарувајте Блутут профилите од типот \'Генерички атрибут\' (GATT) клиент.</string>
-    <string name="description_waiting_for_devicex">Се чека %s да се заврши конекцијата</string>
-    <string name="action_undo">Врати</string>
-    <string name="action_show">Прикажи</string>
     <string name="action_dismiss">Отфрли</string>
-    <string name="action_fix">Поправи</string>
-    <string name="battery_optimizations_issue_description">Оптимизациите на батеријата се овозможени за оваа апликација и може да спречат да примаат Bluetooth настани. Размислете за оневозможување на оптимизации ако имате проблеми.</string>
     <string name="label_bluetooth_settings">Bluetooth поставки</string>
-    <string name="android10_applaunch_issue_description">Андроид 10 ограничува како апликациите можат да бидат лансирани од позадината. За да дозволите отворање на апликации кога Bluetooth-уред ќе се поврзе, дајте дозвола „Прикажи преку други апликации\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Изворен код</string>
-    <string name="android13_notification_permission_description">Дај дозвола на оваа апликација да испраќа известувања. Ова овозможува прикажување на известување кога апликацијата е активна и се прават прилагодувања на јачината на звукот.</string>
-    <string name="privacy_policy_label">Политика за приватност</string>
     <string name="managed_devices_empty_message">Нема конфигурирани Bluetooth уреди.\nДопри го копчето + за да го додадеш твојот прв уред.</string>
     <string name="label_pro_feature">Премиум функција</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Преглед</string>
     <string name="review_app_dismiss_action">Можеби подоцна</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Купувањето е откажано</string>
-    <string name="error_iap_unavailable_message">Купувањата во апликацијата не се достапни</string>
-    <string name="error_generic_message">Настана грешка. Обиди се повторно.</string>
-    <string name="error_iap_owned_message">Веќе го поседуваш овој предмет</string>
     <string name="label_no_devices_title">Нема уреди</string>
     <string name="bluemusic_mascot_description">Икона на апликацијата</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Избери апликации</string>
     <string name="devices_app_selection_search_hint">Барај апликации…</string>
-    <string name="devices_app_selection_currently_selected">Моментално избрани</string>
     <string name="devices_app_selection_selected_count">%d апликации избрани</string>
     <string name="general_navigate_back_action">Навигирај назад</string>
     <string name="general_reset_action">Ресетирај</string>
     <string name="general_clear_action">Исчисти</string>
-    <string name="general_save_action">Зачувај</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Заклучи</string>
     <string name="devices_indicator_awake">Буден</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Лимит</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Засилување</string>
-    <string name="devices_indicator_launch">Стартај</string>
     <string name="devices_indicator_home">Почеток</string>
     <string name="devices_indicator_dnd">НВ</string>
     <string name="devices_indicator_alert">Известување</string>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">അപ്ഡേറ്റ് സമയത്ത് ചില ഫീച്ചറുകൾ മാറിയിട്ടുണ്ട്. എല്ലാം ശരിയായി ക്രമീകരിച്ചിട്ടുണ്ടെന്ന് ഉറപ്പാക്കാൻ ദയവായി നിങ്ങളുടെ ഉപകരണ ക്രമീകരണങ്ങൾ പരിശോധിക്കുക.</string>
     <string name="onboarding_rewrite_action">തുടരുക</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">നിർവ്വഹിക്കാത്ത ഉപകരണങ്ങൾ കണ്ടെത്തിയില്ല</string>
     <string name="discover_all_devices_managed_msg">നിങ്ങളുടെ എല്ലാ ജോടിചേർത്ത ഉപകരണങ്ങളും നിർവ്വഹിക്കുന്നു! ഒരു പുതിയത് വേണോ?</string>
     <string name="discover_pair_new_device_action">പുതിയ ഉപകരണം ജോടിചേർക്കുക</string>
     <string name="discover_device_speaker_desc">ഈ ഫോണിന്റെ സ്വന്ത സ്പീക്കർ. നിങ്ങളുടെ Bluetooth ഡിവൈസ് വിച്ഛേദിക്കുമ്പോൾ അതിന്റെ വോളിയങ്ങൾ ഫോണിലേക്ക് ഓഡിയോ മടങ്ങുമ്പോൾ പ്രയോഗിക്കുന്നു.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ഉപകരണ ക്രമീകരണം</string>
-    <string name="devices_device_config_section_general_label">പൊതുവായ</string>
     <string name="devices_device_config_remove_device_label">ഉപകരണം മറക്കുക</string>
-    <string name="devices_device_config_remove_device_desc">ഈ ആപ്പിൽ നിന്ന് ഉപകരണം മറക്കുകയും അതിന്റെ ക്രമീകരണം ഇല്ലാതാക്കുകയും ചെയ്യുന്നു. ഇത് ഉപകരണത്തിന്റെ ജോടിചേർൽ നീക്കുന്നില്ല.</string>
     <string name="devices_device_config_remove_device_action">മറക്കുക</string>
     <string name="devices_device_config_remove_device_confirmation">നിർവ്വഹിക്കുന്ന ഉപകരണങ്ങളിൽ നിന്ന് %s മറക്കണോ?</string>
-    <string name="devices_device_config_rename_device_label">ഉപകരണം പുനർനാമകരണം ചെയ്യുക</string>
-    <string name="devices_device_config_rename_device_desc">ഈ ആപ്പിൽ, സാധ്യമെങ്കിൽ സിസ്റ്റത്തിലും ഈ ഉപകരണം പുനർനാമകരണം ചെയ്യുക.</string>
     <string name="devices_device_config_rename_device_action">പുനർനാമകരണം</string>
     <string name="devices_device_config_enabled_label">പ്രവർത്തനക്ഷമം</string>
     <string name="devices_device_config_enabled_desc">കണക്‌റ് ചെയ്യുമ്പോൾ ഈ ഉപകരണത്തിനോട് പ്രതികരിക്കുക</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">ഓട്ടോപ്ലേ കമാൻഡുകൾ</string>
     <string name="devices_device_config_autoplay_keycodes_order">കമാൻഡ് ക്രമം</string>
     <string name="devices_device_config_autoplay_keycodes_label">കമാൻഡുകൾ</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">ഏതൊക്കെ കമാൻഡുകൾ അയക്കണം, ഏത് ക്രമത്തിൽ എന്ന് ക്രമീകരിക്കുക</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">കമാൻഡുകളൊന്നും ക്രമീകരിച്ചിട്ടില്ല</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">കമാൻഡ് ചേർക്കുക</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">പരമാവധി %1$d കമാൻഡുകൾ</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">മേല്പ്പോട്ട് നീക്കുക</string>
     <string name="cd_autoplay_keycode_move_down">താഴോട്ട് നീക്കുക</string>
     <string name="cd_autoplay_keycode_remove">നീക്കം ചെയ്യുക</string>
-    <string name="devices_device_config_section_volumes_label">വോള്യങ്ങൾ</string>
     <string name="devices_device_config_section_volume_label">വോള്യം</string>
     <string name="devices_device_config_alarm_volume_label">അലാം വോള്യം</string>
     <string name="devices_device_config_alarm_volume_desc">ചില അലാം ആപ്പുകൾ പകരം മ്യൂസിക് വോള്യം ഉപയോഗിക്കുന്നു.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">റിംഗ്</string>
     <string name="devices_audio_stream_notification_label">നോട്ടിഫിക്കേഷൻ</string>
     <string name="devices_audio_stream_alarm_label">അലാം</string>
-    <string name="devices_neverseen_label">ഒരിക്കലും കണ്ടിട്ടില്ല</string>
-    <string name="devices_state_connected_label">കണക്‌റ് ആണ്</string>
     <string name="devices_last_connected_label">അവസാനം കണക്‌റ് ആയത്: %s</string>
     <string name="devices_currently_connected_label">ഇപ്പോൾ കണക്‌റ് ആണ്</string>
     <string name="devices_device_disabled_label">ഉപകരണം പ്രവർത്തനരഹിതമാണ്</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">നിർവ്വഹിക്കുന്ന എല്ലാ ഉപകരണങ്ങളെയും ബാധിക്കുന്ന ക്രമീകരണങ്ങൾ.</string>
     <string name="label_app_enabled">ആപ്പ് പ്രവർത്തനക്ഷമം</string>
     <string name="description_app_enabled">വോള്യം, Bluetooth ഇവന്റുകളോട് പ്രതികരിക്കാനുള്ള ആപ്പിന്റെ കഴിവ് ടോഗിൾ ചെയ്യുന്നു.</string>
-    <string name="label_visible_volume_adjustments">ദൃശ്യ ക്രമീകരണങ്ങൾ</string>
-    <string name="description_visible_volume_adjustments">ഈ ആപ്പ് ക്രമീകരണങ്ങൾ നടത്തുമ്പോൾ സിസ്റ്റത്തിന്റെ വോള്യം വിൻഡോ കാണിക്കുക.</string>
     <string name="label_volume_listener">മാറ്റങ്ങൾ നിരീക്ഷിക്കുക</string>
-    <string name="description_volume_listener">ഒരു ഉപകരണം കണക്‌റ് ആയിരിക്കുമ്പോൾ സജീവമായിരിക്കുകയും ഈ ആപ്പ് കാരണമല്ലാത്ത വോള്യം മാറ്റങ്ങൾ സംരക്ഷിക്കുകയും ചെയ്യുക.</string>
     <string name="label_boot_restore">ബൂട്ടിൽ പുനഃസ്ഥാപിക്കുക</string>
     <string name="description_boot_restore">ഒരു Bluetooth ഉപകരണം കണക്‌റ് ആണെങ്കിൽ ബൂട്ടിംഗ്/റീബൂട്ടിംഗ് ശേഷം വോള്യം പുനഃസ്ഥാപിക്കുക.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM ഫലപ്രദമായി ഉപയോഗിക്കുന്നത് പഠിക്കുക</string>
     <string name="settings_support_issue_tracker_description">ബഗ് റിപ്പോർട്ടുകൾക്കും ഫീച്ചർ അഭ്യർത്ഥനകൾക്കുമുള്ള പൊതു ഇഷ്യൂ ട്രാക്കർ.</string>
     <string name="settings_support_issue_tracker_label">ഇഷ്യൂ ട്രാക്കർ</string>
-    <string name="settings_support_debuglog_label">ഡീബഗ് ലോഗ്</string>
     <string name="settings_support_debuglog_desc">ആപ്പ് ചെയ്യുന്ന എല്ലാം നിങ്ങൾക്ക് പങ്കിടാനാകുന്ന ടെക്സ്റ്റ് ഫയലിലേക്ക് രേഖപ്പെടുത്തുക.</string>
-    <string name="settings_support_debuglog_recording_desc">നിലവിൽ ഡീബഗ് വിവരങ്ങൾ റെക്കോർഡ് ചെയ്യുന്നു. റെക്കോർഡിംഗ് നിർത്താൻ ടാപ്പ് ചെയ്യുക.</string>
-    <string name="settings_support_debuglog_path">ലോഗ് പാത: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">വളരെ ഹ്രസ്വ റെക്കോർഡിംഗ്</string>
     <string name="settings_support_debuglog_short_recording_msg">അത് വളരെ ഹ്രസ്വമായ ഒരു റെക്കോർഡിംഗ് ആയിരുന്നു. ഡീബഗ് ലോഗുകൾ റെക്കോർഡിംഗുകളാണ്, സ്നാപ്ഷോട്ടുകളല്ല — ലോഗ് ഉപകാരപ്രദമാകണമെങ്കിൽ റെക്കോർഡിംഗ് സജീവമായിരിക്കുമ്പോൾ പ്രശ്നം പുനഃസൃഷ്ടിക്കുക.</string>
     <string name="settings_support_debuglog_short_recording_continue">റെക്കോർഡിംഗ് തുടരുക</string>
     <string name="settings_support_debuglog_short_recording_stop">എന്തായാലും നിർത്തുക</string>
-    <string name="settings_support_debuglog_folder_label">ഡീബഗ് ലോഗ് ഫോർഡർ</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d സെഷൻ %2$s ഉപയോഗിക്കുന്നു</item>
-        <item quantity="other">%1$d സെഷനുകൾ %2$s ഉപയോഗിക്കുന്നു</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">ഡീബഗ് ലോഗുകൾ ഒന്നും സംഭരിച്ചിട്ടില്ല</string>
-    <string name="settings_support_debuglog_folder_delete_title">എല്ലാ ഡീബഗ് ലോഗുകളും ഇല്ലാതാക്കണോ?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">ഇത് സംഭരിച്ച എല്ലാ ഡീബഗ് ലോഗ് സെഷനുകളും ശാശ്വതമായി ഇല്ലാതാക്കും.</string>
     <string name="settings_support_discord_label">ഡിസ്കോർഡ്</string>
     <string name="settings_support_discord_description">ചുറ്റിക്കറങ്ങാനും ചോദ്യങ്ങൾ ചോദിക്കാനുമുള്ള ഇടം.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">പരിഭാഷ</string>
     <string name="settings_acks_translators_title">പരിഭാഷകർ</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM വിവർത്തനം ചെയ്യുക</string>
-    <string name="settings_acks_translate_desc">BVM നിങ്ങളുടെ ഭാഷയിലേക്ക് വിവർത്തനം ചെയ്യാൻ സഹായിക്കുക</string>
     <string name="settings_acks_thanks_header">നന്ദി</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">ഓപ്പൺ-സോഴ്‌സ് പ്രോജക്ടുകളുടെ വിവർത്തനം പിന്തുണയ്ക്കുന്നതിന്</string>
     <string name="settings_licenses_label">ലൈസൻസുകൾ</string>
     <string name="settings_translation_label">പരിഭാഷ</string>
     <string name="settings_translation_desc">ആപ്പ് നിങ്ങളുടെ പ്രിയ ഭാഷയിലേക്ക് വിവർത്തനം ചെയ്യാൻ സഹായിക്കുക</string>
-    <string name="settings_sponsor_development_title">വികസനം സ്പോൺസർ ചെയ്യുക</string>
-    <string name="settings_sponsor_development_summary">പ്രണയിയാകുകയും തുടർ വികസനം സാധ്യമാക്കുകയും ചെയ്യുക.</string>
     <string name="settings_privacy_policy_label">സ്വകാര്യതാ നയം</string>
     <string name="settings_privacy_policy_desc">ഡാറ്റ ഉത്തരവാദിത്തത്തോടെ കൈകാര്യം ചെയ്യുന്നു.</string>
     <string name="changelog_label">മാറ്റങ്ങളുടെ പട്ടിക</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">പുനഃസ്ഥാപനം പൂർത്തിയായി — %1$d ഉപകരണങ്ങൾ പുനഃസ്ഥാപിച്ചു, %2$d ഒഴിവാക്കി.</string>
     <string name="backup_restore_version_warning">ഈ ബാക്കപ്പ് %1$s പതിപ്പ് ഉപയോഗിച്ചാണ് സൃഷ്ടിച്ചത്. നിങ്ങൾ %2$s പ്രവർത്തിപ്പിക്കുന്നു. ചില ക്രമീകരണങ്ങൾ ശരിയായി പുനഃസ്ഥാപിക്കപ്പെടാതിരിക്കാം.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">ഡീബഗ് അറിയിപ്പുകൾ</string>
     <string name="debug_log_consent_title">ഡീബഗ് ലോഗ്</string>
     <string name="debug_log_consent_explanation">ഈ ഫീച്ചർ ആപ്പ് ചെയ്യുന്ന എല്ലാം പങ്കിടാവുന്ന ഫയലിലേക്ക് രേഖപ്പെടുത്തുന്നു. സൃഷ്ടിക്കപ്പെട്ട ഫയലിൽ സെൻസിറ്റീവ് വിവരങ്ങൾ അടങ്ങിയിരിക്കുന്നു (ഉദാ. ഫയൽ പേരുകൾ, ഇൻസ്റ്റാൾ ചെയ്ത ആപ്പുകൾ). വിശ്വസ്ത കക്ഷികളുമായി മാത്രം പങ്കിടുക (ഉദാ. പ്രശ്നം പരിഹരിക്കുന്ന ഡെവലപ്പർ).</string>
-    <string name="debug_log_recording_progress">ഡീബഗ് ലോഗ് രേഖപ്പെടുത്തുന്നു</string>
     <string name="debug_log_record_action">റെക്കോർഡ്</string>
     <string name="debug_log_stop_action">രേഖപ്പെടുത്തൽ നിർത്തുക</string>
     <string name="debug_log_screen_title">ഡീബഗ് ലോഗ് റെക്കോർഡർ</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">ഉപേക്ഷിക്കുക</string>
     <string name="debug_log_screen_keep_action">സൂക്ഷിക്കുക</string>
-    <string name="debug_log_compressing_label">കംപ്രസ് ചെയ്യുന്നു…</string>
     <string name="debug_log_file_label">രേഖപ്പെടുത്തിയ ലോഗ് ഫയൽ</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">ലോഗ് അയച്ചോ?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">നിങ്ങളുടെ ചോദ്യം വിശദമായി വിവരിക്കുക.</string>
     <string name="contact_category_section_label">വിഭാഗം</string>
     <string name="contact_debug_log_label">ഡീബഗ് ലോഗ്</string>
-    <string name="contact_debug_log_select_hint">ഒരു ഡീബഗ് ലോഗ് ഘടിപ്പിക്കാൻ തിരഞ്ഞെടുക്കുക</string>
     <string name="contact_debug_log_picker_hint">പ്രശ്നം വേഗത്തിൽ രോഗനിർണ്ണയം ചെയ്യാൻ സഹായിക്കാൻ ഒരു ഡീബഗ് ലോഗ് ഘടിപ്പിക്കുക.</string>
     <string name="contact_debug_log_picker_empty">ഡീബഗ് ലോഗുകൾ ലഭ്യമല്ല. ആദ്യം ഒന്ന് റെക്കോർഡ് ചെയ്യുക.</string>
     <string name="contact_expected_behavior_label">പ്രതീക്ഷിത സ്വഭാവം</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">ഞാൻ ഓരോ സന്ദേശവും സ്വയം വായിക്കുകയും മറുപടി നൽകാൻ പരമാവധി ശ്രമിക്കുകയും ചെയ്യുന്നു, പക്ഷേ ഞാൻ ഇത് ഒറ്റയ്ക്ക് ചെയ്യുന്നതിനാൽ, അൽപ്പം സമയം ആകാം. ക്ഷമയ്ക്ക് നന്ദി.</string>
     <string name="contact_footer_msg">നിങ്ങളുടെ സന്ദേശം ഇമെയിൽ വഴി അയക്കും. ഉപകരണ, ക്രമീകരണ വിവരങ്ങൾ സ്വതോഭൂതമായി ഘടിപ്പിക്കും.</string>
     <string name="contact_no_email_app_msg">ഈ ഉപകരണത്തിൽ ഇമെയിൽ ആപ്പ് കണ്ടെത്തിയില്ല.</string>
-    <string name="contact_attachment_missing_msg">ഡീബഗ് ലോഗ് ഫയൽ ഇനി നിലവിലില്ല</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">സംഭരിച്ച ഡീബഗ് ലോഗുകൾ</string>
     <string name="settings_support_stored_logs_desc">%1$d സെഷനുകൾ (%2$s)</string>
     <string name="settings_support_stored_logs_empty">സംഭരിച്ച ഡീബഗ് ലോഗുകൾ ഇല്ല</string>
-    <string name="settings_support_stored_logs_delete_title">സംഭരിച്ച ലോഗുകൾ ഇല്ലാതാക്കണോ?</string>
-    <string name="settings_support_stored_logs_delete_msg">ഇത് %1$d സംഭരിച്ച ഡീബഗ് ലോഗ് സെഷനുകൾ ഇല്ലാതാക്കും.</string>
-    <string name="settings_support_stored_logs_deleted_msg">സംഭരിച്ച ഡീബഗ് ലോഗുകൾ ഇല്ലാതാക്കി</string>
-    <string name="label_bug_reports">ബഗ് റിപ്പോർട്ടുകൾ</string>
-    <string name="description_bug_reports">സ്വതോഭൂതമായ ബഗ്, ക്രാഷ് റിപ്പോർട്ടിംഗ്.</string>
     <string name="label_add_device">ഉപകരണം ചേർക്കുക</string>
-    <string name="label_just_a_moment_please">ഒരു നിമിഷം, ദയവായി.</string>
     <string name="label_notification_channel_status">നില</string>
     <string name="label_notification_channel_setup">സജ്ജീകരണം ആവശ്യമാണ്</string>
     <string name="monitor_notification_starting">ആരംഭിക്കുന്നു…</string>
     <string name="action_set">സജ്ജീകരിക്കുക</string>
     <string name="action_cancel">റദ്ദ്ചെയ്യുക</string>
-    <string name="label_invalid_input">അസാധുവായ ഇൻപുട്ട്</string>
     <string name="action_reset">പുനഃക്രമീകരിക്കുക</string>
     <string name="label_no_connected_devices">ഉപകരണങ്ങൾ ഒന്നും കണക്‌റ് ആയിട്ടില്ല</string>
-    <string name="label_status_idle">നിഷ്ക്രിയം</string>
-    <string name="label_status_adjusting_volumes">വോള്യങ്ങൾ ക്രമീകരിക്കുന്നു</string>
-    <string name="label_premium_version">പ്രീമിയം വേർഷൻ</string>
     <string name="general_upgrade_action">അപ്ഗ്രേഡുചെയ്യുക</string>
     <string name="common_upgrade_required_label">അപ്‌ഗ്രേഡ് ആവശ്യമാണ്</string>
-    <string name="label_premium_version_required">പ്രീമിയം വേർഷൻ ആവശ്യമാണ്</string>
-    <string name="description_intro_purpose">ഈ ആപ്പ് നിങ്ങളുടെ Android ഉപകരണത്തെ വ്യത്യസ്ത Bluetooth ഉപകരണങ്ങളുടെ വോള്യം ഓർക്കാൻ അനുവദിക്കുന്നു.</string>
-    <string name="upgrade_benefit_unlimited_devices">പരിധിയില്ലാത്ത ഉപകരണ പ്രൊഫൈലുകൾ</string>
-    <string name="upgrade_benefit_connection_actions">ഓട്ടോപ്ലേ, ആപ്പ് ലോഞ്ച്, കണക്ഷൻ അലർട്ടുകൾ</string>
-    <string name="upgrade_benefit_theme_customization">തീം, ശൈലി, നിറ കസ്റ്റമൈസേഷൻ</string>
-    <string name="upgrade_benefit_power_controls">വോളിയം ലോക്കും റേറ്റ് ലിമിറ്റിങ്ങും</string>
-    <string name="upgrade_benefit_support">സ്വതന്ത്ര വികസനം പിന്തുനക്കുക</string>
     <string name="upgrade_benefit_equalizer">• പ്രതി-ഉപകരണ ഇക്വലൈസർ (സിസ്റ്റം ഇക്വലൈസർ പിന്തുണയുള്ള മ്യൂസിക് ആപ്പുകൾക്കായി)</string>
-    <string name="description_intro_tap_the_button">നിങ്ങളുടെ ആദ്യ ഉപകരണം ചേർത്ത് ആരംഭിക്കുക.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth പ്രവർത്തനരഹിതമാക്കിയിരിക്കുന്നു.</string>
     <string name="title_bluetooth_is_off">Bluetooth ഓഫ്ഫ് ആണ്</string>
     <string name="action_enable_bluetooth">Bluetooth പ്രവർത്തനക്ഷമമാക്കുക</string>
     <string name="title_bluetooth_permission_required">Bluetooth അനുമതി ആവശ്യമാണ്</string>
     <string name="description_bluetooth_permission_required">നിങ്ങളുടെ ഉപകരണ വോള്യങ്ങൾ നിർവ്വഹിക്കാൻ ഈ ആപ്പിന് Bluetooth അനുമതി ആവശ്യമാണ്.</string>
     <string name="action_grant_permission">അനുമതി നൽകുക</string>
-    <string name="label_status_listening_for_changes">വോള്യം മാറ്റങ്ങൾ ശ്രദ്ധിക്കുന്നു</string>
     <string name="action_exit">പുറത്തുകടക്കുക</string>
-    <string name="action_start">ആരംഭിക്കുക</string>
-    <string name="label_welcome">സ്വാഗതം</string>
-    <string name="description_intro_contact">നിങ്ങൾക്ക് ചോദ്യങ്ങളോ ഒരു പുതിയ ഫീച്ചറിനുള്ള ആശയമോ ഉണ്ടെങ്കിൽ എന്നെ ബന്ധപ്പെടാൻ മടിക്കേണ്ടതില്ല.</string>
-    <string name="label_translation">പരിഭാഷ</string>
-    <string name="description_help_translate">ഈ ആപ്പ് മറ്റ് ഭാഷകളിൽ ലഭ്യമാക്കാൻ എന്നെ സഹായിക്കൂ.</string>
     <string name="label_device_speaker">ഉപകരണ സ്പീക്കർ</string>
-    <string name="label_keyevent_playpause">പ്ലേ-പോസ്</string>
-    <string name="label_keyevent_play">പ്ലേ</string>
-    <string name="label_keyevent_next">അടുത്തത്</string>
-    <string name="label_install_id">ഇൻസ്റ്റാൾ ID</string>
     <string name="message_copied_to_clipboard">ക്ലിപ്പ്ബോർഡിലേക്ക് പകർത്തി</string>
-    <string name="label_thanks">നന്ദി</string>
-    <string name="label_licenses">ലൈസൻസുകൾ</string>
-    <string name="description_ring_volume_additional_permission">റിംഗ് വോള്യം മാറ്റാൻ അധിക അനുമതികൾ ആവശ്യമാണ്.</string>
-    <string name="label_missing_permissions">അനുമതികൾ കാണ്ണുന്നില്ല</string>
-    <string name="action_grant">അനുവദിക്കുക</string>
-    <string name="label_advanced">വിന്യസ്തമായ</string>
-    <string name="label_exclude_health">ഹെൽത്ത് പ്രൊഫൈലുകൾ ഭ്രമിപ്പിക്കുക</string>
-    <string name="description_exclude_health">ചില Android ഉപകരണങ്ങൾ \'ഹെൽത്ത് ഉപകരണം\' Bluetooth പ്രൊഫൈലുകൾ (HDP, 0x1400) തെരയാൻ വിസ്തിക്കുംപോൾ തടസപ്പെടുന്നു.</string>
-    <string name="label_exclude_gattserver">GATT സേവക പ്രൊഫൈലുകൾ ഭ്രമിപ്പിക്കുക</string>
-    <string name="label_exclude_gatt">GATT പ്രൊഫൈലുകൾ ഭ്രമിപ്പിക്കുക</string>
-    <string name="description_exclude_gattserver">\'ജെനേരിക് ആറ്റ്രിബ്യൂട്\' (GATT) സേവക തരത്തിലുള്ള Bluetooth പ്രൊഫൈലുകൾ അന്വേഷിക്കല്ല.</string>
-    <string name="description_exclude_gatt">\'ജെനേരിക് ആറ്റ്രിബ്യൂട്\' (GATT) ക്ലൈയ്യന്റ് തരത്തിലുള്ള Bluetooth പ്രൊഫൈലുകൾ അന്വേഷിക്കല്ല.</string>
-    <string name="description_waiting_for_devicex">%s കണക്ഷൻ പൂർത്തിയാകുന്നതിനായ് കാത്തിരിക്കുന്നു</string>
-    <string name="action_undo">പഴയപടിയാക്കുക</string>
-    <string name="action_show">കാണിക്കുക</string>
     <string name="action_dismiss">തള്ളിക്കളയുക</string>
-    <string name="action_fix">ശരിയാക്കുക</string>
-    <string name="battery_optimizations_issue_description">ഈ ആപ്പിന് ബാറ്റരി ഒപ്റ്റിമൈസേഷൻ സക്രിയമാണ്, ഇത് ആപ്പിന് Bluetooth ഇവന്റുകൾ ലഭിക്കുന്നത് തടയാമ്. പ്രശ്നങ്ങൾ ഉണ്ടെങ്കിൽ ഒപ്റ്റിമൈസേഷൻ പ്രവർത്തനം ംഗം വേണ്ടെണ്ഡു പരിഗണിക്കുക.</string>
     <string name="label_bluetooth_settings">Bluetooth ക്രമീകരണങ്ങൾ</string>
-    <string name="android10_applaunch_issue_description">Android 10 പ്രവർത്തന പിൻത്തിൽ നിന്ന് ആപ്പുകൾ ദൂരൈക്കേൻ കഴിയുന്ന രീതി പരിമിതപ്പെടുത്തുന്നു. Bluetooth ഉപകരണം കണെക്ട് ചെയ്യുമ്പോൾ ആപ്പുകൾ തുറക്കല് അനുവദിക്കാൻ \"മറ്റ് ആപ്പുകൾക് മുകളിൽ പ്രദർശിപ്പിക്കുക\" (SYSTEM_ALERT_WINDOW) അനുമതി നൽകുക.</string>
-    <string name="label_opensource">സോർസ് കോഡ്</string>
-    <string name="android13_notification_permission_description">അധിസൂചനകൾ പ്രസിദ്ധമാക്കാൻ ഈ ആപ്പിന് അനുമതി നൽകുക. ഈ ആപ്പ് സക്രിയമാകുമ്പോൾ വോള്യം ക്രമീകരണം നിര്വഹിക്കുമ്പോൾ ഇത് ഒരു അധിസൂചന പ്രദർശിപ്പിക്കുന്നു.</string>
-    <string name="privacy_policy_label">സ്വകാര്യതാ നയം</string>
     <string name="managed_devices_empty_message">യാതൊരു Bluetooth ഉപകരണവും ക്രമീകരിക്കപ്പെട്ടിട്ടില്ല.\nഫസ്റ്റ് ഉപകരണം ചേർക്കാൻ + ബട്ടൻ ടാപ് ചെയ്യുക.</string>
     <string name="label_pro_feature">പ്രീമിയം ഫീച്ചർ</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">നിരൂപണം</string>
     <string name="review_app_dismiss_action">പിന്നീട്</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">വാങ്ങൽ റദ്ദാകി</string>
-    <string name="error_iap_unavailable_message">ആപ്പിനുള്ളിലെ വാങ്ങലുകൾ ലഭ്യമല്ല</string>
-    <string name="error_generic_message">ഒരു തൃടി സംഭവിച്ചു. വീണ്ടും ശ്രമിക്കുക.</string>
-    <string name="error_iap_owned_message">ഈ ആയത്തം നിങ്ങൾക്ക് ഇതിനക്ക് സ്വന്തമാണ്</string>
     <string name="label_no_devices_title">ഉപകരണങ്ങളില്ല</string>
     <string name="bluemusic_mascot_description">ആപ്പ് ഐകോൻ</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">ആപ്പുകൾ തിരഞ്ഞെടുക്കുക</string>
     <string name="devices_app_selection_search_hint">ആപ്പുകൾ താൽക്കാൻ…</string>
-    <string name="devices_app_selection_currently_selected">ഇപ്പോൾ തിരഞ്ഞെടുത്ത്തിരിക്കുന്നു</string>
     <string name="devices_app_selection_selected_count">%d ആപ്പുകൾ തിരഞ്ഞെടുത്തു</string>
     <string name="general_navigate_back_action">തിരിച്ച് നാവിഗേറ്റ് ചെയ്യുക</string>
     <string name="general_reset_action">പുനഃക്രമീകരിക്കുക</string>
     <string name="general_clear_action">മാർജിക്കുക</string>
-    <string name="general_save_action">സേവ്</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">ലോക്ക് ചെയ്യുക</string>
     <string name="devices_indicator_awake">ഉണേര്ന്ന</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">പരിധി</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">ബൂസ്റ്റ്</string>
-    <string name="devices_indicator_launch">തുറക്കുക</string>
     <string name="devices_indicator_home">ഹോം</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">മുന്നറിയിപ്പ്</string>

--- a/app/src/main/res/values-mn-rMN/strings.xml
+++ b/app/src/main/res/values-mn-rMN/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Шинэчлэлтийн уцаар зарим үед өөрчлөгдсөн. Бүх зүйл зөв байдлаар тохиргуулан тохиргуулалтаа төхөөрөмийнӮ шалгаад үзьгээ ньгтгүйг няах.</string>
     <string name="onboarding_rewrite_action">Үргэлжлүүлэх</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Удаалагдаагүй төхөөрөмжий олдсонгүй</string>
     <string name="discover_all_devices_managed_msg">Таны харилцан бүх төхөөрөмжийг удааладаж байна! Шинэ нэг нэмжийг хариалцуулах гэж</string>
     <string name="discover_pair_new_device_action">Шинэ төхөөрөмжийг харилцах</string>
     <string name="discover_device_speaker_desc">Энэ утасны өөрийн чанга яригч. Түүний эзлэхүүнүүд аудио утас руу эргэж ирэхэд хэрэглэгдэнэ, жишээлбэл таны Bluetooth төхөөрөмж салсны дараа.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Төхөөрөмжийн тохиргуулалт</string>
-    <string name="devices_device_config_section_general_label">Ерөнхийлэл</string>
     <string name="devices_device_config_remove_device_label">Төхөөрөмжийг мартах</string>
-    <string name="devices_device_config_remove_device_desc">Төхөөрөмжийг энэ аппаас мартаад төхөөрөмжийн тохиргуулалтыг устгана. Энэ харилцалтыг цуцлахгүй.</string>
     <string name="devices_device_config_remove_device_action">Мартах</string>
     <string name="devices_device_config_remove_device_confirmation">%s-иг удаалагдсан төхөөрөмжүүдээс хасах уу?</string>
-    <string name="devices_device_config_rename_device_label">Төхөөрөмжийг өөрчлөх</string>
-    <string name="devices_device_config_rename_device_desc">Энэ аппд төхөөрөмжийн нэрийг өөрчлох, боломжтой бол системдч өөрчлөх.</string>
     <string name="devices_device_config_rename_device_action">Өөрчлөх</string>
     <string name="devices_device_config_enabled_label">Идэвхүүлсэн</string>
     <string name="devices_device_config_enabled_desc">Холбогдсон үед энэ төхөөрөмжийд хариулах</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Автоматаар тоглуулах командууд</string>
     <string name="devices_device_config_autoplay_keycodes_order">Командын дараалал</string>
     <string name="devices_device_config_autoplay_keycodes_label">Командууд</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Ямар командуудыг ямар дарааллаар илгээхийг тохируулах</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Тохируулсан команд байхгүй</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Команд нэмэх</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Хамгийн ихдээ %1$d команд</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Дээш шилжүүлэх</string>
     <string name="cd_autoplay_keycode_move_down">Доош шилжүүлэх</string>
     <string name="cd_autoplay_keycode_remove">Хасах</string>
-    <string name="devices_device_config_section_volumes_label">Дууннууд</string>
     <string name="devices_device_config_section_volume_label">Дуу</string>
     <string name="devices_device_config_alarm_volume_label">Дохианы дуу</string>
     <string name="devices_device_config_alarm_volume_desc">Зарим дохионы аппнууд хүщүүг дуу ашигладаг.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Дүүгэх</string>
     <string name="devices_audio_stream_notification_label">Мэдэгдэлгэ</string>
     <string name="devices_audio_stream_alarm_label">Дохио</string>
-    <string name="devices_neverseen_label">Хэзээгүй байсан</string>
-    <string name="devices_state_connected_label">Холбогдсон</string>
     <string name="devices_last_connected_label">Сүүлийн холбогдолт: %s</string>
     <string name="devices_currently_connected_label">Одоо холбогдсон</string>
     <string name="devices_device_disabled_label">Төхөөрөмжий идэвхүүлгүй</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Бүх удаалагдсан төхөөрөмжүүдд нөлөөлөх тохиргуулалт.</string>
     <string name="label_app_enabled">Апп идэвхүүлсэн</string>
     <string name="description_app_enabled">Аппын дуу ба Bluetooth үйл цахадлах чадварыг асаалах.</string>
-    <string name="label_visible_volume_adjustments">Харагдах тохиргуулалт</string>
-    <string name="description_visible_volume_adjustments">Энэ апп тохиргуулалт хийгээд системийн дууны цонхыг харуулах.</string>
     <string name="label_volume_listener">Өөрчлөлт ажиглах</string>
-    <string name="description_volume_listener">Төхөөрөмжий холбогдсон байхд идэвхүүлэн тогтноод энэ аппын үйлдлгүй дууны өөрчлөлтийг хадгалах.</string>
     <string name="label_boot_restore">Ньюцлэхэд сэргээлэх</string>
     <string name="description_boot_restore">Bluetooth төхөөрөмжий холбогдсон байсаалд ньюцлэх/дахин ньюцлэхийн дараа дууг сэргээлэх.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM-иг үр дүнтэй ашиглахыг сурах</string>
     <string name="settings_support_issue_tracker_description">Алдаа мэдэглэл ба онцлогдох хүсэлтийн нийтлӝмжийн нийтьлэл.</string>
     <string name="settings_support_issue_tracker_label">Асуудал хянагч</string>
-    <string name="settings_support_debuglog_label">Дибаг лог</string>
     <string name="settings_support_debuglog_desc">Апп-н хийж буй бүх зүйлийг хуваалцаж болох текст файлд бүртгэнэ.</string>
-    <string name="settings_support_debuglog_recording_desc">Одоо дибаг мэдээллэл бичлэж байна. Бичлэлтийг зогссохын дараа цохйно дарна.</string>
-    <string name="settings_support_debuglog_path">Логийн зам: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Маш богино бичлэлт</string>
     <string name="settings_support_debuglog_short_recording_msg">Энэ маш богино бичлэлт байлаа. Дибаг лог нь зураг биш, агшаамбиш биш бичлэлт идэвхүүлтэй байхад асуудалыг дахин утгасгаа лог ашиглагдай болно.</string>
     <string name="settings_support_debuglog_short_recording_continue">Бичлэлт үргэлжлэх</string>
     <string name="settings_support_debuglog_short_recording_stop">Жам зогсох</string>
-    <string name="settings_support_debuglog_folder_label">Дибаг логийн хавтас</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%2$s ашигласан %1$d сешүүлэлт</item>
-        <item quantity="other">%2$s ашигласан %1$d сешүүлэлт</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Дибаг лог хадгалаагүй</string>
-    <string name="settings_support_debuglog_folder_delete_title">Бүх дибаг логыг устгах уу?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Энэ хадгалагдсан бүх дибаг лог сешүүлэлтийг бүрмөсөн устгана.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Чөлөөт цагаа өнгөрөөх, асуулт асуух газар.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Орчуулга</string>
     <string name="settings_acks_translators_title">Орчуулагчид</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM орчуулах</string>
-    <string name="settings_acks_translate_desc">BVM-иг таны хэлрүү орчуулахад туслах</string>
     <string name="settings_acks_thanks_header">Баярлалаа</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Нээлт эхийн проектүүдийн орчуулалтыг дэмжлэхийн түлә</string>
     <string name="settings_licenses_label">Лиценз</string>
     <string name="settings_translation_label">Орчуулга</string>
     <string name="settings_translation_desc">Аппыг таны дуртай хэлрүү орчуулахад туслах</string>
-    <string name="settings_sponsor_development_title">Хөгжлийг дэмжих</string>
-    <string name="settings_sponsor_development_summary">Патрон болж цаашид хөгжлөлтийг боломжтой болгох.</string>
     <string name="settings_privacy_policy_label">Нууцлалын бодлого</string>
     <string name="settings_privacy_policy_desc">Өгөгдлийг хариуцлагатайгаар зохицуулах.</string>
     <string name="changelog_label">Өөрчлөлтийн түүх</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Сэргээлт дууссан — %1$d төхөөрөмж сэргээгдсэн, %2$d алгассан.</string>
     <string name="backup_restore_version_warning">Энэ нөөцлөлт %1$s хувилбариар үүсгэгдсэн. Та %2$s ашиглаж байна. Деяки тохируулга зөв сэргээгдсэхгүй байж болно.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Дебаг мэдэгдэл</string>
     <string name="debug_log_consent_title">Дибаг лог</string>
     <string name="debug_log_consent_explanation">Энэ функц нь аппликешний бүх үйлдлийг хуваалцах боломжтой файлд бичдэг. Үүсгэсэн файл нь эмзэг мэдээлэл агуулдаг (жишээ нь файлын нэр, суулгасан аппликешн). Зөвхөн итгэмжлэгдсэн талуудтай хуваалцана уу (жишээ нь асуудлыг шийдэж байгаа хөгжүүлэгч).</string>
-    <string name="debug_log_recording_progress">Дебаг лог бичиж байна</string>
     <string name="debug_log_record_action">Бичлэх</string>
     <string name="debug_log_stop_action">Бичлэгийг зогсоох</string>
     <string name="debug_log_screen_title">Дибаг лог бичлэгч</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Хаях</string>
     <string name="debug_log_screen_keep_action">Хадгалах</string>
-    <string name="debug_log_compressing_label">Цуурадаж байна…</string>
     <string name="debug_log_file_label">Бичсэн лог файл</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Лог илгээ уу?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Асуултаа дэлгэрэнгүй тайлбарла.</string>
     <string name="contact_category_section_label">Айлга</string>
     <string name="contact_debug_log_label">Дибаг лог</string>
-    <string name="contact_debug_log_select_hint">Хавсрахаар дибаг лог сонгох</string>
     <string name="contact_debug_log_picker_hint">Асуудалыг хүрдан ошуурхан оношлохын тулд дибаг лог хавсра.</string>
     <string name="contact_debug_log_picker_empty">Дибаг лог байхгүй. Эхлээд нэгийг бичлэ.</string>
     <string name="contact_expected_behavior_label">Хүлээлсэн зандлын байдл</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Би бүх зурварыг өөрөө уншаад хариулахаар чадалах боловч гэжээд нэг нэг хугацаа зарим авах болно. Тэвчээлтийн байдал байлала.</string>
     <string name="contact_footer_msg">Таны зурварыг имэйлеэр илгэнэ. Төхөөрөмжий ба тохиргуулалтын мэдээлел автоматаар хавсрагдана.</string>
     <string name="contact_no_email_app_msg">Энэ төхөөрөмжийд имэйл апп олдсонгүй.</string>
-    <string name="contact_attachment_missing_msg">Дибаг лог файл алга байхгүй</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Хадгалагдсан дибаг лог</string>
     <string name="settings_support_stored_logs_desc">%1$d сешүүлэлт (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Хадгалагдсан дибаг лог байхгүй</string>
-    <string name="settings_support_stored_logs_delete_title">Хадгалагдсан логуудыг устгах уу?</string>
-    <string name="settings_support_stored_logs_delete_msg">Энэ хадгалагдсан %1$d дибаг лог сешүүлэлтийг устгана.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Хадгалагдсан дибаг лог устгагдсан</string>
-    <string name="label_bug_reports">Алдаа мэдэглэлүүд</string>
-    <string name="description_bug_reports">Автомат алдаа ба гэмтрэлсэн мэдэглэл.</string>
     <string name="label_add_device">Төхөөрөмжий нэмэх</string>
-    <string name="label_just_a_moment_please">Нэг зураар хүлээнүү.</string>
     <string name="label_notification_channel_status">Төлөв</string>
     <string name="label_notification_channel_setup">Тохиргоо шаардлагатай</string>
     <string name="monitor_notification_starting">Эхэлж байна…</string>
     <string name="action_set">Тохируулах</string>
     <string name="action_cancel">Цуцлах</string>
-    <string name="label_invalid_input">Буруу оролт</string>
     <string name="action_reset">Дахин тохируулах</string>
     <string name="label_no_connected_devices">Холбогдсон төхөөрөмжий байхгүй</string>
-    <string name="label_status_idle">Хүлээглэхийн</string>
-    <string name="label_status_adjusting_volumes">Дууг тохиргуулаж байна</string>
-    <string name="label_premium_version">Премиум хувилбар</string>
     <string name="general_upgrade_action">Сайжруулах</string>
     <string name="common_upgrade_required_label">Шинэчлэлт шаардлагатай</string>
-    <string name="label_premium_version_required">Премиум хувилбар шаардлагана</string>
-    <string name="description_intro_purpose">Энэ апп таны Android төхөөрөмжийд өөр өөр Bluetooth төхөөрөмжийн дууг санаах боломжийг олгодог.</string>
-    <string name="upgrade_benefit_unlimited_devices">Хязгаалаггүй төхөөрөмжийн профайлууд</string>
-    <string name="upgrade_benefit_connection_actions">Автомат тоглуулалт, апп нээх, холбооны мэдэгдэл</string>
-    <string name="upgrade_benefit_theme_customization">Тем, хэв болон өнгийн өнгөрөмжийнх тохиргулалт</string>
-    <string name="upgrade_benefit_power_controls">Дууны түгжээ болон хурдаасыйн хязаалалт</string>
-    <string name="upgrade_benefit_support">Бие хөгжлөлтийн хөгжлөлтийг дэмжлээх</string>
     <string name="upgrade_benefit_equalizer">• Төхөөрөмж бүрийн эквалайзер (систем эквалайзерыг дэмждэг хөгжмийн апп-уудад)</string>
-    <string name="description_intro_tap_the_button">Эхлээд анхны төхөөрөмжийгӝэ нэмж эхлээ.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth идэвхгүй байна.</string>
     <string name="title_bluetooth_is_off">Bluetooth унтраассан</string>
     <string name="action_enable_bluetooth">Bluetooth идэвхүүлэх</string>
     <string name="title_bluetooth_permission_required">Bluetooth зөвшөөрөл шаардлагана</string>
     <string name="description_bluetooth_permission_required">Энэ апп таны төхөөрөмжийн дууг удирдахад Bluetooth зөвшөөрөл шаардлагана.</string>
     <string name="action_grant_permission">Зөвшөөрөл олгох</string>
-    <string name="label_status_listening_for_changes">Дууны өөрчлөлтийг сонсож байна</string>
     <string name="action_exit">Гарах</string>
-    <string name="action_start">Эхлэх</string>
-    <string name="label_welcome">Тавтай морил</string>
-    <string name="description_intro_contact">Асуулт тай шинэ онцлог байвал надаад надаад холбогдохд ээдэрхэлгүй.</string>
-    <string name="label_translation">Орчуулга</string>
-    <string name="description_help_translate">Энэ аппыг өөр хэлнүүд боломжтой болгоход надаад тусла.</string>
     <string name="label_device_speaker">Төхөөрөмжийн чайгъ</string>
-    <string name="label_keyevent_playpause">Тоглоох-зогсох</string>
-    <string name="label_keyevent_play">Тоглоох</string>
-    <string name="label_keyevent_next">Дараах</string>
-    <string name="label_install_id">Суулгалтын ID</string>
     <string name="message_copied_to_clipboard">Тахлуурд хуулагдсан</string>
-    <string name="label_thanks">Баярлалаа</string>
-    <string name="label_licenses">Лиценз</string>
-    <string name="description_ring_volume_additional_permission">Дүүгэх дууг өөрчлөхд нэмэлт зөвшөөрөл шаардлагана.</string>
-    <string name="label_missing_permissions">Зөвшөөрөл дутагдсана</string>
-    <string name="action_grant">Олгох</string>
-    <string name="label_advanced">Нарийнцагсан</string>
-    <string name="label_exclude_health">Эрүүл профайлуудыг хасах</string>
-    <string name="description_exclude_health">Зарим Android төхөөрөмжийнүүд \'Эрүүл төхөөрөмжий\' Bluetooth профайлыг (HDP, 0x1400) хайхан үед тунаарсан тохиолддог.</string>
-    <string name="label_exclude_gattserver">GATT сервер профайлуудыг хасах</string>
-    <string name="label_exclude_gatt">GATT профайлуудыг хасах</string>
-    <string name="description_exclude_gattserver">\'Нийтлэг шинж чанар\' (GATT) сервер төрлийн Bluetooth профайлыг өршигүүлэхгүй.</string>
-    <string name="description_exclude_gatt">\'Нийтлэг шинж чанар\' (GATT) клиент төрлийн Bluetooth профайлыг өршигүүлэхгүй.</string>
-    <string name="description_waiting_for_devicex">%s холболцыг дуусгахыг хүлээж байна</string>
-    <string name="action_undo">Буцаах</string>
-    <string name="action_show">Харуулах</string>
     <string name="action_dismiss">Хаах</string>
-    <string name="action_fix">Засах</string>
-    <string name="battery_optimizations_issue_description">Энэ аппаар батарейн оптимчлал идэвхүүлсэн бөгөөд Bluetooth үйл ц авахаас сэргийлэж болно. Асуудал тулгарсан бол, оптимчлалалтыг унтраахыг анхаарай.</string>
     <string name="label_bluetooth_settings">Bluetooth тохиргуулалт</string>
-    <string name="android10_applaunch_issue_description">Android 10 аппуудыг арьанаас ажиллуулахыг хязгаалдаг. Bluetooth төхөөрөмжий холбогдоход апп нэехийг зөвшөөрлэх ийн \"Өөр аппуудаас харах\" (SYSTEM_ALERT_WINDOW) зөвшөөрөл олго.</string>
-    <string name="label_opensource">Эх код</string>
-    <string name="android13_notification_permission_description">Энэ аппд мэдэгдэлгэ илгээх зөвшөөрөл олго. Энэ апп идэвхүүлтэй ба дууны тохиргуулалт хийгдэж байхад мэдэгдэлгэ харуулахыг идэвхүүлдэг.</string>
-    <string name="privacy_policy_label">Нууцлалын бодлого</string>
     <string name="managed_devices_empty_message">Bluetooth төхөөрөмжий тохиргоогүй.\nАнхны төхөөрөмжийгӝэ нэмж + товч дарна.</string>
     <string name="label_pro_feature">Премиум онцлог</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Үнэлгээ</string>
     <string name="review_app_dismiss_action">Дараа нь магадгүй</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Худалдалцаагүй болсон</string>
-    <string name="error_iap_unavailable_message">Апп дотоодх худалдалцаа боломжгүй</string>
-    <string name="error_generic_message">Алдаа гарлаа. Дахин оролдоно үз.</string>
-    <string name="error_iap_owned_message">Та энэ зүйлийг аанач байна</string>
     <string name="label_no_devices_title">Төхөөрөмжий байхгүй</string>
     <string name="bluemusic_mascot_description">Аппын дүрс зураг</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Апп сонгох</string>
     <string name="devices_app_selection_search_hint">Апп хайхах…</string>
-    <string name="devices_app_selection_currently_selected">Одоо сонгогдсон</string>
     <string name="devices_app_selection_selected_count">%d апп сонгогдсон</string>
     <string name="general_navigate_back_action">Буцах шилжих</string>
     <string name="general_reset_action">Дахин тохируулах</string>
     <string name="general_clear_action">Цэвцлэх</string>
-    <string name="general_save_action">Хадгалах</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Түгжийх</string>
     <string name="devices_indicator_awake">Сэржүүлээр</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Хязгаалалт</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Ихэсгэлт</string>
-    <string name="devices_indicator_launch">Ажиллуулах</string>
     <string name="devices_indicator_home">Дэлгэц</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Дохиолго</string>

--- a/app/src/main/res/values-mr-rIN/strings.xml
+++ b/app/src/main/res/values-mr-rIN/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">अद्यतनादरम्यान काही वैशिष्ट्ये बदलली आहेत. कृपया सर्व काही योग्यरित्या कॉन्फिगर केले आहे याची खात्री करण्यासाठी आपल्या डिव्हाइसच्या सेटिंग्ज तपासा.</string>
     <string name="onboarding_rewrite_action">सुरू ठेवा</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">कोणतेही अव्यवस्थापित डिव्हाइस आढळले नाही</string>
     <string name="discover_all_devices_managed_msg">तुमची सर्व जोडलेली डिव्हाइस व्यवस्थापित आहेत! नवीन हवे आहे का?</string>
     <string name="discover_pair_new_device_action">नवीन डिव्हाइस जोडा</string>
     <string name="discover_device_speaker_desc">या फोनचा स्वतःचा स्पीकर. जेव्हा ऑडिओ फोनवर परत स्विच होते तेव्हा त्याचे व्हॉल्यूम लागू होतात, उदा. तुमचे Bluetooth डिव्हाइस डिस्कनेक्ट झाल्यानंतर.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">डिव्हाइस कॉन्फिगरेशन</string>
-    <string name="devices_device_config_section_general_label">सामान्य</string>
     <string name="devices_device_config_remove_device_label">डिव्हाइस विसरा</string>
-    <string name="devices_device_config_remove_device_desc">या अॅपमधून डिव्हाइस विसरते आणि त्याचे कॉन्फिगरेशन हटवते. हे डिव्हाइस अनपेअर करत नाही.</string>
     <string name="devices_device_config_remove_device_action">विसरा</string>
     <string name="devices_device_config_remove_device_confirmation">%s ला व्यवस्थापित डिव्हाइसमधून विसरायचे का?</string>
-    <string name="devices_device_config_rename_device_label">डिव्हाइसचे नाव बदला</string>
-    <string name="devices_device_config_rename_device_desc">या अॅपमध्ये आणि शक्य असल्यास सिस्टेममध्ये या डिव्हाइसचे नाव बदला.</string>
     <string name="devices_device_config_rename_device_action">नाव बदला</string>
     <string name="devices_device_config_enabled_label">सक्षम केले</string>
     <string name="devices_device_config_enabled_desc">कनेक्ट झाल्यावर या डिव्हाइसवर प्रतिक्रिया द्या</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">ऑटोप्ले कमांड</string>
     <string name="devices_device_config_autoplay_keycodes_order">कमांड क्रम</string>
     <string name="devices_device_config_autoplay_keycodes_label">कमांड</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">कोणत्या कमांड पाठवायच्या आणि कोणत्या क्रमाने ते कॉन्फिगर करा</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">कोणत्याही कमांड कॉन्फिगर केल्या नाहीत</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">कमांड जोडा</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">जास्तीत जास्त %1$d कमांड</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">वर हलवा</string>
     <string name="cd_autoplay_keycode_move_down">खाली हलवा</string>
     <string name="cd_autoplay_keycode_remove">काढा</string>
-    <string name="devices_device_config_section_volumes_label">व्हॉल्युम्स</string>
     <string name="devices_device_config_section_volume_label">व्हॉल्युम</string>
     <string name="devices_device_config_alarm_volume_label">अलार्म व्हॉल्युम</string>
     <string name="devices_device_config_alarm_volume_desc">काही अलार्म अॅप्स त्याएवजी म्युझिक व्हॉल्युम वापरतात.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">रिंग</string>
     <string name="devices_audio_stream_notification_label">सूचना</string>
     <string name="devices_audio_stream_alarm_label">अलार्म</string>
-    <string name="devices_neverseen_label">कधीही दिसले नाही</string>
-    <string name="devices_state_connected_label">कनेक्ट केलेले</string>
     <string name="devices_last_connected_label">शेवटचे कनेक्ट: %s</string>
     <string name="devices_currently_connected_label">सध्या कनेक्ट केलेले</string>
     <string name="devices_device_disabled_label">डिव्हाइस अक्षम केले</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">सर्व व्यवस्थापित डिव्हाइसवर परिणाम करणाऱ्या सेटिंग्ज.</string>
     <string name="label_app_enabled">अॅप सक्षम केला</string>
     <string name="description_app_enabled">व्हॉल्युम आणि Bluetooth इव्हेंटवर प्रतिक्रिया देण्याच्या अॅपच्या क्षमतेला टॉगल करते.</string>
-    <string name="label_visible_volume_adjustments">दृश्यमान समायोजने</string>
-    <string name="description_visible_volume_adjustments">हा अॅप समायोजने करत असताना सिस्टमचे व्हॉल्युम विंडो दाखवा.</string>
     <string name="label_volume_listener">बदल निरीक्षण करा</string>
-    <string name="description_volume_listener">डिव्हाइस कनेक्ट असताना सक्रिय राहा आणि या अॅपमुळे न झालेले व्हॉल्युम बदल जतन करा.</string>
     <string name="label_boot_restore">बूटवर पुनर्संचयित करा</string>
     <string name="description_boot_restore">Bluetooth डिव्हाइस कनेक्ट असल्यास बूटिंग/रीबूटिंगनंतर व्हॉल्युम पुनर्संचयित करा.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM प्रभावीपणे कसे वापरायचे ते जाणा</string>
     <string name="settings_support_issue_tracker_description">बग रिपोर्ट आणि वैशिष्ट्य विनंत्यांसाठी एक सार्वजनिक समस्या ट्रॅकर.</string>
     <string name="settings_support_issue_tracker_label">समस्या ट्रॅकर</string>
-    <string name="settings_support_debuglog_label">डीबग लॉग</string>
     <string name="settings_support_debuglog_desc">अॅप करत असलेल्या प्रत्येक गोष्टीची नोंद तुम्ही शेअर करू शकता अशा टेक्स्ट फाइलमध्ये करा.</string>
-    <string name="settings_support_debuglog_recording_desc">सध्या डीबग माहिती रेकॉर्ड करत आहे. रेकॉर्डिंग थांबवण्यासाठी टॅप करा.</string>
-    <string name="settings_support_debuglog_path">लॉग मार्ग: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">अतिशय लहान रेकॉर्डिंग</string>
     <string name="settings_support_debuglog_short_recording_msg">ते अतिशय लहान रेकॉर्डिंग होते. डीबग लॉग हे स्नॅपशॉट नाहीत तर रेकॉर्डिंग आहेत — लॉग उपयुक्त होण्यासाठी रेकॉर्डिंग सक्रिय असताना समस्या पुनरुत्पादित करा.</string>
     <string name="settings_support_debuglog_short_recording_continue">रेकॉर्डिंग सुरू ठेवा</string>
     <string name="settings_support_debuglog_short_recording_stop">तरीही थांबवा</string>
-    <string name="settings_support_debuglog_folder_label">डीबग लॉग फोल्डर</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d सत्र %2$s वापरत आहे</item>
-        <item quantity="other">%1$d सत्रे %2$s वापरत आहेत</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">कोणतेही डीबग लॉग साठवलेले नाहीत</string>
-    <string name="settings_support_debuglog_folder_delete_title">सर्व डीबग लॉग हटवायचे का?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">हे सर्व साठवलेले डीबग लॉग सत्रे कायमचे हटवेल.</string>
     <string name="settings_support_discord_label">डिस्कॉर्ड</string>
     <string name="settings_support_discord_description">वेळ घालवण्यासाठी आणि प्रश्न विचारण्यासाठी एक जागा.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">भाषांतर</string>
     <string name="settings_acks_translators_title">भाषांतरकर्ते</string>
     <string name="settings_acks_translators_people">व्यक्ती1;व्यक्ती2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM चे भाषांतर करा</string>
-    <string name="settings_acks_translate_desc">BVM चे तुमच्या भाषेत भाषांतर करण्यात मदत करा</string>
     <string name="settings_acks_thanks_header">धन्यवाद</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">ओपन-सोर्स प्रकल्पांच्या भाषांतरास समर्थन केल्याबद्दल</string>
     <string name="settings_licenses_label">परवाने</string>
     <string name="settings_translation_label">भाषांतर</string>
     <string name="settings_translation_desc">अॅपचे तुमच्या आवडत्या भाषेत भाषांतर करण्यात मदत करा</string>
-    <string name="settings_sponsor_development_title">विकास प्रायोजित करा</string>
-    <string name="settings_sponsor_development_summary">संरक्षक व्हा आणि सतत विकास शक्य करा.</string>
     <string name="settings_privacy_policy_label">गोपनीयता धोरण</string>
     <string name="settings_privacy_policy_desc">डेटा जबाबदारीने हाताळणे.</string>
     <string name="changelog_label">बदल लॉग</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">पुनर्संचयित पूर्ण — %1$d डिव्हाइसेस पुनर्संचयित, %2$d वगळले.</string>
     <string name="backup_restore_version_warning">हा बॅकअप आवृत्ती %1$s सह तयार केला होता. तुम्ही %2$s चालवत आहात. काही सेटिंग्ज योग्यरित्या पुनर्संचयित होणार नाहीत.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">डीबग सूचना</string>
     <string name="debug_log_consent_title">डीबग लॉग</string>
     <string name="debug_log_consent_explanation">हे वैशिष्ट्य अॅप काय करत आहे ते सर्व एका सामायिक करण्यायोग्य फाइलमध्ये रेकॉर्ड करते. तयार केलेल्या फाइलमध्ये संवेदनशील माहिती आहे (उदा. फाइल नावे आणि स्थापित अॅप्स). ती केवळ विश्वासू पक्षांशी (उदा. समस्येचे निवारण करणारा विकसक) सामायिक करा.</string>
-    <string name="debug_log_recording_progress">डीबग लॉग रेकॉर्ड करत आहे</string>
     <string name="debug_log_record_action">रेकॉर्ड करा</string>
     <string name="debug_log_stop_action">रेकॉर्डिंग थांबवा</string>
     <string name="debug_log_screen_title">डीबग लॉग रेकॉर्डर</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">टाकून द्या</string>
     <string name="debug_log_screen_keep_action">ठेवा</string>
-    <string name="debug_log_compressing_label">संकुचित करत आहे…</string>
     <string name="debug_log_file_label">नोंदणीकृत लॉग फाइल</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">लॉग पाठवला का?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">तुमचा प्रश्न तपशीलवार वर्णन करा.</string>
     <string name="contact_category_section_label">श्रेणी</string>
     <string name="contact_debug_log_label">डीबग लॉग</string>
-    <string name="contact_debug_log_select_hint">जोडण्यासाठी डीबग लॉग निवडा</string>
     <string name="contact_debug_log_picker_hint">समस्या जलद निदान करण्यात मदत करण्यासाठी डीबग लॉग जोडा.</string>
     <string name="contact_debug_log_picker_empty">कोणतेही डीबग लॉग उपलब्ध नाहीत. प्रथम एक रेकॉर्ड करा.</string>
     <string name="contact_expected_behavior_label">अपेक्षित वर्तन</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">मी प्रत्येक संदेश स्वतः वाचतो आणि उत्तर देण्याचा माझा सर्वोत्तम प्रयत्न करतो, परंतु मी हे एकट्याने करत असल्याने, थोडा वेळ लागू शकतो. तुमच्या संयमाबद्दल धन्यवाद.</string>
     <string name="contact_footer_msg">तुमचा संदेश ईमेलद्वारे पाठवला जाईल. डिव्हाइस आणि सेटअप माहिती आपोआप संलग्न केली जाते.</string>
     <string name="contact_no_email_app_msg">या डिव्हाइसवर कोणताही ईमेल अॅप आढळला नाही.</string>
-    <string name="contact_attachment_missing_msg">डीबग लॉग फाइल यापुढे अस्तित्वात नाही</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">साठवलेले डीबग लॉग</string>
     <string name="settings_support_stored_logs_desc">%1$d सत्रे (%2$s)</string>
     <string name="settings_support_stored_logs_empty">कोणतेही साठवलेले डीबग लॉग नाहीत</string>
-    <string name="settings_support_stored_logs_delete_title">साठवलेले लॉग हटवायचे का?</string>
-    <string name="settings_support_stored_logs_delete_msg">हे सर्व %1$d साठवलेले डीबग लॉग सत्रे हटवेल.</string>
-    <string name="settings_support_stored_logs_deleted_msg">साठवलेले डीबग लॉग हटवले</string>
-    <string name="label_bug_reports">बग अहवाल</string>
-    <string name="description_bug_reports">स्वयंचलित बग आणि क्रॅश अहवाल.</string>
     <string name="label_add_device">डिव्हाइस जोडा</string>
-    <string name="label_just_a_moment_please">एक क्षण, कृपया.</string>
     <string name="label_notification_channel_status">स्थिती</string>
     <string name="label_notification_channel_setup">सेटअप आवश्यक</string>
     <string name="monitor_notification_starting">शुरू होत आहे…</string>
     <string name="action_set">सेट करा</string>
     <string name="action_cancel">रद्द करा</string>
-    <string name="label_invalid_input">अवैध इनपुट</string>
     <string name="action_reset">रीसेट करा</string>
     <string name="label_no_connected_devices">कोणतेही डिव्हाइस कनेक्ट नाहीत</string>
-    <string name="label_status_idle">निष्क्रिय</string>
-    <string name="label_status_adjusting_volumes">व्हॉल्युम समायोजित करत आहे</string>
-    <string name="label_premium_version">प्रीमियम आवृत्ती</string>
     <string name="general_upgrade_action">अपग्रेड करा</string>
     <string name="common_upgrade_required_label">अपग्रेड आवश्यक</string>
-    <string name="label_premium_version_required">प्रीमियम आवृत्ती आवश्यक</string>
-    <string name="description_intro_purpose">हा अॅप तुमच्या Android डिव्हाइसला वेगवेगळ्या Bluetooth डिव्हाइसचे व्हॉल्युम लक्षात ठेवण्याची परवानगी देतो.</string>
-    <string name="upgrade_benefit_unlimited_devices">अमर्यादित डिव्हाइस प्रोफाइल</string>
-    <string name="upgrade_benefit_connection_actions">ऑटोप्ले, अ‍ॅप लॉन्च आणि कनेक्शन सूचना</string>
-    <string name="upgrade_benefit_theme_customization">थीम, स्टाइल आणि रंग सानुकूलन</string>
-    <string name="upgrade_benefit_power_controls">व्हॉल्युम लॉक आणि दर मर्यादा</string>
-    <string name="upgrade_benefit_support">स्वतंत्र विकासाला समर्थन द्या</string>
     <string name="upgrade_benefit_equalizer">• प्रति-डिव्हाइस इक्वलायझर (सिस्टम इक्वलायझर समर्थन असलेल्या संगीत ॲप्ससाठी)</string>
-    <string name="description_intro_tap_the_button">तुमचे पहिले डिव्हाइस जोडून सुरुवात करा.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth अक्षम केले आहे.</string>
     <string name="title_bluetooth_is_off">Bluetooth बंद आहे</string>
     <string name="action_enable_bluetooth">Bluetooth सक्षम करा</string>
     <string name="title_bluetooth_permission_required">Bluetooth परवानगी आवश्यक</string>
     <string name="description_bluetooth_permission_required">तुमच्या डिव्हाइसचे व्हॉल्युम व्यवस्थापित करण्यासाठी या अॅपला Bluetooth परवानगी आवश्यक आहे.</string>
     <string name="action_grant_permission">परवानगी द्या</string>
-    <string name="label_status_listening_for_changes">व्हॉल्युम बदलांसाठी ऐकत आहे</string>
     <string name="action_exit">बाहेर पडा</string>
-    <string name="action_start">सुरू करा</string>
-    <string name="label_welcome">स्वागत</string>
-    <string name="description_intro_contact">तुमच्याकडे प्रश्न असल्यास किंवा नवीन वैशिष्ट्यासाठी कल्पना असल्यास मला संपर्क करण्यास संकोच करू नका.</string>
-    <string name="label_translation">भाषांतर</string>
-    <string name="description_help_translate">हा अॅप इतर भाषांमध्ये उपलब्ध करण्यात मला मदत करा.</string>
     <string name="label_device_speaker">डिव्हाइस स्पीकर</string>
-    <string name="label_keyevent_playpause">प्ले-पॉज</string>
-    <string name="label_keyevent_play">प्ले</string>
-    <string name="label_keyevent_next">पुढे</string>
-    <string name="label_install_id">इंस्टॉल आयडी</string>
     <string name="message_copied_to_clipboard">क्लिपबोर्डवर कॉपी केले</string>
-    <string name="label_thanks">धन्यवाद</string>
-    <string name="label_licenses">परवाने</string>
-    <string name="description_ring_volume_additional_permission">रिंग व्हॉल्युम बदलण्यासाठी अतिरिक्त परवानग्या आवश्यक आहेत.</string>
-    <string name="label_missing_permissions">परवानग्या गहाळ आहेत</string>
-    <string name="action_grant">मंजूर करा</string>
-    <string name="label_advanced">प्रगत</string>
-    <string name="label_exclude_health">आरोग्य प्रोफाइल वगळा</string>
-    <string name="description_exclude_health">काही Android डिव्हाइस \'Health Device\' Bluetooth प्रोफाइल (HDP, 0x1400) शोधताना थांबतात.</string>
-    <string name="label_exclude_gattserver">GATT सर्व्हर प्रोफाइल वगळा</string>
-    <string name="label_exclude_gatt">GATT प्रोफाइल वगळा</string>
-    <string name="description_exclude_gattserver">\'Generic Attribute\' (GATT) सर्व्हर प्रकाराचे Bluetooth प्रोफाइल चौकशी करू नका.</string>
-    <string name="description_exclude_gatt">\'Generic Attribute\' (GATT) क्लायंट प्रकाराचे Bluetooth प्रोफाइल चौकशी करू नका.</string>
-    <string name="description_waiting_for_devicex">%s ने कनेक्शन पूर्ण करण्याची प्रतीक्षा करत आहे</string>
-    <string name="action_undo">पूर्ववत करा</string>
-    <string name="action_show">दाखवा</string>
     <string name="action_dismiss">डिसमिस करा</string>
-    <string name="action_fix">दुरुस्त करा</string>
-    <string name="battery_optimizations_issue_description">या अॅपसाठी बॅटरी ऑप्टिमायझेशन सक्षम आहेत आणि ते ब्लूटूथ इव्हेंट प्राप्त करण्यापासून रोखू शकतात. जर तुम्हाला समस्या येत असतील तर ऑप्टिमायझेशन अक्षम करण्याचा विचार करा.</string>
     <string name="label_bluetooth_settings">ब्लूटूथ सेटिंग्ज</string>
-    <string name="android10_applaunch_issue_description">Android 10 अॅप्स पार्श्वभूमीतून कसे लाँच केले जाऊ शकतात यावर निर्बंध घालतो. ब्लूटूथ डिव्हाइस कनेक्ट झाल्यावर अॅप्स उघडण्यास परवानगी देण्यासाठी, \"इतर अॅप्सवर प्रदर्शित करा\" (SYSTEM_ALERT_WINDOW) परवानगी द्या.</string>
-    <string name="label_opensource">स्रोत कोड</string>
-    <string name="android13_notification_permission_description">या अॅपला सूचना पोस्ट करण्याची परवानगी द्या. हे अॅप सक्रिय असताना आणि व्हॉल्यूम समायोजन केले जात असताना सूचना प्रदर्शित करण्यास सक्षम करते.</string>
-    <string name="privacy_policy_label">गोपनीयता धोरण</string>
     <string name="managed_devices_empty_message">कोणतेही ब्लूटूथ डिव्हाइस कॉन्फिगर केलेले नाही.
 + बटण टॅप करा आणि तुमचे पहिले डिव्हाइस जोडा.</string>
     <string name="label_pro_feature">प्रीमियम वैशिष्ट्य</string>
@@ -426,21 +345,15 @@
     <string name="review_app_review_action">रिव्यू</string>
     <string name="review_app_dismiss_action">मग नंतर</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">खरेदी रद्द केली</string>
-    <string name="error_iap_unavailable_message">इन-अॅप खरेदी उपलब्ध नाहीत</string>
-    <string name="error_generic_message">एक त्रुटी आली. कृपया पुन्हा प्रयत्न करा.</string>
-    <string name="error_iap_owned_message">ही वस्तू तुम्ही आधीच विकत घेतली आहे</string>
     <string name="label_no_devices_title">कोणतेही डिव्हाइस नाही</string>
     <string name="bluemusic_mascot_description">अॅप अयकॉन</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">अॅप्स निवडा</string>
     <string name="devices_app_selection_search_hint">अॅप्स शोधा…</string>
-    <string name="devices_app_selection_currently_selected">सध्या निवडलेले</string>
     <string name="devices_app_selection_selected_count">%d अॅप्स निवडले</string>
     <string name="general_navigate_back_action">मागे नेविगेट करा</string>
     <string name="general_reset_action">रीसेट</string>
     <string name="general_clear_action">साफ करा</string>
-    <string name="general_save_action">सेव्ह करा</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">लॉक</string>
     <string name="devices_indicator_awake">जागृत</string>
@@ -450,7 +363,6 @@
     <string name="devices_indicator_limit">मर्यादा</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">बूस्ट</string>
-    <string name="devices_indicator_launch">लाँच करा</string>
     <string name="devices_indicator_home">होम</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">सूचना</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Sesetengah tetapan peranti mungkin telah diset semula semasa kemas kini ini. Sila periksa konfigurasi peranti anda.</string>
     <string name="onboarding_rewrite_action">Teruskan</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Tiada peranti tidak terurus dijumpai</string>
     <string name="discover_all_devices_managed_msg">Semua peranti berpasangan anda diurus! Perlukan yang baru?</string>
     <string name="discover_pair_new_device_action">Pasangkan peranti baru</string>
     <string name="discover_device_speaker_desc">Pembesar suara milik telefon ini. Volumnya digunakan apabila audio beralih kembali ke telefon, cth. selepas peranti Bluetooth anda terputus.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfigurasi peranti</string>
-    <string name="devices_device_config_section_general_label">Umum</string>
     <string name="devices_device_config_remove_device_label">Lupakan peranti</string>
-    <string name="devices_device_config_remove_device_desc">Melupakan peranti dari apl ini dan memadamkan konfigurasinya. Ini tidak memutuskan pasangan peranti.</string>
     <string name="devices_device_config_remove_device_action">Lupakan</string>
     <string name="devices_device_config_remove_device_confirmation">Lupakan %s dari peranti terurus?</string>
-    <string name="devices_device_config_rename_device_label">Namakan semula peranti</string>
-    <string name="devices_device_config_rename_device_desc">Namakan semula peranti ini dalam apl ini, dan jika boleh, dalam sistem.</string>
     <string name="devices_device_config_rename_device_action">Namakan semula</string>
     <string name="devices_device_config_enabled_label">Didayakan</string>
     <string name="devices_device_config_enabled_desc">Bertindak balas kepada peranti ini apabila bersambung</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Arahan main semula automatik</string>
     <string name="devices_device_config_autoplay_keycodes_order">Urutan arahan</string>
     <string name="devices_device_config_autoplay_keycodes_label">Arahan</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Konfigurasikan arahan yang hendak dihantar dan dalam urutan apa</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Tiada arahan dikonfigurasikan</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Tambah arahan</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimum %1$d arahan</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">Gerak ke atas</string>
     <string name="cd_autoplay_keycode_move_down">Gerak ke bawah</string>
     <string name="cd_autoplay_keycode_remove">Alih keluar</string>
-    <string name="devices_device_config_section_volumes_label">Volum</string>
     <string name="devices_device_config_section_volume_label">Volum</string>
     <string name="devices_device_config_alarm_volume_label">Volum penggera</string>
     <string name="devices_device_config_alarm_volume_desc">Sebahagian apl penggera sebaliknya menggunakan volum muzik.</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">Deringan</string>
     <string name="devices_audio_stream_notification_label">Pemberitahuan</string>
     <string name="devices_audio_stream_alarm_label">Penggera</string>
-    <string name="devices_neverseen_label">Tiada terlihat</string>
-    <string name="devices_state_connected_label">Dihubungkan</string>
     <string name="devices_last_connected_label">Terakhir disambung: %s</string>
     <string name="devices_currently_connected_label">Sedang disambung</string>
     <string name="devices_device_disabled_label">Peranti dimatikan</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">Tetapan yang mempengaruhi semua peranti terurus.</string>
     <string name="label_app_enabled">Apl didayakan</string>
     <string name="description_app_enabled">Toggel kebolehan apl untuk bereaksi pada volum serta acara Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Pelarasan yang nyata</string>
-    <string name="description_visible_volume_adjustments">Tampilkan tetingkap volum sistem sementara apl ini melakukan pelarasan.</string>
     <string name="label_volume_listener">Perhatikan perubahan</string>
-    <string name="description_volume_listener">Kekal aktif sementara peranti dihubungkan dan simpan perubahan volum yang tiada terkesan dari apl ini.</string>
     <string name="label_boot_restore">Simpan semula semasa boot</string>
     <string name="description_boot_restore">Simpan semula volum selepas booting/rebooting jika peranti Bluetooth disambungkan.</string>
     <!-- Settings/Support-->
@@ -203,21 +191,11 @@
     <string name="settings_support_wiki_description">Belajar cara menggunakan BVM dengan berkesan</string>
     <string name="settings_support_issue_tracker_description">Penjejak isu awam untuk laporan pepijat dan permintaan ciri.</string>
     <string name="settings_support_issue_tracker_label">Penjejak isu</string>
-    <string name="settings_support_debuglog_label">Log nyahpepijat</string>
     <string name="settings_support_debuglog_desc">Rakam semua yang apl lakukan ke dalam fail teks yang boleh anda kongsikan.</string>
-    <string name="settings_support_debuglog_recording_desc">Sedang merakam maklumat nyahpepijat. Ketik untuk hentikan rakaman.</string>
-    <string name="settings_support_debuglog_path">Laluan log: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Rakaman sangat pendek</string>
     <string name="settings_support_debuglog_short_recording_msg">Itu rakaman yang sangat pendek. Log nyahpepijat adalah rakaman, bukan syot kilat — reproduksi masalah semasa rakaman aktif supaya log berguna.</string>
     <string name="settings_support_debuglog_short_recording_continue">Teruskan rakaman</string>
     <string name="settings_support_debuglog_short_recording_stop">Henti juga</string>
-    <string name="settings_support_debuglog_folder_label">Folder log nyahpepijat</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d sesi menggunakan %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Tiada log nyahpepijat tersimpan</string>
-    <string name="settings_support_debuglog_folder_delete_title">Padam semua log nyahpepijat?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Ini akan memadamkan semua sesi log nyahpepijat yang tersimpan secara kekal.</string>
     <string name="settings_support_discord_label">Percanggahan</string>
     <string name="settings_support_discord_description">Tempat untuk bergaul dan bertanya soalan.</string>
     <!-- Settings/Acks-->
@@ -226,16 +204,12 @@
     <string name="settings_acks_translation_header">Terjemahan</string>
     <string name="settings_acks_translators_title">Penterjemah</string>
     <string name="settings_acks_translators_people">Orang1;Orang2(pilihan@email.com)</string>
-    <string name="settings_acks_translate_title">Terjemah BVM</string>
-    <string name="settings_acks_translate_desc">Bantu terjemah BVM ke dalam bahasa anda</string>
     <string name="settings_acks_thanks_header">Terima kasih</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Kerana menyokong terjemahan projek sumber terbuka</string>
     <string name="settings_licenses_label">Lesen</string>
     <string name="settings_translation_label">Terjemahan</string>
     <string name="settings_translation_desc">Bantu terjemahkan apl ke dalam bahasa kegemaran anda</string>
-    <string name="settings_sponsor_development_title">Sponsor pembangunan</string>
-    <string name="settings_sponsor_development_summary">Jadi penyokong dan menjadikan pembangunan berterusan mungkin.</string>
     <string name="settings_privacy_policy_label">Dasar privasi</string>
     <string name="settings_privacy_policy_desc">Mengendalikan data secara bertanggungjawab.</string>
     <string name="changelog_label">Log perubahan</string>
@@ -257,10 +231,8 @@
     <string name="backup_restore_success_restore">Pemulihan selesai — %1$d peranti dipulihkan, %2$d dilangkau.</string>
     <string name="backup_restore_version_warning">Sandaran ini dibuat dengan versi %1$s. Anda sedang menggunakan %2$s. Sesetengah tetapan mungkin tidak dipulihkan dengan betul.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Pemberitahuan nyahpepijat</string>
     <string name="debug_log_consent_title">Log nyahpepijat</string>
     <string name="debug_log_consent_explanation">Ciri ini merakam semua yang apl lakukan ke dalam fail yang boleh dikongsi. Fail yang dijana mengandungi maklumat sensitif (contohnya nama fail dan apl yang dipasang). Hanya kongsi dengan pihak yang dipercayai (contohnya pembangun yang menyelesaikan masalah).</string>
-    <string name="debug_log_recording_progress">Merakam log nyahpepijat</string>
     <string name="debug_log_record_action">Rakam</string>
     <string name="debug_log_stop_action">Henti rakaman</string>
     <string name="debug_log_screen_title">Perakam Log Nyahpepijat</string>
@@ -274,7 +246,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Buang</string>
     <string name="debug_log_screen_keep_action">Simpan</string>
-    <string name="debug_log_compressing_label">Memampatkan…</string>
     <string name="debug_log_file_label">Fail log yang dirakam</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log dihantar?</string>
@@ -302,7 +273,6 @@
     <string name="contact_description_question_hint">Terangkan soalan anda dengan terperinci.</string>
     <string name="contact_category_section_label">Kategori</string>
     <string name="contact_debug_log_label">Log nyahpepijat</string>
-    <string name="contact_debug_log_select_hint">Pilih log nyahpepijat untuk dilampirkan</string>
     <string name="contact_debug_log_picker_hint">Lampirkan log nyahpepijat untuk membantu mendiagnosis masalah lebih cepat.</string>
     <string name="contact_debug_log_picker_empty">Tiada log nyahpepijat tersedia. Rakam satu dahulu.</string>
     <string name="contact_expected_behavior_label">Tingkah laku yang dijangka</string>
@@ -315,82 +285,32 @@
     <string name="contact_welcome_msg">Saya membaca setiap mesej sendiri dan berusaha membalas, tetapi memandangkan saya bekerja seorang diri, mungkin mengambil sedikit masa. Terima kasih atas kesabaran anda.</string>
     <string name="contact_footer_msg">Mesej anda akan dihantar melalui e-mel. Maklumat peranti dan persediaan dilampirkan secara automatik.</string>
     <string name="contact_no_email_app_msg">Tiada apl e-mel ditemui pada peranti ini.</string>
-    <string name="contact_attachment_missing_msg">Fail log nyahpepijat tidak lagi wujud</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Log nyahpepijat tersimpan</string>
     <string name="settings_support_stored_logs_desc">%1$d sesi (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Tiada log nyahpepijat tersimpan</string>
-    <string name="settings_support_stored_logs_delete_title">Padam log tersimpan?</string>
-    <string name="settings_support_stored_logs_delete_msg">Ini akan memadamkan semua %1$d sesi log nyahpepijat yang tersimpan.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Log nyahpepijat tersimpan dipadamkan</string>
-    <string name="label_bug_reports">Laporan pepijat</string>
-    <string name="description_bug_reports">Pelaporan pepijat dan kecelaruan automatik.</string>
     <string name="label_add_device">Tambah peranti</string>
-    <string name="label_just_a_moment_please">Sila tunggu sebentar.</string>
     <string name="label_notification_channel_status">Status Semasa</string>
     <string name="label_notification_channel_setup">Persediaan diperlukan</string>
     <string name="monitor_notification_starting">Memulai…</string>
     <string name="action_set">Tetapkan</string>
     <string name="action_cancel">Batal</string>
-    <string name="label_invalid_input">Input tidak sah</string>
     <string name="action_reset">Set semula</string>
     <string name="label_no_connected_devices">Tiada peranti yang terhubung</string>
-    <string name="label_status_idle">Melahu</string>
-    <string name="label_status_adjusting_volumes">Melaraskan volum</string>
-    <string name="label_premium_version">Versi premium</string>
     <string name="general_upgrade_action">Naik taraf</string>
     <string name="common_upgrade_required_label">Naik taraf diperlukan</string>
-    <string name="label_premium_version_required">Versi premium diperlukan</string>
-    <string name="description_intro_purpose">Apl ini membolehkan peranti Android anda mengingati volum dari peranti Bluetooth yang berbeza.</string>
-    <string name="upgrade_benefit_unlimited_devices">Profil peranti tanpa had</string>
-    <string name="upgrade_benefit_connection_actions">Main auto, lancar aplikasi dan amaran sambungan</string>
-    <string name="upgrade_benefit_theme_customization">Penyesuaian tema, gaya dan warna</string>
-    <string name="upgrade_benefit_power_controls">Kunci kelantangan dan pengehadan kadar</string>
-    <string name="upgrade_benefit_support">Sokong pembangunan bebas</string>
     <string name="upgrade_benefit_equalizer">• Penyama setiap peranti (untuk apl muzik dengan sokongan penyama sistem)</string>
-    <string name="description_intro_tap_the_button">Mula dengan memasukkan peranti pertama anda.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth dinyahdayakan.</string>
     <string name="title_bluetooth_is_off">Bluetooth Dimatikan</string>
     <string name="action_enable_bluetooth">Dayakan Bluetooth</string>
     <string name="title_bluetooth_permission_required">Kebenaran Bluetooth Diperlukan</string>
     <string name="description_bluetooth_permission_required">Apl ini memerlukan kebenaran Bluetooth untuk mengurus volum peranti anda.</string>
     <string name="action_grant_permission">Beri Kebenaran</string>
-    <string name="label_status_listening_for_changes">Mendengar untuk perubahan volum</string>
     <string name="action_exit">Keluar</string>
-    <string name="action_start">Mula</string>
-    <string name="label_welcome">Selamat datang</string>
-    <string name="description_intro_contact">Jangan teragak-agak untuk hubungi saya jika anda ada soalan mahu pun idea untuk ciri yang baru.</string>
-    <string name="label_translation">Terjemahan</string>
-    <string name="description_help_translate">Bantu saya menjadikan apl ini diperolehi dalam lain-lain bahasa.</string>
     <string name="label_device_speaker">Pembesar suara peranti</string>
-    <string name="label_keyevent_playpause">Main-Jeda</string>
-    <string name="label_keyevent_play">Main</string>
-    <string name="label_keyevent_next">Seterusnya</string>
-    <string name="label_install_id">Pasang ID</string>
     <string name="message_copied_to_clipboard">Disalin ke papan klip</string>
-    <string name="label_thanks">Terima kasih</string>
-    <string name="label_licenses">Lesen-lesen</string>
-    <string name="description_ring_volume_additional_permission">Kebenaran tambahan adalah perlu bagi mengubah volum deringan.</string>
-    <string name="label_missing_permissions">Kehilangan kebenaran</string>
-    <string name="action_grant">Keizinan</string>
-    <string name="label_advanced">Lanjutan</string>
-    <string name="label_exclude_health">Tanpa profil kesihatan</string>
-    <string name="description_exclude_health">Sesetengah peranti Android tergantung bila melihat kepada profil Bluetooth (HDP, 0x1400) \'Peranti Sihat\'.</string>
-    <string name="label_exclude_gattserver">Tanpa profil pelayan GATT</string>
-    <string name="label_exclude_gatt">Tanpa profil GATT</string>
-    <string name="description_exclude_gattserver">Jangan soal profil Bluetooth dari jenis pelayan \'Generic Attribute\' (GATT).</string>
-    <string name="description_exclude_gatt">Jangan soal profil Bluetooth dari jenis klien \'Generic Attribute\' (GATT).</string>
-    <string name="description_waiting_for_devicex">Tunggu %s untuk penyelesaian sambungan</string>
-    <string name="action_undo">Batal buat</string>
-    <string name="action_show">Tunjuk</string>
     <string name="action_dismiss">Bubar</string>
-    <string name="action_fix">Betulkan</string>
-    <string name="battery_optimizations_issue_description">Pengoptimuman bateri boleh didayakan bagi apl ini dan dapat mencegahnya dari menerima aktiviti Bluetooth. Pertimbang untuk nyahdayakan pengoptimuman jika anda mengalami isu.</string>
     <string name="label_bluetooth_settings">Tetapan bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 mengawal bagaimana apl boleh dilancarkan dari latar belakang. Bagi membolehkan apl dibuka bila peranti Bluetooth bersambung, berikan kebenaran \&quot;Paparan ke atas apl lain\&quot; (SISTEM_WASPADA_TETINGKAP).</string>
-    <string name="label_opensource">Kod sumber</string>
-    <string name="android13_notification_permission_description">Beri apl ini kebenaran untuk hantar pemberitahuan. Ini membolehkan memaparkan pemberitahuan apabila apl ini aktif dan pelarasan volum sedang dibuat.</string>
-    <string name="privacy_policy_label">Dasar privasi</string>
     <string name="managed_devices_empty_message">Tiada peranti Bluetooth dikonfigurasi.\nKetik butang + untuk tambah peranti pertama anda.</string>
     <string name="label_pro_feature">Ciri premium</string>
     <plurals name="discover_device_limit_banner">
@@ -420,21 +340,15 @@
     <string name="review_app_review_action">Ulas aplikasi</string>
     <string name="review_app_dismiss_action">Tidak, terima kasih</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Pembelian dibatalkan</string>
-    <string name="error_iap_unavailable_message">Pembelian dalam apl tidak tersedia</string>
-    <string name="error_generic_message">Ralat berlaku. Sila cuba lagi.</string>
-    <string name="error_iap_owned_message">Anda sudah memiliki item ini</string>
     <string name="label_no_devices_title">Tiada Peranti</string>
     <string name="bluemusic_mascot_description">Ikon Apl</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Pilih Apl</string>
     <string name="devices_app_selection_search_hint">Cari apl…</string>
-    <string name="devices_app_selection_currently_selected">Sedang dipilih</string>
     <string name="devices_app_selection_selected_count">%d apl dipilih</string>
     <string name="general_navigate_back_action">Navigasi kembali</string>
     <string name="general_reset_action">Set semula</string>
     <string name="general_clear_action">Kosongkan</string>
-    <string name="general_save_action">Simpan</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Kunci</string>
     <string name="devices_indicator_awake">Berjaga</string>
@@ -444,7 +358,6 @@
     <string name="devices_indicator_limit">Had</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Tambahan</string>
-    <string name="devices_indicator_launch">Lancar</string>
     <string name="devices_indicator_home">Utama</string>
     <string name="devices_indicator_dnd">JG</string>
     <string name="devices_indicator_alert">Amaran</string>

--- a/app/src/main/res/values-my-rMM/strings.xml
+++ b/app/src/main/res/values-my-rMM/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">အပ်ဒိတ်တစ်လျှောက် အချို့ လုပ်ဆောင်ချက်များ ပြောင်းလဲသွားနိုင်သည်။ အရာအားလုံး မှန်ကန်စွာ သတ်မှတ်ထားကြောင်း ကိရိယာ ဆက်တင်များကို စစ်ဆေးပါ။</string>
     <string name="onboarding_rewrite_action">ဆက်သွားမည်</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">စီမံမထားသော ကိရိယာ မတွေ့ပါ</string>
     <string name="discover_all_devices_managed_msg">ချိတ်ဆက်ထားသည့် ကိရိယာ အားလုံး စီမံပြီးပါပြီ! အသစ်တစ်ခု လိုပါသလား?</string>
     <string name="discover_pair_new_device_action">ကိရိယာ အသစ် တွဲချိတ်မည်</string>
     <string name="discover_device_speaker_desc">ဤဖုန်း၏ကိုယ်ပိုင်စပီကာ။ အသံသည် ဖုန်းသို့ပြန်ပြောင်းလဲသောအခါ ၎င်း၏အသံအတိုးအကျယ်များ အသုံးချထားသည်၊ ဥပမာ၊ သင်၏Bluetooth စက်ပစ္စည်း ချိတ်ဆက်မှုအဆုံးသတ်ပြီးနောက်။</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ကိရိယာ ဖွဲ့စည်းမှု</string>
-    <string name="devices_device_config_section_general_label">အထွေထွေ</string>
     <string name="devices_device_config_remove_device_label">ကိရိယာ မေ့မည်</string>
-    <string name="devices_device_config_remove_device_desc">ဤအပ်မှ ကိရိယာကို မေ့ပြီး ၎င်း၏ ဖွဲ့စည်းမှုကို ဖျက်မည်။ ကိရိယာကို တွဲချိတ်မှု ဖြတ်မည် မဟုတ်ပါ။</string>
     <string name="devices_device_config_remove_device_action">မေ့မည်</string>
     <string name="devices_device_config_remove_device_confirmation">%s ကို စီမံထားသော ကိရိယာများမှ မေ့မည်လား?</string>
-    <string name="devices_device_config_rename_device_label">ကိရိယာ အမည်ပြောင်းမည်</string>
-    <string name="devices_device_config_rename_device_desc">ဤအပ်အတွင်း ကိရိယာ အမည် ပြောင်းပြီး ဖြစ်နိုင်လျှင် စနစ်အတွင်းပါ ပြောင်းမည်။</string>
     <string name="devices_device_config_rename_device_action">အမည်ပြောင်းမည်</string>
     <string name="devices_device_config_enabled_label">ဖွင့်ထားသည်</string>
     <string name="devices_device_config_enabled_desc">ဤကိရိယာ ချိတ်ဆက်သောအခါ တုံ့ပြန်မည်</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">အလိုအလျောက်ဖွင့်ခြင်း အမိန့်များ</string>
     <string name="devices_device_config_autoplay_keycodes_order">အမိန့်အစီအစဉ်</string>
     <string name="devices_device_config_autoplay_keycodes_label">အမိန့်များ</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">မည်သည့်အမိန့်များကို မည်သည့်အစီအစဉ်ဖြင့် ပေးပို့မည်ကို သတ်မှတ်ပါ</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">အမိန့်များ မသတ်မှတ်ရသေး</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">အမိန့်ထည့်သွင်းပါ</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">အများဆုံး %1$d အမိန့်</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">အပေါ်သို့ ရွှေ့ပါ</string>
     <string name="cd_autoplay_keycode_move_down">အောက်သို့ ရွှေ့ပါ</string>
     <string name="cd_autoplay_keycode_remove">ဖယ်ရှားပါ</string>
-    <string name="devices_device_config_section_volumes_label">အသံများ</string>
     <string name="devices_device_config_section_volume_label">အသံ</string>
     <string name="devices_device_config_alarm_volume_label">နှိုးစက် အသံ</string>
     <string name="devices_device_config_alarm_volume_desc">အချို့ နှိုးစက် အပ်များသည် အစား music အသံ သုံးသည်။</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">မြည်သံ</string>
     <string name="devices_audio_stream_notification_label">အကြောင်းကြားချက်</string>
     <string name="devices_audio_stream_alarm_label">နှိုးစက်</string>
-    <string name="devices_neverseen_label">မတွေ့ဖူးသေး</string>
-    <string name="devices_state_connected_label">ချိတ်ဆက်ထားသည်</string>
     <string name="devices_last_connected_label">နောက်ဆုံး ချိတ်ဆက်: %s</string>
     <string name="devices_currently_connected_label">လောလောဆယ် ချိတ်ဆက်နေသည်</string>
     <string name="devices_device_disabled_label">ကိရိယာ ပိတ်ထားသည်</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">စီမံခန့်ခွဲထားသော ကိရိယာ အားလုံးကို အကျိုးသက်ရောက်သော ဆက်တင်များ</string>
     <string name="label_app_enabled">အပ် ဖွင့်ထားသည်</string>
     <string name="description_app_enabled">အသံနှင့် Bluetooth ဖြစ်ရပ်များကို တုံ့ပြန်ရန် အပ်၏ စွမ်းရည်ကို ပြောင်းလဲသည်</string>
-    <string name="label_visible_volume_adjustments">မြင်သာသော ချိန်ညှိမှုများ</string>
-    <string name="description_visible_volume_adjustments">ဤအပ် ချိန်ညှိမှုများ ပြုလုပ်နေစဉ် စနစ်၏ အသံ ဝင်းဒိုး ပြသမည်။</string>
     <string name="label_volume_listener">ပြောင်းလဲမှုများ စောင့်ကြည့်မည်</string>
-    <string name="description_volume_listener">ကိရိယာ ချိတ်ဆက်နေစဉ် အသက်ဝင်နေ၍ ဤအပ် မဖြစ်ပေါ် စေသော အသံ ပြောင်းလဲမှုများ သိမ်းဆည်းမည်။</string>
     <string name="label_boot_restore">ဖွင့်လှစ်သောအခါ ပြန်လည်ရယူမည်</string>
     <string name="description_boot_restore">Bluetooth ကိရိယာ ချိတ်ဆက်ထားလျှင် ဖွင့်/ပြန်ဖွင့်ပြီးနောက် အသံ ပြန်လည်ရယူမည်။</string>
     <!-- Settings/Support-->
@@ -203,21 +191,11 @@
     <string name="settings_support_wiki_description">BVM ကို ထိရောက်စွာ သုံးနည်း သင်ယူပါ</string>
     <string name="settings_support_issue_tracker_description">ချို့ယွင်းချက် အစီရင်ခံစာများနှင့် အင်္ဂါရပ် တောင်းဆိုမှုများအတွက် အများသုံး ပြဿနာ ခြေရာခံကိရိယာ</string>
     <string name="settings_support_issue_tracker_label">ပြဿနာ ခြေရာခံ</string>
-    <string name="settings_support_debuglog_label">Debug မှတ်တမ်း</string>
     <string name="settings_support_debuglog_desc">အပ် လုပ်ဆောင်မှု အားလုံးကို မျှဝေနိုင်သော စာသားဖိုင်တစ်ခုတွင် ရိုက်ကူးမည်။</string>
-    <string name="settings_support_debuglog_recording_desc">Debug သတင်းအချက်အလက် ရိုက်ကူးနေသည်။ ရပ်တန့်ရန် နှိပ်ပါ။</string>
-    <string name="settings_support_debuglog_path">မှတ်တမ်း လမ်းကြောင်း: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">အလွန် တိုသော ရိုက်ကူးမှု</string>
     <string name="settings_support_debuglog_short_recording_msg">ဒါဟာ အလွန် တိုသော ရိုက်ကူးမှုတစ်ခု ဖြစ်သည်။ Debug မှတ်တမ်းများသည် ရိုက်ကူးမှုများ ဖြစ်ပြီး snapshot များ မဟုတ်ပါ — မှတ်တမ်းကို အသုံးဝင်အောင် ရိုက်ကူးနေစဉ် ပြဿနာကို ပြန်ပြုလုပ်ပါ။</string>
     <string name="settings_support_debuglog_short_recording_continue">ဆက်လက် ရိုက်ကူးမည်</string>
     <string name="settings_support_debuglog_short_recording_stop">ဘာပဲဖြစ်ဖြစ် ရပ်တန့်မည်</string>
-    <string name="settings_support_debuglog_folder_label">Debug မှတ်တမ်း ဖိုင်တွဲ</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d session သည် %2$s သုံးနေသည်</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">သိမ်းဆည်းထားသော debug မှတ်တမ်း မရှိ</string>
-    <string name="settings_support_debuglog_folder_delete_title">Debug မှတ်တမ်း အားလုံး ဖျက်မည်လား?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">ဤလုပ်ဆောင်မှုသည် သိမ်းဆည်းထားသော debug မှတ်တမ်း session အားလုံးကို အပြီးတိုင် ဖျက်မည်။</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">တွေ့ဆုံ၍ မေးခွန်းများ မေးနိုင်သော နေရာ</string>
     <!-- Settings/Acks-->
@@ -226,16 +204,12 @@
     <string name="settings_acks_translation_header">ဘာသာပြန်ခြင်း</string>
     <string name="settings_acks_translators_title">ဘာသာပြန်သူများ</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM ဘာသာပြန်မည်</string>
-    <string name="settings_acks_translate_desc">BVM ကို သင်၏ ဘာသာစကားသို့ ဘာသာပြန်ရန် ကူညီပါ</string>
     <string name="settings_acks_thanks_header">ကျေးဇူးတင်သည်</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">အဖွင့်ရင်းမြစ် ပရောဂျက်များ ဘာသာပြန်ခြင်းကို ပံ့ပိုးသောအတွက်</string>
     <string name="settings_licenses_label">လိုင်စင်များ</string>
     <string name="settings_translation_label">ဘာသာပြန်ဆိုခြင်း</string>
     <string name="settings_translation_desc">အက်ပ်ကို သင်အကြိုက်ဆုံးဘာသာစကားသို့ ဘာသာပြန်ဆိုရာတွင် ကူညီပါ</string>
-    <string name="settings_sponsor_development_title">ဖွံ့ဖြိုးမှုကို ပံ့ပိုးမည်</string>
-    <string name="settings_sponsor_development_summary">အားပေးသူ ဖြစ်ပြီး ဆက်လက် ဖွံ့ဖြိုးမှုကို ဖြစ်နိုင်အောင် ပြုလုပ်ပါ။</string>
     <string name="settings_privacy_policy_label">ကိုယ်ရေးအချက်အလက် မူဝါဒ</string>
     <string name="settings_privacy_policy_desc">ဒေတာကို တာဝန်ယူမှုဖြင့် ကိုင်တွယ်ခြင်း</string>
     <string name="changelog_label">ပြောင်းလဲမှု မှတ်တမ်း</string>
@@ -257,10 +231,8 @@
     <string name="backup_restore_success_restore">ပြန်လည်ရယူမှု ပြီးဆုံး — %1$d ကိရိယာများ ပြန်လည်ရယူပြီး၊ %2$d ခု ကျော်သွားသည်။</string>
     <string name="backup_restore_version_warning">ဤ backup ကို ဗားရှင်း %1$s ဖြင့် ဖန်တီးထားသည်။ သင် %2$s ဖြင့် လည်ပတ်နေသည်။ ဆက်တင်အချို့ မှန်မှန်ကန်ကန် ပြန်လည်ရယူနိုင်မည် မဟုတ်ပါ။</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Debug အကြောင်းကြားချက်များ</string>
     <string name="debug_log_consent_title">Debug မှတ်တမ်း</string>
     <string name="debug_log_consent_explanation">ဤအင်္ဂါရပ်သည် အပ် လုပ်ဆောင်မှု အားလုံးကို မျှဝေနိုင်သော ဖိုင်တစ်ခုတွင် ရိုက်ကူးသည်။ ထုတ်လုပ်ထားသော ဖိုင်တွင် အထိခိုက်မခံသော သတင်းအချက်အလက် (ဥပမာ - ဖိုင်အမည်များနှင့် တပ်ဆင်ထားသော အပ်များ) ပါဝင်သည်။ ယုံကြည်စိတ်ချရသော ပါတီများနှင့် (ဥပမာ - ပြဿနာ ဖြေရှင်းနေသော developer) သာ မျှဝေပါ။</string>
-    <string name="debug_log_recording_progress">Debug မှတ်တမ်း ရိုက်ကူးနေသည်</string>
     <string name="debug_log_record_action">ရိုက်ကူး</string>
     <string name="debug_log_stop_action">ရိုက်ကူးမှု ရပ်တန့်မည်</string>
     <string name="debug_log_screen_title">Debug မှတ်တမ်း ရိုက်ကူးကိရိယာ</string>
@@ -274,7 +246,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">ဖျက်ပစ်မည်</string>
     <string name="debug_log_screen_keep_action">သိမ်းထားမည်</string>
-    <string name="debug_log_compressing_label">ချုံ့နေသည်…</string>
     <string name="debug_log_file_label">ရိုက်ကူးထားသော မှတ်တမ်းဖိုင်</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">မှတ်တမ်း ပို့ပြီးပြီလား?</string>
@@ -302,7 +273,6 @@
     <string name="contact_description_question_hint">သင်၏ မေးခွန်းကို အသေးစိတ် ဖော်ပြပါ။</string>
     <string name="contact_category_section_label">အမျိုးအစား</string>
     <string name="contact_debug_log_label">Debug မှတ်တမ်း</string>
-    <string name="contact_debug_log_select_hint">ပူးတွဲရန် debug မှတ်တမ်း ရွေးချယ်ပါ</string>
     <string name="contact_debug_log_picker_hint">ပြဿနာကို ပိုမြန်စွာ ရှင်းလင်းနိုင်ရန် debug မှတ်တမ်း ပူးတွဲပါ။</string>
     <string name="contact_debug_log_picker_empty">Debug မှတ်တမ်း မရှိပါ။ ဦးစွာ တစ်ခု ရိုက်ကူးပါ။</string>
     <string name="contact_expected_behavior_label">မျှော်မှန်းထားသော အပြုအမူ</string>
@@ -315,82 +285,32 @@
     <string name="contact_welcome_msg">မက်ဆေ့ချ် တိုင်းကို ကိုယ်တိုင် ဖတ်ပြီး တတ်နိုင်သမျှ ပြန်ကြားရန် ကြိုးစားသည်၊ သို့သော် တစ်ယောက်တည်း လုပ်နေသောကြောင့် အချိန် ကြာနိုင်သည်။ ကျေးဇူးတင်သည်။</string>
     <string name="contact_footer_msg">သင်၏ မက်ဆေ့ချ်ကို email မှတစ်ဆင့် ပို့မည်။ ကိရိယာနှင့် ဆက်တင် သတင်းအချက်အလက် အလိုအလျောက် ပူးတွဲသည်။</string>
     <string name="contact_no_email_app_msg">ဤကိရိယာတွင် email အပ် မတွေ့ပါ။</string>
-    <string name="contact_attachment_missing_msg">Debug မှတ်တမ်းဖိုင် မတည်ရှိတော့</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">သိမ်းဆည်းထားသော debug မှတ်တမ်းများ</string>
     <string name="settings_support_stored_logs_desc">%1$d session (%2$s)</string>
     <string name="settings_support_stored_logs_empty">သိမ်းဆည်းထားသော debug မှတ်တမ်း မရှိ</string>
-    <string name="settings_support_stored_logs_delete_title">သိမ်းဆည်းထားသော မှတ်တမ်းများ ဖျက်မည်လား?</string>
-    <string name="settings_support_stored_logs_delete_msg">သိမ်းဆည်းထားသော debug မှတ်တမ်း session %1$d ခုလုံး ဖျက်မည်။</string>
-    <string name="settings_support_stored_logs_deleted_msg">သိမ်းဆည်းထားသော debug မှတ်တမ်းများ ဖျက်ပြီး</string>
-    <string name="label_bug_reports">ချို့ယွင်းချက် အစီရင်ခံမှုများ</string>
-    <string name="description_bug_reports">အလိုအလျောက် ချို့ယွင်းချက်နှင့် ပျက်ကျမှု အစီရင်ခံခြင်း</string>
     <string name="label_add_device">ကိရိယာ ထည့်မည်</string>
-    <string name="label_just_a_moment_please">ခဏစောင့်ပါ</string>
     <string name="label_notification_channel_status">အခြေအနေ</string>
     <string name="label_notification_channel_setup">အစ်တင်တည်ဆောက်ခြင်း လိုအပ်ပါသည်</string>
     <string name="monitor_notification_starting">စတင်နေပါသည်…</string>
     <string name="action_set">သတ်မှတ်မည်</string>
     <string name="action_cancel">ပယ်ဖျက်</string>
-    <string name="label_invalid_input">မမှန်ကန်သော ထည့်သွင်းမှု</string>
     <string name="action_reset">ပြန်လည်သတ်မှတ်မည်</string>
     <string name="label_no_connected_devices">ချိတ်ဆက်ထားသော ကိရိယာ မရှိ</string>
-    <string name="label_status_idle">အနားယူနေသည်</string>
-    <string name="label_status_adjusting_volumes">အသံ ချိန်ညှိနေသည်</string>
-    <string name="label_premium_version">Premium မျိုးကွဲ</string>
     <string name="general_upgrade_action">အဆင့်မြှင့်တင်မည်</string>
     <string name="common_upgrade_required_label">အဆင့်မြှင့်တင်ရန် လိုအပ်သည်</string>
-    <string name="label_premium_version_required">Premium မျိုးကွဲ လိုအပ်သည်</string>
-    <string name="description_intro_purpose">ဤအပ်သည် သင့် Android ကိရိယာကို မတူညီသော Bluetooth ကိရိယာများ၏ အသံကို မှတ်မိစေသည်။</string>
-    <string name="upgrade_benefit_unlimited_devices">ကန့်သတ်မှုမရှိသော ကိရိယာ ပရိုဖိုင်များ</string>
-    <string name="upgrade_benefit_connection_actions">အလိုအလျောက်ဖွင့်ခြင်း၊ အက်ပ်ဖွင့်ခြင်းနှင့် ချိတ်ဆက်မှု သတိပေးချက်များ</string>
-    <string name="upgrade_benefit_theme_customization">အပြင်အဆင်၊ ပုံစံနှင့် အရောင် စိတ်ကြိုက်ပြင်ဆင်မှု</string>
-    <string name="upgrade_benefit_power_controls">အသံအတိုးအကျယ် လော့ခ်နှင့် နှုန်ကန့်သတ်ခြင်း</string>
-    <string name="upgrade_benefit_support">လွတ်လပ်သော ဖန်တီးမှုကို ပံ့ပိုးပါ</string>
     <string name="upgrade_benefit_equalizer">• ကိရိယာအလိုက် ညီမျှစာစီစဉ် (စနစ်ညီမျှစာစီစဉ်ပံ့ပိုးပေးသည့် ဂီတအက်ပ်များအတွက်)</string>
-    <string name="description_intro_tap_the_button">ပထမဆုံး ကိရိယာ ထည့်ခြင်းဖြင့် စတင်ပါ။</string>
     <string name="description_bluetooth_is_disabled">Bluetooth ပိတ်ထားသည်။</string>
     <string name="title_bluetooth_is_off">Bluetooth ပိတ်ထားသည်</string>
     <string name="action_enable_bluetooth">Bluetooth ဖွင့်မည်</string>
     <string name="title_bluetooth_permission_required">Bluetooth ခွင့်ပြုချက် လိုအပ်သည်</string>
     <string name="description_bluetooth_permission_required">ဤအပ်သည် သင့်ကိရိယာ အသံများ စီမံခန့်ခွဲရန် Bluetooth ခွင့်ပြုချက် လိုအပ်သည်။</string>
     <string name="action_grant_permission">ခွင့်ပြုချက် ပေးမည်</string>
-    <string name="label_status_listening_for_changes">အသံ ပြောင်းလဲမှုများ နားထောင်နေသည်</string>
     <string name="action_exit">ထွက်မည်</string>
-    <string name="action_start">စတင်မည်</string>
-    <string name="label_welcome">ကြိုဆိုပါသည်</string>
-    <string name="description_intro_contact">မေးခွန်းများ သို့မဟုတ် အင်္ဂါရပ် အသစ် အကြံဉာဏ်ရှိလျှင် ဆက်သွယ်ရန် မတွန့်ဆုတ်ပါနှင့်။</string>
-    <string name="label_translation">ဘာသာပြန်ခြင်း</string>
-    <string name="description_help_translate">ဤအပ်ကို အခြားဘာသာစကားများတွင် ရနိုင်အောင် ကူညီပါ။</string>
     <string name="label_device_speaker">ကိရိယာ စပီကာ</string>
-    <string name="label_keyevent_playpause">ဖွင့်/ရပ်</string>
-    <string name="label_keyevent_play">ဖွင့်</string>
-    <string name="label_keyevent_next">နောက်တစ်ပုဒ်</string>
-    <string name="label_install_id">တပ်ဆင်မှု ID</string>
     <string name="message_copied_to_clipboard">Clipboard သို့ ကူးယူပြီး</string>
-    <string name="label_thanks">ကျေးဇူးတင်သည်</string>
-    <string name="label_licenses">လိုင်စင်များ</string>
-    <string name="description_ring_volume_additional_permission">မြည်သံ ပြောင်းရန် ထပ်ဆောင်း ခွင့်ပြုချက်များ လိုအပ်သည်။</string>
-    <string name="label_missing_permissions">ခွင့်ပြုချက် မပြည့်စုံ</string>
-    <string name="action_grant">ပေးမည်</string>
-    <string name="label_advanced">အဆင့်မြင့်</string>
-    <string name="label_exclude_health">ကျန်းမာရေး ပရိုဖိုင်များ ဖယ်ထားမည်</string>
-    <string name="description_exclude_health">အချို့ Android ကိရိယာများသည် \'Health Device\' Bluetooth ပရိုဖိုင်များ (HDP, 0x1400) ကို ရှာဖွေသောအခါ တိမ်ကောနေသည်။</string>
-    <string name="label_exclude_gattserver">GATT server ပရိုဖိုင်များ ဖယ်ထားမည်</string>
-    <string name="label_exclude_gatt">GATT ပရိုဖိုင်များ ဖယ်ထားမည်</string>
-    <string name="description_exclude_gattserver">\'Generic Attribute\' (GATT) server အမျိုးအစား Bluetooth ပရိုဖိုင်များ မမေးမြန်းပါ။</string>
-    <string name="description_exclude_gatt">\'Generic Attribute\' (GATT) client အမျိုးအစား Bluetooth ပရိုဖိုင်များ မမေးမြန်းပါ။</string>
-    <string name="description_waiting_for_devicex">%s ချိတ်ဆက်မှု ပြည့်စုံရန် စောင့်နေသည်</string>
-    <string name="action_undo">နောက်ပြန်ဆွဲမည်</string>
-    <string name="action_show">ပြသမည်</string>
     <string name="action_dismiss">ပိတ်မည်</string>
-    <string name="action_fix">ပြင်မည်</string>
-    <string name="battery_optimizations_issue_description">ဤအပ်အတွက် ဘက်ထရီ ပိုမိုကောင်းမွန်အောင် ပြုလုပ်ခြင်း ဖွင့်ထားပြီး Bluetooth ဖြစ်ရပ်များ လက်ခံရယူမှုကို တားဆီးနိုင်သည်။ ပြဿနာများ ကြုံနေလျှင် ပိုမိုကောင်းမွန်အောင် ပြုလုပ်ခြင်းကို ပိတ်ရန် စဉ်းစားပါ။</string>
     <string name="label_bluetooth_settings">Bluetooth ဆက်တင်များ</string>
-    <string name="android10_applaunch_issue_description">Android 10 သည် အပ်များကို နောက်ခံမှ မည်ကဲ့သို့ ဖွင့်နိုင်သည်ကို ကန့်သတ်သည်။ Bluetooth ကိရိယာ ချိတ်ဆက်သောအခါ အပ်များ ဖွင့်ရန် ခွင့်ပြုရန် &quot;အခြားအပ်များ အပေါ် ပြသမည်&quot; (SYSTEM_ALERT_WINDOW) ခွင့်ပြုချက် ပေးပါ။</string>
-    <string name="label_opensource">ဆော့ဝဲကုဒ်</string>
-    <string name="android13_notification_permission_description">ဤအပ်သည် အကြောင်းကြားချက်များ ပြသရန် ခွင့်ပြုချက် ပေးပါ။ ဤအပ် အသက်ဝင်နေ၍ အသံ ချိန်ညှိမှုများ ပြုလုပ်နေစဉ် အကြောင်းကြားချက် ပြသနိုင်ပါသည်။</string>
-    <string name="privacy_policy_label">ကိုယ်ရေးအချက်အလက် မူဝါဒ</string>
     <string name="managed_devices_empty_message">Bluetooth ကိရိယာ မသတ်မှတ်ရသေး။\nပထမဆုံး ကိရိယာ ထည့်ရန် + ခလုတ် နှိပ်ပါ။</string>
     <string name="label_pro_feature">Premium လုပ်ဆောင်ချက်</string>
     <plurals name="discover_device_limit_banner">
@@ -420,21 +340,15 @@
     <string name="review_app_review_action">သုံးသပ်ချက် ပေးရန်</string>
     <string name="review_app_dismiss_action">နောက်ပိုင်းမှ</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">ဝယ်ယူမှု ပယ်ဖျက်ခဲ့သည်</string>
-    <string name="error_iap_unavailable_message">အပ် အတွင်း ဝယ်ယူမှုများ မရနိုင်</string>
-    <string name="error_generic_message">အမှားတစ်ခု ဖြစ်ပေါ်ခဲ့သည်။ ထပ်မံ ကြိုးစားပါ။</string>
-    <string name="error_iap_owned_message">သင်သည် ဤပစ္စည်းကို ပိုင်ဆိုင်ပြီးဖြစ်သည်</string>
     <string name="label_no_devices_title">ကိရိယာ မရှိ</string>
     <string name="bluemusic_mascot_description">အပ် အိုင်ကွန်</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">အပ်များ ရွေးချယ်ပါ</string>
     <string name="devices_app_selection_search_hint">အပ်များ ရှာဖွေ…</string>
-    <string name="devices_app_selection_currently_selected">လက်ရှိ ရွေးချယ်ထားသည်</string>
     <string name="devices_app_selection_selected_count">%d အပ် ရွေးချယ်ထားသည်</string>
     <string name="general_navigate_back_action">နောက်သို့ သွားမည်</string>
     <string name="general_reset_action">ပြန်လည်သတ်မှတ်မည်</string>
     <string name="general_clear_action">ရှင်းလင်းမည်</string>
-    <string name="general_save_action">သိမ်းဆည်းမည်</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">သော့ခတ်</string>
     <string name="devices_indicator_awake">နိုးနေ</string>
@@ -444,7 +358,6 @@
     <string name="devices_indicator_limit">ကန့်သတ်</string>
     <string name="devices_indicator_eq">ညီမျှစာစီစဉ်</string>
     <string name="devices_indicator_boost">အတိုး</string>
-    <string name="devices_indicator_launch">စတင်</string>
     <string name="devices_indicator_home">ပင်မ</string>
     <string name="devices_indicator_dnd">မနှောင့်ယှက်နှင့်</string>
     <string name="devices_indicator_alert">သတိပေးချက်</string>

--- a/app/src/main/res/values-ne-rNP/strings.xml
+++ b/app/src/main/res/values-ne-rNP/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">अपडेटको क्रममा केही सुविधाहरू परिवर्तन भएका छन्। सबै कुरा सही रूपमा कन्फिगर भएको छ भनी सुनिश्चित गर्न कृपया आफ्नो उपकरण सेटिङहरू जाँच गर्नुहोस्।</string>
     <string name="onboarding_rewrite_action">जारी राख्नुहोस्</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">कुनै अव्यवस्थित उपकरण फेला परेन</string>
     <string name="discover_all_devices_managed_msg">तपाईंका सबै जोडिएका उपकरणहरू व्यवस्थित छन्! नयाँ चाहिन्छ?</string>
     <string name="discover_pair_new_device_action">नयाँ उपकरण जोड्नुहोस्</string>
     <string name="discover_device_speaker_desc">यो फोनको आफ्नो स्पिकर। यसको भलिउमहरू लागू हुन्छन् जब अडियो फोनमा फेरि स्विच हुन्छ, उदाहरणार्थ आपको Bluetooth उपकरण काट हुन्छ पछि।</string>
     <!-- Devices -->
     <string name="devices_device_config_label">उपकरण कन्फिगरेसन</string>
-    <string name="devices_device_config_section_general_label">सामान्य</string>
     <string name="devices_device_config_remove_device_label">उपकरण बिर्सनुहोस्</string>
-    <string name="devices_device_config_remove_device_desc">यस एपबाट उपकरण बिर्सन्छ र यसको कन्फिगरेसन मेटाउँछ। यसले उपकरण अनपेयर गर्दैन।</string>
     <string name="devices_device_config_remove_device_action">बिर्सनुहोस्</string>
     <string name="devices_device_config_remove_device_confirmation">व्यवस्थित उपकरणहरूबाट %s बिर्स्ने?</string>
-    <string name="devices_device_config_rename_device_label">उपकरण पुनर्नाम गर्नुहोस्</string>
-    <string name="devices_device_config_rename_device_desc">यस एप भित्र र सम्भव भएमा प्रणालीमा पनि यस उपकरणको नाम परिवर्तन गर्नुहोस्।</string>
     <string name="devices_device_config_rename_device_action">पुनर्नाम गर्नुहोस्</string>
     <string name="devices_device_config_enabled_label">सक्षम</string>
     <string name="devices_device_config_enabled_desc">जडान भएमा यस उपकरणमा प्रतिक्रिया दिनुहोस्</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">अटोप्ले आदेशहरू</string>
     <string name="devices_device_config_autoplay_keycodes_order">आदेश अनुक्रम</string>
     <string name="devices_device_config_autoplay_keycodes_label">आदेशहरू</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">कुन आदेशहरू पठाउने र कुन क्रममा पठाउने कन्फिगर गर्नुहोस्</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">कुनै आदेश कन्फिगर गरिएको छैन</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">आदेश थप्नुहोस्</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">अधिकतम %1$d आदेशहरू</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">माथि सार्नुहोस्</string>
     <string name="cd_autoplay_keycode_move_down">तल सार्नुहोस्</string>
     <string name="cd_autoplay_keycode_remove">हटाउनुहोस्</string>
-    <string name="devices_device_config_section_volumes_label">भोल्युमहरू</string>
     <string name="devices_device_config_section_volume_label">भोल्युम</string>
     <string name="devices_device_config_alarm_volume_label">अलार्म भोल्युम</string>
     <string name="devices_device_config_alarm_volume_desc">केही अलार्म एपहरूले यसको सट्टा सङ्गीत भोल्युम प्रयोग गर्छन्।</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">रिङ</string>
     <string name="devices_audio_stream_notification_label">सूचना</string>
     <string name="devices_audio_stream_alarm_label">अलार्म</string>
-    <string name="devices_neverseen_label">कहिल्यै देखिएन</string>
-    <string name="devices_state_connected_label">जडान भयो</string>
     <string name="devices_last_connected_label">अन्तिम जडान: %s</string>
     <string name="devices_currently_connected_label">हाल जडान भएको छ</string>
     <string name="devices_device_disabled_label">उपकरण अक्षम गरियो</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">सबै व्यवस्थित उपकरणहरूलाई असर गर्ने सेटिङहरू।</string>
     <string name="label_app_enabled">एप सक्षम</string>
     <string name="description_app_enabled">भोल्युम र Bluetooth घटनाहरूमा प्रतिक्रिया दिने एपको क्षमता टगल गर्दछ।</string>
-    <string name="label_visible_volume_adjustments">दृश्यमान समायोजनहरू</string>
-    <string name="description_visible_volume_adjustments">यस एपले समायोजन गर्दा प्रणालीको भोल्युम विन्डो देखाउनुहोस्।</string>
     <string name="label_volume_listener">परिवर्तनहरू अवलोकन गर्नुहोस्</string>
-    <string name="description_volume_listener">कुनै उपकरण जडान भएको बेला सक्रिय रहनुहोस् र यस एपले नगराएका भोल्युम परिवर्तनहरू सुरक्षित गर्नुहोस्।</string>
     <string name="label_boot_restore">बुट गर्दा पुनर्स्थापना गर्नुहोस्</string>
     <string name="description_boot_restore">Bluetooth उपकरण जडान भएको छ भने बुट/रिबुट पछि भोल्युम पुनर्स्थापना गर्नुहोस्।</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM प्रभावकारी रूपमा कसरी प्रयोग गर्ने सिक्नुहोस्</string>
     <string name="settings_support_issue_tracker_description">बग रिपोर्ट र सुविधा अनुरोधहरूको लागि सार्वजनिक समस्या ट्र्याकर।</string>
     <string name="settings_support_issue_tracker_label">समस्या ट्र्याकर</string>
-    <string name="settings_support_debuglog_label">डिबग लग</string>
     <string name="settings_support_debuglog_desc">एपले गरिरहेको सबै कुरा एक टेक्स्ट फाइलमा रेकर्ड गर्नुहोस् जुन तपाईंले साझा गर्न सक्नुहुन्छ।</string>
-    <string name="settings_support_debuglog_recording_desc">हाल डिबग जानकारी रेकर्ड गर्दैछ। रेकर्डिङ रोक्न थिच्नुहोस्।</string>
-    <string name="settings_support_debuglog_path">लग मार्ग: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">धेरै छोटो रेकर्डिङ</string>
     <string name="settings_support_debuglog_short_recording_msg">त्यो धेरै छोटो रेकर्डिङ थियो। डिबग लगहरू रेकर्डिङहरू हुन्, स्न्यापसटहरू होइनन् — लग उपयोगी हुनको लागि रेकर्डिङ सक्रिय हुँदा समस्या पुनर्उत्पादन गर्नुहोस्।</string>
     <string name="settings_support_debuglog_short_recording_continue">रेकर्डिङ जारी राख्नुहोस्</string>
     <string name="settings_support_debuglog_short_recording_stop">जे भए पनि रोक्नुहोस्</string>
-    <string name="settings_support_debuglog_folder_label">डिबग लग फोल्डर</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d सत्र %2$s प्रयोग गर्दै</item>
-        <item quantity="other">%1$d सत्रहरू %2$s प्रयोग गर्दै</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">कुनै डिबग लग भण्डारण गरिएको छैन</string>
-    <string name="settings_support_debuglog_folder_delete_title">सबै डिबग लगहरू मेट्ने?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">यसले भण्डारण गरिएका सबै डिबग लग सत्रहरू स्थायी रूपमा मेट्नेछ।</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">घुम्न र प्रश्नहरू सोध्नको लागि ठाउँ।</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">अनुवाद</string>
     <string name="settings_acks_translators_title">अनुवादकहरू</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM अनुवाद गर्नुहोस्</string>
-    <string name="settings_acks_translate_desc">BVM लाई तपाईंको भाषामा अनुवाद गर्न मद्दत गर्नुहोस्</string>
     <string name="settings_acks_thanks_header">धन्यवाद</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">खुला स्रोत परियोजनाहरूको अनुवाद समर्थन गर्नको लागि</string>
     <string name="settings_licenses_label">इजाजतपत्रहरू</string>
     <string name="settings_translation_label">अनुवाद</string>
     <string name="settings_translation_desc">एपलाई तपाईंको मनपर्ने भाषामा अनुवाद गर्न मद्दत गर्नुहोस्</string>
-    <string name="settings_sponsor_development_title">विकासलाई प्रायोजन गर्नुहोस्</string>
-    <string name="settings_sponsor_development_summary">संरक्षक बन्नुहोस् र निरन्तर विकासलाई सम्भव बनाउनुहोस्।</string>
     <string name="settings_privacy_policy_label">गोपनीयता नीति</string>
     <string name="settings_privacy_policy_desc">डेटा जिम्मेवारीपूर्वक ह्यान्डल गर्दै।</string>
     <string name="changelog_label">परिवर्तन लग</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">रिस्टोर सम्पन्न — %1$d यन्त्रहरू रिस्टोर गरियो, %2$d छोडियो।</string>
     <string name="backup_restore_version_warning">यो ब्याकअप संस्करण %1$s सँग सिर्जना गरिएको थियो। तपाईं %2$s चलाउँदै हुनुहुन्छ। केही सेटिङहरू सही ढंगले रिस्टोर नहुन सक्छन्।</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">डिबग सूचनाहरू</string>
     <string name="debug_log_consent_title">डिबग लग</string>
     <string name="debug_log_consent_explanation">यो सुविधाले एपले गरिरहेको सबै कुरा साझा गर्न मिल्ने फाइलमा रेकर्ड गर्छ। उत्पन्न फाइलमा संवेदनशील जानकारी छ (जस्तै फाइल नामहरू र स्थापना गरिएका एपहरू)। यसलाई केवल विश्वसनीय पक्षहरूसँग साझा गर्नुहोस् (जस्तै समस्या समाधान गर्ने विकासकर्ता)।</string>
-    <string name="debug_log_recording_progress">डिबग लग रेकर्ड गर्दै</string>
     <string name="debug_log_record_action">रेकर्ड गर्नुहोस्</string>
     <string name="debug_log_stop_action">रेकर्डिङ रोक्नुहोस्</string>
     <string name="debug_log_screen_title">डिबग लग रेकर्डर</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">छोड्नुहोस्</string>
     <string name="debug_log_screen_keep_action">राख्नुहोस्</string>
-    <string name="debug_log_compressing_label">सङ्कुचित गर्दै…</string>
     <string name="debug_log_file_label">रेकर्ड गरिएको लग फाइल</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">लग पठाइयो?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">तपाईंको प्रश्न विस्तृत रूपमा वर्णन गर्नुहोस्।</string>
     <string name="contact_category_section_label">श्रेणी</string>
     <string name="contact_debug_log_label">डिबग लग</string>
-    <string name="contact_debug_log_select_hint">संलग्न गर्न डिबग लग चयन गर्नुहोस्</string>
     <string name="contact_debug_log_picker_hint">समस्या छिटो पत्ता लगाउन मद्दत गर्न डिबग लग संलग्न गर्नुहोस्।</string>
     <string name="contact_debug_log_picker_empty">कुनै डिबग लग उपलब्ध छैन। पहिले एउटा रेकर्ड गर्नुहोस्।</string>
     <string name="contact_expected_behavior_label">अपेक्षित व्यवहार</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">म हरेक सन्देश आफैं पढ्छु र जवाफ दिन मेरो सर्वोत्तम प्रयास गर्छु, तर यसमा एकलै काम गर्दा अलि समय लाग्न सक्छ। तपाईंको धैर्यताको लागि धन्यवाद।</string>
     <string name="contact_footer_msg">तपाईंको सन्देश इमेलमार्फत पठाइनेछ। उपकरण र सेटअप जानकारी स्वचालित रूपमा संलग्न हुन्छ।</string>
     <string name="contact_no_email_app_msg">यस उपकरणमा कुनै इमेल एप फेला परेन।</string>
-    <string name="contact_attachment_missing_msg">डिबग लग फाइल अब अवस्थित छैन</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">भण्डारण गरिएका डिबग लगहरू</string>
     <string name="settings_support_stored_logs_desc">%1$d सत्रहरू (%2$s)</string>
     <string name="settings_support_stored_logs_empty">कुनै भण्डारण गरिएका डिबग लगहरू छैनन्</string>
-    <string name="settings_support_stored_logs_delete_title">भण्डारण गरिएका लगहरू मेट्ने?</string>
-    <string name="settings_support_stored_logs_delete_msg">यसले सबै %1$d भण्डारण गरिएका डिबग लग सत्रहरू मेट्नेछ।</string>
-    <string name="settings_support_stored_logs_deleted_msg">भण्डारण गरिएका डिबग लगहरू मेटियो</string>
-    <string name="label_bug_reports">बग रिपोर्टहरू</string>
-    <string name="description_bug_reports">स्वचालित बग र क्र्याश रिपोर्टिङ।</string>
     <string name="label_add_device">उपकरण थप्नुहोस्</string>
-    <string name="label_just_a_moment_please">एक क्षण पर्खनुहोस्।</string>
     <string name="label_notification_channel_status">स्थिति</string>
     <string name="label_notification_channel_setup">सेटअप आवश्यक</string>
     <string name="monitor_notification_starting">सुरु हो दै…</string>
     <string name="action_set">सेट गर्नुहोस्</string>
     <string name="action_cancel">रद्द गर्नुहोस्</string>
-    <string name="label_invalid_input">अवैध इनपुट</string>
     <string name="action_reset">रिसेट गर्नुहोस्</string>
     <string name="label_no_connected_devices">कुनै उपकरण जडान भएको छैन</string>
-    <string name="label_status_idle">निष्क्रिय</string>
-    <string name="label_status_adjusting_volumes">भोल्युमहरू समायोजन गर्दै</string>
-    <string name="label_premium_version">प्रिमियम संस्करण</string>
     <string name="general_upgrade_action">अपग्रेड गर्नुहोस्</string>
     <string name="common_upgrade_required_label">अपग्रेड आवश्यक छ</string>
-    <string name="label_premium_version_required">प्रिमियम संस्करण आवश्यक</string>
-    <string name="description_intro_purpose">यो एपले तपाईंको Android उपकरणलाई विभिन्न Bluetooth उपकरणहरूको भोल्युम सम्झन दिन्छ।</string>
-    <string name="upgrade_benefit_unlimited_devices">असीमित यन्त्र प्रोफाइलहरू</string>
-    <string name="upgrade_benefit_connection_actions">अटोप्ले, एप लन्च र कनेक्सन अलर्टहरू</string>
-    <string name="upgrade_benefit_theme_customization">थिम, शैली र रङ्ग अनुकूलन</string>
-    <string name="upgrade_benefit_power_controls">भोल्युम लक र दर सीमाकरण</string>
-    <string name="upgrade_benefit_support">स्वतन्त्र विकासलाई सहयोग गर्नुहोस्</string>
     <string name="upgrade_benefit_equalizer">• प्रति-यन्त्र इक्वलाइजर (सिस्टम इक्वलाइजर समर्थन गर्ने संगीत एपहरूका लागि)</string>
-    <string name="description_intro_tap_the_button">आफ्नो पहिलो उपकरण थपेर सुरु गर्नुहोस्।</string>
     <string name="description_bluetooth_is_disabled">ब्लुटुथ असक्षम पारिएको छ.</string>
     <string name="title_bluetooth_is_off">Bluetooth बन्द छ</string>
     <string name="action_enable_bluetooth">Bluetooth सक्षम गर्नुहोस्</string>
     <string name="title_bluetooth_permission_required">Bluetooth अनुमति आवश्यक</string>
     <string name="description_bluetooth_permission_required">तपाईंको उपकरण भोल्युमहरू व्यवस्थापन गर्न यस एपलाई Bluetooth अनुमति चाहिन्छ।</string>
     <string name="action_grant_permission">अनुमति दिनुहोस्</string>
-    <string name="label_status_listening_for_changes">भोल्युम परिवर्तनहरूको लागि सुन्दै</string>
     <string name="action_exit">बाहिर निस्कनुहोस्</string>
-    <string name="action_start">सुरु गर्नुहोस्</string>
-    <string name="label_welcome">स्वागत</string>
-    <string name="description_intro_contact">यदि तपाईंसँग प्रश्नहरू छन् वा नयाँ सुविधाको विचार पनि छ भने मलाई सम्पर्क गर्न नहिचकिचाउनुहोस्।</string>
-    <string name="label_translation">अनुवाद</string>
-    <string name="description_help_translate">यो एपलाई अन्य भाषाहरूमा उपलब्ध गराउन मलाई मद्दत गर्नुहोस्।</string>
     <string name="label_device_speaker">उपकरण स्पिकर</string>
-    <string name="label_keyevent_playpause">प्ले-पज</string>
-    <string name="label_keyevent_play">प्ले</string>
-    <string name="label_keyevent_next">अर्को</string>
-    <string name="label_install_id">स्थापना ID</string>
     <string name="message_copied_to_clipboard">क्लिपबोर्डमा प्रतिलिपि गरियो</string>
-    <string name="label_thanks">धन्यवाद</string>
-    <string name="label_licenses">इजाजतपत्रहरू</string>
-    <string name="description_ring_volume_additional_permission">रिङ भोल्युम परिवर्तन गर्न थप अनुमतिहरू आवश्यक छन्।</string>
-    <string name="label_missing_permissions">अनुमतिहरू हराइरहेका छन्</string>
-    <string name="action_grant">दिनुहोस्</string>
-    <string name="label_advanced">उन्नत</string>
-    <string name="label_exclude_health">स्वास्थ्य प्रोफाइलहरू बहिष्कार गर्नुहोस्</string>
-    <string name="description_exclude_health">केही Android उपकरणहरू \'Health Device\' Bluetooth प्रोफाइलहरू (HDP, 0x1400) खोज्दा झुण्डिन्छन्।</string>
-    <string name="label_exclude_gattserver">GATT सर्भर प्रोफाइलहरू बहिष्कार गर्नुहोस्</string>
-    <string name="label_exclude_gatt">GATT प्रोफाइलहरू बहिष्कार गर्नुहोस्</string>
-    <string name="description_exclude_gattserver">\'Generic Attribute\' (GATT) सर्भर प्रकारका Bluetooth प्रोफाइलहरू क्वेरी नगर्नुहोस्।</string>
-    <string name="description_exclude_gatt">\'Generic Attribute\' (GATT) क्लाइन्ट प्रकारका Bluetooth प्रोफाइलहरू क्वेरी नगर्नुहोस्।</string>
-    <string name="description_waiting_for_devicex">%s ले जडान पूरा गर्नको लागि पर्खिँदै</string>
-    <string name="action_undo">पूर्ववत गर्नुहोस्</string>
-    <string name="action_show">देखाउनुहोस्</string>
     <string name="action_dismiss">बन्द गर्नुहोस्</string>
-    <string name="action_fix">ठिक गर्नुहोस्</string>
-    <string name="battery_optimizations_issue_description">यस एपका लागि ब्याट्री अप्टिमाइजेसनहरू सक्षम छन् र यसलाई Bluetooth घटनाहरू प्राप्त गर्नबाट रोक्न सक्छ। यदि तपाईं समस्याहरू अनुभव गर्दै हुनुहुन्छ भने अप्टिमाइजेसनहरू अक्षम गर्ने विचार गर्नुहोस्।</string>
     <string name="label_bluetooth_settings">Bluetooth सेटिङहरू</string>
-    <string name="android10_applaunch_issue_description">Android 10 ले पृष्ठभूमिबाट एपहरू कसरी खोल्न सकिन्छ भनेर सीमित गर्दछ। Bluetooth उपकरण जडान हुँदा एपहरू खोल्न अनुमति दिन, \"अन्य एपहरूमाथि प्रदर्शन\" (SYSTEM_ALERT_WINDOW) अनुमति दिनुहोस्।</string>
-    <string name="label_opensource">स्रोत कोड</string>
-    <string name="android13_notification_permission_description">सूचनाहरू पोस्ट गर्न यस एपलाई अनुमति दिनुहोस्। यसले यो एप सक्रिय हुँदा र भोल्युम समायोजन हुँदा सूचना प्रदर्शन गर्न सक्षम गर्दछ।</string>
-    <string name="privacy_policy_label">गोपनीयता नीति</string>
     <string name="managed_devices_empty_message">कुनै Bluetooth उपकरण कन्फिगर गरिएको छैन।\nआफ्नो पहिलो उपकरण थप्न + बटन थिज्नुहोस्।</string>
     <string name="label_pro_feature">प्रिमियम सुविधा</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">समीक्षा</string>
     <string name="review_app_dismiss_action">पछि गर्ने</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">खरिद रद्द गरियो</string>
-    <string name="error_iap_unavailable_message">इन-एप खरिदहरू उपलब्ध छैनन्</string>
-    <string name="error_generic_message">एउटा त्रुटि भयो। कृपया पुनः प्रयास गर्नुहोस्।</string>
-    <string name="error_iap_owned_message">तपाईं पहिले नै यो वस्तुको स्वामी हुनुहुन्छ</string>
     <string name="label_no_devices_title">कुनै उपकरण छैन</string>
     <string name="bluemusic_mascot_description">एप आइकन</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">एपहरू चयन गर्नुहोस्</string>
     <string name="devices_app_selection_search_hint">एपहरू खोज्नुहोस्…</string>
-    <string name="devices_app_selection_currently_selected">हाल चयन गरिएको</string>
     <string name="devices_app_selection_selected_count">%d एपहरू चयन गरिए</string>
     <string name="general_navigate_back_action">पछाडि नेभिगेट गर्नुहोस्</string>
     <string name="general_reset_action">रिसेट गर्नुहोस्</string>
     <string name="general_clear_action">खाली गर्नुहोस्</string>
-    <string name="general_save_action">सेभ गर्नुहोस्</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">लक</string>
     <string name="devices_indicator_awake">जागृत</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">सीमा</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">बुस्ट</string>
-    <string name="devices_indicator_launch">सुरू गर्नुस्</string>
     <string name="devices_indicator_home">गृह</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">सूचना</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Sommige apparaatinstellingen zijn mogelijk gereset tijdens deze update. Controleer alsjeblieft je apparaatconfiguraties.</string>
     <string name="onboarding_rewrite_action">Doorgaan</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Geen onbeheerde apparaten gevonden</string>
     <string name="discover_all_devices_managed_msg">Al je gekoppelde apparaten worden beheerd! Tijd voor een nieuwe?</string>
     <string name="discover_pair_new_device_action">Nieuw apparaat koppelen</string>
     <string name="discover_device_speaker_desc">De eigen spreker van deze telefoon. De volumes ervan worden toegepast wanneer audio terugschakelt naar de telefoon, bijvoorbeeld nadat je Bluetooth-apparaat wordt verbroken.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Apparaatconfiguratie</string>
-    <string name="devices_device_config_section_general_label">Algemeen</string>
     <string name="devices_device_config_remove_device_label">Apparaat vergeten</string>
-    <string name="devices_device_config_remove_device_desc">Vergeet het apparaat uit deze app en verwijdert de configuratie. Dit ontkoppelt het apparaat niet.</string>
     <string name="devices_device_config_remove_device_action">Vergeten</string>
     <string name="devices_device_config_remove_device_confirmation">%s vergeten uit beheerde apparaten?</string>
-    <string name="devices_device_config_rename_device_label">Apparaat hernoemen</string>
-    <string name="devices_device_config_rename_device_desc">Hernoem dit apparaat binnen deze app, en indien mogelijk, binnen het systeem.</string>
     <string name="devices_device_config_rename_device_action">Hernoemen</string>
     <string name="devices_device_config_enabled_label">Ingeschakeld</string>
     <string name="devices_device_config_enabled_desc">Reageer op dit apparaat wanneer verbonden</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Automatisch afspelen opdrachten</string>
     <string name="devices_device_config_autoplay_keycodes_order">Opdrachtvolgorde</string>
     <string name="devices_device_config_autoplay_keycodes_label">Opdrachten</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Stel in welke opdrachten verzonden worden en in welke volgorde</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Geen opdrachten geconfigureerd</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Opdracht toevoegen</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximaal %1$d opdrachten</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Omhoog verplaatsen</string>
     <string name="cd_autoplay_keycode_move_down">Omlaag verplaatsen</string>
     <string name="cd_autoplay_keycode_remove">Verwijderen</string>
-    <string name="devices_device_config_section_volumes_label">Volumes</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
     <string name="devices_device_config_alarm_volume_label">Alarmvolume</string>
     <string name="devices_device_config_alarm_volume_desc">Sommige alarm-apps gebruiken in plaats daarvan het muziekvolume.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Beltoon</string>
     <string name="devices_audio_stream_notification_label">Melding</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Nooit gezien</string>
-    <string name="devices_state_connected_label">Verbonden</string>
     <string name="devices_last_connected_label">Laatst verbonden: %s</string>
     <string name="devices_currently_connected_label">Momenteel verbonden</string>
     <string name="devices_device_disabled_label">Apparaat uitgeschakeld</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Instellingen die alle beheerde apparaten beïnvloeden.</string>
     <string name="label_app_enabled">App ingeschakeld</string>
     <string name="description_app_enabled">Geeft de app mogelijkheid te reageren op volume en bluetooth gebeurtenissen.</string>
-    <string name="label_visible_volume_adjustments">Zichtbare aanpassingen</string>
-    <string name="description_visible_volume_adjustments">Het systeem volume venster weergegeven terwijl deze app aanpassingen maakt.</string>
     <string name="label_volume_listener">Observeer wijzigingen</string>
-    <string name="description_volume_listener">Actief blijven terwijl een apparaat is aangesloten en sla de volume veranderingen die niet zijn veroorzaakt door deze app op.</string>
     <string name="label_boot_restore">Herstel bij opstarten</string>
     <string name="description_boot_restore">Volume terugzet na het opstarten/rebooten als een Bluetooth-apparaat is aangesloten.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Leer hoe je BVM effectief gebruikt</string>
     <string name="settings_support_issue_tracker_description">Een openbare probleemtracker voor bugrapporten en functieverzoeken.</string>
     <string name="settings_support_issue_tracker_label">Probleemtracker</string>
-    <string name="settings_support_debuglog_label">Debug-log</string>
     <string name="settings_support_debuglog_desc">Leg alles wat de app doet vast in een tekstbestand dat je kunt delen.</string>
-    <string name="settings_support_debuglog_recording_desc">Momenteel debug-informatie opnemen. Tik om te stoppen.</string>
-    <string name="settings_support_debuglog_path">Logpad: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Zeer korte opname</string>
     <string name="settings_support_debuglog_short_recording_msg">Dat was een zeer korte opname. Debug-logs zijn opnames, geen momentopnames — reproduceer het probleem tijdens de opname zodat de log nuttig is.</string>
     <string name="settings_support_debuglog_short_recording_continue">Doorgaan met opnemen</string>
     <string name="settings_support_debuglog_short_recording_stop">Toch stoppen</string>
-    <string name="settings_support_debuglog_folder_label">Debug-logmap</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sessie gebruikt %2$s</item>
-        <item quantity="other">%1$d sessies gebruiken %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Geen debug-logs opgeslagen</string>
-    <string name="settings_support_debuglog_folder_delete_title">Alle debug-logs verwijderen?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Alle opgeslagen debug-logsessies worden permanent verwijderd.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Een plek om te chillen en vragen te stellen.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Vertaling</string>
     <string name="settings_acks_translators_title">Vertalers</string>
     <string name="settings_acks_translators_people">Erik Paelman</string>
-    <string name="settings_acks_translate_title">BVM vertalen</string>
-    <string name="settings_acks_translate_desc">Help BVM te vertalen naar jouw taal</string>
     <string name="settings_acks_thanks_header">Bedankt</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Voor het ondersteunen van de vertaling van open-source projecten</string>
     <string name="settings_licenses_label">Licenties</string>
     <string name="settings_translation_label">Vertaling</string>
     <string name="settings_translation_desc">Help de app te vertalen naar je favoriete taal</string>
-    <string name="settings_sponsor_development_title">Ontwikkeling sponsoren</string>
-    <string name="settings_sponsor_development_summary">Word een patroon en maak voortdurende ontwikkeling mogelijk.</string>
     <string name="settings_privacy_policy_label">Privacybeleid</string>
     <string name="settings_privacy_policy_desc">Verantwoord omgaan met gegevens.</string>
     <string name="changelog_label">Wijzigingslog</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Herstel voltooid — %1$d apparaten hersteld, %2$d overgeslagen.</string>
     <string name="backup_restore_version_warning">Deze back-up is gemaakt met versie %1$s. Je gebruikt %2$s. Sommige instellingen worden mogelijk niet correct hersteld.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Debug-meldingen</string>
     <string name="debug_log_consent_title">Debug-log</string>
     <string name="debug_log_consent_explanation">Deze functie legt alles wat de app doet vast in een deelbaar bestand. Het gegenereerde bestand bevat gevoelige informatie (bijv. bestandsnamen en geïnstalleerde apps). Deel het alleen met vertrouwde partijen (bijv. een ontwikkelaar die een probleem oplost).</string>
-    <string name="debug_log_recording_progress">Debug-log opnemen</string>
     <string name="debug_log_record_action">Opnemen</string>
     <string name="debug_log_stop_action">Opname stoppen</string>
     <string name="debug_log_screen_title">Debug-logrecorder</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Verwerpen</string>
     <string name="debug_log_screen_keep_action">Bewaren</string>
-    <string name="debug_log_compressing_label">Bezig met comprimeren…</string>
     <string name="debug_log_file_label">Opgenomen logbestand</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log verstuurd?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Beschrijf je vraag in detail.</string>
     <string name="contact_category_section_label">Categorie</string>
     <string name="contact_debug_log_label">Debug-log</string>
-    <string name="contact_debug_log_select_hint">Selecteer een debug-log om te bijvoegen</string>
     <string name="contact_debug_log_picker_hint">Voeg een debug-log toe om het probleem sneller te diagnosticeren.</string>
     <string name="contact_debug_log_picker_empty">Geen debug-logs beschikbaar. Neem er eerst een op.</string>
     <string name="contact_expected_behavior_label">Verwacht gedrag</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Ik lees elk bericht zelf en doe mijn best om te antwoorden, maar omdat ik er alleen aan werk, kan het even duren. Bedankt voor je geduld.</string>
     <string name="contact_footer_msg">Je bericht wordt per e-mail verstuurd. Apparaat- en instellingsinformatie wordt automatisch bijgevoegd.</string>
     <string name="contact_no_email_app_msg">Geen e-mailapplicatie gevonden op dit apparaat.</string>
-    <string name="contact_attachment_missing_msg">Debug-logbestand bestaat niet meer</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Opgeslagen debug-logs</string>
     <string name="settings_support_stored_logs_desc">%1$d sessies (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Geen opgeslagen debug-logs</string>
-    <string name="settings_support_stored_logs_delete_title">Opgeslagen logs verwijderen?</string>
-    <string name="settings_support_stored_logs_delete_msg">Alle %1$d opgeslagen debug-logsessies worden verwijderd.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Opgeslagen debug-logs verwijderd</string>
-    <string name="label_bug_reports">Foutrapport</string>
-    <string name="description_bug_reports">Automatisch verzenden fout en crash rapporten.</string>
     <string name="label_add_device">Apparaat toevoegen</string>
-    <string name="label_just_a_moment_please">Een ogenblik, alstublieft.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Setup vereist</string>
     <string name="monitor_notification_starting">Aan de slag…</string>
     <string name="action_set">Stel in</string>
     <string name="action_cancel">Annuleren</string>
-    <string name="label_invalid_input">Ongeldige invoer</string>
     <string name="action_reset">Opnieuw instellen</string>
     <string name="label_no_connected_devices">Geen apparaten verbonden</string>
-    <string name="label_status_idle">Inactief</string>
-    <string name="label_status_adjusting_volumes">Aanpassen volumes</string>
-    <string name="label_premium_version">Premium versie</string>
     <string name="general_upgrade_action">Upgraden</string>
     <string name="common_upgrade_required_label">Upgrade vereist</string>
-    <string name="label_premium_version_required">Premium versie vereist</string>
-    <string name="description_intro_purpose">Deze app staat je Android toestel toe het volume te onthouden van verschillende Bluetooth-apparaten.</string>
-    <string name="upgrade_benefit_unlimited_devices">Onbeperkte apparaatprofielen</string>
-    <string name="upgrade_benefit_connection_actions">Autoplay, app starten en verbindingswaarschuwingen</string>
-    <string name="upgrade_benefit_theme_customization">Thema-, stijl- en kleurcustomisatie</string>
-    <string name="upgrade_benefit_power_controls">Volumevergrendeling en snelheidsbegrenzing</string>
-    <string name="upgrade_benefit_support">Ondersteun onafhankelijke ontwikkeling</string>
     <string name="upgrade_benefit_equalizer">• Per-apparaat-equalizer (voor muziek-apps met ondersteuning voor systeemequalizers)</string>
-    <string name="description_intro_tap_the_button">Begin met het toevoegen van het eerste apparaat.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth is uitgeschakeld.</string>
     <string name="title_bluetooth_is_off">Bluetooth is Uit</string>
     <string name="action_enable_bluetooth">Bluetooth Inschakelen</string>
     <string name="title_bluetooth_permission_required">Bluetooth Toestemming Vereist</string>
     <string name="description_bluetooth_permission_required">Deze app heeft Bluetooth-toestemming nodig om het volume van je apparaten te beheren.</string>
     <string name="action_grant_permission">Toestemming Verlenen</string>
-    <string name="label_status_listening_for_changes">Luisteren voor veranderingen in volume</string>
     <string name="action_exit">Verlaten</string>
-    <string name="action_start">Starten</string>
-    <string name="label_welcome">Welkom</string>
-    <string name="description_intro_contact">Aarzel niet om me te contacteren als u vragen of zelfs een idee voor een nieuwe functie hebt.</string>
-    <string name="label_translation">Vertaling</string>
-    <string name="description_help_translate">Help me deze app beschikbaar maken in andere talen.</string>
     <string name="label_device_speaker">Apparaat luidspreker</string>
-    <string name="label_keyevent_playpause">Afspelen/pauzeren</string>
-    <string name="label_keyevent_play">Afspelen</string>
-    <string name="label_keyevent_next">Volgende</string>
-    <string name="label_install_id">Installatie ID</string>
     <string name="message_copied_to_clipboard">Gekopieerd naar klipbord</string>
-    <string name="label_thanks">Bedankt</string>
-    <string name="label_licenses">Licenties</string>
-    <string name="description_ring_volume_additional_permission">Aanvullende machtigingen zijn nodig om het beltvolume te wijzigen.</string>
-    <string name="label_missing_permissions">Ontbrekende machtigingen</string>
-    <string name="action_grant">Toestaan</string>
-    <string name="label_advanced">Geavanceerd</string>
-    <string name="label_exclude_health">Gezondheid profielen uitsluiten</string>
-    <string name="description_exclude_health">Sommige Android-apparaten hangen vast bij het zoeken naar Bluetooth-profielen (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">GATT server profielen uitsluiten</string>
-    <string name="label_exclude_gatt">GATT server profielen uitsluiten</string>
-    <string name="description_exclude_gattserver">Vraag geen Bluetooth profielen van type \'Algemene Attribuut\' (GATT) server aan.</string>
-    <string name="description_exclude_gatt">Vraag geen Bluetooth profielen van type \'Algemene Attribuut\' (GATT) server aan.</string>
-    <string name="description_waiting_for_devicex">Wachten op %s om de verbinding te voltooien</string>
-    <string name="action_undo">Ongedaan maken</string>
-    <string name="action_show">Toon</string>
     <string name="action_dismiss">Afwijzen</string>
-    <string name="action_fix">Repareren</string>
-    <string name="battery_optimizations_issue_description">Batterij optimalisaties zijn ingeschakeld voor deze app en kunnen voorkomen dat deze Bluetooth-events ontvangt. Overweeg optimalisaties uit te schakelen als u problemen ondervindt.</string>
     <string name="label_bluetooth_settings">Bluetooth-instellingen</string>
-    <string name="android10_applaunch_issue_description">Android 10 beperkt hoe apps vanuit de achtergrond kunnen worden gestart. Om apps te kunnen openen wanneer een Bluetooth-apparaat verbinding maakt, verleen de toestemming &quot;Over andere apps weergeven&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Broncode</string>
-    <string name="android13_notification_permission_description">Geef deze app toestemming om meldingen te plaatsen. Dit zorgt ervoor dat er een melding wordt weergegeven wanneer deze app actief is en volume-aanpassingen worden gemaakt.</string>
-    <string name="privacy_policy_label">Privacybeleid</string>
     <string name="managed_devices_empty_message">Geen Bluetooth-apparaten geconfigureerd.\nTik op de + knop om je eerste apparaat toe te voegen.</string>
     <string name="label_pro_feature">Premiumfunctie</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Beoordeling</string>
     <string name="review_app_dismiss_action">Misschien later</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Aankoop geannuleerd</string>
-    <string name="error_iap_unavailable_message">In-app aankopen zijn niet beschikbaar</string>
-    <string name="error_generic_message">Er is een fout opgetreden. Probeer het opnieuw.</string>
-    <string name="error_iap_owned_message">Je bezit dit item al</string>
     <string name="label_no_devices_title">Geen Apparaten</string>
     <string name="bluemusic_mascot_description">App-pictogram</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Apps selecteren</string>
     <string name="devices_app_selection_search_hint">Zoek apps…</string>
-    <string name="devices_app_selection_currently_selected">Momenteel geselecteerd</string>
     <string name="devices_app_selection_selected_count">%d apps geselecteerd</string>
     <string name="general_navigate_back_action">Ga terug</string>
     <string name="general_reset_action">Herstellen</string>
     <string name="general_clear_action">Wissen</string>
-    <string name="general_save_action">Opslaan</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Vergr</string>
     <string name="devices_indicator_awake">Wakker</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Lim</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Boost</string>
-    <string name="devices_indicator_launch">Start</string>
     <string name="devices_indicator_home">Thuis</string>
     <string name="devices_indicator_dnd">NS</string>
     <string name="devices_indicator_alert">Melding</string>

--- a/app/src/main/res/values-no/strings.xml
+++ b/app/src/main/res/values-no/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Noen enhetsinnstillinger kan ha blitt tilbakestilt under denne oppdateringen. Sjekk enhetskonfigurasjonene dine.</string>
     <string name="onboarding_rewrite_action">Fortsett</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Ingen uhåndterte enheter funnet</string>
     <string name="discover_all_devices_managed_msg">Alle de parkoblede enhetene dine håndteres allerede! Trenger du en ny en?</string>
     <string name="discover_pair_new_device_action">Koble til ny enhet</string>
     <string name="discover_device_speaker_desc">Denne telefonens egen høyttaler. Volumene brukes når lyden byttes tilbake til telefonen, f.eks. etter at Bluetooth-enheten din kobles fra.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Enhetskonfigurasjon</string>
-    <string name="devices_device_config_section_general_label">Generelt</string>
     <string name="devices_device_config_remove_device_label">Glem enhet</string>
-    <string name="devices_device_config_remove_device_desc">Glemmer enheten fra denne appen og sletter konfigurasjonen. Dette kobler ikke fra enheten.</string>
     <string name="devices_device_config_remove_device_action">Glem</string>
     <string name="devices_device_config_remove_device_confirmation">Glem %s fra administrerte enheter?</string>
-    <string name="devices_device_config_rename_device_label">Gi nytt navn til enhet</string>
-    <string name="devices_device_config_rename_device_desc">Gi denne enheten et nytt navn i denne appen, og hvis mulig, i systemet.</string>
     <string name="devices_device_config_rename_device_action">Gi nytt navn</string>
     <string name="devices_device_config_enabled_label">Aktivert</string>
     <string name="devices_device_config_enabled_desc">Reager på denne enheten når den kobles til</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Autoplay-kommandoer</string>
     <string name="devices_device_config_autoplay_keycodes_order">Kommandosekvens</string>
     <string name="devices_device_config_autoplay_keycodes_label">Kommandoer</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Konfigurer hvilke kommandoer som skal sendes og i hvilken rekkefølge</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Ingen kommandoer konfigurert</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Legg til kommando</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimalt %1$d kommandoer</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Flytt opp</string>
     <string name="cd_autoplay_keycode_move_down">Flytt ned</string>
     <string name="cd_autoplay_keycode_remove">Fjern</string>
-    <string name="devices_device_config_section_volumes_label">Volumer</string>
     <string name="devices_device_config_section_volume_label">Volum</string>
     <string name="devices_device_config_alarm_volume_label">Alarmvolum</string>
     <string name="devices_device_config_alarm_volume_desc">Noen alarm-apper bruker musikkvolumet i stedet.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Ringing</string>
     <string name="devices_audio_stream_notification_label">Varsling</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Aldri sett</string>
-    <string name="devices_state_connected_label">Tilkoblet</string>
     <string name="devices_last_connected_label">Sist tilkoblet: %s</string>
     <string name="devices_currently_connected_label">Nå tilkoblet</string>
     <string name="devices_device_disabled_label">Enhet deaktivert</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Innstillinger som påvirker alle administrerte enheter.</string>
     <string name="label_app_enabled">App aktivert</string>
     <string name="description_app_enabled">Veksler appens evne til å reagere på volum og Bluetooth hendelser.</string>
-    <string name="label_visible_volume_adjustments">Synlige justeringer</string>
-    <string name="description_visible_volume_adjustments">Vis systemets volumvindu når denne appen gjør endringer.</string>
     <string name="label_volume_listener">Observer endringer</string>
-    <string name="description_volume_listener">Forbli aktiv mens en enhet er koblet til og lagre volumendringer som ikke har blitt forårsaket av denne appen.</string>
     <string name="label_boot_restore">Gjenopprett på oppstart</string>
     <string name="description_boot_restore">Gjenopprett volum etter oppstart/omstart hvis en Bluetooth-enhet er tilkoblet.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Lær hvordan du bruker BVM effektivt</string>
     <string name="settings_support_issue_tracker_description">En offentlig problemtracker for feilrapporter og funksjonsønsker.</string>
     <string name="settings_support_issue_tracker_label">Problemtracker</string>
-    <string name="settings_support_debuglog_label">Feilsøkingslogg</string>
     <string name="settings_support_debuglog_desc">Ta opp alt appen gjør i en tekstfil som du kan dele.</string>
-    <string name="settings_support_debuglog_recording_desc">Tar nå opp feilsøkingsinformasjon. Trykk for å stoppe opptaket.</string>
-    <string name="settings_support_debuglog_path">Loggsti: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Veldig kort opptak</string>
     <string name="settings_support_debuglog_short_recording_msg">Det var et veldig kort opptak. Feilsøkingslogger er opptak, ikke øyeblikksbilder — reproduser problemet mens opptaket er aktivt for at loggen skal være nyttig.</string>
     <string name="settings_support_debuglog_short_recording_continue">Fortsett opptak</string>
     <string name="settings_support_debuglog_short_recording_stop">Stopp uansett</string>
-    <string name="settings_support_debuglog_folder_label">Feilsøkingslogg-mappe</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d økt bruker %2$s</item>
-        <item quantity="other">%1$d økter bruker %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Ingen feilsøkingslogger lagret</string>
-    <string name="settings_support_debuglog_folder_delete_title">Slette alle feilsøkingslogger?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Dette vil slette alle lagrede feilsøkingslogg-økter permanent.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Et sted å henge på og stille spørsmål.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Oversettelse</string>
     <string name="settings_acks_translators_title">Oversettere</string>
     <string name="settings_acks_translators_people">Kristoffer Vassbø (kristoffer@vassbo.net)</string>
-    <string name="settings_acks_translate_title">Oversett BVM</string>
-    <string name="settings_acks_translate_desc">Hjelp med å oversette BVM til ditt språk</string>
     <string name="settings_acks_thanks_header">Takk</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">For å støtte oversetting av åpen kildekode-prosjekter</string>
     <string name="settings_licenses_label">Lisenser</string>
     <string name="settings_translation_label">Oversetting</string>
     <string name="settings_translation_desc">Hjelp til med å oversette appen til ditt favorittspråk</string>
-    <string name="settings_sponsor_development_title">Sponsør utvikling</string>
-    <string name="settings_sponsor_development_summary">Bli en patron og gjør fortsatt utvikling mulig.</string>
     <string name="settings_privacy_policy_label">Personvernregler</string>
     <string name="settings_privacy_policy_desc">Håndtere data ansvarlig.</string>
     <string name="changelog_label">Endringslogg</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Gjenoppretting fullført — %1$d enheter gjenopprettet, %2$d hoppet over.</string>
     <string name="backup_restore_version_warning">Denne sikkerhetskopien ble opprettet med versjon %1$s. Du kjører %2$s. Noen innstillinger gjenopprettes kanskje ikke riktig.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Feilsøkingsvarsler</string>
     <string name="debug_log_consent_title">Feilsøkingslogg</string>
     <string name="debug_log_consent_explanation">Denne funksjonen registrerer alt appen gjør i en delbar fil. Den genererte filen inneholder sensitiv informasjon (f.eks. filnavn og installerte apper). Del den bare med pålitelige parter (f.eks. en utvikler som feilsøker et problem).</string>
-    <string name="debug_log_recording_progress">Tar opp feilsøkingslogg</string>
     <string name="debug_log_record_action">Ta opp</string>
     <string name="debug_log_stop_action">Stopp opptak</string>
     <string name="debug_log_screen_title">Feilsøkingslogg-opptaker</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Forkast</string>
     <string name="debug_log_screen_keep_action">Behold</string>
-    <string name="debug_log_compressing_label">Komprimerer…</string>
     <string name="debug_log_file_label">Innspilt loggfil</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Logg sendt?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Beskriv spørsmålet ditt i detalj.</string>
     <string name="contact_category_section_label">Kategori</string>
     <string name="contact_debug_log_label">Feilsøkingslogg</string>
-    <string name="contact_debug_log_select_hint">Velg en feilsøkingslogg å legge ved</string>
     <string name="contact_debug_log_picker_hint">Legg ved en feilsøkingslogg for å hjelpe med å diagnostisere problemet raskere.</string>
     <string name="contact_debug_log_picker_empty">Ingen feilsøkingslogger tilgjengelig. Ta opp en først.</string>
     <string name="contact_expected_behavior_label">Forventet oppførsel</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Jeg leser alle meldinger selv og gjør mitt beste for å svare, men siden jeg jobber alene, kan det ta litt tid. Takk for tålmodigheten.</string>
     <string name="contact_footer_msg">Meldingen din vil bli sendt via e-post. Enhets- og oppsettsinformasjon vedlegges automatisk.</string>
     <string name="contact_no_email_app_msg">Ingen e-postapp funnet på denne enheten.</string>
-    <string name="contact_attachment_missing_msg">Feilsøkingslogg-filen eksisterer ikke lenger</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Lagrede feilsøkingslogger</string>
     <string name="settings_support_stored_logs_desc">%1$d økter (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Ingen lagrede feilsøkingslogger</string>
-    <string name="settings_support_stored_logs_delete_title">Slette lagrede logger?</string>
-    <string name="settings_support_stored_logs_delete_msg">Alle %1$d lagrede feilsøkingslogg-økter vil bli slettet.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Lagrede feilsøkingslogger slettet</string>
-    <string name="label_bug_reports">Feilrapporter</string>
-    <string name="description_bug_reports">Automatisk feil og krasjrapportering.</string>
     <string name="label_add_device">Legg til enhet</string>
-    <string name="label_just_a_moment_please">Bare et øyeblikk.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Oppsett kreves</string>
     <string name="monitor_notification_starting">Starter opp…</string>
     <string name="action_set">Sett</string>
     <string name="action_cancel">Avbryt</string>
-    <string name="label_invalid_input">Ugyldig inndata</string>
     <string name="action_reset">Tilbakestill</string>
     <string name="label_no_connected_devices">Ingen enheter tilkoblet</string>
-    <string name="label_status_idle">Inaktiv</string>
-    <string name="label_status_adjusting_volumes">Justerer volumer</string>
-    <string name="label_premium_version">Premiumversjon</string>
     <string name="general_upgrade_action">Oppgrader</string>
     <string name="common_upgrade_required_label">Oppgradering kreves</string>
-    <string name="label_premium_version_required">Premiumversjon krevet</string>
-    <string name="description_intro_purpose">Denne appen lar din Android-enhet huske volumet av forskjellige Bluetooth enheter.</string>
-    <string name="upgrade_benefit_unlimited_devices">Ubegrenset antall enhetsprofiler</string>
-    <string name="upgrade_benefit_connection_actions">Autoavspilling, appstart og tilkoblingsvarsler</string>
-    <string name="upgrade_benefit_theme_customization">Tilpasning av tema, stil og farge</string>
-    <string name="upgrade_benefit_power_controls">Volumlås og hastighetsbegrensning</string>
-    <string name="upgrade_benefit_support">Støtt uavhengig utvikling</string>
     <string name="upgrade_benefit_equalizer">• Equalizer per enhet (for musikkapper med støtte for systemequalizer)</string>
-    <string name="description_intro_tap_the_button">Start ved å legge til din første enhet.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth er deaktivert.</string>
     <string name="title_bluetooth_is_off">Bluetooth er av</string>
     <string name="action_enable_bluetooth">Aktiver Bluetooth</string>
     <string name="title_bluetooth_permission_required">Bluetooth-tillatelse kreves</string>
     <string name="description_bluetooth_permission_required">Denne appen trenger Bluetooth-tillatelse for å administrere enhetsvolumet ditt.</string>
     <string name="action_grant_permission">Gi tillatelse</string>
-    <string name="label_status_listening_for_changes">Lytter etter volumendringer</string>
     <string name="action_exit">Avslutt</string>
-    <string name="action_start">Start</string>
-    <string name="label_welcome">Velkommen</string>
-    <string name="description_intro_contact">Ikke nøl med å kontakte meg hvis du har noen spørsmål eller en idé om en ny funksjon.</string>
-    <string name="label_translation">Oversetting</string>
-    <string name="description_help_translate">Hjelp meg med å gjøre denne appen tilgjengelig på andre språk.</string>
     <string name="label_device_speaker">Enhetshøyttaler</string>
-    <string name="label_keyevent_playpause">Spill-Pause</string>
-    <string name="label_keyevent_play">Spill</string>
-    <string name="label_keyevent_next">Neste</string>
-    <string name="label_install_id">Installerings ID</string>
     <string name="message_copied_to_clipboard">Kopiert til utklippstavlen</string>
-    <string name="label_thanks">Takk</string>
-    <string name="label_licenses">Lisenser</string>
-    <string name="description_ring_volume_additional_permission">Tilleggstillatelser er nødvendige for å endre ringevolumet.</string>
-    <string name="label_missing_permissions">Mangler tillatelser</string>
-    <string name="action_grant">Gi</string>
-    <string name="label_advanced">Avansert</string>
-    <string name="label_exclude_health">Ekskluder helseprofiler</string>
-    <string name="description_exclude_health">Noen Android enheter henger seg opp når de ser etter \'Helse Enhet\' Bluetooth profiler (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Utelat GATT server profiler</string>
-    <string name="label_exclude_gatt">Utelat GATT profiler</string>
-    <string name="description_exclude_gattserver">Ikke spør etter Bluetooth-profiler av typen \'Generisk Attributt\' (GATT) server.</string>
-    <string name="description_exclude_gatt">Ikke spør etter Bluetooth-profiler av typen \'Generisk Attributt\' (GATT) klient.</string>
-    <string name="description_waiting_for_devicex">Venter på %s for å fullføre tilkoblingen</string>
-    <string name="action_undo">Angre</string>
-    <string name="action_show">Vis</string>
     <string name="action_dismiss">Avvis</string>
-    <string name="action_fix">Reparer</string>
-    <string name="battery_optimizations_issue_description">Batterioptimalisering er aktivert for denne appen og kan forhindre at den mottar Bluetooth-hendelser. Vurder å deaktivere optimaliseringer hvis du opplever problemer.</string>
     <string name="label_bluetooth_settings">Bluetooth-innstillinger</string>
-    <string name="android10_applaunch_issue_description">Android 10 begrenser hvordan apper kan åpnes fra bakgrunnen. For å tillate åpning av apper når en Bluetooth-enhet kobles til, gir du tillatelsen \&quot;Ligge over andre apper\&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Kildekode</string>
-    <string name="android13_notification_permission_description">Gi denne appen tillatelse til å sende varsler. Dette gjør det mulig å vise et varsel når denne appen er aktiv og volumjusteringer gjøres.</string>
-    <string name="privacy_policy_label">Personvernregler</string>
     <string name="managed_devices_empty_message">Ingen Bluetooth-enheter konfigurert.\nTrykk på +-knappen for å legge til din første enhet.</string>
     <string name="label_pro_feature">Premiumfunksjon</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Anmeldelse</string>
     <string name="review_app_dismiss_action">Kanskje senere</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Kjøp avbrutt</string>
-    <string name="error_iap_unavailable_message">Kjøp i appen er ikke tilgjengelig</string>
-    <string name="error_generic_message">En feil oppstod. Vennligst prøv igjen.</string>
-    <string name="error_iap_owned_message">Du eier allerede denne varen</string>
     <string name="label_no_devices_title">Ingen enheter</string>
     <string name="bluemusic_mascot_description">App-ikon</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Velg apper</string>
     <string name="devices_app_selection_search_hint">Søk etter apper…</string>
-    <string name="devices_app_selection_currently_selected">Valgt for øyeblikket</string>
     <string name="devices_app_selection_selected_count">%d apper valgt</string>
     <string name="general_navigate_back_action">Naviger tilbake</string>
     <string name="general_reset_action">Tilbakestill</string>
     <string name="general_clear_action">Tøm</string>
-    <string name="general_save_action">Lagre</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Lås</string>
     <string name="devices_indicator_awake">Våken</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Begrens</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Forsterkning</string>
-    <string name="devices_indicator_launch">Start</string>
     <string name="devices_indicator_home">Hjem</string>
     <string name="devices_indicator_dnd">IF</string>
     <string name="devices_indicator_alert">Varsel</string>

--- a/app/src/main/res/values-pcm-rNG/strings.xml
+++ b/app/src/main/res/values-pcm-rNG/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Some features don change during di update. Abeg check your device settings to make sure everything set correctly.</string>
     <string name="onboarding_rewrite_action">Continue</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">No unmanaged devices found</string>
     <string name="discover_all_devices_managed_msg">All your paired devices dey managed! You need new one?</string>
     <string name="discover_pair_new_device_action">Pair new device</string>
     <string name="discover_device_speaker_desc">Di phone speaker. E apply di volumes when audio switch back to phone, like afta your Bluetooth device disconnect.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Device configuration</string>
-    <string name="devices_device_config_section_general_label">General</string>
     <string name="devices_device_config_remove_device_label">Forget device</string>
-    <string name="devices_device_config_remove_device_desc">Forget dis device from dis app and delete im configuration. Dis no go unpair di device.</string>
     <string name="devices_device_config_remove_device_action">Forget</string>
     <string name="devices_device_config_remove_device_confirmation">Forget %s from managed devices?</string>
-    <string name="devices_device_config_rename_device_label">Rename device</string>
-    <string name="devices_device_config_rename_device_desc">Rename dis device inside dis app, and if possible, inside di system.</string>
     <string name="devices_device_config_rename_device_action">Rename</string>
     <string name="devices_device_config_enabled_label">Enabled</string>
     <string name="devices_device_config_enabled_desc">React to dis device when e connect</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Autoplay commands</string>
     <string name="devices_device_config_autoplay_keycodes_order">Command sequence</string>
     <string name="devices_device_config_autoplay_keycodes_label">Commands</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configure which commands to send and how dem go follow each other</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">No commands configure yet</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Add command</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximum %1$d commands</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Move up</string>
     <string name="cd_autoplay_keycode_move_down">Move down</string>
     <string name="cd_autoplay_keycode_remove">Remove</string>
-    <string name="devices_device_config_section_volumes_label">Volumes</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
     <string name="devices_device_config_alarm_volume_label">Alarm volume</string>
     <string name="devices_device_config_alarm_volume_desc">Some alarm apps dey use music volume instead.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Ring</string>
     <string name="devices_audio_stream_notification_label">Notification</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Never seen</string>
-    <string name="devices_state_connected_label">Connected</string>
     <string name="devices_last_connected_label">Last connected: %s</string>
     <string name="devices_currently_connected_label">Currently connected</string>
     <string name="devices_device_disabled_label">Device disabled</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Settings wey affect all managed devices.</string>
     <string name="label_app_enabled">App enabled</string>
     <string name="description_app_enabled">Toggle di app ability to react to volume and Bluetooth events.</string>
-    <string name="label_visible_volume_adjustments">Visible adjustments</string>
-    <string name="description_visible_volume_adjustments">Show di system volume window while dis app dey make adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
-    <string name="description_volume_listener">Stay active while device dey connected and save volume changes wey dis app no cause.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume afta booting/rebooting if Bluetooth device dey connected.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Learn how to use BVM well well</string>
     <string name="settings_support_issue_tracker_description">Public issue tracker for bug reports and feature requests.</string>
     <string name="settings_support_issue_tracker_label">Issue tracker</string>
-    <string name="settings_support_debuglog_label">Debug log</string>
     <string name="settings_support_debuglog_desc">Record everything di app dey do into text file wey you fit share.</string>
-    <string name="settings_support_debuglog_recording_desc">E dey record debug information now. Tap to stop recording.</string>
-    <string name="settings_support_debuglog_path">Log path: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Very short recording</string>
     <string name="settings_support_debuglog_short_recording_msg">Dat recording was very short. Debug logs na recordings, not snapshots — reproduce di issue while recording dey active for di log to be useful.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continue recording</string>
     <string name="settings_support_debuglog_short_recording_stop">Stop anyway</string>
-    <string name="settings_support_debuglog_folder_label">Debug log folder</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d session using %2$s</item>
-        <item quantity="other">%1$d sessions using %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">No debug logs stored</string>
-    <string name="settings_support_debuglog_folder_delete_title">Delete all debug logs?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Dis go permanently delete all stored debug log sessions.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Place to chill and ask questions.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Translation</string>
     <string name="settings_acks_translators_title">Translators</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Translate BVM</string>
-    <string name="settings_acks_translate_desc">Help translate BVM to your language</string>
     <string name="settings_acks_thanks_header">Thanks</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">For supporting translation of open-source projects</string>
     <string name="settings_licenses_label">Licenses</string>
     <string name="settings_translation_label">Translation</string>
     <string name="settings_translation_desc">Help translate di app to your favorite language</string>
-    <string name="settings_sponsor_development_title">Sponsor development</string>
-    <string name="settings_sponsor_development_summary">Become patron and make continued development possible.</string>
     <string name="settings_privacy_policy_label">Privacy policy</string>
     <string name="settings_privacy_policy_desc">Handling data responsibly.</string>
     <string name="changelog_label">Changelog</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restore don finish — %1$d devices restored, %2$d skipped.</string>
     <string name="backup_restore_version_warning">Dem create dis backup with version %1$s. You dey run %2$s. Some settings fit no restore well.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Debug notifications</string>
     <string name="debug_log_consent_title">Debug log</string>
     <string name="debug_log_consent_explanation">Dis feature dey record everything di app dey do into shareable file. Di file wey dem generate get sensitive information (e.g. file names and installed apps). Only share am with people wey you trust (e.g. developer wey dey troubleshoot issue).</string>
-    <string name="debug_log_recording_progress">Recording debug log</string>
     <string name="debug_log_record_action">Record</string>
     <string name="debug_log_stop_action">Stop recording</string>
     <string name="debug_log_screen_title">Debug Log Recorder</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Discard</string>
     <string name="debug_log_screen_keep_action">Keep</string>
-    <string name="debug_log_compressing_label">Compressing...</string>
     <string name="debug_log_file_label">Recorded log file</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log sent?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Describe your question well well.</string>
     <string name="contact_category_section_label">Category</string>
     <string name="contact_debug_log_label">Debug log</string>
-    <string name="contact_debug_log_select_hint">Select debug log to attach</string>
     <string name="contact_debug_log_picker_hint">Attach debug log to help diagnose di issue faster.</string>
     <string name="contact_debug_log_picker_empty">No debug logs available. Record one first.</string>
     <string name="contact_expected_behavior_label">Expected behavior</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">I dey read every message myself and I try my best to reply, but since I dey work alone on dis, e fit take small time. Thanks for your patience.</string>
     <string name="contact_footer_msg">Your message go send via email. Device and setup information go attach automatically.</string>
     <string name="contact_no_email_app_msg">No email app found on dis device.</string>
-    <string name="contact_attachment_missing_msg">Debug log file no dey exist again</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Stored debug logs</string>
     <string name="settings_support_stored_logs_desc">%1$d sessions (%2$s)</string>
     <string name="settings_support_stored_logs_empty">No stored debug logs</string>
-    <string name="settings_support_stored_logs_delete_title">Delete stored logs?</string>
-    <string name="settings_support_stored_logs_delete_msg">Dis go delete all %1$d stored debug log sessions.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Stored debug logs deleted</string>
-    <string name="label_bug_reports">Bug reports</string>
-    <string name="description_bug_reports">Automatic bug and crash reporting.</string>
     <string name="label_add_device">Add device</string>
-    <string name="label_just_a_moment_please">Wait small, abeg.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Setup dey required</string>
     <string name="monitor_notification_starting">Dey start…</string>
     <string name="action_set">Set</string>
     <string name="action_cancel">Cancel</string>
-    <string name="label_invalid_input">Invalid input</string>
     <string name="action_reset">Reset</string>
     <string name="label_no_connected_devices">No devices connected</string>
-    <string name="label_status_idle">Idle</string>
-    <string name="label_status_adjusting_volumes">Adjusting volumes</string>
-    <string name="label_premium_version">Premium version</string>
     <string name="general_upgrade_action">Upgrade</string>
     <string name="common_upgrade_required_label">You need upgrade</string>
-    <string name="label_premium_version_required">Premium version required</string>
-    <string name="description_intro_purpose">Dis app go allow your Android device remember di volume of different Bluetooth devices.</string>
-    <string name="upgrade_benefit_unlimited_devices">Unlimited device profiles</string>
-    <string name="upgrade_benefit_connection_actions">Autoplay, app launch and connection alerts</string>
-    <string name="upgrade_benefit_theme_customization">Theme, style and color customization</string>
-    <string name="upgrade_benefit_power_controls">Volume lock and rate limiting</string>
-    <string name="upgrade_benefit_support">Support independent development</string>
     <string name="upgrade_benefit_equalizer">• Equalizer for each device (for music apps wey support system equalizer)</string>
-    <string name="description_intro_tap_the_button">Start by adding your first device.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth don off.</string>
     <string name="title_bluetooth_is_off">Bluetooth dey Off</string>
     <string name="action_enable_bluetooth">Enable Bluetooth</string>
     <string name="title_bluetooth_permission_required">Bluetooth Permission Required</string>
     <string name="description_bluetooth_permission_required">Dis app need Bluetooth permission to manage your device volumes.</string>
     <string name="action_grant_permission">Grant Permission</string>
-    <string name="label_status_listening_for_changes">Dey listen for volume changes</string>
     <string name="action_exit">Exit</string>
-    <string name="action_start">Start</string>
-    <string name="label_welcome">Welcome</string>
-    <string name="description_intro_contact">No hesitate to contact me if you get questions or even idea for new feature.</string>
-    <string name="label_translation">Translation</string>
-    <string name="description_help_translate">Help me make dis app available for other languages.</string>
     <string name="label_device_speaker">Device speaker</string>
-    <string name="label_keyevent_playpause">Play-Pause</string>
-    <string name="label_keyevent_play">Play</string>
-    <string name="label_keyevent_next">Next</string>
-    <string name="label_install_id">Install ID</string>
     <string name="message_copied_to_clipboard">Copied to clipboard</string>
-    <string name="label_thanks">Thanks</string>
-    <string name="label_licenses">Licenses</string>
-    <string name="description_ring_volume_additional_permission">Additional permissions dey necessary to change di ring volume.</string>
-    <string name="label_missing_permissions">Missing permissions</string>
-    <string name="action_grant">Grant</string>
-    <string name="label_advanced">Advanced</string>
-    <string name="label_exclude_health">Exclude health profiles</string>
-    <string name="description_exclude_health">Some Android devices dey hang when dem dey look up \'Health Device\' Bluetooth profiles (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Exclude GATT server profiles</string>
-    <string name="label_exclude_gatt">Exclude GATT profiles</string>
-    <string name="description_exclude_gattserver">No query Bluetooth profiles of type \'Generic Attribute\' (GATT) server.</string>
-    <string name="description_exclude_gatt">No query Bluetooth profiles of type \'Generic Attribute\' (GATT) client.</string>
-    <string name="description_waiting_for_devicex">Dey wait for %s to complete connection</string>
-    <string name="action_undo">Undo</string>
-    <string name="action_show">Show</string>
     <string name="action_dismiss">Dismiss</string>
-    <string name="action_fix">Fix</string>
-    <string name="battery_optimizations_issue_description">Battery optimizations dey enabled for dis app and e fit prevent am from receiving Bluetooth events. Consider disable di optimizations if you dey experience issues.</string>
     <string name="label_bluetooth_settings">Bluetooth settings</string>
-    <string name="android10_applaunch_issue_description">Android 10 dey restrict how apps fit launch from background. To allow opening apps when Bluetooth device connect, grant di permission \"Display over other apps\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Source code</string>
-    <string name="android13_notification_permission_description">Grant dis app permission to post notifications. Dis go allow di app show notification when e dey active and volume adjustments dey happen.</string>
-    <string name="privacy_policy_label">Privacy policy</string>
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap di + button to add your first device.</string>
     <string name="label_pro_feature">Premium feature</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Review</string>
     <string name="review_app_dismiss_action">Later nau</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Purchase cancelled</string>
-    <string name="error_iap_unavailable_message">In-app purchases no dey available</string>
-    <string name="error_generic_message">Error don happen. Abeg try again.</string>
-    <string name="error_iap_owned_message">You don already get dis item</string>
     <string name="label_no_devices_title">No Devices</string>
     <string name="bluemusic_mascot_description">App Icon</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Select Apps</string>
     <string name="devices_app_selection_search_hint">Search apps...</string>
-    <string name="devices_app_selection_currently_selected">Currently selected</string>
     <string name="devices_app_selection_selected_count">%d apps selected</string>
     <string name="general_navigate_back_action">Navigate back</string>
     <string name="general_reset_action">Reset</string>
     <string name="general_clear_action">Clear</string>
-    <string name="general_save_action">Save</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Lock</string>
     <string name="devices_indicator_awake">Awake</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Limit</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Boost</string>
-    <string name="devices_indicator_launch">Launch</string>
     <string name="devices_indicator_home">Home</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Alert</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Niektóre ustawienia urządzeń mogły zostać zresetowane podczas tej aktualizacji. Sprawdź konfiguracje swoich urządzeń.</string>
     <string name="onboarding_rewrite_action">Kontynuuj</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nie znaleziono niezarządzanych urządzeń</string>
     <string name="discover_all_devices_managed_msg">Wszystkie twoje sparowane urządzenia są już zarządzane! Potrzebujesz nowego?</string>
     <string name="discover_pair_new_device_action">Sparuj nowe urządzenie</string>
     <string name="discover_device_speaker_desc">Wbudowany głośnik telefonu. Jego głośności są stosowane, gdy dźwięk wraca do telefonu, np. po rozłączeniu urządzenia Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfiguracja urządzenia</string>
-    <string name="devices_device_config_section_general_label">Ogólne</string>
     <string name="devices_device_config_remove_device_label">Zapomnij urządzenie</string>
-    <string name="devices_device_config_remove_device_desc">Zapomina urządzenie z tej aplikacji i usuwa jego konfigurację. Nie rozłącza to urządzenia.</string>
     <string name="devices_device_config_remove_device_action">Zapomnij</string>
     <string name="devices_device_config_remove_device_confirmation">Zapomnieć %s z zarządzanych urządzeń?</string>
-    <string name="devices_device_config_rename_device_label">Zmień nazwę urządzenia</string>
-    <string name="devices_device_config_rename_device_desc">Zmień nazwę tego urządzenia w tej aplikacji i, jeśli to możliwe, w systemie.</string>
     <string name="devices_device_config_rename_device_action">Zmień nazwę</string>
     <string name="devices_device_config_enabled_label">Włączone</string>
     <string name="devices_device_config_enabled_desc">Reaguj na to urządzenie po podłączeniu</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Polecenia autoodtwarzania</string>
     <string name="devices_device_config_autoplay_keycodes_order">Sekwencja poleceń</string>
     <string name="devices_device_config_autoplay_keycodes_label">Polecenia</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Skonfiguruj, które polecenia wysyłać i w jakiej kolejności</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nie skonfigurowano poleceń</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Dodaj polecenie</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksymalnie %1$d poleceń</string>
@@ -123,7 +117,6 @@
     <string name="cd_autoplay_keycode_move_up">Przesuń w górę</string>
     <string name="cd_autoplay_keycode_move_down">Przesuń w dół</string>
     <string name="cd_autoplay_keycode_remove">Usuń</string>
-    <string name="devices_device_config_section_volumes_label">Głośności</string>
     <string name="devices_device_config_section_volume_label">Głośność</string>
     <string name="devices_device_config_alarm_volume_label">Głośność budzika</string>
     <string name="devices_device_config_alarm_volume_desc">Niektóre aplikacje budzika używają zamiast niej głośności multimediów.</string>
@@ -157,8 +150,6 @@
     <string name="devices_audio_stream_ring_label">Dzwonek</string>
     <string name="devices_audio_stream_notification_label">Powiadomienie</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Nigdy nie podłączone</string>
-    <string name="devices_state_connected_label">Połączony</string>
     <string name="devices_last_connected_label">Ostatnio połączony: %s</string>
     <string name="devices_currently_connected_label">Aktualnie połączony</string>
     <string name="devices_device_disabled_label">Urządzenie wyłączone</string>
@@ -193,10 +184,7 @@
     <string name="devices_settings_desc">Ustawienia wpływające na wszystkie zarządzane urządzenia.</string>
     <string name="label_app_enabled">Aktywność aplikacji</string>
     <string name="description_app_enabled">Aktywuje lub dezaktywuje aplikację, co pozwala na zadziałanie w przypadku wystąpienia zdarzeń głośności lub Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Wizualne dostosowanie</string>
-    <string name="description_visible_volume_adjustments">Wyświetla systemowe okno głośności, podczas zmiany wartości przez aplikację.</string>
     <string name="label_volume_listener">Obserwacja zmian</string>
-    <string name="description_volume_listener">Pozostaje aktywna, gdy urządzenie jest podłączone i rejestruje zmiany głośności, które nie zostały wprowadzone przez aplikację.</string>
     <string name="label_boot_restore">Przywróć przy uruchomieniu</string>
     <string name="description_boot_restore">Przywraca głośność po ponownym uruchomieniu, jeśli urządzenie Bluetooth zostanie podłączone.</string>
     <!-- Settings/Support-->
@@ -206,24 +194,11 @@
     <string name="settings_support_wiki_description">Naucz się efektywnie korzystać z BVM</string>
     <string name="settings_support_issue_tracker_description">Publiczny śledzik problemów do zgłaszania błędów i prośb o nowe funkcje.</string>
     <string name="settings_support_issue_tracker_label">Śledzik problemów</string>
-    <string name="settings_support_debuglog_label">Log debugowania</string>
     <string name="settings_support_debuglog_desc">Rejestruj wszystko, co robi aplikacja w pliku tekstowym, którym możesz się podzielić.</string>
-    <string name="settings_support_debuglog_recording_desc">Aktualnie nagrywane informacje debugowania. Dotknij, aby zatrzymać nagrywanie.</string>
-    <string name="settings_support_debuglog_path">Ścieżka logu: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Bardzo krótkie nagranie</string>
     <string name="settings_support_debuglog_short_recording_msg">To było bardzo krótkie nagranie. Logi debugowania to nagrania, nie migawki — odtwórz problem podczas aktywnego nagrywania, żeby log był przydatny.</string>
     <string name="settings_support_debuglog_short_recording_continue">Kontynuuj nagrywanie</string>
     <string name="settings_support_debuglog_short_recording_stop">Zatrzymaj mimo to</string>
-    <string name="settings_support_debuglog_folder_label">Folder logów debugowania</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sesja używa %2$s</item>
-        <item quantity="few">%1$d sesje używają %2$s</item>
-        <item quantity="many">%1$d sesji używa %2$s</item>
-        <item quantity="other">%1$d sesji używa %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Brak przechowywanych logów debugowania</string>
-    <string name="settings_support_debuglog_folder_delete_title">Usunąć wszystkie logi debugowania?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Spowoduje to trwałe usunięcie wszystkich zapisanych sesji logów debugowania.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Miejsce do spędzania czasu i zadawania pytań.</string>
     <!-- Settings/Acks-->
@@ -233,16 +208,12 @@
     <string name="settings_acks_translators_title">Tłumacze</string>
     <string name="settings_acks_translators_people">Łukasz Kuchta (kuchtapc2015@gmail.com);
 Karol Szastok (K4r0lSz);</string>
-    <string name="settings_acks_translate_title">Tłumacz BVM</string>
-    <string name="settings_acks_translate_desc">Pomóż przetłumaczyć BVM na twój język</string>
     <string name="settings_acks_thanks_header">Podziękowania</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Za wspieranie tłumaczenia projektów open-source</string>
     <string name="settings_licenses_label">Licencje</string>
     <string name="settings_translation_label">Tłumaczenie</string>
     <string name="settings_translation_desc">Pomóż przetłumaczyć aplikację na swój ulubiony język</string>
-    <string name="settings_sponsor_development_title">Wsprzyj rozwój</string>
-    <string name="settings_sponsor_development_summary">Zostań patronem i umożliw kontynuację rozwoju.</string>
     <string name="settings_privacy_policy_label">Polityka prywatności</string>
     <string name="settings_privacy_policy_desc">Odpowiedzialne zarządzanie danymi.</string>
     <string name="changelog_label">Lista zmian</string>
@@ -264,10 +235,8 @@ Karol Szastok (K4r0lSz);</string>
     <string name="backup_restore_success_restore">Przywracanie zakończone — przywrócono %1$d urządzeń, pominięto %2$d.</string>
     <string name="backup_restore_version_warning">Ta kopia zapasowa została utworzona w wersji %1$s. Użwasz wersji %2$s. Niektóre ustawienia mogą nie zostać przywrócone poprawnie.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Powiadomienia debugowania</string>
     <string name="debug_log_consent_title">Log debugowania</string>
     <string name="debug_log_consent_explanation">Ta funkcja rejestruje wszystko, co robi aplikacja w pliku, którym można się podzielić. Wygenerowany plik zawiera wrażliwe informacje (np. nazwy plików i zainstalowane aplikacje). Udostępniaj go tylko zaufanym stronom (np. programiście rozwiązującemu problem).</string>
-    <string name="debug_log_recording_progress">Nagrywanie logu debugowania</string>
     <string name="debug_log_record_action">Nagraj</string>
     <string name="debug_log_stop_action">Zatrzymaj nagrywanie</string>
     <string name="debug_log_screen_title">Rejestrator logu debugowania</string>
@@ -284,7 +253,6 @@ Karol Szastok (K4r0lSz);</string>
     </plurals>
     <string name="debug_log_screen_discard_action">Odrzuć</string>
     <string name="debug_log_screen_keep_action">Zachowaj</string>
-    <string name="debug_log_compressing_label">Kompresowanie…</string>
     <string name="debug_log_file_label">Nagrany plik logu</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log wysłany?</string>
@@ -312,7 +280,6 @@ Karol Szastok (K4r0lSz);</string>
     <string name="contact_description_question_hint">Opisz szczegółowo swoje pytanie.</string>
     <string name="contact_category_section_label">Kategoria</string>
     <string name="contact_debug_log_label">Log debugowania</string>
-    <string name="contact_debug_log_select_hint">Wybierz log debugowania do załączenia</string>
     <string name="contact_debug_log_picker_hint">Załącz log debugowania, aby szybciej zdiagnozować problem.</string>
     <string name="contact_debug_log_picker_empty">Brak dostępnych logów debugowania. Najpierw nagraj jeden.</string>
     <string name="contact_expected_behavior_label">Oczekiwane zachowanie</string>
@@ -328,82 +295,32 @@ Karol Szastok (K4r0lSz);</string>
     <string name="contact_welcome_msg">Sam czytam każdą wiadomość i staram się odpowiadać, ale ponieważ pracuję nad tym sam, może to trochę potrwać. Dzięki za cierpliwość.</string>
     <string name="contact_footer_msg">Twoja wiadomość zostanie wysłana e-mailem. Informacje o urządzeniu i konfiguracji zostaną dołączone automatycznie.</string>
     <string name="contact_no_email_app_msg">Nie znaleziono aplikacji e-mail na tym urządzeniu.</string>
-    <string name="contact_attachment_missing_msg">Plik logu debugowania już nie istnieje</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Zapisane logi debugowania</string>
     <string name="settings_support_stored_logs_desc">%1$d sesji (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Brak zapisanych logów debugowania</string>
-    <string name="settings_support_stored_logs_delete_title">Usunąć zapisane logi?</string>
-    <string name="settings_support_stored_logs_delete_msg">Spowoduje to usunięcie wszystkich %1$d zapisanych sesji logów debugowania.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Zapisane logi debugowania usunięte</string>
-    <string name="label_bug_reports">Zgłaszanie błędów</string>
-    <string name="description_bug_reports">Automatyczne zgłaszanie problemów.</string>
     <string name="label_add_device">Dodaj urządzenie</string>
-    <string name="label_just_a_moment_please">Chwileczkę.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Wymagana konfiguracja</string>
     <string name="monitor_notification_starting">Uruchamianie…</string>
     <string name="action_set">Ustaw</string>
     <string name="action_cancel">Anuluj</string>
-    <string name="label_invalid_input">Nieprawidłowa wartość</string>
     <string name="action_reset">Resetuj</string>
     <string name="label_no_connected_devices">Brak podłączonych urządzeń</string>
-    <string name="label_status_idle">Bezczynny</string>
-    <string name="label_status_adjusting_volumes">Dostosowanie głośności</string>
-    <string name="label_premium_version">Wersja Premium</string>
     <string name="general_upgrade_action">Ulepszenie</string>
     <string name="common_upgrade_required_label">Wymagane ulepszenie</string>
-    <string name="label_premium_version_required">Wymagana wersja Premium</string>
-    <string name="description_intro_purpose">Aplikacja zezwala Androidowi na zapamiętanie głośności dla różnych urządzeń Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Nieograniczone profile urządzeń</string>
-    <string name="upgrade_benefit_connection_actions">Autoodtwarzanie, uruchamianie aplikacji i alerty połączeń</string>
-    <string name="upgrade_benefit_theme_customization">Personalizacja motywu, stylu i kolorów</string>
-    <string name="upgrade_benefit_power_controls">Blokada głośności i ograniczanie szybkości</string>
-    <string name="upgrade_benefit_support">Wspieraj niezależny rozwój</string>
     <string name="upgrade_benefit_equalizer">• Korektor dla każdego urządzenia (dla aplikacji muzycznych obsługujących systemowy korektor)</string>
-    <string name="description_intro_tap_the_button">Rozpocznij od dodania pierwszego urządzenia.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth jest wyłączony.</string>
     <string name="title_bluetooth_is_off">Bluetooth jest wyłączony</string>
     <string name="action_enable_bluetooth">Włącz Bluetooth</string>
     <string name="title_bluetooth_permission_required">Wymagane uprawnienie Bluetooth</string>
     <string name="description_bluetooth_permission_required">Ta aplikacja potrzebuje uprawnienia Bluetooth do zarządzania głośnościami twoich urządzeń.</string>
     <string name="action_grant_permission">Przyznaj uprawnienie</string>
-    <string name="label_status_listening_for_changes">Śledzenie zmian głośności</string>
     <string name="action_exit">Zamknij</string>
-    <string name="action_start">Uruchom</string>
-    <string name="label_welcome">Witaj</string>
-    <string name="description_intro_contact">Nie wahaj się ze mną skontaktować, jeśli masz pytania lub pomysł na nową funkcję.</string>
-    <string name="label_translation">Tłumaczenie</string>
-    <string name="description_help_translate">Pomóż przetłumaczyć aplikację na inne języki.</string>
     <string name="label_device_speaker">Głośnik urządzenia</string>
-    <string name="label_keyevent_playpause">Odtwórz-Wstrzymaj</string>
-    <string name="label_keyevent_play">Odtwórz</string>
-    <string name="label_keyevent_next">Następny</string>
-    <string name="label_install_id">ID instalacji</string>
     <string name="message_copied_to_clipboard">Skopiowano do schowka</string>
-    <string name="label_thanks">Dziękuję</string>
-    <string name="label_licenses">Licencje</string>
-    <string name="description_ring_volume_additional_permission">Dodatkowe uprawnienia są wymagane, aby móc sterować głośnością dzwonka.</string>
-    <string name="label_missing_permissions">Brak uprawnień</string>
-    <string name="action_grant">Przyznaj</string>
-    <string name="label_advanced">Zaawansowane</string>
-    <string name="label_exclude_health">Wyklucz profile \'Health Device\'</string>
-    <string name="description_exclude_health">Niektóre urządzenia z Androidem zawieszają się przy wyszukiwaniu profilu Bluetooth \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Wyklucz profile serwerowe GATT</string>
-    <string name="label_exclude_gatt">Wyklucz profile GATT</string>
-    <string name="description_exclude_gattserver">Nie pytaj profili Bluetooth z typem serwera \'Generic Attribute\' (GATT).</string>
-    <string name="description_exclude_gatt">Nie pytaj profili Bluetooth z typem klienta \'Generic Attribute\' (GATT).</string>
-    <string name="description_waiting_for_devicex">Oczekiwanie na %s, aż zakończy połączenie</string>
-    <string name="action_undo">Cofnij</string>
-    <string name="action_show">Wyświetl</string>
     <string name="action_dismiss">Odrzuć</string>
-    <string name="action_fix">Napraw</string>
-    <string name="battery_optimizations_issue_description">Optymalizacje baterii są włączone dla tej aplikacji i mogą uniemożliwić odbieranie zdarzeń Bluetooth. Rozważ wyłączenie optymalizacji, jeśli występują problemy.</string>
     <string name="label_bluetooth_settings">Ustawienia Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 ogranicza możliwości uruchamiania aplikacji w tle. Aby zezwolić na uruchamianie aplikacji, gdy podłączane jest urządzenie Bluetooth, udziel uprawnienia \&quot;Wyświetl na pierwszym planie\&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Kod źródłowy</string>
-    <string name="android13_notification_permission_description">Przyznaj tej aplikacji uprawnienie do wyświetlania powiadomień. To umożliwia pokazywanie powiadomienia, gdy aplikacja jest aktywna i dokonywane są zmiany głośności.</string>
-    <string name="privacy_policy_label">Polityka prywatności</string>
     <string name="managed_devices_empty_message">Brak skonfigurowanych urządzeń Bluetooth.\nDotknij przycisk +, aby dodać swoje pierwsze urządzenie.</string>
     <string name="label_pro_feature">Funkcja premium</string>
     <plurals name="discover_device_limit_banner">
@@ -436,21 +353,15 @@ Karol Szastok (K4r0lSz);</string>
     <string name="review_app_review_action">Oceń</string>
     <string name="review_app_dismiss_action">Może później</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Zakup anulowany</string>
-    <string name="error_iap_unavailable_message">Zakupy w aplikacji nie są dostępne</string>
-    <string name="error_generic_message">Wystąpił błąd. Spróbuj ponownie.</string>
-    <string name="error_iap_owned_message">Już posiadasz ten element</string>
     <string name="label_no_devices_title">Brak urządzeń</string>
     <string name="bluemusic_mascot_description">Ikona aplikacji</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Wybierz aplikacje</string>
     <string name="devices_app_selection_search_hint">Szukaj aplikacji…</string>
-    <string name="devices_app_selection_currently_selected">Aktualnie wybrane</string>
     <string name="devices_app_selection_selected_count">Wybrano %d aplikacji</string>
     <string name="general_navigate_back_action">Wróć</string>
     <string name="general_reset_action">Resetuj</string>
     <string name="general_clear_action">Wyczyść</string>
-    <string name="general_save_action">Zapisz</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Blokada</string>
     <string name="devices_indicator_awake">Aktywny</string>
@@ -460,7 +371,6 @@ Karol Szastok (K4r0lSz);</string>
     <string name="devices_indicator_limit">Limit</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Wzmocnienie</string>
-    <string name="devices_indicator_launch">Uruchom</string>
     <string name="devices_indicator_home">Dom</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Alert</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Algumas configurações de dispositivos podem ter sido redefinidas durante esta atualização. Por favor, verifique suas configurações de dispositivos.</string>
     <string name="onboarding_rewrite_action">Continuar</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nenhum dispositivo não gerenciado encontrado</string>
     <string name="discover_all_devices_managed_msg">Todos os seus dispositivos pareados já estão gerenciados! Precisa de um novo?</string>
     <string name="discover_pair_new_device_action">Parear novo dispositivo</string>
     <string name="discover_device_speaker_desc">O próprio alto-falante do telefone. Seus volumes são aplicados quando o áudio volta ao telefone, por ex. após seu dispositivo Bluetooth desconectar.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuração do dispositivo</string>
-    <string name="devices_device_config_section_general_label">Geral</string>
     <string name="devices_device_config_remove_device_label">Esquecer dispositivo</string>
-    <string name="devices_device_config_remove_device_desc">Remove o dispositivo deste app e exclui sua configuração. Isso não despareia o dispositivo.</string>
     <string name="devices_device_config_remove_device_action">Esquecer</string>
     <string name="devices_device_config_remove_device_confirmation">Esquecer %s dos dispositivos gerenciados?</string>
-    <string name="devices_device_config_rename_device_label">Renomear dispositivo</string>
-    <string name="devices_device_config_rename_device_desc">Renomeia este dispositivo no app e, se possível, no sistema.</string>
     <string name="devices_device_config_rename_device_action">Renomear</string>
     <string name="devices_device_config_enabled_label">Habilitado</string>
     <string name="devices_device_config_enabled_desc">Reagir a este dispositivo quando conectado</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Comandos de reprodução automática</string>
     <string name="devices_device_config_autoplay_keycodes_order">Sequência de comandos</string>
     <string name="devices_device_config_autoplay_keycodes_label">Comandos</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configure quais comandos enviar e em que ordem</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nenhum comando configurado</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Adicionar comando</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Máximo de %1$d comandos</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Mover para cima</string>
     <string name="cd_autoplay_keycode_move_down">Mover para baixo</string>
     <string name="cd_autoplay_keycode_remove">Remover</string>
-    <string name="devices_device_config_section_volumes_label">Volumes</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
     <string name="devices_device_config_alarm_volume_label">Volume do alarme</string>
     <string name="devices_device_config_alarm_volume_desc">Em vez disso, alguns aplicativos de alarme usam o volume da música.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Toque</string>
     <string name="devices_audio_stream_notification_label">Notificação</string>
     <string name="devices_audio_stream_alarm_label">Alarme</string>
-    <string name="devices_neverseen_label">Nunca visto</string>
-    <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Última conexão: %s</string>
     <string name="devices_currently_connected_label">Conectado atualmente</string>
     <string name="devices_device_disabled_label">Dispositivo desabilitado</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Configurações que afetam todos os dispositivos gerenciados.</string>
     <string name="label_app_enabled">Aplicativo ativo</string>
     <string name="description_app_enabled">Ativa/desativa a capacidade do aplicativo para reagir as ocorrências de volume e Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Ajustes visíveis</string>
-    <string name="description_visible_volume_adjustments">Mostra a janela de volume do sistema enquanto este aplicativo faz ajustes.</string>
     <string name="label_volume_listener">Acompanhar as mudanças</string>
-    <string name="description_volume_listener">Mantenha-se ativo enquanto um dispositivo estiver conectado e salve as alterações de volume que não forem decorrente deste aplicativo.</string>
     <string name="label_boot_restore">Restaurar ao ligar</string>
     <string name="description_boot_restore">Restaura o volume após a inicialização/reinicialização caso um dispositivo Bluetooth esteja conectado.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Aprenda como usar o BVM efetivamente</string>
     <string name="settings_support_issue_tracker_description">Um rastreador público de problemas para relatórios de bugs e solicitações de recursos.</string>
     <string name="settings_support_issue_tracker_label">Rastreador de problemas</string>
-    <string name="settings_support_debuglog_label">Log de debug</string>
     <string name="settings_support_debuglog_desc">Grava tudo que o app está fazendo em um arquivo de texto que você pode compartilhar.</string>
-    <string name="settings_support_debuglog_recording_desc">Gravando informações de debug atualmente. Toque para parar a gravação.</string>
-    <string name="settings_support_debuglog_path">Caminho do log: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Gravação muito curta</string>
     <string name="settings_support_debuglog_short_recording_msg">Foi uma gravação muito curta. Os logs de debug são gravações, não instantâneos — reproduza o problema enquanto a gravação está ativa para que o log seja útil.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continuar gravando</string>
     <string name="settings_support_debuglog_short_recording_stop">Parar mesmo assim</string>
-    <string name="settings_support_debuglog_folder_label">Pasta de logs de debug</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sessão usando %2$s</item>
-        <item quantity="other">%1$d sessões usando %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nenhum log de debug armazenado</string>
-    <string name="settings_support_debuglog_folder_delete_title">Excluir todos os logs de debug?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Isso excluirá permanentemente todas as sessões de logs de debug armazenadas.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Um lugar para conversar e fazer perguntas.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Tradução</string>
     <string name="settings_acks_translators_title">Tradutores</string>
     <string name="settings_acks_translators_people">Natanaelrj(natanael.caetano@gmail.com)</string>
-    <string name="settings_acks_translate_title">Traduzir BVM</string>
-    <string name="settings_acks_translate_desc">Ajude a traduzir o BVM para seu idioma</string>
     <string name="settings_acks_thanks_header">Agradecimentos</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Por apoiar a tradução de projetos de código aberto</string>
     <string name="settings_licenses_label">Licenças</string>
     <string name="settings_translation_label">Tradução</string>
     <string name="settings_translation_desc">Ajude a traduzir o app para seu idioma favorito</string>
-    <string name="settings_sponsor_development_title">Patrocinar desenvolvimento</string>
-    <string name="settings_sponsor_development_summary">Torne-se um padrinho e torne possível o desenvolvimento contínuo.</string>
     <string name="settings_privacy_policy_label">Política de privacidade</string>
     <string name="settings_privacy_policy_desc">Tratamento responsável de dados.</string>
     <string name="changelog_label">Histórico de mudanças</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restauração concluída — %1$d dispositivos restaurados, %2$d ignorados.</string>
     <string name="backup_restore_version_warning">Este backup foi criado com a versão %1$s. Você está usando a %2$s. Algumas configurações podem não ser restauradas corretamente.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notificações de debug</string>
     <string name="debug_log_consent_title">Log de debug</string>
     <string name="debug_log_consent_explanation">Este recurso grava tudo que o app está fazendo em um arquivo compartilhável. O arquivo gerado contém informações sensíveis (ex: nomes de arquivos e apps instalados). Compartilhe apenas com partes confiáveis (ex: um desenvolvedor investigando um problema).</string>
-    <string name="debug_log_recording_progress">Gravando log de debug</string>
     <string name="debug_log_record_action">Gravar</string>
     <string name="debug_log_stop_action">Parar gravação</string>
     <string name="debug_log_screen_title">Gravador de Log de Debug</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Descartar</string>
     <string name="debug_log_screen_keep_action">Manter</string>
-    <string name="debug_log_compressing_label">Comprimindo…</string>
     <string name="debug_log_file_label">Arquivo de log gravado</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log enviado?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Descreva sua pergunta em detalhes.</string>
     <string name="contact_category_section_label">Categoria</string>
     <string name="contact_debug_log_label">Log de debug</string>
-    <string name="contact_debug_log_select_hint">Selecione um log de debug para anexar</string>
     <string name="contact_debug_log_picker_hint">Anexe um log de debug para ajudar a diagnosticar o problema mais rapidamente.</string>
     <string name="contact_debug_log_picker_empty">Nenhum log de debug disponível. Grave um primeiro.</string>
     <string name="contact_expected_behavior_label">Comportamento esperado</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Leio cada mensagem pessoalmente e faço o meu melhor para responder, mas como trabalho nisso sozinho, pode demorar um pouco. Obrigado pela sua paciência.</string>
     <string name="contact_footer_msg">Sua mensagem será enviada por e-mail. Informações do dispositivo e configuração são anexadas automaticamente.</string>
     <string name="contact_no_email_app_msg">Nenhum app de e-mail encontrado neste dispositivo.</string>
-    <string name="contact_attachment_missing_msg">O arquivo de log de debug não existe mais</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Logs de debug armazenados</string>
     <string name="settings_support_stored_logs_desc">%1$d sessões (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Nenhum log de debug armazenado</string>
-    <string name="settings_support_stored_logs_delete_title">Excluir logs armazenados?</string>
-    <string name="settings_support_stored_logs_delete_msg">Isso excluirá todas as %1$d sessões de logs de debug armazenadas.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Logs de debug armazenados excluídos</string>
-    <string name="label_bug_reports">Relatório de erros</string>
-    <string name="description_bug_reports">Relatório automático de erros e falhas.</string>
     <string name="label_add_device">Adicionar dispositivo</string>
-    <string name="label_just_a_moment_please">Um momento, por favor.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Configuração necessária</string>
     <string name="monitor_notification_starting">Iniciando…</string>
     <string name="action_set">Definir</string>
     <string name="action_cancel">Cancelar</string>
-    <string name="label_invalid_input">Entrada inválida</string>
     <string name="action_reset">Redefinir</string>
     <string name="label_no_connected_devices">Nenhum dispositivo conectado</string>
-    <string name="label_status_idle">Inativo</string>
-    <string name="label_status_adjusting_volumes">Ajustando volumes</string>
-    <string name="label_premium_version">Versão Premium</string>
     <string name="general_upgrade_action">Atualizar</string>
     <string name="common_upgrade_required_label">Atualização necessária</string>
-    <string name="label_premium_version_required">Requer versão Premium</string>
-    <string name="description_intro_purpose">Este aplicativo possibilita ao seu dispositivo Android memorizar o volume de diferentes dispositivos Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Perfis de dispositivos ilimitados</string>
-    <string name="upgrade_benefit_connection_actions">Reprodução automática, lançamento de aplicativos e alertas de conexão</string>
-    <string name="upgrade_benefit_theme_customization">Personalização de tema, estilo e cor</string>
-    <string name="upgrade_benefit_power_controls">Bloqueio de volume e limitação de taxa</string>
-    <string name="upgrade_benefit_support">Apoiar o desenvolvimento independente</string>
     <string name="upgrade_benefit_equalizer">• Equalizador por dispositivo (para apps de música com suporte ao equalizador do sistema)</string>
-    <string name="description_intro_tap_the_button">Comece adicionando seu primeiro dispositivo.</string>
     <string name="description_bluetooth_is_disabled">O Bluetooth está desativado.</string>
     <string name="title_bluetooth_is_off">Bluetooth está Desligado</string>
     <string name="action_enable_bluetooth">Ativar Bluetooth</string>
     <string name="title_bluetooth_permission_required">Permissão de Bluetooth Necessária</string>
     <string name="description_bluetooth_permission_required">Este app precisa de permissão Bluetooth para gerenciar os volumes dos seus dispositivos.</string>
     <string name="action_grant_permission">Conceder Permissão</string>
-    <string name="label_status_listening_for_changes">Atento às mudanças de volume</string>
     <string name="action_exit">Sair</string>
-    <string name="action_start">Iniciar</string>
-    <string name="label_welcome">Bem-vindo</string>
-    <string name="description_intro_contact">Não hesite em contactar-me se tiver dúvidas ou mesmo uma ideia para um novo recurso.</string>
-    <string name="label_translation">Tradução</string>
-    <string name="description_help_translate">Ajude-me a disponibilizar este aplicativo em outros idiomas.</string>
     <string name="label_device_speaker">Alto-falante do dispositivo</string>
-    <string name="label_keyevent_playpause">Reproduzir/Pausar</string>
-    <string name="label_keyevent_play">Reproduzir</string>
-    <string name="label_keyevent_next">Avançar</string>
-    <string name="label_install_id">Identificador de Instalação</string>
     <string name="message_copied_to_clipboard">Copiado para área de transferência</string>
-    <string name="label_thanks">Agradecimentos</string>
-    <string name="label_licenses">Licenças</string>
-    <string name="description_ring_volume_additional_permission">Permissões adicionais são necessárias para alterar o volume do toque.</string>
-    <string name="label_missing_permissions">Permissões inexistentes</string>
-    <string name="action_grant">Conceder</string>
-    <string name="label_advanced">Avançadas</string>
-    <string name="label_exclude_health">Excluir perfis de saúde</string>
-    <string name="description_exclude_health">Alguns dispositivos Android travam ao procurar perfis Bluetooth de \'Dispositivos de Saúde\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Excluir perfis de servidor GATT</string>
-    <string name="label_exclude_gatt">Excluir perfis GATT</string>
-    <string name="description_exclude_gattserver">Não consultar perfis Bluetooth de servidores do tipo \'Atributo Genérico\' (GATT).</string>
-    <string name="description_exclude_gatt">Não consultar perfis Bluetooth de clientes do tipo \'Atributo Genérico\' (GATT).</string>
-    <string name="description_waiting_for_devicex">Aguardando %s para completar a conexão</string>
-    <string name="action_undo">Desfazer</string>
-    <string name="action_show">Mostrar</string>
     <string name="action_dismiss">Dispensar</string>
-    <string name="action_fix">Corrigir</string>
-    <string name="battery_optimizations_issue_description">Otimizações de bateria estão habilitadas para este aplicativo e podem impedi-lo de receber eventos de Bluetooth. Considere desativar as otimizações, se você estiver enfrentando problemas.</string>
     <string name="label_bluetooth_settings">Configurações do Bluetooth</string>
-    <string name="android10_applaunch_issue_description">O Android 10 restringe como apps podem ser iniciados a partir de segundo plano. Para permitir a abertura de aplicativos quando um dispositivo Bluetooth se conectar, conceda a permissão \&quot;Exibição sobre outros apps\&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Código fonte</string>
-    <string name="android13_notification_permission_description">Conceda a este app permissão para postar notificações. Isso habilita exibir uma notificação quando este app estiver ativo e ajustes de volume estiverem sendo feitos.</string>
-    <string name="privacy_policy_label">Política de privacidade</string>
     <string name="managed_devices_empty_message">Nenhum dispositivo Bluetooth configurado.\nToque no botão + para adicionar seu primeiro dispositivo.</string>
     <string name="label_pro_feature">Recurso premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Avaliar</string>
     <string name="review_app_dismiss_action">Talvez depois</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Compra cancelada</string>
-    <string name="error_iap_unavailable_message">Compras no app não estão disponíveis</string>
-    <string name="error_generic_message">Ocorreu um erro. Tente novamente.</string>
-    <string name="error_iap_owned_message">Você já possui este item</string>
     <string name="label_no_devices_title">Nenhum Dispositivo</string>
     <string name="bluemusic_mascot_description">Ícone do App</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Selecionar Aplicativos</string>
     <string name="devices_app_selection_search_hint">Buscar aplicativos…</string>
-    <string name="devices_app_selection_currently_selected">Atualmente selecionados</string>
     <string name="devices_app_selection_selected_count">%d aplicativos selecionados</string>
     <string name="general_navigate_back_action">Voltar</string>
     <string name="general_reset_action">Redefinir</string>
     <string name="general_clear_action">Limpar</string>
-    <string name="general_save_action">Salvar</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Bloquear</string>
     <string name="devices_indicator_awake">Ativo</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Limite</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Reforço</string>
-    <string name="devices_indicator_launch">Abrir</string>
     <string name="devices_indicator_home">Início</string>
     <string name="devices_indicator_dnd">NP</string>
     <string name="devices_indicator_alert">Alerta</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Algumas configurações dos dispositivos podem ter sido reposts durante esta atualização. Por favor, verifica as configurações dos teus dispositivos.</string>
     <string name="onboarding_rewrite_action">Continuar</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nenhum dispositivo não gerido encontrado</string>
     <string name="discover_all_devices_managed_msg">Todos os seus dispositivos emparelhados estão geridos! Precisa de um novo?</string>
     <string name="discover_pair_new_device_action">Emparelhar novo dispositivo</string>
     <string name="discover_device_speaker_desc">O altifalante integrado do telefone. Os seus volumes são aplicados quando o áudio regressa ao telefone, por exemplo, após o seu dispositivo Bluetooth se desligar.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuração do dispositivo</string>
-    <string name="devices_device_config_section_general_label">Geral</string>
     <string name="devices_device_config_remove_device_label">Esquecer dispositivo</string>
-    <string name="devices_device_config_remove_device_desc">Esquece o dispositivo desta aplicação e elimina a sua configuração. Isto não desemparelha o dispositivo.</string>
     <string name="devices_device_config_remove_device_action">Esquecer</string>
     <string name="devices_device_config_remove_device_confirmation">Esquecer %s dos dispositivos geridos?</string>
-    <string name="devices_device_config_rename_device_label">Renomear dispositivo</string>
-    <string name="devices_device_config_rename_device_desc">Renomeia este dispositivo dentro desta aplicação e, se possível, dentro do sistema.</string>
     <string name="devices_device_config_rename_device_action">Renomear</string>
     <string name="devices_device_config_enabled_label">Ativado</string>
     <string name="devices_device_config_enabled_desc">Reagir a este dispositivo quando conectado</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Comandos de reprodução automática</string>
     <string name="devices_device_config_autoplay_keycodes_order">Sequência de comandos</string>
     <string name="devices_device_config_autoplay_keycodes_label">Comandos</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configurar quais os comandos a enviar e por que ordem</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nenhum comando configurado</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Adicionar comando</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Máximo de %1$d comandos</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Mover para cima</string>
     <string name="cd_autoplay_keycode_move_down">Mover para baixo</string>
     <string name="cd_autoplay_keycode_remove">Remover</string>
-    <string name="devices_device_config_section_volumes_label">Volumes de som</string>
     <string name="devices_device_config_section_volume_label">Volume de som</string>
     <string name="devices_device_config_alarm_volume_label">Volume de alarmes</string>
     <string name="devices_device_config_alarm_volume_desc">Algumas aplicações de alarme usam o volume da música em vez deste.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Toque</string>
     <string name="devices_audio_stream_notification_label">Notificação</string>
     <string name="devices_audio_stream_alarm_label">Alarme</string>
-    <string name="devices_neverseen_label">Nunca</string>
-    <string name="devices_state_connected_label">Conectado</string>
     <string name="devices_last_connected_label">Última conexão: %s</string>
     <string name="devices_currently_connected_label">Atualmente conectado</string>
     <string name="devices_device_disabled_label">Dispositivo desativado</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Definições que afetam todos os dispositivos geridos.</string>
     <string name="label_app_enabled">Aplicação ativa</string>
     <string name="description_app_enabled">Alterna a capacidade da aplicação reagir aos eventos de volume e de bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Ajustementos visíveis</string>
-    <string name="description_visible_volume_adjustments">Mostra a janela de volume do sistema enquanto a aplicação estiver a fazer as alterações.</string>
     <string name="label_volume_listener">Observar alterações</string>
-    <string name="description_volume_listener">Manter atividade enquanto um dispositivo é conectado e guardar alterações de volume não criadas por esta aplicação.</string>
     <string name="label_boot_restore">Restaurar ao iniciar</string>
     <string name="description_boot_restore">Restaura o volume depois de iniciar/reiniciar o dispositivo se o dispositivo Bluetooth estiver conectado.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Aprende a usar o BVM eficazmente</string>
     <string name="settings_support_issue_tracker_description">Um rastreador de problemas público para relatórios de erros e pedidos de funcionalidades.</string>
     <string name="settings_support_issue_tracker_label">Rastreador de problemas</string>
-    <string name="settings_support_debuglog_label">Registo de depuração</string>
     <string name="settings_support_debuglog_desc">Grava tudo o que a aplicação está a fazer num ficheiro de texto que podes partilhar.</string>
-    <string name="settings_support_debuglog_recording_desc">A gravar informações de depuração. Toca para parar a gravação.</string>
-    <string name="settings_support_debuglog_path">Caminho do registo: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Gravação muito curta</string>
     <string name="settings_support_debuglog_short_recording_msg">Foi uma gravação muito curta. Os logs de depuração são gravações, não instantâneos — reproduz o problema enquanto a gravação está ativa para que o log seja útil.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continuar a gravar</string>
     <string name="settings_support_debuglog_short_recording_stop">Parar mesmo assim</string>
-    <string name="settings_support_debuglog_folder_label">Pasta de logs de depuração</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sessão a usar %2$s</item>
-        <item quantity="other">%1$d sessões a usar %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nenhum log de depuração guardado</string>
-    <string name="settings_support_debuglog_folder_delete_title">Eliminar todos os logs de depuração?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Isto irá eliminar permanentemente todas as sessões de logs de depuração guardadas.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Um sítio para conversar e fazer perguntas.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Tradução</string>
     <string name="settings_acks_translators_title">Tradutores</string>
     <string name="settings_acks_translators_people">Pessoa1;Pessoa2(email@opcional.com)</string>
-    <string name="settings_acks_translate_title">Traduzir BVM</string>
-    <string name="settings_acks_translate_desc">Ajuda a traduzir o BVM para a tua língua</string>
     <string name="settings_acks_thanks_header">Agradecimentos</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Por apoiar a tradução de projetos de código aberto</string>
     <string name="settings_licenses_label">Licenças</string>
     <string name="settings_translation_label">Tradução</string>
     <string name="settings_translation_desc">Ajuda a traduzir a app para o teu idioma favorito</string>
-    <string name="settings_sponsor_development_title">Patrocinar desenvolvimento</string>
-    <string name="settings_sponsor_development_summary">Torna-te um patrono e torna possível o desenvolvimento contínuo.</string>
     <string name="settings_privacy_policy_label">Política de privacidade</string>
     <string name="settings_privacy_policy_desc">Tratamento responsável de dados.</string>
     <string name="changelog_label">Registo de alterações</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restauro concluído — %1$d dispositivos restaurados, %2$d ignorados.</string>
     <string name="backup_restore_version_warning">Esta cópia de segurança foi criada com a versão %1$s. Estás a usar a versão %2$s. Algumas definições podem não ser restauradas corretamente.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notificações de depuração</string>
     <string name="debug_log_consent_title">Registo de depuração</string>
     <string name="debug_log_consent_explanation">Esta funcionalidade grava tudo o que a aplicação está a fazer num ficheiro partilhável. O ficheiro gerado contém informações sensíveis (ex: nomes de ficheiros e aplicações instaladas). Partilha apenas com partes de confiança (ex: um programador a resolver um problema).</string>
-    <string name="debug_log_recording_progress">A gravar registo de depuração</string>
     <string name="debug_log_record_action">Gravar</string>
     <string name="debug_log_stop_action">Parar gravação</string>
     <string name="debug_log_screen_title">Gravador de Registo de Depuração</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Descartar</string>
     <string name="debug_log_screen_keep_action">Guardar</string>
-    <string name="debug_log_compressing_label">A comprimir…</string>
     <string name="debug_log_file_label">Ficheiro de registo gravado</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log enviado?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Descreve a tua pergunta em detalhe.</string>
     <string name="contact_category_section_label">Categoria</string>
     <string name="contact_debug_log_label">Log de depuração</string>
-    <string name="contact_debug_log_select_hint">Seleciona um log de depuração para anexar</string>
     <string name="contact_debug_log_picker_hint">Anexa um log de depuração para ajudar a diagnosticar o problema mais rapidamente.</string>
     <string name="contact_debug_log_picker_empty">Nenhum log de depuração disponível. Grava um primeiro.</string>
     <string name="contact_expected_behavior_label">Comportamento esperado</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Leio cada mensagem pessoalmente e faço o meu melhor para responder, mas como trabalho nisto sozinho, pode demorar um pouco. Obrigado pela tua paciência.</string>
     <string name="contact_footer_msg">A tua mensagem será enviada por e-mail. As informações do dispositivo e configuração são anexadas automaticamente.</string>
     <string name="contact_no_email_app_msg">Não foi encontrada nenhuma aplicação de e-mail neste dispositivo.</string>
-    <string name="contact_attachment_missing_msg">O ficheiro de log de depuração já não existe</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Logs de depuração guardados</string>
     <string name="settings_support_stored_logs_desc">%1$d sessões (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Nenhum log de depuração guardado</string>
-    <string name="settings_support_stored_logs_delete_title">Eliminar logs guardados?</string>
-    <string name="settings_support_stored_logs_delete_msg">Isto irá eliminar todas as %1$d sessões de logs de depuração guardadas.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Logs de depuração guardados eliminados</string>
-    <string name="label_bug_reports">Relatórios de erros</string>
-    <string name="description_bug_reports">Reporte automático de erros e problemas.</string>
     <string name="label_add_device">Adicionar dispositivo</string>
-    <string name="label_just_a_moment_please">Aguarde um pouco.</string>
     <string name="label_notification_channel_status">Estado</string>
     <string name="label_notification_channel_setup">Configuração necessária</string>
     <string name="monitor_notification_starting">A iniciar…</string>
     <string name="action_set">Definir</string>
     <string name="action_cancel">Cancelar</string>
-    <string name="label_invalid_input">Entrada inválida</string>
     <string name="action_reset">Repor</string>
     <string name="label_no_connected_devices">Nenhum dispositivo conectado</string>
-    <string name="label_status_idle">Inativo</string>
-    <string name="label_status_adjusting_volumes">Ajuste de volume</string>
-    <string name="label_premium_version">Versão Premium</string>
     <string name="general_upgrade_action">Atualizar</string>
     <string name="common_upgrade_required_label">Atualização necessária</string>
-    <string name="label_premium_version_required">Necessita da versão Premium</string>
-    <string name="description_intro_purpose">Esta aplicação permite que o seu dispositivo memorize o volume dos diferentes dispositivos Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Perfis de dispositivos ilimitados</string>
-    <string name="upgrade_benefit_connection_actions">Reprodução automática, início de aplicações e alertas de ligação</string>
-    <string name="upgrade_benefit_theme_customization">Personalização de tema, estilo e cor</string>
-    <string name="upgrade_benefit_power_controls">Bloqueio de volume e limitação de velocidade</string>
-    <string name="upgrade_benefit_support">Apoiar o desenvolvimento independente</string>
     <string name="upgrade_benefit_equalizer">• Equalizador por dispositivo (para apps de música com suporte ao equalizador de sistema)</string>
-    <string name="description_intro_tap_the_button">Deve começar por adicionar o seu dispositivo.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth está desativado.</string>
     <string name="title_bluetooth_is_off">Bluetooth está desligado</string>
     <string name="action_enable_bluetooth">Ativar Bluetooth</string>
     <string name="title_bluetooth_permission_required">Permissão de Bluetooth Necessária</string>
     <string name="description_bluetooth_permission_required">Esta aplicação precisa de permissão de Bluetooth para gerir os volumes dos teus dispositivos.</string>
     <string name="action_grant_permission">Conceder Permissão</string>
-    <string name="label_status_listening_for_changes">À espera das alterações de volume</string>
     <string name="action_exit">Sair</string>
-    <string name="action_start">Iniciar</string>
-    <string name="label_welcome">Bem-vindo</string>
-    <string name="description_intro_contact">Não hesite em me contactar se tiver questões ou ideias para o desenvolvimento da funcionalidades.</string>
-    <string name="label_translation">Tradução</string>
-    <string name="description_help_translate">Ajude-me a traduzir esta aplicação para vários idiomas.</string>
     <string name="label_device_speaker">Altifalante do dispositivo</string>
-    <string name="label_keyevent_playpause">Reproduzir/pausa</string>
-    <string name="label_keyevent_play">Reproduzir</string>
-    <string name="label_keyevent_next">Seguinte</string>
-    <string name="label_install_id">ID de instalação</string>
     <string name="message_copied_to_clipboard">Copiado para a área de transferência</string>
-    <string name="label_thanks">Agradecimentos</string>
-    <string name="label_licenses">Licenças</string>
-    <string name="description_ring_volume_additional_permission">São necessárias permissões extra para alterar o volume do toque.</string>
-    <string name="label_missing_permissions">Permissões em falta</string>
-    <string name="action_grant">Conceder</string>
-    <string name="label_advanced">Avançado</string>
-    <string name="label_exclude_health">Excluir perfis de saúde</string>
-    <string name="description_exclude_health">Alguns dispositivos bloqueiam aos procurar pelos perfis \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Excluir perfis de servidores GATT</string>
-    <string name="label_exclude_gatt">Excluir perfis GATT</string>
-    <string name="description_exclude_gattserver">Não analisar perfis Bluetooth dos servidores do tipo \'Generic Attribute\' (GATT).</string>
-    <string name="description_exclude_gatt">Não analisar perfis Bluetooth dos clientes do tipo \'Generic Attribute\' (GATT).</string>
-    <string name="description_waiting_for_devicex">À espera de %s para completar a conexão</string>
-    <string name="action_undo">Desfazer</string>
-    <string name="action_show">Mostrar</string>
     <string name="action_dismiss">Dispensar</string>
-    <string name="action_fix">Corrigir</string>
-    <string name="battery_optimizations_issue_description">As otimizações de bateria estão ativadas para esta aplicação e podem impedi-la de receber eventos Bluetooth. Considera desativar as otimizações se estiveres a ter problemas.</string>
     <string name="label_bluetooth_settings">Definições Bluetooth</string>
-    <string name="android10_applaunch_issue_description">O Android 10 restringe como as aplicações podem ser lançadas em segundo plano. Para permitir a abertura de aplicações quando um dispositivo Bluetooth se conecta, concede a permissão &quot;Mostrar sobre outras aplicações&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Código fonte</string>
-    <string name="android13_notification_permission_description">Concede a esta aplicação permissão para publicar notificações. Isto permite mostrar uma notificação quando esta aplicação está ativa e estão a ser feitos ajustes de volume.</string>
-    <string name="privacy_policy_label">Política de privacidade</string>
     <string name="managed_devices_empty_message">Nenhum dispositivo Bluetooth configurado.\nToca no botão + para adicionar o teu primeiro dispositivo.</string>
     <string name="label_pro_feature">Funcionalidade premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Avaliar</string>
     <string name="review_app_dismiss_action">Talvez mais tarde</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Compra cancelada</string>
-    <string name="error_iap_unavailable_message">Compras na aplicação não estão disponíveis</string>
-    <string name="error_generic_message">Ocorreu um erro. Por favor, tenta novamente.</string>
-    <string name="error_iap_owned_message">Já possuis este item</string>
     <string name="label_no_devices_title">Nenhum Dispositivo</string>
     <string name="bluemusic_mascot_description">Ícone da Aplicação</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Selecionar Aplicações</string>
     <string name="devices_app_selection_search_hint">Pesquisar aplicações…</string>
-    <string name="devices_app_selection_currently_selected">Atualmente selecionado</string>
     <string name="devices_app_selection_selected_count">%d aplicações selecionadas</string>
     <string name="general_navigate_back_action">Navegar para trás</string>
     <string name="general_reset_action">Repor</string>
     <string name="general_clear_action">Limpar</string>
-    <string name="general_save_action">Guardar</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Bloqueio</string>
     <string name="devices_indicator_awake">Acordar</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Limite</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Reforço</string>
-    <string name="devices_indicator_launch">Iniciar</string>
     <string name="devices_indicator_home">Início</string>
     <string name="devices_indicator_dnd">NI</string>
     <string name="devices_indicator_alert">Alerta</string>

--- a/app/src/main/res/values-rm/strings.xml
+++ b/app/src/main/res/values-rm/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Pliras funcziuns han midà durant l\'actualisaziun. Controlleschai per plaschair ils parameters da tiu apparat per s\'assicurar che tut saja configurà correctamain.</string>
     <string name="onboarding_rewrite_action">Cuntinuar</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nagins apparats betg administrads chattads</string>
     <string name="discover_all_devices_managed_msg">Tuts tes apparats accopplads èn administrads! Dovras in nov?</string>
     <string name="discover_pair_new_device_action">Accopplar nov apparat</string>
     <string name="discover_device_speaker_desc">La proprisa lavaglia dal telefon. Sias volumen vegn applitgada tgidoñ che l\'audio cuntrescha novamain ala lavaglia dal telefon, p.ex. sdraa che tia apparail Bluetooth sa deconnecta.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuraziún da l\'apparat</string>
-    <string name="devices_device_config_section_general_label">General</string>
     <string name="devices_device_config_remove_device_label">Scurdar apparat</string>
-    <string name="devices_device_config_remove_device_desc">Scurda l\'apparat da questa app e stizza sia configuraziún. Quai na desaccoppla betg l\'apparat.</string>
     <string name="devices_device_config_remove_device_action">Scurdar</string>
     <string name="devices_device_config_remove_device_confirmation">Scurdar %s dals apparats administrads?</string>
-    <string name="devices_device_config_rename_device_label">Renominar apparat</string>
-    <string name="devices_device_config_rename_device_desc">Renomina quest apparat en questa app e, sch\'ei è pussaivel, en il sistem.</string>
     <string name="devices_device_config_rename_device_action">Renominar</string>
     <string name="devices_device_config_enabled_label">Activà</string>
     <string name="devices_device_config_enabled_desc">Reagir sin quest apparat cura ch\'el è connectà</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Comands d\'autoplay</string>
     <string name="devices_device_config_autoplay_keycodes_order">Sequenza da comands</string>
     <string name="devices_device_config_autoplay_keycodes_label">Comands</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configura quals comands trametter ed en tge urden</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nagins comands configurads</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Agiuntar comand</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximum %1$d comands</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Spustar si</string>
     <string name="cd_autoplay_keycode_move_down">Spustar giu</string>
     <string name="cd_autoplay_keycode_remove">Allontanar</string>
-    <string name="devices_device_config_section_volumes_label">Volumes</string>
     <string name="devices_device_config_section_volume_label">Volum</string>
     <string name="devices_device_config_alarm_volume_label">Volum d\'alarm</string>
     <string name="devices_device_config_alarm_volume_desc">Pliras apps d\'alarm utiliseschan empè il volum da musica.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Siglun</string>
     <string name="devices_audio_stream_notification_label">Notificaziún</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Mai vist</string>
-    <string name="devices_state_connected_label">Connectà</string>
     <string name="devices_last_connected_label">Ultima connexiun: %s</string>
     <string name="devices_currently_connected_label">Actualamain connectà</string>
     <string name="devices_device_disabled_label">Apparat deactivà</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Parameters che pertoccan tuts apparats administrads.</string>
     <string name="label_app_enabled">App activada</string>
     <string name="description_app_enabled">Commuta la capacitad da l\'app da reagir sin events da volum e Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Adattaments visibels</string>
-    <string name="description_visible_volume_adjustments">Mussar la fanestra da volum dal sistem cura ch\'esta app fa adattaments.</string>
     <string name="label_volume_listener">Observar midadas</string>
-    <string name="description_volume_listener">Restar activ cura che in apparat è connectà e salvar midadas da volum che n\'han betg vegnì chaschunadas da questa app.</string>
     <string name="label_boot_restore">Restaurar tar il start</string>
     <string name="description_boot_restore">Restaurar il volum suenter il start/restart sch\'in apparat Bluetooth è connectà.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Emprender co utilisar BVM efficacamain</string>
     <string name="settings_support_issue_tracker_description">In tracker da problems public per rapports da bugs e dumondas da funcziuns.</string>
     <string name="settings_support_issue_tracker_label">Tracker da problems</string>
-    <string name="settings_support_debuglog_label">Protocol da debugging</string>
     <string name="settings_support_debuglog_desc">Registrar tut quai che l\'app fa en in datotec text che Vus pudais partir.</string>
-    <string name="settings_support_debuglog_recording_desc">Actualamain en enregistraziún da las infurmaziuns da debug. Tuca per stopper l\'enregistraziún.</string>
-    <string name="settings_support_debuglog_path">Plaz dal log: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Enregistraziún memia curta</string>
     <string name="settings_support_debuglog_short_recording_msg">Quella enregistraziún era memia curta. Logs da debug èn enregistraziuns, betg fotografias — reproduzi il problem durant ch\'il enregistrament è activ per che il log saja util.</string>
     <string name="settings_support_debuglog_short_recording_continue">Cuntinuar enregistrar</string>
     <string name="settings_support_debuglog_short_recording_stop">Stopper uschiglio</string>
-    <string name="settings_support_debuglog_folder_label">Dossier da logs da debug</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sessiun cun %2$s</item>
-        <item quantity="other">%1$d sessiuns cun %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nagins logs da debug memorisads</string>
-    <string name="settings_support_debuglog_folder_delete_title">Stizzar tuts ils logs da debug?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Quai stizzerà permanentamain tut las sessiuns da log da debug memorisadas.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">In lieu per star ensemen e far dumondas.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Translaziun</string>
     <string name="settings_acks_translators_title">Translataders</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Translatar BVM</string>
-    <string name="settings_acks_translate_desc">Gidar a translatar BVM en tia lingua</string>
     <string name="settings_acks_thanks_header">Grazia</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Per sustegnair la translaziun da projects open-source</string>
     <string name="settings_licenses_label">Licenzas</string>
     <string name="settings_translation_label">Translaziun</string>
     <string name="settings_translation_desc">Gidar a translatar l\'app en tia lingua preferida</string>
-    <string name="settings_sponsor_development_title">Sponsorar il svilup</string>
-    <string name="settings_sponsor_development_summary">Daventar in patron ed enginar il svilup cuntinuà.</string>
     <string name="settings_privacy_policy_label">Protecziun da datas</string>
     <string name="settings_privacy_policy_desc">Tractar datas a moda responsabla.</string>
     <string name="changelog_label">Protocol da midadas</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restauraziun cumpletta — %1$d apparats restaurads, %2$d siglids.</string>
     <string name="backup_restore_version_warning">Quest backup è vegnì creà cun la versiun %1$s. Ti stais utilisond %2$s. Tscherts parameters na vegnan betg restaurads correctly.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notificaziuns da debugging</string>
     <string name="debug_log_consent_title">Protocol da debugging</string>
     <string name="debug_log_consent_explanation">Questa funcziun registrescha tut quai che l\'app fa en in datotec che sa lascha partir. Il datotec generà cuntegn infurmaziuns sensiblas (p.ex. nums da datotecs ed apps instaladas). Partir el be cun terzas persunas fidadas (p.ex. in sviluppader che tracta in problem).</string>
-    <string name="debug_log_recording_progress">Registrar il protocol da debugging</string>
     <string name="debug_log_record_action">Enregistrar</string>
     <string name="debug_log_stop_action">Finir la registraziun</string>
     <string name="debug_log_screen_title">Enregistrader da logs da debug</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Scartar</string>
     <string name="debug_log_screen_keep_action">Mantegnair</string>
-    <string name="debug_log_compressing_label">Cumprimer…</string>
     <string name="debug_log_file_label">Datotec da protocol registrà</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log tramess?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Descriva tia dumonda en detagl.</string>
     <string name="contact_category_section_label">Categoria</string>
     <string name="contact_debug_log_label">Protocol da debugging</string>
-    <string name="contact_debug_log_select_hint">Tscherner in log da debug per attachar</string>
     <string name="contact_debug_log_picker_hint">Attacha in log da debug per gidar a diagnosticar il problem pli svelt.</string>
     <string name="contact_debug_log_picker_empty">Nagins logs da debug disponibels. Enregistra emprim in.</string>
     <string name="contact_expected_behavior_label">Cumportament spetgà</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Jau less mintga messadi medemamain ed emprova da rispunder sin la meglra maniera, ma pertge ch\'jau lavur sin quai be, po cuzar in pau. Grazia per tia pazientscha.</string>
     <string name="contact_footer_msg">Tiu messadi vegn tramess via e-mail. Infurmaziuns davart l\'apparat e la configuraziún vegnan attachadas automaticamain.</string>
     <string name="contact_no_email_app_msg">Nagina app d\'e-mail chattada sin quest apparat.</string>
-    <string name="contact_attachment_missing_msg">Il datotec da log da debug n\'exista betg pli</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Logs da debug memorisads</string>
     <string name="settings_support_stored_logs_desc">%1$d sessiuns (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Nagins logs da debug memorisads</string>
-    <string name="settings_support_stored_logs_delete_title">Stizzar ils logs memorisads?</string>
-    <string name="settings_support_stored_logs_delete_msg">Quai stizzerà tut las %1$d sessiuns da log da debug memorisadas.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Logs da debug memorisads stizzads</string>
-    <string name="label_bug_reports">Rapports da bugs</string>
-    <string name="description_bug_reports">Rapport automatic da bugs e da crashes.</string>
     <string name="label_add_device">Agiuntar apparat</string>
-    <string name="label_just_a_moment_please">In mument, per plaschair.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Configuraziun necessaria</string>
     <string name="monitor_notification_starting">Davart uschieus…</string>
     <string name="action_set">Fixar</string>
     <string name="action_cancel">Interrumper</string>
-    <string name="label_invalid_input">Intrada invalida</string>
     <string name="action_reset">Reinizialisàr</string>
     <string name="label_no_connected_devices">Nagins apparats connectads</string>
-    <string name="label_status_idle">Inactiv</string>
-    <string name="label_status_adjusting_volumes">Adattar ils volumes</string>
-    <string name="label_premium_version">Versiun premium</string>
     <string name="general_upgrade_action">Actualisar</string>
     <string name="common_upgrade_required_label">Actualisaziun necessaria</string>
-    <string name="label_premium_version_required">Versiun premium necessaria</string>
-    <string name="description_intro_purpose">Questa app permetta a tiu apparat Android da memorar il volum da differents apparats Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Profils d\'apparat senza limita</string>
-    <string name="upgrade_benefit_connection_actions">Autoplay, aviadira d\'app ed avis da connexiun</string>
-    <string name="upgrade_benefit_theme_customization">Personalisaziun da tema, stil e colur</string>
-    <string name="upgrade_benefit_power_controls">Blocco dal volumen e limitaziun da debit</string>
-    <string name="upgrade_benefit_support">Sustegn al svilup independent</string>
     <string name="upgrade_benefit_equalizer">• Equalizer per apparat (per applicaziuns da musica cun sustegn da l\'equalizer da sistem)</string>
-    <string name="description_intro_tap_the_button">Cumenza cun agiuntar tiu emprim apparat.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth è deactivà.</string>
     <string name="title_bluetooth_is_off">Bluetooth è deactivà</string>
     <string name="action_enable_bluetooth">Activar Bluetooth</string>
     <string name="title_bluetooth_permission_required">Permissiun Bluetooth necessaria</string>
     <string name="description_bluetooth_permission_required">Questa app dastga la permissiun Bluetooth per administrar ils volumes da tiu apparat.</string>
     <string name="action_grant_permission">Dar permissiun</string>
-    <string name="label_status_listening_for_changes">Surlauschand per midadas da volum</string>
     <string name="action_exit">Sortir</string>
-    <string name="action_start">Aviar</string>
-    <string name="label_welcome">Bainvegni</string>
-    <string name="description_intro_contact">Na hesitar betg da contactarmi sch\'ti has dumondas u era ina idea per ina nova funcziún.</string>
-    <string name="label_translation">Translaziun</string>
-    <string name="description_help_translate">Gidar mai a render questa app disponibla en autras linguas.</string>
     <string name="label_device_speaker">Locutur da l\'apparat</string>
-    <string name="label_keyevent_playpause">Play-Pausa</string>
-    <string name="label_keyevent_play">Play</string>
-    <string name="label_keyevent_next">Suenter</string>
-    <string name="label_install_id">ID d\'installaziun</string>
     <string name="message_copied_to_clipboard">Copià en il clipboard</string>
-    <string name="label_thanks">Grazia</string>
-    <string name="label_licenses">Licenzas</string>
-    <string name="description_ring_volume_additional_permission">Permissiuns supplementaras èn necessarias per midar il volum da siglun.</string>
-    <string name="label_missing_permissions">Permissiuns mancantes</string>
-    <string name="action_grant">Conceder</string>
-    <string name="label_advanced">Avanzà</string>
-    <string name="label_exclude_health">Excluder profils da sanadad</string>
-    <string name="description_exclude_health">Plirs apparats Android s\'inmoveschan cura ch\'ins retschertgescha profils Bluetooth \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Excluder profils da server GATT</string>
-    <string name="label_exclude_gatt">Excluder profils GATT</string>
-    <string name="description_exclude_gattserver">Na interrogar betg profils Bluetooth da tip \'Generic Attribute\' (GATT) server.</string>
-    <string name="description_exclude_gatt">Na interrogar betg profils Bluetooth da tip \'Generic Attribute\' (GATT) client.</string>
-    <string name="description_waiting_for_devicex">Spetgar che %s complettia la connexiun</string>
-    <string name="action_undo">Anullar</string>
-    <string name="action_show">Mussar</string>
     <string name="action_dismiss">Serrar</string>
-    <string name="action_fix">Reglamentar</string>
-    <string name="battery_optimizations_issue_description">Las optimisaziuns da battaria èn activadas per questa app e pon evitar ch\'ella retschevia events Bluetooth. Considera da deactivar las optimisaziuns sch\'ti has problems.</string>
     <string name="label_bluetooth_settings">Parameters Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 restritgescha co las apps pon vegnir aviadar dal fund. Per permetter d\'avrir apps cura ch\'in apparat Bluetooth sa connecta, conceder la permissiun \"Mussar sur autras apps\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Codigo font</string>
-    <string name="android13_notification_permission_description">Conceder a questa app la permissiun da trametter notificaziuns. Quai activescha la visualisaziún d\'ina notificaziún cura ch\'esta app è activa e ch\'ils adattaments da volum vegnan fatgs.</string>
-    <string name="privacy_policy_label">Protecziun da datas</string>
     <string name="managed_devices_empty_message">Nagins apparats Bluetooth configurads.\nTuca il buttun + per agiuntar tiu emprim apparat.</string>
     <string name="label_pro_feature">Funcziún premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Recenziun</string>
     <string name="review_app_dismiss_action">Magari pli tard</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Cumpra annullada</string>
-    <string name="error_iap_unavailable_message">Cumpras en l\'app na sun betg disponiblas</string>
-    <string name="error_generic_message">In sbagl ha capità. Emprova anc ina giada, per plaschair.</string>
-    <string name="error_iap_owned_message">Ti possessas gia quest artitgel</string>
     <string name="label_no_devices_title">Nagins apparats</string>
     <string name="bluemusic_mascot_description">Icona da l\'app</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Tscherner apps</string>
     <string name="devices_app_selection_search_hint">Retscherchar apps…</string>
-    <string name="devices_app_selection_currently_selected">Actualmain selecziunà</string>
     <string name="devices_app_selection_selected_count">%d apps tschernidas</string>
     <string name="general_navigate_back_action">Navigar enavos</string>
     <string name="general_reset_action">Reinizialisar</string>
     <string name="general_clear_action">Stizzar</string>
-    <string name="general_save_action">Memorisar</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Bloccar</string>
     <string name="devices_indicator_awake">Svegl</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Limitar</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Augment</string>
-    <string name="devices_indicator_launch">Aviar</string>
     <string name="devices_indicator_home">Pagina principala</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Alert</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Unele setări ale dispozitivului s-ar putea să fi fost resetate în timpul acestei actualizări. Te rog să verifici configurațiile dispozitivelor tale.</string>
     <string name="onboarding_rewrite_action">Continuă</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nu s-au găsit dispozitive negestionate</string>
     <string name="discover_all_devices_managed_msg">Toate dispozitivele tale asociate sunt gestionate! Ai nevoie de unul nou?</string>
     <string name="discover_pair_new_device_action">Asociază dispozitiv nou</string>
     <string name="discover_device_speaker_desc">Difuzorul propriu al telefonului. Volumele sale sunt aplicate când audio se comută înapoi la telefon, de exemplu după ce dispozitivul Bluetooth se deconectează.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configurația dispozitivului</string>
-    <string name="devices_device_config_section_general_label">General</string>
     <string name="devices_device_config_remove_device_label">Uită dispozitivul</string>
-    <string name="devices_device_config_remove_device_desc">Uită dispozitivul din această aplicație și șterge configurația lui. Aceasta nu dezasociază dispozitivul.</string>
     <string name="devices_device_config_remove_device_action">Uită</string>
     <string name="devices_device_config_remove_device_confirmation">Uiți %s din dispozitivele gestionate?</string>
-    <string name="devices_device_config_rename_device_label">Redenumește dispozitivul</string>
-    <string name="devices_device_config_rename_device_desc">Redenumește acest dispozitiv în această aplicație, și dacă este posibil, în sistem.</string>
     <string name="devices_device_config_rename_device_action">Redenumește</string>
     <string name="devices_device_config_enabled_label">Activat</string>
     <string name="devices_device_config_enabled_desc">Reacționează la acest dispozitiv când este conectat</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Comenzi de redare automată</string>
     <string name="devices_device_config_autoplay_keycodes_order">Secvența de comenzi</string>
     <string name="devices_device_config_autoplay_keycodes_label">Comenzi</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configurați ce comenzi să trimiteți și în ce ordine</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nicio comandă configurată</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Adaugă comandă</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximum %1$d comenzi</string>
@@ -122,7 +116,6 @@
     <string name="cd_autoplay_keycode_move_up">Mută în sus</string>
     <string name="cd_autoplay_keycode_move_down">Mută în jos</string>
     <string name="cd_autoplay_keycode_remove">Elimină</string>
-    <string name="devices_device_config_section_volumes_label">Volume</string>
     <string name="devices_device_config_section_volume_label">Volum</string>
     <string name="devices_device_config_alarm_volume_label">Volum alarmă</string>
     <string name="devices_device_config_alarm_volume_desc">Unele aplicații de alarmă folosesc în schimb volumul muzicii.</string>
@@ -156,8 +149,6 @@
     <string name="devices_audio_stream_ring_label">Sonerie</string>
     <string name="devices_audio_stream_notification_label">Notificare</string>
     <string name="devices_audio_stream_alarm_label">Alarmă</string>
-    <string name="devices_neverseen_label">Niciodată văzut</string>
-    <string name="devices_state_connected_label">Conectat</string>
     <string name="devices_last_connected_label">Ultima conectare: %s</string>
     <string name="devices_currently_connected_label">Conectat în prezent</string>
     <string name="devices_device_disabled_label">Dispozitiv dezactivat</string>
@@ -192,10 +183,7 @@
     <string name="devices_settings_desc">Setări care afectează toate dispozitivele gestionate.</string>
     <string name="label_app_enabled">Aplicație activată</string>
     <string name="description_app_enabled">Comută capacitatea aplicației de a reacționa la evenimente de volum și Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Ajustări vizibile</string>
-    <string name="description_visible_volume_adjustments">Afișează fereastra de volum a sistemului în timp ce această aplicație face ajustări.</string>
     <string name="label_volume_listener">Observă schimbările</string>
-    <string name="description_volume_listener">Rămâi activ cât timp un dispozitiv este conectat și salvează schimbările de volum care nu au fost cauzate de această aplicație.</string>
     <string name="label_boot_restore">Restaurează la pornire</string>
     <string name="description_boot_restore">Restaurează volumul după pornire/repornire dacă un dispozitiv Bluetooth este conectat.</string>
     <!-- Settings/Support-->
@@ -205,23 +193,11 @@
     <string name="settings_support_wiki_description">Învață cum să folosești BVM eficient</string>
     <string name="settings_support_issue_tracker_description">Un sistem public de urmărire a problemelor pentru raportarea de erori și cereri de funcționalități.</string>
     <string name="settings_support_issue_tracker_label">Urmăritor de probleme</string>
-    <string name="settings_support_debuglog_label">Jurnal de depanare</string>
     <string name="settings_support_debuglog_desc">Înregistrează tot ce face aplicația într-un fișier text pe care îl poți distribui.</string>
-    <string name="settings_support_debuglog_recording_desc">Înregistrarea informațiilor de depanare în curs. Atinge pentru a opri înregistrarea.</string>
-    <string name="settings_support_debuglog_path">Calea jurnalului: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Înregistrare foarte scurtă</string>
     <string name="settings_support_debuglog_short_recording_msg">A fost o înregistrare foarte scurtă. Jurnalele de depanare sunt înregistrări, nu instantanee — reproduce problema în timp ce înregistrarea este activă pentru ca jurnalul să fie util.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continuă înregistrarea</string>
     <string name="settings_support_debuglog_short_recording_stop">Oprește oricum</string>
-    <string name="settings_support_debuglog_folder_label">Folder jurnal de depanare</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sesiune folosind %2$s</item>
-        <item quantity="few">%1$d sesiuni folosind %2$s</item>
-        <item quantity="other">%1$d de sesiuni folosind %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nu există jurnale de depanare stocate</string>
-    <string name="settings_support_debuglog_folder_delete_title">Ștergi toate jurnalele de depanare?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Aceasta va șterge permanent toate sesiunile de jurnale de depanare stocate.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Un loc unde să petreci timp și să pui întrebări.</string>
     <!-- Settings/Acks-->
@@ -230,16 +206,12 @@
     <string name="settings_acks_translation_header">Traducere</string>
     <string name="settings_acks_translators_title">Traducători</string>
     <string name="settings_acks_translators_people">Alex (alexcsy on Crowdin);Alexandru51 (Alexandru 9035 on Crowdin)</string>
-    <string name="settings_acks_translate_title">Traduce BVM</string>
-    <string name="settings_acks_translate_desc">Ajută la traducerea BVM în limba ta</string>
     <string name="settings_acks_thanks_header">Mulțumiri</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Pentru sprijinirea traducării proiectelor open-source</string>
     <string name="settings_licenses_label">Licențe</string>
     <string name="settings_translation_label">Traducere</string>
     <string name="settings_translation_desc">Ajută la traducerea aplicației în limba ta preferată</string>
-    <string name="settings_sponsor_development_title">Sponsorizează dezvoltarea</string>
-    <string name="settings_sponsor_development_summary">Devino patron și face dezvoltarea continuată posibilă.</string>
     <string name="settings_privacy_policy_label">Politica de confidențialitate</string>
     <string name="settings_privacy_policy_desc">Gestionarea datelor în mod responsabil.</string>
     <string name="changelog_label">Jurnalul de modificari</string>
@@ -261,10 +233,8 @@
     <string name="backup_restore_success_restore">Restaurare completă — %1$d dispozitive restaurate, %2$d omise.</string>
     <string name="backup_restore_version_warning">Acest backup a fost creat cu versiunea %1$s. Rulați versiunea %2$s. Unele setări s-ar putea să nu fie restaurate corect.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notificări de depanare</string>
     <string name="debug_log_consent_title">Jurnal de depanare</string>
     <string name="debug_log_consent_explanation">Această funcționalitate înregistrează tot ce face aplicația într-un fișier ce poate fi distribuit. Fișierul generat conține informații sensibile (de ex. nume de fișiere și aplicații instalate). Distribuie-l doar cu părți de încredere (de ex. un dezvoltator care rezolvă o problemă).</string>
-    <string name="debug_log_recording_progress">Înregistrare jurnal de depanare</string>
     <string name="debug_log_record_action">Înregistrează</string>
     <string name="debug_log_stop_action">Oprește înregistrarea</string>
     <string name="debug_log_screen_title">Recorder Jurnal de Depanare</string>
@@ -280,7 +250,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Anulează</string>
     <string name="debug_log_screen_keep_action">Păstrează</string>
-    <string name="debug_log_compressing_label">Se comprimă…</string>
     <string name="debug_log_file_label">Fișier jurnal înregistrat</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Jurnal trimis?</string>
@@ -308,7 +277,6 @@
     <string name="contact_description_question_hint">Descrie întrebarea ta în detaliu.</string>
     <string name="contact_category_section_label">Categorie</string>
     <string name="contact_debug_log_label">Jurnal de depanare</string>
-    <string name="contact_debug_log_select_hint">Selectează un jurnal de depanare pentru a atașa</string>
     <string name="contact_debug_log_picker_hint">Atașează un jurnal de depanare pentru a ajuta la diagnosticarea problemei mai rapid.</string>
     <string name="contact_debug_log_picker_empty">Nu există jurnale de depanare disponibile. Înregistrează unul mai întâi.</string>
     <string name="contact_expected_behavior_label">Comportament așteptat</string>
@@ -323,82 +291,32 @@
     <string name="contact_welcome_msg">Citesc fiecare mesaj personal și fac tot posibilul să răspund, dar deoarece lucrez singur la asta, poate dura puțin. Mulțumesc pentru răbdare.</string>
     <string name="contact_footer_msg">Mesajul tău va fi trimis prin e-mail. Informațiile despre dispozitiv și configurație sunt atașate automat.</string>
     <string name="contact_no_email_app_msg">Nu s-a găsit nicio aplicație de e-mail pe acest dispozitiv.</string>
-    <string name="contact_attachment_missing_msg">Fișierul jurnal de depanare nu mai există</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Jurnale de depanare stocate</string>
     <string name="settings_support_stored_logs_desc">%1$d sesiuni (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Nu există jurnale de depanare stocate</string>
-    <string name="settings_support_stored_logs_delete_title">Ștergi jurnalele stocate?</string>
-    <string name="settings_support_stored_logs_delete_msg">Aceasta va șterge toate cele %1$d sesiuni de jurnale de depanare stocate.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Jurnalele de depanare stocate au fost șterse</string>
-    <string name="label_bug_reports">Rapoarte de erori</string>
-    <string name="description_bug_reports">Raportarea automată de erori și blocaje.</string>
     <string name="label_add_device">Adaugă dispozitiv</string>
-    <string name="label_just_a_moment_please">O clipă, te rog.</string>
     <string name="label_notification_channel_status">Stare</string>
     <string name="label_notification_channel_setup">Configurare necesară</string>
     <string name="monitor_notification_starting">Se pornește…</string>
     <string name="action_set">Setează</string>
     <string name="action_cancel">Anulează</string>
-    <string name="label_invalid_input">Date de intrare nevalide</string>
     <string name="action_reset">Resetează</string>
     <string name="label_no_connected_devices">Niciun dispozitiv conectat</string>
-    <string name="label_status_idle">Inactiv</string>
-    <string name="label_status_adjusting_volumes">Ajustez volumele</string>
-    <string name="label_premium_version">Versiune Premium</string>
     <string name="general_upgrade_action">Actualizează</string>
     <string name="common_upgrade_required_label">Upgrade necesar</string>
-    <string name="label_premium_version_required">Versiune premium necesară</string>
-    <string name="description_intro_purpose">Această aplicație permite dispozitivului tău Android să îi amintească volumul diferitelor dispozitive Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Profile nelimitate de dispozitive</string>
-    <string name="upgrade_benefit_connection_actions">Redare automată, lansare aplicație și alerte de conexiune</string>
-    <string name="upgrade_benefit_theme_customization">Personalizare temă, stil și culori</string>
-    <string name="upgrade_benefit_power_controls">Blocare volum și limitare rată</string>
-    <string name="upgrade_benefit_support">Susține dezvoltarea independentă</string>
     <string name="upgrade_benefit_equalizer">• Egalizator per dispozitiv (pentru aplicații muzicale cu suport pentru egalizatorul de sistem)</string>
-    <string name="description_intro_tap_the_button">Începe prin adăugarea primului tău dispozitiv.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth este dezactivat.</string>
     <string name="title_bluetooth_is_off">Bluetooth este Oprit</string>
     <string name="action_enable_bluetooth">Activează Bluetooth</string>
     <string name="title_bluetooth_permission_required">Permisiune Bluetooth Necesară</string>
     <string name="description_bluetooth_permission_required">Această aplicație are nevoie de permisiunea Bluetooth pentru a gestiona volumele dispozitivelor tale.</string>
     <string name="action_grant_permission">Acordă Permisiunea</string>
-    <string name="label_status_listening_for_changes">Ascult schimbări de volum</string>
     <string name="action_exit">Ieșire</string>
-    <string name="action_start">Pornire</string>
-    <string name="label_welcome">Bun venit</string>
-    <string name="description_intro_contact">Nu ezita să mă contactezi dacă ai întrebări sau chiar o idee pentru o funcționalitate nouă.</string>
-    <string name="label_translation">Traducere</string>
-    <string name="description_help_translate">Ajută-mă să fac această aplicație disponibilă în alte limbi.</string>
     <string name="label_device_speaker">Difuzorul dispozitivului</string>
-    <string name="label_keyevent_playpause">Redare-Pauză</string>
-    <string name="label_keyevent_play">Redare</string>
-    <string name="label_keyevent_next">Următorul</string>
-    <string name="label_install_id">ID Instalare</string>
     <string name="message_copied_to_clipboard">Copiat în clipboard</string>
-    <string name="label_thanks">Mulțumiri</string>
-    <string name="label_licenses">Licențe</string>
-    <string name="description_ring_volume_additional_permission">Sunt necesare permisiuni adiționale pentru a schimba volumul soneriei.</string>
-    <string name="label_missing_permissions">Permisiuni lipsă</string>
-    <string name="action_grant">Acordă</string>
-    <string name="label_advanced">Avansat</string>
-    <string name="label_exclude_health">Exclude profilurile de sănătate</string>
-    <string name="description_exclude_health">Unele dispozitive Android se blochează când caută profilurile Bluetooth \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Exclude profilurile de server GATT</string>
-    <string name="label_exclude_gatt">Exclude profilurile GATT</string>
-    <string name="description_exclude_gattserver">Nu interoga profilurile Bluetooth de tipul server \'Generic Attribute\' (GATT).</string>
-    <string name="description_exclude_gatt">Nu interoga profilurile Bluetooth de tipul client \'Generic Attribute\' (GATT).</string>
-    <string name="description_waiting_for_devicex">Aștept ca %s să finalizeze conexiunea</string>
-    <string name="action_undo">Anulează</string>
-    <string name="action_show">Arată</string>
     <string name="action_dismiss">Respinge</string>
-    <string name="action_fix">Reparați</string>
-    <string name="battery_optimizations_issue_description">Optimizările de baterie sunt activate pentru această aplicație și pot împiedica primirea de evenimente Bluetooth. Ia în considerare dezactivarea optimizărilor dacă întâmpini probleme.</string>
     <string name="label_bluetooth_settings">Setări Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 restricționează modul în care aplicațiile pot fi lansate din fundal. Pentru a permite deschiderea aplicațiilor când se conectează un dispozitiv Bluetooth, acordă permisiunea &quot;Afișare peste alte aplicații&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Cod sursă</string>
-    <string name="android13_notification_permission_description">Acordă acestei aplicații permisiunea de a posta notificări. Aceasta permite afișarea unei notificări când aplicația este activă și se fac ajustări de volum.</string>
-    <string name="privacy_policy_label">Politica de confidențialitate</string>
     <string name="managed_devices_empty_message">Niciun dispozitiv Bluetooth configurat.\nAtinge butonul + pentru a adăuga primul tău dispozitiv.</string>
     <string name="label_pro_feature">Funcționalitate premium</string>
     <plurals name="discover_device_limit_banner">
@@ -430,21 +348,15 @@
     <string name="review_app_review_action">Revizuire</string>
     <string name="review_app_dismiss_action">Poate mai târziu</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Achiziţie anulată</string>
-    <string name="error_iap_unavailable_message">Achiziţiile din aplicație nu sunt disponibile</string>
-    <string name="error_generic_message">A apărut o eroare. Te rog să încerci din nou.</string>
-    <string name="error_iap_owned_message">Deții deja acest element</string>
     <string name="label_no_devices_title">Niciun Dispozitiv</string>
     <string name="bluemusic_mascot_description">Icona Aplicației</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Selectează aplicații</string>
     <string name="devices_app_selection_search_hint">Caută aplicații…</string>
-    <string name="devices_app_selection_currently_selected">Selectate în prezent</string>
     <string name="devices_app_selection_selected_count">%d aplicații selectate</string>
     <string name="general_navigate_back_action">Navighează înapoi</string>
     <string name="general_reset_action">Resetează</string>
     <string name="general_clear_action">Șterge</string>
-    <string name="general_save_action">Salvează</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Blocare</string>
     <string name="devices_indicator_awake">Activ</string>
@@ -454,7 +366,6 @@
     <string name="devices_indicator_limit">Limită</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Amplificare</string>
-    <string name="devices_indicator_launch">Lansare</string>
     <string name="devices_indicator_home">Acasă</string>
     <string name="devices_indicator_dnd">DNT</string>
     <string name="devices_indicator_alert">Alertă</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Некоторые настройки устройств могли быть сброшены во время этого обновления. Пожалуйста, проверьте конфигурации ваших устройств.</string>
     <string name="onboarding_rewrite_action">Продолжить</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Нет неуправляемых устройств</string>
     <string name="discover_all_devices_managed_msg">Все твои подключенные устройства уже управляются! Нужно новое?</string>
     <string name="discover_pair_new_device_action">Подключить новое устройство</string>
     <string name="discover_device_speaker_desc">Встроенный динамик телефона. Его громкость применяется, когда звук переключается обратно на телефон, например, после отключения устройства Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Настройки устройства</string>
-    <string name="devices_device_config_section_general_label">Общее</string>
     <string name="devices_device_config_remove_device_label">Удалить устройство</string>
-    <string name="devices_device_config_remove_device_desc">Удаляет устройство из этого приложения и его настройки. Не разъединяет устройство.</string>
     <string name="devices_device_config_remove_device_action">Удалить</string>
     <string name="devices_device_config_remove_device_confirmation">Удалить %s из управляемых устройств?</string>
-    <string name="devices_device_config_rename_device_label">Переименовать устройство</string>
-    <string name="devices_device_config_rename_device_desc">Переименовать устройство в этом приложении и, если возможно, в системе.</string>
     <string name="devices_device_config_rename_device_action">Переименовать</string>
     <string name="devices_device_config_enabled_label">Включено</string>
     <string name="devices_device_config_enabled_desc">Реагировать на это устройство при подключении</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Команды автовоспроизведения</string>
     <string name="devices_device_config_autoplay_keycodes_order">Последовательность команд</string>
     <string name="devices_device_config_autoplay_keycodes_label">Команды</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Настройте, какие команды отправлять и в каком порядке</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Команды не настроены</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Добавить команду</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Максимум %1$d команд</string>
@@ -123,7 +117,6 @@
     <string name="cd_autoplay_keycode_move_up">Переместить выше</string>
     <string name="cd_autoplay_keycode_move_down">Переместить ниже</string>
     <string name="cd_autoplay_keycode_remove">Удалить</string>
-    <string name="devices_device_config_section_volumes_label">Громкость</string>
     <string name="devices_device_config_section_volume_label">Громкость</string>
     <string name="devices_device_config_alarm_volume_label">Громкость будильника</string>
     <string name="devices_device_config_alarm_volume_desc">В некоторых приложениях будильника вместо этого используется громкость музыки.</string>
@@ -157,8 +150,6 @@
     <string name="devices_audio_stream_ring_label">Звонок</string>
     <string name="devices_audio_stream_notification_label">Уведомления</string>
     <string name="devices_audio_stream_alarm_label">Будильник</string>
-    <string name="devices_neverseen_label">Не обнаруживалось</string>
-    <string name="devices_state_connected_label">Подключено</string>
     <string name="devices_last_connected_label">Последнее подключение: %s</string>
     <string name="devices_currently_connected_label">Сейчас подключено</string>
     <string name="devices_device_disabled_label">Устройство отключено</string>
@@ -193,10 +184,7 @@
     <string name="devices_settings_desc">Настройки, которые влияют на все управляемые устройства.</string>
     <string name="label_app_enabled">Приложение запущено</string>
     <string name="description_app_enabled">Включение отслеживания приложением событий, связанных с громкостью и Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Видимость настроек</string>
-    <string name="description_visible_volume_adjustments">Отображение окна системной громкости при выполнении приложением настроек.</string>
     <string name="label_volume_listener">Отслеживание изменений</string>
-    <string name="description_volume_listener">Поддержание активного режима при наличии подключенного устройства и сохранение изменений громкости, выполненных вне данного приложения.</string>
     <string name="label_boot_restore">Восстановить при загрузке</string>
     <string name="description_boot_restore">Восстановление громкости после загрузки/перезагрузки при подключенном устройстве Bluetooth.</string>
     <!-- Settings/Support-->
@@ -206,24 +194,11 @@
     <string name="settings_support_wiki_description">Научись эффективно использовать BVM</string>
     <string name="settings_support_issue_tracker_description">Публичный трекер ошибок для отчётов о багах и запросов новых функций.</string>
     <string name="settings_support_issue_tracker_label">Трекер ошибок</string>
-    <string name="settings_support_debuglog_label">Лог отладки</string>
     <string name="settings_support_debuglog_desc">Записывай всё, что делает приложение, в текстовый файл, которым можно поделиться.</string>
-    <string name="settings_support_debuglog_recording_desc">Сейчас записываем информацию для отладки. Нажми, чтобы остановить запись.</string>
-    <string name="settings_support_debuglog_path">Путь к логу: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Очень короткая запись</string>
     <string name="settings_support_debuglog_short_recording_msg">Запись оказалась очень короткой. Логи отладки — это записи, а не снимки — воспроизведи проблему во время активной записи, чтобы лог был полезен.</string>
     <string name="settings_support_debuglog_short_recording_continue">Продолжить запись</string>
     <string name="settings_support_debuglog_short_recording_stop">Остановить всё равно</string>
-    <string name="settings_support_debuglog_folder_label">Папка логов отладки</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d сессия использует %2$s</item>
-        <item quantity="few">%1$d сессии используют %2$s</item>
-        <item quantity="many">%1$d сессий используют %2$s</item>
-        <item quantity="other">%1$d сессий используют %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Логи отладки не сохранены</string>
-    <string name="settings_support_debuglog_folder_delete_title">Удалить все логи отладки?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Это навсегда удалит все сохранённые сессии логов отладки.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Место, где можно общаться и задавать вопросы.</string>
     <!-- Settings/Acks-->
@@ -232,16 +207,12 @@
     <string name="settings_acks_translation_header">Перевод</string>
     <string name="settings_acks_translators_title">Переводчики</string>
     <string name="settings_acks_translators_people">Gaich;antoon334;notmerennor;grapie</string>
-    <string name="settings_acks_translate_title">Перевести BVM</string>
-    <string name="settings_acks_translate_desc">Помоги перевести BVM на твой язык</string>
     <string name="settings_acks_thanks_header">Благодарность</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">За поддержку переводов проектов с открытым исходным кодом</string>
     <string name="settings_licenses_label">Лицензии</string>
     <string name="settings_translation_label">Перевод</string>
     <string name="settings_translation_desc">Помогите перевести приложение на ваш любимый язык</string>
-    <string name="settings_sponsor_development_title">Поддержать разработку</string>
-    <string name="settings_sponsor_development_summary">Стань покровителем и сделай продолжение разработки возможным.</string>
     <string name="settings_privacy_policy_label">Политика конфиденциальности</string>
     <string name="settings_privacy_policy_desc">Ответственное обращение с данными.</string>
     <string name="changelog_label">Список изменений</string>
@@ -263,10 +234,8 @@
     <string name="backup_restore_success_restore">Восстановление завершено — восстановлено: %1$d, пропущено: %2$d.</string>
     <string name="backup_restore_version_warning">Эта резервная копия создана в версии %1$s. У вас запущена версия %2$s. Некоторые настройки могут не восстановиться корректно.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Уведомления отладки</string>
     <string name="debug_log_consent_title">Лог отладки</string>
     <string name="debug_log_consent_explanation">Эта функция записывает всё, что делает приложение, в файл, которым можно поделиться. Созданный файл содержит конфиденциальную информацию (например, имена файлов и установленные приложения). Делись им только с доверенными лицами (например, разработчиком, решающим проблему).</string>
-    <string name="debug_log_recording_progress">Запись лога отладки</string>
     <string name="debug_log_record_action">Записать</string>
     <string name="debug_log_stop_action">Остановить запись</string>
     <string name="debug_log_screen_title">Запись лога отладки</string>
@@ -283,7 +252,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Отменить</string>
     <string name="debug_log_screen_keep_action">Сохранить</string>
-    <string name="debug_log_compressing_label">Сжатие…</string>
     <string name="debug_log_file_label">Записанный лог-файл</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Лог отправлен?</string>
@@ -311,7 +279,6 @@
     <string name="contact_description_question_hint">Опиши свой вопрос подробно.</string>
     <string name="contact_category_section_label">Категория</string>
     <string name="contact_debug_log_label">Лог отладки</string>
-    <string name="contact_debug_log_select_hint">Выбери лог отладки для прикрепления</string>
     <string name="contact_debug_log_picker_hint">Прикрепи лог отладки, чтобы помочь диагностировать проблему быстрее.</string>
     <string name="contact_debug_log_picker_empty">Логи отладки недоступны. Сначала запиши один.</string>
     <string name="contact_expected_behavior_label">Ожидаемое поведение</string>
@@ -327,82 +294,32 @@
     <string name="contact_welcome_msg">Я лично читаю каждое сообщение и стараюсь ответить, но поскольку работаю над этим один, это может занять немного времени. Спасибо за терпение.</string>
     <string name="contact_footer_msg">Твоё сообщение будет отправлено по электронной почте. Информация об устройстве и настройках прикрепляется автоматически.</string>
     <string name="contact_no_email_app_msg">На этом устройстве не найдено почтовое приложение.</string>
-    <string name="contact_attachment_missing_msg">Файл лога отладки больше не существует</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Сохранённые логи отладки</string>
     <string name="settings_support_stored_logs_desc">%1$d сессий (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Нет сохранённых логов отладки</string>
-    <string name="settings_support_stored_logs_delete_title">Удалить сохранённые логи?</string>
-    <string name="settings_support_stored_logs_delete_msg">Это удалит все %1$d сохранённых сессий логов отладки.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Сохранённые логи отладки удалены</string>
-    <string name="label_bug_reports">Сообщения об ошибках</string>
-    <string name="description_bug_reports">Автоматическая отправка отчётов о сбоях и ошибках.</string>
     <string name="label_add_device">Добавить устройство</string>
-    <string name="label_just_a_moment_please">Минуточку, пожалуйста.</string>
     <string name="label_notification_channel_status">Состояние</string>
     <string name="label_notification_channel_setup">Требуется настройка</string>
     <string name="monitor_notification_starting">Запуск…</string>
     <string name="action_set">Установка</string>
     <string name="action_cancel">Отмена</string>
-    <string name="label_invalid_input">Недопустимый ввод</string>
     <string name="action_reset">Сброс</string>
     <string name="label_no_connected_devices">Нет подключённых устройств</string>
-    <string name="label_status_idle">Ожидание</string>
-    <string name="label_status_adjusting_volumes">Настройка громкости</string>
-    <string name="label_premium_version">Премиум-версия</string>
     <string name="general_upgrade_action">Обновление</string>
     <string name="common_upgrade_required_label">Требуется обновление</string>
-    <string name="label_premium_version_required">Необходима премиум-версия</string>
-    <string name="description_intro_purpose">Приложение позволяет системе Андроид запомнить громкость различных устройств Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Неограниченное количество профилей устройств</string>
-    <string name="upgrade_benefit_connection_actions">Автовоспроизведение, запуск приложений и оповещения о подключении</string>
-    <string name="upgrade_benefit_theme_customization">Настройка темы, стиля и цвета</string>
-    <string name="upgrade_benefit_power_controls">Блокировка громкости и ограничение скорости</string>
-    <string name="upgrade_benefit_support">Поддержать независимую разработку</string>
     <string name="upgrade_benefit_equalizer">• Эквалайзер для каждого устройства (для музыкальных приложений с поддержкой системного эквалайзера)</string>
-    <string name="description_intro_tap_the_button">Начните с добавления первого устройства.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth отключен.</string>
     <string name="title_bluetooth_is_off">Bluetooth выключен</string>
     <string name="action_enable_bluetooth">Включить Bluetooth</string>
     <string name="title_bluetooth_permission_required">Нужно разрешение Bluetooth</string>
     <string name="description_bluetooth_permission_required">Этому приложению нужно разрешение Bluetooth для управления громкостью твоих устройств.</string>
     <string name="action_grant_permission">Дать разрешение</string>
-    <string name="label_status_listening_for_changes">Отслеживание изменений громкости</string>
     <string name="action_exit">Выход</string>
-    <string name="action_start">Старт</string>
-    <string name="label_welcome">Добро пожаловать</string>
-    <string name="description_intro_contact">Не стесняйтесь связаться со мной, если у Вас есть вопросы или идеи касательно новой функции.</string>
-    <string name="label_translation">Перевод</string>
-    <string name="description_help_translate">Помогите мне сделать приложение доступным на других языках.</string>
     <string name="label_device_speaker">Динамик устройства</string>
-    <string name="label_keyevent_playpause">Воспр.-пауза</string>
-    <string name="label_keyevent_play">Воспр.</string>
-    <string name="label_keyevent_next">След.</string>
-    <string name="label_install_id">Идентификатор установки</string>
     <string name="message_copied_to_clipboard">Скопировано в буфер</string>
-    <string name="label_thanks">Спасибо</string>
-    <string name="label_licenses">Лицензии</string>
-    <string name="description_ring_volume_additional_permission">Для изменения громкости звонка необходимы дополнительные разрешения.</string>
-    <string name="label_missing_permissions">Отсутствуют разрешения</string>
-    <string name="action_grant">Предоставить</string>
-    <string name="label_advanced">Дополнительно</string>
-    <string name="label_exclude_health">Исключить профили health</string>
-    <string name="description_exclude_health">Некоторые устройства Андроид зависают при поиске профилей Bluetooth \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Исключить профили сервера GATT</string>
-    <string name="label_exclude_gatt">Исключить профили GATT</string>
-    <string name="description_exclude_gattserver">Не обрабатывать профили Bluetooth сервера \'Generic Attribute\' (GATT).</string>
-    <string name="description_exclude_gatt">Не обрабатывать профили Bluetooth клиента \'Generic Attribute\' (GATT).</string>
-    <string name="description_waiting_for_devicex">Ожидание %s для соединения</string>
-    <string name="action_undo">Отмена</string>
-    <string name="action_show">Показать</string>
     <string name="action_dismiss">Отклонить</string>
-    <string name="action_fix">Исправить</string>
-    <string name="battery_optimizations_issue_description">Для данного приложения включена оптимизация батареи, поэтому оно может пропускать события Bluetooth. Если возникают проблемы, отключите оптимизацию.</string>
     <string name="label_bluetooth_settings">Настройки Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 ограничивает запуск приложений в фоне. Чтобы разрешить открытие приложений при подключении Bluetooth-устройства, предоставьте разрешение \&quot;Отображать поверх других приложений\&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Исходный код</string>
-    <string name="android13_notification_permission_description">Предоставь этому приложению разрешение на отправку уведомлений. Это позволит отображать уведомление, когда приложение активно и выполняются настройки громкости.</string>
-    <string name="privacy_policy_label">Политика конфиденциальности</string>
     <string name="managed_devices_empty_message">Нет настроенных Bluetooth-устройств.\nНажми кнопку +, чтобы добавить первое устройство.</string>
     <string name="label_pro_feature">Премиум-функция</string>
     <plurals name="discover_device_limit_banner">
@@ -435,21 +352,15 @@
     <string name="review_app_review_action">Отзыв</string>
     <string name="review_app_dismiss_action">Возможно, позже</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Покупка отменена</string>
-    <string name="error_iap_unavailable_message">Покупки в приложении недоступны</string>
-    <string name="error_generic_message">Произошла ошибка. Попробуй ещё раз.</string>
-    <string name="error_iap_owned_message">У тебя уже есть этот элемент</string>
     <string name="label_no_devices_title">Нет устройств</string>
     <string name="bluemusic_mascot_description">Иконка приложения</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Выбрать приложения</string>
     <string name="devices_app_selection_search_hint">Поиск приложений…</string>
-    <string name="devices_app_selection_currently_selected">Выбрано сейчас</string>
     <string name="devices_app_selection_selected_count">Выбрано приложений: %d</string>
     <string name="general_navigate_back_action">Вернуться назад</string>
     <string name="general_reset_action">Сбросить</string>
     <string name="general_clear_action">Очистить</string>
-    <string name="general_save_action">Сохранить</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Блок</string>
     <string name="devices_indicator_awake">Акт</string>
@@ -459,7 +370,6 @@
     <string name="devices_indicator_limit">Огр</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Усиление</string>
-    <string name="devices_indicator_launch">Зап</string>
     <string name="devices_indicator_home">Дом</string>
     <string name="devices_indicator_dnd">НБ</string>
     <string name="devices_indicator_alert">Оповещение</string>

--- a/app/src/main/res/values-sc-rIT/strings.xml
+++ b/app/src/main/res/values-sc-rIT/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Calicuna funtzionalidade est cambiàda durante s\'aggiornamentu. Controlla sos configuraziònis de su dispositivu tuo pro assicurare chi totu siat configuràdu bene.</string>
     <string name="onboarding_rewrite_action">Còntinuat</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nessun dispositivu non gestidu trovàdu</string>
     <string name="discover_all_devices_managed_msg">Totu sos dispositivos accoppiàdos tuos sunt gestidos! Bi cheres unu nou?</string>
     <string name="discover_pair_new_device_action">Accòppia nou dispositivu</string>
     <string name="discover_device_speaker_desc">Su parlante de sa tua telefonada. Sos volmenes sunt aplicados cuan su sonu cambiat in sa telefonada, p.e. dae su disconnect de su tuo dispositivu Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Configuratzione de su dispositivu</string>
-    <string name="devices_device_config_section_general_label">Generali</string>
     <string name="devices_device_config_remove_device_label">Ismentica su dispositivu</string>
-    <string name="devices_device_config_remove_device_desc">Iscancella su dispositivu dae s\'app e nde càncella sa configuratzione. Custu non disconnèttit su dispositivu.</string>
     <string name="devices_device_config_remove_device_action">Ismentica</string>
     <string name="devices_device_config_remove_device_confirmation">Ismentica %s dae sos dispositivos gestidos?</string>
-    <string name="devices_device_config_rename_device_label">Rinòmina su dispositivu</string>
-    <string name="devices_device_config_rename_device_desc">Rinòmina custu dispositivu dèntro s\'app, e, si est pòssibile, dèntro su sistema.</string>
     <string name="devices_device_config_rename_device_action">Rinòmina</string>
     <string name="devices_device_config_enabled_label">Abilitàdu</string>
     <string name="devices_device_config_enabled_desc">Reagessi a custu dispositivu cando si connèttet</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Cumandos de reprodutzione automàtica</string>
     <string name="devices_device_config_autoplay_keycodes_order">Sequèntzia de cumandos</string>
     <string name="devices_device_config_autoplay_keycodes_label">Cumandos</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configura cales cumandos mandare e in cale òrdine</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nisciunu cumandu configuradu</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Agiungi cumandu</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Màssimu %1$d cumandos</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Movi in artu</string>
     <string name="cd_autoplay_keycode_move_down">Movi in bassu</string>
     <string name="cd_autoplay_keycode_remove">Bogare</string>
-    <string name="devices_device_config_section_volumes_label">Volumes de sonu</string>
     <string name="devices_device_config_section_volume_label">Volume de sonu</string>
     <string name="devices_device_config_alarm_volume_label">Volume de s\'alarma</string>
     <string name="devices_device_config_alarm_volume_desc">Calicuna app de alarma ùsat su volume de sa mùsica in su pòstu.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Suoneria</string>
     <string name="devices_audio_stream_notification_label">Notìfica</string>
     <string name="devices_audio_stream_alarm_label">Alarma</string>
-    <string name="devices_neverseen_label">Mai vìstu</string>
-    <string name="devices_state_connected_label">Connètidu</string>
     <string name="devices_last_connected_label">Ùltimu connètidu: %s</string>
     <string name="devices_currently_connected_label">Attualmènte connètidu</string>
     <string name="devices_device_disabled_label">Dispositivu disabilitàdu</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Impostatziones chi inflùint subra tùdos sos dispositivos gestidos.</string>
     <string name="label_app_enabled">App abilitàda</string>
     <string name="description_app_enabled">Comùtat sa capatzidade de s\'app de reagèssere a sos eventos de volume e Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Aggiustamentos visìbbiles</string>
-    <string name="description_visible_volume_adjustments">Amostra sa finestra de volume de su sistema mentre s\'app fàchet aggiustamentos.</string>
     <string name="label_volume_listener">Osserva sos cambios</string>
-    <string name="description_volume_listener">Remàni ativu mentre unu dispositivu est connètidu e sàlva sos cambios de volume chi non sunt istados causàdos dae s\'app.</string>
     <string name="label_boot_restore">Ripristina a s\'avvio</string>
     <string name="description_boot_restore">Ripristina su volume dòpo s\'avvio/riavvio se unu dispositivu Bluetooth est connètidu.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Impàra a ùsare BVM in manera eficàtze</string>
     <string name="settings_support_issue_tracker_description">Un tracker de problemas pùbblicu pro segnalatziones de bug e richièstas de funtzionalidades.</string>
     <string name="settings_support_issue_tracker_label">Tracker de problemas</string>
-    <string name="settings_support_debuglog_label">Log de debug</string>
     <string name="settings_support_debuglog_desc">Registra tùtu chello chi s\'app est fachèndende in unu file de testu chi podes cumunicare.</string>
-    <string name="settings_support_debuglog_recording_desc">Attualmènte registrende informatzione de debug. Toca pro pàrare sa registratzione.</string>
-    <string name="settings_support_debuglog_path">Percorsu de log: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Registratzione tropu curta</string>
     <string name="settings_support_debuglog_short_recording_msg">Sa registratzione est istada tropu curta. Sos logs de debug sunt registratziones, non instantàneas — reproduzi su problema mentres sa registratzione est ativa pro chi su log siat ùtile.</string>
     <string name="settings_support_debuglog_short_recording_continue">Còntinuat sa registratzione</string>
     <string name="settings_support_debuglog_short_recording_stop">Para a su matessi modu</string>
-    <string name="settings_support_debuglog_folder_label">Cartella de sos logs de debug</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d sessione chi ùsat %2$s</item>
-        <item quantity="other">%1$d sessiones chi ùsant %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nessun log de debug immagatzinàdu</string>
-    <string name="settings_support_debuglog_folder_delete_title">Càncella tùdos sos logs de debug?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Custu càncellat permanèntement tùdas sas sessiones de logs de debug immagatzinàdas.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Un postu addú istare e fàghere dòmandas.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Tradutzione</string>
     <string name="settings_acks_translators_title">Tradutores</string>
     <string name="settings_acks_translators_people">Persone1;Persone2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Tradùi BVM</string>
-    <string name="settings_acks_translate_desc">Agiùda a tradùere BVM in sa lìngua tua</string>
     <string name="settings_acks_thanks_header">Gràtzias</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Pro su suporte a sa tradutzione de sos progèttos open-source</string>
     <string name="settings_licenses_label">Litzèntzias</string>
     <string name="settings_translation_label">Tradutzione</string>
     <string name="settings_translation_desc">Agiuda a traduire s\'app in sa limba tua preferida</string>
-    <string name="settings_sponsor_development_title">Spònsora su sviluppu</string>
-    <string name="settings_sponsor_development_summary">Deventa unu sponsor e rènde pòssibile su sviluppu còntinuu.</string>
     <string name="settings_privacy_policy_label">Política de privatesa</string>
     <string name="settings_privacy_policy_desc">Gestire sos datos in manera responsàbbile.</string>
     <string name="changelog_label">Registro de cambios</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Restauratzione compia — %1$d dispositivus restauraus, %2$d saltaus.</string>
     <string name="backup_restore_version_warning">Custu backup est istadu creadu cun sa versione %1$s. Ses impreende %2$s. Calecuna impostazione poderet non si restaurare bene.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Notìfigas de debug</string>
     <string name="debug_log_consent_title">Log de debug</string>
     <string name="debug_log_consent_explanation">Cussa funtzionalidade registrat tùtu chello chi s\'app est fachèndende in unu file cumunicàbbile. Su file generàdu cuntenet informatzione sensìbbile (p.e. nòmines de file e apps instalàdas). Cumunicalu solu a persones de fidùcia (p.e. unu sviluppatore chi est solutzionende unu problema).</string>
-    <string name="debug_log_recording_progress">Registrende log de debug</string>
     <string name="debug_log_record_action">Registra</string>
     <string name="debug_log_stop_action">Para sa registratzione</string>
     <string name="debug_log_screen_title">Registradore de Log de Debug</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Iscarta</string>
     <string name="debug_log_screen_keep_action">Mantèni</string>
-    <string name="debug_log_compressing_label">Comprimende…</string>
     <string name="debug_log_file_label">File de log registràdu</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log mandàdu?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Descrivi sa dòmanda tua in detàlliu.</string>
     <string name="contact_category_section_label">Categoria</string>
     <string name="contact_debug_log_label">Log de debug</string>
-    <string name="contact_debug_log_select_hint">Selètziona unu log de debug pro allegare</string>
     <string name="contact_debug_log_picker_hint">Allega unu log de debug pro aiuare a diagnosticare su problema pius in fràtta.</string>
     <string name="contact_debug_log_picker_empty">Nessun log de debug disponìbbile. Registra unu primu.</string>
     <string name="contact_expected_behavior_label">Cumportamentu attèsu</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Lègio ogni messàgiu personalmènte e fàzo su mèglius pro rispòndere, ma poiché traballio a custu a su solu, podet impiegare unu pagu de tempus. Gràtzias pro sa patièntzia tua.</string>
     <string name="contact_footer_msg">Su messàgiu tuo serrà mandàdu via email. Informatzione de su dispositivu e de sa configuratzione est allegàda automàticament.</string>
     <string name="contact_no_email_app_msg">Nessuna app de email agatàda in custu dispositivu.</string>
-    <string name="contact_attachment_missing_msg">Su file de log de debug non esistit prus</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Logs de debug immagatzinàdos</string>
     <string name="settings_support_stored_logs_desc">%1$d sessiones (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Nessun log de debug immagatzinàdu</string>
-    <string name="settings_support_stored_logs_delete_title">Càncella sos logs immagatzinàdos?</string>
-    <string name="settings_support_stored_logs_delete_msg">Custu càncellat tùdas sas %1$d sessiones de logs de debug immagatzinàdas.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Logs de debug immagatzinàdos cancelàdos</string>
-    <string name="label_bug_reports">Segnalatziones de bug</string>
-    <string name="description_bug_reports">Segnalazione automàtica de bug e crash.</string>
     <string name="label_add_device">Aggiunghe dispositivu</string>
-    <string name="label_just_a_moment_please">Unu momentu, prite.</string>
     <string name="label_notification_channel_status">Istadu</string>
     <string name="label_notification_channel_setup">Cunfiguratzione iscantzelada</string>
     <string name="monitor_notification_starting">Iniciende…</string>
     <string name="action_set">Imposta</string>
     <string name="action_cancel">Annùlla</string>
-    <string name="label_invalid_input">Input non vàlidu</string>
     <string name="action_reset">Resètta</string>
     <string name="label_no_connected_devices">Nessun dispositivu connètidu</string>
-    <string name="label_status_idle">In attesa</string>
-    <string name="label_status_adjusting_volumes">Aggiustende sos volumes</string>
-    <string name="label_premium_version">Versione premium</string>
     <string name="general_upgrade_action">Aggiornamentu</string>
     <string name="common_upgrade_required_label">Aggiornamentu requeridu</string>
-    <string name="label_premium_version_required">Versione premium richièsta</string>
-    <string name="description_intro_purpose">S\'app permìttit a su dispositivu Android tuo de recordare su volume de sos diversos dispositivos Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Profilis de dispositivu illimitaus</string>
-    <string name="upgrade_benefit_connection_actions">Riprodutzione automàtica, apertura de app e avisos de connessione</string>
-    <string name="upgrade_benefit_theme_customization">Personalizatzione de tema, stile e colore</string>
-    <string name="upgrade_benefit_power_controls">Blocu de volume e limitatzione de velotzidade</string>
-    <string name="upgrade_benefit_support">Sostieni su svilupu indipendente</string>
     <string name="upgrade_benefit_equalizer">• Equalizadore pro cada aparatu (pro aplicatziones de mùsica cun sustegnu de s\'equalizadore de sistema)</string>
-    <string name="description_intro_tap_the_button">Cumintzat aggiungèndende su primu dispositivu tuo.</string>
     <string name="description_bluetooth_is_disabled">Su Bluetooth est disabilitàdu.</string>
     <string name="title_bluetooth_is_off">Su Bluetooth est isgèliu</string>
     <string name="action_enable_bluetooth">Abìlita su Bluetooth</string>
     <string name="title_bluetooth_permission_required">Permissu Bluetooth richièstu</string>
     <string name="description_bluetooth_permission_required">S\'app richièdet su permissu Bluetooth pro gestire sos volumes de su dispositivu tuo.</string>
     <string name="action_grant_permission">Contzèddi su permissu</string>
-    <string name="label_status_listening_for_changes">Ascultende sos cambios de volume</string>
     <string name="action_exit">Nche bessit</string>
-    <string name="action_start">Cumintzat</string>
-    <string name="label_welcome">Bènnidu</string>
-    <string name="description_intro_contact">Non istas in duda de contàttaremi si as dòmandas o fintzas un\'idea pro una nova funtzionalidade.</string>
-    <string name="label_translation">Tradutzione</string>
-    <string name="description_help_translate">Agiùdami a rèndere s\'app disponìbbile in àteras lìnguas.</string>
     <string name="label_device_speaker">Altoparlante de su dispositivu</string>
-    <string name="label_keyevent_playpause">Play-Pausa</string>
-    <string name="label_keyevent_play">Reprodutzet</string>
-    <string name="label_keyevent_next">Sighènte</string>
-    <string name="label_install_id">ID de installatzione</string>
     <string name="message_copied_to_clipboard">Copiàdu in su clipboard</string>
-    <string name="label_thanks">Gràtzias</string>
-    <string name="label_licenses">Litzèntzias</string>
-    <string name="description_ring_volume_additional_permission">Sunt netzessàrios permissos aditzionales pro cambiare su volume de suoneria.</string>
-    <string name="label_missing_permissions">Permissos mancantes</string>
-    <string name="action_grant">Contzèddi</string>
-    <string name="label_advanced">Avanzàdu</string>
-    <string name="label_exclude_health">Esclùi sos perfiles de salute</string>
-    <string name="description_exclude_health">Calicunu dispositivu Android si blocat cando cerca sos perfiles Bluetooth \'Dispositivu de Salute\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Esclùi sos perfiles de su server GATT</string>
-    <string name="label_exclude_gatt">Esclùi sos perfiles GATT</string>
-    <string name="description_exclude_gattserver">Non consultare sos perfiles Bluetooth de tipu \'Attributo Genericu\' (GATT) server.</string>
-    <string name="description_exclude_gatt">Non consultare sos perfiles Bluetooth de tipu \'Attributo Genericu\' (GATT) client.</string>
-    <string name="description_waiting_for_devicex">Attèndende %s pro cumpletare sa connessione</string>
-    <string name="action_undo">Annùlla</string>
-    <string name="action_show">Amostra</string>
     <string name="action_dismiss">Iscarta</string>
-    <string name="action_fix">Corrègi</string>
-    <string name="battery_optimizations_issue_description">Sas ottimizatziones de bateria sunt abilitàdas pro s\'app e podent prevènnere chi retzibat eventos Bluetooth. Cunsìdera de disabilitare sas ottimizatziones si às problemas.</string>
     <string name="label_bluetooth_settings">Impostatziones Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 restringhe cumme sas apps podent essere lantzàdas dae su background. Pro permìttere de abèrrere apps cando unu dispositivu Bluetooth si connèttet, contzèddi su permissu &quot;Amostra subra àteras apps&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Còdighe sorgente</string>
-    <string name="android13_notification_permission_description">Contzèddi a s\'app su permissu de publicare notìfigas. Custu permìttit de amostare una notìfica cando s\'app est ativa e sunt fachèndende aggiustamentos de volume.</string>
-    <string name="privacy_policy_label">Política de privatesa</string>
     <string name="managed_devices_empty_message">Nessun dispositivu Bluetooth configuràdu.\nToca su butone + pro aggiunghere su primu dispositivu tuo.</string>
     <string name="label_pro_feature">Funtzionalidade premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Revisione</string>
     <string name="review_app_dismiss_action">Forsis più in antis</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Acchìstu annullàdu</string>
-    <string name="error_iap_unavailable_message">Sos acchìstos in-app non sunt disponìbbiles</string>
-    <string name="error_generic_message">Si est verificàdu unu errore. Prova de nou.</string>
-    <string name="error_iap_owned_message">Possèdis già custu elementu</string>
     <string name="label_no_devices_title">Nessun dispositivu</string>
     <string name="bluemusic_mascot_description">Icona de s\'app</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Selètziona Apps</string>
     <string name="devices_app_selection_search_hint">Cerca apps…</string>
-    <string name="devices_app_selection_currently_selected">Attualmènte seletziòndas</string>
     <string name="devices_app_selection_selected_count">%d apps seletziòndas</string>
     <string name="general_navigate_back_action">Torra a nàrrere</string>
     <string name="general_reset_action">Resètta</string>
     <string name="general_clear_action">Imbòida</string>
-    <string name="general_save_action">Sàlva</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Bloccu</string>
     <string name="devices_indicator_awake">In veglia</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Limita</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Aumento</string>
-    <string name="devices_indicator_launch">Làntzia</string>
     <string name="devices_indicator_home">Pantalla printzipale</string>
     <string name="devices_indicator_dnd">SND</string>
     <string name="devices_indicator_alert">Avisu</string>

--- a/app/src/main/res/values-si-rLK/strings.xml
+++ b/app/src/main/res/values-si-rLK/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">යාවත්කාලීන කිරීමේදී සමහර උපාංග සැකසීම් යළි සකසෙන්නට ඇත. සෑම දෙයක්ම නිවැරදිව සකසා ඇති බව සහතික කිරීමට ඔබේ උපාංගය සැකසීම් පරීක්ෂා කරන්න.</string>
     <string name="onboarding_rewrite_action">ඉදිරියට</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">කළමනා නොකළ උපාංග හමු නොවිණි</string>
     <string name="discover_all_devices_managed_msg">ඔබේ සියලු සම්බන්ධ කළ උපාංගයන් කළමනා කෙරෙයි! අලුත් එකක් ඕනෑද?</string>
     <string name="discover_pair_new_device_action">නව උපාංගයක් සම්බන්ධ කරන්න</string>
     <string name="discover_device_speaker_desc">මේ ජංගම දූරකතනයේ තමන්ගේ ශබ්දකය. ශබ්ද ජංගම දූරකතනයට ආපසු මාරු වූ විට එහි පරිමාවන් යෙදේ, උදා. ඔබේ Bluetooth උපාංගය විසංයෝගිත වූ පසු.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">උපාංග සැකසුම</string>
-    <string name="devices_device_config_section_general_label">සාමාන්‍ය</string>
     <string name="devices_device_config_remove_device_label">උපාංගය අමතක කරන්න</string>
-    <string name="devices_device_config_remove_device_desc">මෙම යෙදුමෙන් උපාංගය ඉවත් කර එහි සැකසුම් මකයි. මෙය උපාංගය unpair නොකරයි.</string>
     <string name="devices_device_config_remove_device_action">අමතක කරන්න</string>
     <string name="devices_device_config_remove_device_confirmation">%s කළමනා උපාංගයන්ගෙන් අමතක කරන්නද?</string>
-    <string name="devices_device_config_rename_device_label">උපාංගය නැවත නම් කරන්න</string>
-    <string name="devices_device_config_rename_device_desc">මෙම යෙදුම ඇතුළත සහ හැකි නම් system හිදී ද මෙම උපාංගය නැවත නම් කරන්න.</string>
     <string name="devices_device_config_rename_device_action">නම් කරන්න</string>
     <string name="devices_device_config_enabled_label">සබල කර ඇත</string>
     <string name="devices_device_config_enabled_desc">සම්බන්ධ වූ විට මෙම උපාංගයට ප්‍රතිචාර දක්වන්න</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">ස්වයංක්‍රීය ධාවන විධාන</string>
     <string name="devices_device_config_autoplay_keycodes_order">විධාන අනුක්‍රමය</string>
     <string name="devices_device_config_autoplay_keycodes_label">විධාන</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">යැවිය යුතු විධාන සහ ඒවා යැවිය යුතු අනුපිළිවෙල සකසන්න</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">විධාන සකසා නොමැත</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">විධානය එක් කරන්න</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">උපරිම %1$d විධාන</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">ඉහළට ගෙනයන්න</string>
     <string name="cd_autoplay_keycode_move_down">පහළට ගෙනයන්න</string>
     <string name="cd_autoplay_keycode_remove">ඉවත් කරන්න</string>
-    <string name="devices_device_config_section_volumes_label">හඬ මට්ටම්</string>
     <string name="devices_device_config_section_volume_label">හඬ මට්ටම</string>
     <string name="devices_device_config_alarm_volume_label">සීනු හඩ</string>
     <string name="devices_device_config_alarm_volume_desc">සමහර සීනු යෙදුම් ඒ වෙනුවට සංගීත හඩ භාවිතා කරයි.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">රිංඟ</string>
     <string name="devices_audio_stream_notification_label">දැනුම්දීම</string>
     <string name="devices_audio_stream_alarm_label">සීනුව</string>
-    <string name="devices_neverseen_label">කිසිදා දක්නා නොලැබිණ</string>
-    <string name="devices_state_connected_label">සම්බන්ධිතයි</string>
     <string name="devices_last_connected_label">අවසාන සම්බන්ධය: %s</string>
     <string name="devices_currently_connected_label">දැනට සම්බන්ධිතයි</string>
     <string name="devices_device_disabled_label">උපාංගය අබල කර ඇත</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">සියලු කළමනාකරිත උපාංගයන් කෙරෙහි බලපාන සැකසීම්.</string>
     <string name="label_app_enabled">යෙදුම සබල කර ඇත</string>
     <string name="description_app_enabled">හඩ සහ බ්ලූටූත් සිදුවීම් වලට ප්‍රතිචාර දැක්වීමට යෙදුමේ හැකියාව ටොගල් කරයි.</string>
-    <string name="label_visible_volume_adjustments">දෘශ්‍ය සකසීම්</string>
-    <string name="description_visible_volume_adjustments">මෙම යෙදුම සකසීම් සිදු කරන ඕනෑම දිනෙ සිස්ටමයේ හඩ කවුළුව පෙන්වන්න.</string>
     <string name="label_volume_listener">වෙනස්කම් නිරීක්ෂණය කරන්න</string>
-    <string name="description_volume_listener">උපාංගය සම්බන්ධ වී ඇති ඕනෑම දිනෙ සක්‍රිය ව සිටින්න සහ මෙම යෙදුමෙන් නොකළ හඩ වෙනස්කම් සුරකින්න.</string>
     <string name="label_boot_restore">ආරම්භ කළ විට ප්‍රතිස්ථාපනය</string>
     <string name="description_boot_restore">බ්ලූටූත් උපාංගයක් සම්බන්ධ ඇත්නම් ආරම්භ/නැවත ආරම්භ කිරීමෙන් පසු හඩ ප්‍රතිස්ථාපනය කරන්න.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM ඵලදායී ලෙස භාවිතා කරන ආකාරය ඉගෙන ගන්න</string>
     <string name="settings_support_issue_tracker_description">දෝෂ වාර්තා සහ ලක්ෂණ ඉල්ලීම් සඳහා ප්‍රසිද්ධ ගැටළු ලූහුබැඳීමක්.</string>
     <string name="settings_support_issue_tracker_label">ගැටළු ලූහුබැඳීම</string>
-    <string name="settings_support_debuglog_label">Debug ලොගය</string>
     <string name="settings_support_debuglog_desc">යෙදුම කරන සියල්ල ඔබට බෙදාගත හැකි පාඨ ගොනුවකට රේකෝඩ් කරන්න.</string>
-    <string name="settings_support_debuglog_recording_desc">දැනට debug තොරතුරු රේකෝඩ් කරමින් ඇත. රේකෝඩ් කිරීම නැවැත්වීමට ස්පර්ශ කරන්න.</string>
-    <string name="settings_support_debuglog_path">ලොග් මාර්ගය: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">ඉතා කෙටි රේකෝඩ්</string>
     <string name="settings_support_debuglog_short_recording_msg">එය ඉතා කෙටි රේකෝඩ්ගලු. Debug ලොග් රේකෝඩ් ය, snapshot නොවේ — ලොගය ප්‍රයෝජනවත් වීමට රේකෝඩ් ක්‍රියාත්මකව ඇති අතරතුර ගැටලුව ප්‍රතිනිෂ්පාදනය කරන්න.</string>
     <string name="settings_support_debuglog_short_recording_continue">රේකෝඩ් ඉදිරියට</string>
     <string name="settings_support_debuglog_short_recording_stop">කෙසේ හෝ නැවැත්වන්න</string>
-    <string name="settings_support_debuglog_folder_label">Debug ලොග් ෆෝල්ඩරය</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d සැසිය %2$s භාවිතා කිරීම</item>
-        <item quantity="other">%1$d සැසි %2$s භාවිතා කිරීම</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Debug ලොග් ගබඩා නැත</string>
-    <string name="settings_support_debuglog_folder_delete_title">සියලු debug ලොග් මකන්නද?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">මෙය ගබඩා කළ සියලු debug ලොග් සැසි ස්ථිරවම මකනු ඇත.</string>
     <string name="settings_support_discord_label">ඩිස්කෝඩ්</string>
     <string name="settings_support_discord_description">ගැවසීමට සහ ප්‍රශ්න ඇසීමට ස්ථානයකි.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">පරිවර්තනය</string>
     <string name="settings_acks_translators_title">පරිවර්තකයින්</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM පරිවර්තනය කරන්න</string>
-    <string name="settings_acks_translate_desc">BVM ඔබේ භාෂාවට පරිවර්තනය කිරීමට උදව් කරන්න</string>
     <string name="settings_acks_thanks_header">ස්තූතිය</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">විවෘත මූලාශ්‍ර ව්‍යාපෘති පරිවර්තනය සඳහා සහාය</string>
     <string name="settings_licenses_label">බලපත්‍ර</string>
     <string name="settings_translation_label">පරිවර්තනය</string>
     <string name="settings_translation_desc">ඔබේ ප්‍රියතම භාෂාවට යෙදුම පරිවර්තනය කිරීමට උදව් කරන්න</string>
-    <string name="settings_sponsor_development_title">සංවර්ධනයට අනුග්‍රහය දෙන්න</string>
-    <string name="settings_sponsor_development_summary">ආධාරකරුවෙකු වී අඛණ්ඩ සංවර්ධනය හැකිවෙමින් ගත කරන්න.</string>
     <string name="settings_privacy_policy_label">රහස්‍යතා ප්‍රතිපත්තිය</string>
     <string name="settings_privacy_policy_desc">දත්ත වගකිවයුතු ලෙස හැසිරවීම.</string>
     <string name="changelog_label">වෙනස් කිරීම් ලැයිස්තුව</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">ප්‍රතිසාධනය සම්පූර්ණයි — උපාංග %1$d ප්‍රතිසාධනය කරන ලදී, %2$d මඟ හරින ලදී.</string>
     <string name="backup_restore_version_warning">මෙම උපස්ථය %1$s අනුවාදය සමඟ සාදා ඇත. ඔබ %2$s ධාවනය කරයි. සමහර සැකසුම් නිවැරදිව ප්‍රතිසාධනය නොවිය හැක.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Debug දැනුම්දීම්</string>
     <string name="debug_log_consent_title">Debug ලොගය</string>
     <string name="debug_log_consent_explanation">මෙම ලක්ෂණය යෙදුම කරන සියල්ල බෙදාගත හැකි ගොනුවකට රේකෝඩ් කරයි. ජනනය කරන ලද ගොනුවේ සංවේදී තොරතුරු (ගොනු නාම සහ ස්ථාපිත යෙදුම් ආදිය) ඇත. විශ්වාසනීය පාර්ශ්ව (ගැටළු නිරාකරණය කරන සංවර්ධකයෙකු ආදිය) සමඟ පමණක් බෙදා ගන්න.</string>
-    <string name="debug_log_recording_progress">Debug ලොගය රේකෝඩ් කිරීම</string>
     <string name="debug_log_record_action">රේකෝඩ්</string>
     <string name="debug_log_stop_action">රේකෝඩ් කිරීම නැවැත්වීම</string>
     <string name="debug_log_screen_title">Debug ලොග් රේකෝඩරය</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">ඉවත් කිරීම</string>
     <string name="debug_log_screen_keep_action">තබා ගන්න</string>
-    <string name="debug_log_compressing_label">සම්පීඩනය කිරීම…</string>
     <string name="debug_log_file_label">රේකෝඩ් කළ ලොග් ගොනුව</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">ලොගය යැව්වාද?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">ඔබේ ප්‍රශ්නය සවිස්තරාත්මකව විස්තර කරන්න.</string>
     <string name="contact_category_section_label">කාණ්ඩය</string>
     <string name="contact_debug_log_label">Debug ලොගය</string>
-    <string name="contact_debug_log_select_hint">අමුණා ගැනීමට debug ලොගයක් තෝරන්න</string>
     <string name="contact_debug_log_picker_hint">ගැටලුව වේගයෙන් හඳුනා ගැනීමට debug ලොගයක් අමුණන්න.</string>
     <string name="contact_debug_log_picker_empty">Debug ලොග් නොමැත. මුලින් එකක් රේකෝඩ් කරන්න.</string>
     <string name="contact_expected_behavior_label">අපේක්ෂිත හැසිරීම</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">මම සෑම පණිවිඩයක්ම ව්‍යක්තිකව කියවා ප්‍රතිචාර දීමට හැකි පමණ උත්සාහ කරමි, නමුත් මෙය තනිව කරන නිසා, ටිකක් කාලය ගත විය හැකිය. ඔබේ ඉවසීමට ස්තූතියි.</string>
     <string name="contact_footer_msg">ඔබේ පණිවිඩය ඊමේල් හරහා යවනු ඇත. උපාංගය සහ සැකසුම් තොරතුරු ස්වයංක්‍රීයව අමුණයි.</string>
     <string name="contact_no_email_app_msg">මෙම උපාංගයේ ඊමේල් යෙදුමක් හමු නොවිණි.</string>
-    <string name="contact_attachment_missing_msg">Debug ලොග් ගොනුව තවදුරටත් නොමැත</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">ගබඩා කළ debug ලොග්</string>
     <string name="settings_support_stored_logs_desc">%1$d සැසි (%2$s)</string>
     <string name="settings_support_stored_logs_empty">ගබඩා කළ debug ලොග් නැත</string>
-    <string name="settings_support_stored_logs_delete_title">ගබඩා කළ ලොග් මකන්නද?</string>
-    <string name="settings_support_stored_logs_delete_msg">මෙය ගබඩා කළ %1$d debug ලොග් සැසි සියල්ල මකනු ඇත.</string>
-    <string name="settings_support_stored_logs_deleted_msg">ගබඩා කළ debug ලොග් මකා දමන ලදී</string>
-    <string name="label_bug_reports">දෝෂ වාර්තා</string>
-    <string name="description_bug_reports">ස්වයංක්‍රීය දෝෂ සහ බිඳ වැටීම් වාර්තා.</string>
     <string name="label_add_device">උපාංගය එකතු කරන්න</string>
-    <string name="label_just_a_moment_please">ටිකක් ඉන්න.</string>
     <string name="label_notification_channel_status">තත්වය</string>
     <string name="label_notification_channel_setup">සැකසීම අවශ්‍යයි</string>
     <string name="monitor_notification_starting">ආරම්භ කරමින්…</string>
     <string name="action_set">සකසන්න</string>
     <string name="action_cancel">අවලංගු කරන්න</string>
-    <string name="label_invalid_input">වලංගු නොවන ආදානයකි</string>
     <string name="action_reset">යළි සකසන්න</string>
     <string name="label_no_connected_devices">සම්බන්ධිත උපාංග නැත</string>
-    <string name="label_status_idle">නිකන්</string>
-    <string name="label_status_adjusting_volumes">හඩ සකසමින්</string>
-    <string name="label_premium_version">Premium අනුවාදය</string>
     <string name="general_upgrade_action">උසස් කරන්න</string>
     <string name="common_upgrade_required_label">උත්‍යාජනය අවශ්‍යයි</string>
-    <string name="label_premium_version_required">Premium අනුවාදය අවශ්‍යයි</string>
-    <string name="description_intro_purpose">මෙම යෙදුම ඔබේ Android උපාංගයට විවිධ Bluetooth උපාංගයන්හි හඩ මට්ටම් මතක් කර ගැනීමට ඉඩ දෙයි.</string>
-    <string name="upgrade_benefit_unlimited_devices">අසීමිත උපාංග පැතිකඩ</string>
-    <string name="upgrade_benefit_connection_actions">ස්වයංක්‍රීය ධාවනය, යෙදුම් දියත් කිරීම සහ සම්බන්ධ ඇඟවීම්</string>
-    <string name="upgrade_benefit_theme_customization">තේමාව, ශැලිය සහ වර්ණ අභිරුඩිකරණය</string>
-    <string name="upgrade_benefit_power_controls">ශබ්ද අගුල සහ වේග සීමාව</string>
-    <string name="upgrade_benefit_support">ස්වාධීන සංවර්ධනයට සහාය දෙන්න</string>
     <string name="upgrade_benefit_equalizer">• උපාංගය අනුව සමකාරකය (පද්ධති සමකාරක සහාය සහිත සංගීත යෙදුම් සඳහා)</string>
-    <string name="description_intro_tap_the_button">ඔබේ පළමු උපාංගය එකතු කිරීමෙන් ආරම්භ කරන්න.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth අක්‍රිය කර ඇත.</string>
     <string name="title_bluetooth_is_off">Bluetooth ක්‍රියාවිරහිත</string>
     <string name="action_enable_bluetooth">Bluetooth සක්‍රිය කරන්න</string>
     <string name="title_bluetooth_permission_required">Bluetooth අවසරය අවශ්‍යයි</string>
     <string name="description_bluetooth_permission_required">ඔබේ උපාංගයේ හඩ කළමනාකරණය කිරීමට මෙම යෙදුමට Bluetooth අවසරය අවශ්‍ය වෙයි.</string>
     <string name="action_grant_permission">අවසරය ලබා දෙන්න</string>
-    <string name="label_status_listening_for_changes">හඩ වෙනස්කම් සඳහා සවන් දෙමින්</string>
     <string name="action_exit">පිටවන්න</string>
-    <string name="action_start">අරඹන්න</string>
-    <string name="label_welcome">සාදරයෙන් පිළිගන්නවා</string>
-    <string name="description_intro_contact">ප්‍රශ්නයක් හෝ නව ලක්ෂණයකට යෝජනාවක් ඇත්නම් මා හා සම්බන්ධ වීමට නිදහස් ව ගන්න.</string>
-    <string name="label_translation">පරිවර්තනය</string>
-    <string name="description_help_translate">මෙම යෙදුම අනෙකුත් භාෂාවලින් ලබා ගත හැකිවීමට මට උදව් කරන්න.</string>
     <string name="label_device_speaker">උපාංගයේ විකාශකය</string>
-    <string name="label_keyevent_playpause">ධාවනය-විරාමය</string>
-    <string name="label_keyevent_play">ධාවනය</string>
-    <string name="label_keyevent_next">ඊළඟ</string>
-    <string name="label_install_id">ස්ථාපන හැඳු.</string>
     <string name="message_copied_to_clipboard">ක්ලිප්බෝඩ් වලට පිටපත් කළා</string>
-    <string name="label_thanks">ස්තූතියි</string>
-    <string name="label_licenses">බලපත්‍ර</string>
-    <string name="description_ring_volume_additional_permission">රිංඟ හඩ වෙනස් කිරීමට අමතර අවසරයන් අවශ්‍ය වෙයි.</string>
-    <string name="label_missing_permissions">අස්ථාන අවසරයන්</string>
-    <string name="action_grant">ලබා දෙන්න</string>
-    <string name="label_advanced">උසස්</string>
-    <string name="label_exclude_health">සෞඛ්‍ය ගොනු ඇතිමෙව් කරන්න</string>
-    <string name="description_exclude_health">සමහර Android උපාංගයන් \'Health Device\' Bluetooth ගොනු (HDP, 0x1400) සොයන ඕනෑම දිනෙ එල්ලෙයි.</string>
-    <string name="label_exclude_gattserver">GATT server ගොනු ඇතිමෙව් කරන්න</string>
-    <string name="label_exclude_gatt">GATT ගොනු ඇතිමෙව් කරන්න</string>
-    <string name="description_exclude_gattserver">\'Generic Attribute\' (GATT) server ආකාරයේ Bluetooth ගොනු ඇසිය නොකරන්න.</string>
-    <string name="description_exclude_gatt">\'Generic Attribute\' (GATT) client ආකාරයේ Bluetooth ගොනු ඇසිය නොකරන්න.</string>
-    <string name="description_waiting_for_devicex">%s සම්බන්ධය සම්පූර්ණ කිරීම සඳහා බලා සිටිමින්</string>
-    <string name="action_undo">පෙරසේ</string>
-    <string name="action_show">පෙන්වන්න</string>
     <string name="action_dismiss">ඉවතලන්න</string>
-    <string name="action_fix">නිවැරදි කරන්න</string>
-    <string name="battery_optimizations_issue_description">මෙම යෙදුම සඳහා බැටරි ප්‍රශස්තකරණ සබල කර ඇති අතර Bluetooth සිදුවීම් ලබා ගැනීමෙන් වළක්වා ගත හැකිය. ගැටළු ඇත්නම් ප්‍රශස්තකරණ අක්‍රිය කිරීම සලකා බලන්න.</string>
     <string name="label_bluetooth_settings">බ්ලූටූත් සැකසුම්</string>
-    <string name="android10_applaunch_issue_description">Android 10 පසුතල ගෙන් යෙදුම් දියත් කළ හැකි ආකාරය සීමා කරයි. Bluetooth උපාංගයක් සම්බන්ධ වූ විට යෙදුම් විවෘත කිරීමට ඉඩ දීමට, &quot;Display over other apps&quot; (SYSTEM_ALERT_WINDOW) අවසරය ලබා දෙන්න.</string>
-    <string name="label_opensource">නිල කේතය</string>
-    <string name="android13_notification_permission_description">දැනුම්දීම් පළ කිරීමට මෙම යෙදුමට අවසරය ලබා දෙන්න. මෙය යෙදුම සක්‍රිය ඇති ඕනෑම දිනෙ සහ හඩ සකසීම් සිදු කරන ඕනෑම දිනෙ දැනුම්දීමක් පෙන්වීම සබල කරයි.</string>
-    <string name="privacy_policy_label">රහස්‍යතා ප්‍රතිපත්තිය</string>
     <string name="managed_devices_empty_message">Bluetooth උපාංග ව්‍යවස්ථාපිත නැත.\nඔබේ පළමු උපාංගය එකතු කිරීමට + බොත්තම ස්පර්ශ කරන්න.</string>
     <string name="label_pro_feature">Premium ලක්ෂණය</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">සමාලෝචනය</string>
     <string name="review_app_dismiss_action">පසුව සමහර විට</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">මිලදී ගැනීම අවලංගු කළා</string>
-    <string name="error_iap_unavailable_message">යෙදුම් ඇතුළත මිලදී ගැනීම් නොලබා ගත හැකිය</string>
-    <string name="error_generic_message">දෝෂයක් සිදු විය. කරුණාකර නැවත උත්සාහ කරන්න.</string>
-    <string name="error_iap_owned_message">ඔබ දැනටමත් මෙම අයිතමය සතු වෙයි</string>
     <string name="label_no_devices_title">උපාංග නැත</string>
     <string name="bluemusic_mascot_description">යෙදුම් අයිකනය</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">යෙදුම් තෝරන්න</string>
     <string name="devices_app_selection_search_hint">යෙදුම් සොයන්න…</string>
-    <string name="devices_app_selection_currently_selected">දැනට තෝරාගෙන ඇත</string>
     <string name="devices_app_selection_selected_count">%d යෙදුම් තෝරාගෙන ඇත</string>
     <string name="general_navigate_back_action">ආපසු ගමන්</string>
     <string name="general_reset_action">යළි සකසන්න</string>
     <string name="general_clear_action">හිස් කරන්න</string>
-    <string name="general_save_action">සුරකින්න</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">අගුල</string>
     <string name="devices_indicator_awake">සක්‍රිය</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">සීමාව</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">වර්ධනය</string>
-    <string name="devices_indicator_launch">දියත් කිරීම</string>
     <string name="devices_indicator_home">මුල්</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">අනතුරු ඇඟවීම</string>

--- a/app/src/main/res/values-sk/strings.xml
+++ b/app/src/main/res/values-sk/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Niektoré nastavenia zariadení mohli byť počas tejto aktualizácie resetované. Skontroluj konfigurácie svojich zariadení.</string>
     <string name="onboarding_rewrite_action">Pokračovať</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nenašli sa žiadne nespravované zariadenia</string>
     <string name="discover_all_devices_managed_msg">Všetky spárované zariadenia sú spravované! Potrebuješ nové?</string>
     <string name="discover_pair_new_device_action">Spárovať nové zariadenie</string>
     <string name="discover_device_speaker_desc">Vlastný reproduktor telefónu. Jeho hlasitosti sa aplikujú, keď sa zvuk prepne späť na telefón, napr. po odpojení zariadenia Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfigurácia zariadenia</string>
-    <string name="devices_device_config_section_general_label">Všeobecné</string>
     <string name="devices_device_config_remove_device_label">Zabudnúť zariadenie</string>
-    <string name="devices_device_config_remove_device_desc">Zabudne zariadenie z tejto aplikácie a vymaže jeho konfiguráciu. Toto zariadenie neodpáruje.</string>
     <string name="devices_device_config_remove_device_action">Zabudnúť</string>
     <string name="devices_device_config_remove_device_confirmation">Zabudnúť %s zo spravovaných zariadení?</string>
-    <string name="devices_device_config_rename_device_label">Premenovať zariadenie</string>
-    <string name="devices_device_config_rename_device_desc">Premenuj toto zariadenie v tejto aplikácii a ak je to možné, aj v systéme.</string>
     <string name="devices_device_config_rename_device_action">Premenovať</string>
     <string name="devices_device_config_enabled_label">Povolené</string>
     <string name="devices_device_config_enabled_desc">Reagovať na toto zariadenie pri pripojení</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Príkazy automatického prehrávania</string>
     <string name="devices_device_config_autoplay_keycodes_order">Poradie príkazov</string>
     <string name="devices_device_config_autoplay_keycodes_label">Príkazy</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Nastavte, ktoré príkazy odoslať a v akom poradí</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Žiadne príkazy nenakonfigurované</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Pridať príkaz</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximálne %1$d príkazov</string>
@@ -123,7 +117,6 @@
     <string name="cd_autoplay_keycode_move_up">Presunúť nahor</string>
     <string name="cd_autoplay_keycode_move_down">Presunúť nadol</string>
     <string name="cd_autoplay_keycode_remove">Odstrániť</string>
-    <string name="devices_device_config_section_volumes_label">Hlasitosti</string>
     <string name="devices_device_config_section_volume_label">Hlasitosť</string>
     <string name="devices_device_config_alarm_volume_label">Hlasitosť budíka</string>
     <string name="devices_device_config_alarm_volume_desc">Niektoré aplikácie budíka namiesto toho používajú hlasitosť hudby.</string>
@@ -157,8 +150,6 @@
     <string name="devices_audio_stream_ring_label">Zvonenie</string>
     <string name="devices_audio_stream_notification_label">Upozornenie</string>
     <string name="devices_audio_stream_alarm_label">Budík</string>
-    <string name="devices_neverseen_label">Nikdy nevidené</string>
-    <string name="devices_state_connected_label">Pripojené</string>
     <string name="devices_last_connected_label">Naposledy pripojené: %s</string>
     <string name="devices_currently_connected_label">Momentálne pripojené</string>
     <string name="devices_device_disabled_label">Zariadenie zakázané</string>
@@ -193,10 +184,7 @@
     <string name="devices_settings_desc">Nastavenia, ktoré ovplyvňujú všetky spravované zariadenia.</string>
     <string name="label_app_enabled">Povoliť aplikáciu</string>
     <string name="description_app_enabled">Prepne schopnosť aplikácie reagovať na hlasitosť a udalosti Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Viditeľné úpravy</string>
-    <string name="description_visible_volume_adjustments">Zobraziť systémový panel hlasitosti počas vykonávania zmien aplikáciou.</string>
     <string name="label_volume_listener">Sledovanie zmien</string>
-    <string name="description_volume_listener">Majte sa na pozore počas pripojenia zariadenia a uložte zmeny hlasitosti, ktoré vykonala aplikácia.</string>
     <string name="label_boot_restore">Obnovenie po štarte</string>
     <string name="description_boot_restore">Obnoví hlasitosť pri štarte/reštarte ak je Bluetooth zariadenie pripojené.</string>
     <!-- Settings/Support-->
@@ -206,24 +194,11 @@
     <string name="settings_support_wiki_description">Nauč sa efektívne používať BVM</string>
     <string name="settings_support_issue_tracker_description">Verejný sledovač problémov pre hlásenia chýb a žiadosti o funkcie.</string>
     <string name="settings_support_issue_tracker_label">Sledovač problémov</string>
-    <string name="settings_support_debuglog_label">Ladiaci log</string>
     <string name="settings_support_debuglog_desc">Zaznamenaj všetko, čo aplikácia robí, do textového súboru, ktorý môžeš zdieľať.</string>
-    <string name="settings_support_debuglog_recording_desc">Momentálne sa zaznamenávajú ladiace informácie. Klepni pre zastavenie záznamu.</string>
-    <string name="settings_support_debuglog_path">Cesta k logu: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Veľmi krátky záznam</string>
     <string name="settings_support_debuglog_short_recording_msg">Bol to veľmi krátky záznam. Ladiace logy sú záznamy, nie snímky — reprodukuj problém počas aktívneho záznamu, aby bol log užitočný.</string>
     <string name="settings_support_debuglog_short_recording_continue">Pokračovať v zázname</string>
     <string name="settings_support_debuglog_short_recording_stop">Zastaviť napriek tomu</string>
-    <string name="settings_support_debuglog_folder_label">Priečinok ladiaceho logu</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d relácia používa %2$s</item>
-        <item quantity="few">%1$d relácie používajú %2$s</item>
-        <item quantity="many">%1$d relácie používajú %2$s</item>
-        <item quantity="other">%1$d relácií používa %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Žiadne ladiace logy nie sú uložené</string>
-    <string name="settings_support_debuglog_folder_delete_title">Odstrániť všetky ladiace logy?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Toto natrvalo odstráni všetky uložené relácie ladiaceho logu.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Miesto na chatovanie a kladenie otázok.</string>
     <!-- Settings/Acks-->
@@ -232,16 +207,12 @@
     <string name="settings_acks_translation_header">Preklad</string>
     <string name="settings_acks_translators_title">Prekladatelia</string>
     <string name="settings_acks_translators_people">dukelc</string>
-    <string name="settings_acks_translate_title">Preložiť BVM</string>
-    <string name="settings_acks_translate_desc">Pomôž preložiť BVM do svojho jazyka</string>
     <string name="settings_acks_thanks_header">Poďakovania</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Za podporu prekladu open-source projektov</string>
     <string name="settings_licenses_label">Licencie</string>
     <string name="settings_translation_label">Preklad</string>
     <string name="settings_translation_desc">Pomôžte preložiť aplikáciu do svojho obľúbeného jazyka</string>
-    <string name="settings_sponsor_development_title">Sponzorovať vývoj</string>
-    <string name="settings_sponsor_development_summary">Staň sa patrónom a umožni pokračovanie vývoja.</string>
     <string name="settings_privacy_policy_label">Zásady ochrany osobných údajov</string>
     <string name="settings_privacy_policy_desc">Zodpovedné zaobchádzanie s dátami.</string>
     <string name="changelog_label">Zoznam zmien</string>
@@ -263,10 +234,8 @@
     <string name="backup_restore_success_restore">Obnovenie dokončené — obnovených %1$d zariadení, %2$d preskočených.</string>
     <string name="backup_restore_version_warning">Táto záloha bola vytvorená s verziou %1$s. Momentálne používate %2$s. Niektoré nastavenia sa nemusia obnoviť správne.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Ladiace notifikácie</string>
     <string name="debug_log_consent_title">Ladiaci log</string>
     <string name="debug_log_consent_explanation">Táto funkcia zaznamenáva všetko, čo aplikácia robí, do zdieľateľného súboru. Vygenerovaný súbor obsahuje citlivé informácie (napr. názvy súborov a nainštalované aplikácie). Zdieľaj ho len s dôveryhodnými stranami (napr. vývojárom riešiacim problém).</string>
-    <string name="debug_log_recording_progress">Zaznamenávanie ladiaceho logu</string>
     <string name="debug_log_record_action">Zaznamenať</string>
     <string name="debug_log_stop_action">Zastaviť záznam</string>
     <string name="debug_log_screen_title">Zapisovač ladiaceho logu</string>
@@ -283,7 +252,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Zahodiť</string>
     <string name="debug_log_screen_keep_action">Ponechať</string>
-    <string name="debug_log_compressing_label">Komprimuje sa…</string>
     <string name="debug_log_file_label">Zaznamenaný súbor logu</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Log odoslaný?</string>
@@ -311,7 +279,6 @@
     <string name="contact_description_question_hint">Opíš svoju otázku podrobne.</string>
     <string name="contact_category_section_label">Kategória</string>
     <string name="contact_debug_log_label">Ladiaci log</string>
-    <string name="contact_debug_log_select_hint">Vyber ladiaci log na pripojenie</string>
     <string name="contact_debug_log_picker_hint">Pripoj ladiaci log na rýchlejšie diagnostikovanie problému.</string>
     <string name="contact_debug_log_picker_empty">Žiadne ladiace logy nie sú k dispozícii. Najprv nejaký zaznamenaj.</string>
     <string name="contact_expected_behavior_label">Očakávané správanie</string>
@@ -327,82 +294,32 @@
     <string name="contact_welcome_msg">Každú správu čítam osobne a snažím sa odpovedať čo najlepšie, ale keďže na tom pracujem sám, môže to chvíľku trvať. Ďakujem za trpezlivosť.</string>
     <string name="contact_footer_msg">Tvoja správa bude odoslaná emailom. Informácie o zariadení a nastaveniach sú priložené automaticky.</string>
     <string name="contact_no_email_app_msg">Na tomto zariadení nebola nájdená žiadna emailová aplikácia.</string>
-    <string name="contact_attachment_missing_msg">Súbor ladiaceho logu už neexistuje</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Uložené ladiace logy</string>
     <string name="settings_support_stored_logs_desc">%1$d relácií (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Žiadne uložené ladiace logy</string>
-    <string name="settings_support_stored_logs_delete_title">Odstrániť uložené logy?</string>
-    <string name="settings_support_stored_logs_delete_msg">Toto odstráni všetkých %1$d uložených relácií ladiaceho logu.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Uložené ladiace logy boli odstránené</string>
-    <string name="label_bug_reports">Nahlásenie chyby</string>
-    <string name="description_bug_reports">Automatické nahlásenie chyby a pádu.</string>
     <string name="label_add_device">Pridať zariadenie</string>
-    <string name="label_just_a_moment_please">Chvíľočku, prosím.</string>
     <string name="label_notification_channel_status">Stav</string>
     <string name="label_notification_channel_setup">Požaduje sa nastavenie</string>
     <string name="monitor_notification_starting">Spúšťa sa…</string>
     <string name="action_set">Nastaviť</string>
     <string name="action_cancel">Zrušiť</string>
-    <string name="label_invalid_input">Neplatný vstup</string>
     <string name="action_reset">Resetovať</string>
     <string name="label_no_connected_devices">Žiadne pripojené zariadenia</string>
-    <string name="label_status_idle">Nečinný</string>
-    <string name="label_status_adjusting_volumes">Úprava hlasitosti</string>
-    <string name="label_premium_version">Prémiová verzia</string>
     <string name="general_upgrade_action">Upgradovať</string>
     <string name="common_upgrade_required_label">Vyžaduje sa upgrade</string>
-    <string name="label_premium_version_required">Vyžaduje sa verzia prémium</string>
-    <string name="description_intro_purpose">Táto aplikácia umožňuje vášmu Android zariadeniu uložiť hlasitosti pre rôzne Bluetooth zariadenia.</string>
-    <string name="upgrade_benefit_unlimited_devices">Neobmedzené profily zariadení</string>
-    <string name="upgrade_benefit_connection_actions">Automatické prehrávanie, spustenie aplikácie a upozornenia na pripojenie</string>
-    <string name="upgrade_benefit_theme_customization">Prispôsobenie témy, štýlu a farieb</string>
-    <string name="upgrade_benefit_power_controls">Uzamknutie hlasitosti a obmedzenie rýchlosti</string>
-    <string name="upgrade_benefit_support">Podpora nezávislého vývoja</string>
     <string name="upgrade_benefit_equalizer">• Ekvalizér pre jednotlivé zariadenia (pre hudobné aplikácie s podporou systémového ekvalizéra)</string>
-    <string name="description_intro_tap_the_button">Začnite pridaním vášho prvého zariadenia.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth je vypnutý.</string>
     <string name="title_bluetooth_is_off">Bluetooth je vypnutý</string>
     <string name="action_enable_bluetooth">Zapnúť Bluetooth</string>
     <string name="title_bluetooth_permission_required">Vyžaduje sa povolenie Bluetooth</string>
     <string name="description_bluetooth_permission_required">Táto aplikácia potrebuje povolenie Bluetooth na správu hlasitosti zariadenia.</string>
     <string name="action_grant_permission">Udeliť povolenie</string>
-    <string name="label_status_listening_for_changes">Odpočúvanie zmien hlasitosti</string>
     <string name="action_exit">Ukončiť</string>
-    <string name="action_start">Začať</string>
-    <string name="label_welcome">Vitajte</string>
-    <string name="description_intro_contact">Neváhajte ma kontaktovať, ak máte otázky alebo dokonca nápad na novú funkciu.</string>
-    <string name="label_translation">Preklad</string>
-    <string name="description_help_translate">Pomôžte mi preložiť túto aplikáciu do iných jazykov.</string>
     <string name="label_device_speaker">Reproduktor zariadenia</string>
-    <string name="label_keyevent_playpause">Prehrať/Pozastaviť</string>
-    <string name="label_keyevent_play">Prehrať</string>
-    <string name="label_keyevent_next">Ďalšia</string>
-    <string name="label_install_id">Inštalačné ID</string>
     <string name="message_copied_to_clipboard">Skopírované do schránky</string>
-    <string name="label_thanks">Ďakujeme</string>
-    <string name="label_licenses">Licencie</string>
-    <string name="description_ring_volume_additional_permission">Na zmenu hlasitosti zvonenia je potrebné ďalšie povolenie.</string>
-    <string name="label_missing_permissions">Chýbajúce povolenia</string>
-    <string name="action_grant">Povoliť</string>
-    <string name="label_advanced">Pokročilé</string>
-    <string name="label_exclude_health">Vylúčiť health profiles</string>
-    <string name="description_exclude_health">Niektoré Android zariadenia zamrznú pri hľadaní \'Health Device\' Bluetooth profiles (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Vylúčiť GATT server profiles</string>
-    <string name="label_exclude_gatt">Vylúčiť GATT profily</string>
-    <string name="description_exclude_gattserver">Nepýtať sa na profily Bluetooth typu \&quot;Generic Attributes\&quot; (GATT) server.</string>
-    <string name="description_exclude_gatt">Nepýtať sa na profily Bluetooth typu \&quot;Generic Attributes\&quot; (GATT) klient.</string>
-    <string name="description_waiting_for_devicex">Čaká sa na %s pre dokončenie pripojenia</string>
-    <string name="action_undo">Späť</string>
-    <string name="action_show">Zobraziť</string>
     <string name="action_dismiss">Zrušiť</string>
-    <string name="action_fix">Opraviť</string>
-    <string name="battery_optimizations_issue_description">Optimalizácia batérie pre túto aplikáciu je zapnutá a môže zabrániť prijímaniu Bluetooth udalostí. Zvážte zakázanie optimalizácie, ak máte problémy.</string>
     <string name="label_bluetooth_settings">Nastavenia Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 obmedzuje spôsob spúšťania aplikácií na pozadí. Pre povolenie spúšťania aplikácií po pripojení Bluetooth zariadenia, udeľte povolenie \&quot;Vykresliť cez ďalšie aplikácie\&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Zdrojový kód</string>
-    <string name="android13_notification_permission_description">Udeľ tejto aplikácii povolenie na zobrazovanie notifikácií. Toto umožní zobrazenie notifikácie, keď je aplikácia aktívna a vykonáva úpravy hlasitosti.</string>
-    <string name="privacy_policy_label">Zásady ochrany osobných údajov</string>
     <string name="managed_devices_empty_message">Žiadne Bluetooth zariadenia nie sú nakonfigurované.\nKlepni na tlačidlo + a pridaj svoje prvé zariadenie.</string>
     <string name="label_pro_feature">Prémiová funkcia</string>
     <plurals name="discover_device_limit_banner">
@@ -435,21 +352,15 @@
     <string name="review_app_review_action">Ohodnotiť</string>
     <string name="review_app_dismiss_action">Možno pozdejšie</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Nákup zrušený</string>
-    <string name="error_iap_unavailable_message">Nákupy v aplikácii nie sú dostupné</string>
-    <string name="error_generic_message">Vyskytla sa chyba. Skús to znova.</string>
-    <string name="error_iap_owned_message">Túto položku už vlastníš</string>
     <string name="label_no_devices_title">Žiadne zariadenia</string>
     <string name="bluemusic_mascot_description">Ikona aplikácie</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Vyber aplikácie</string>
     <string name="devices_app_selection_search_hint">Hľadaj aplikácie…</string>
-    <string name="devices_app_selection_currently_selected">Aktuálne vybrané</string>
     <string name="devices_app_selection_selected_count">%d aplikácií vybraných</string>
     <string name="general_navigate_back_action">Navigovať späť</string>
     <string name="general_reset_action">Resetovať</string>
     <string name="general_clear_action">Vymazať</string>
-    <string name="general_save_action">Uložiť</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Zámok</string>
     <string name="devices_indicator_awake">Bude</string>
@@ -459,7 +370,6 @@
     <string name="devices_indicator_limit">Obmedzenie</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Zosilnenie</string>
-    <string name="devices_indicator_launch">Spusti</string>
     <string name="devices_indicator_home">Domov</string>
     <string name="devices_indicator_dnd">NR</string>
     <string name="devices_indicator_alert">Upozornenie</string>

--- a/app/src/main/res/values-sl/strings.xml
+++ b/app/src/main/res/values-sl/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Nekatere funkcije so se spremenile med posodobitvijo. Preverite nastavitve naprave, da se prepričate, da je vse pravilno konfigurirano.</string>
     <string name="onboarding_rewrite_action">Nadaljuj</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Ni najdenih neupravljanih naprav</string>
     <string name="discover_all_devices_managed_msg">Vse vaše seznanjene naprave so upravljane! Želite dodati novo?</string>
     <string name="discover_pair_new_device_action">Seznani novo napravo</string>
     <string name="discover_device_speaker_desc">Lastni zvočnik telefona. Njegove glasnosti se uporabijo, ko se avdio vrne na telefon, npr. po preklopu vaše naprave Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfiguracija naprave</string>
-    <string name="devices_device_config_section_general_label">Splošno</string>
     <string name="devices_device_config_remove_device_label">Pozabi napravo</string>
-    <string name="devices_device_config_remove_device_desc">Pozabi napravo v tej aplikaciji in izbriše njeno konfiguracijo. To ne odseznani naprave.</string>
     <string name="devices_device_config_remove_device_action">Pozabi</string>
     <string name="devices_device_config_remove_device_confirmation">Pozabi %s iz upravljanih naprav?</string>
-    <string name="devices_device_config_rename_device_label">Preimenuj napravo</string>
-    <string name="devices_device_config_rename_device_desc">Preimenuj to napravo v tej aplikaciji in po možnosti tudi v sistemu.</string>
     <string name="devices_device_config_rename_device_action">Preimenuj</string>
     <string name="devices_device_config_enabled_label">Omogočeno</string>
     <string name="devices_device_config_enabled_desc">Reagiraj na to napravo ob priklopu</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Ukazi za samodejno predvajanje</string>
     <string name="devices_device_config_autoplay_keycodes_order">Zaporedje ukazov</string>
     <string name="devices_device_config_autoplay_keycodes_label">Ukazi</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Nastavi, katere ukaze poslati in kakšnem vrstnem redu</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Ni konfiguriranih ukazov</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Dodaj ukaz</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Največ %1$d ukazov</string>
@@ -123,7 +117,6 @@
     <string name="cd_autoplay_keycode_move_up">Premakni gor</string>
     <string name="cd_autoplay_keycode_move_down">Premakni dol</string>
     <string name="cd_autoplay_keycode_remove">Odstrani</string>
-    <string name="devices_device_config_section_volumes_label">Glasnosti</string>
     <string name="devices_device_config_section_volume_label">Glasnost</string>
     <string name="devices_device_config_alarm_volume_label">Glasnost alarma</string>
     <string name="devices_device_config_alarm_volume_desc">Nekatere aplikacije za alarme namesto tega uporabljajo glasnost glasbe.</string>
@@ -157,8 +150,6 @@
     <string name="devices_audio_stream_ring_label">Zvonjenje</string>
     <string name="devices_audio_stream_notification_label">Obvestilo</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Nikoli videno</string>
-    <string name="devices_state_connected_label">Povezano</string>
     <string name="devices_last_connected_label">Nazadnje povezano: %s</string>
     <string name="devices_currently_connected_label">Trenutno povezano</string>
     <string name="devices_device_disabled_label">Naprava onemogočena</string>
@@ -193,10 +184,7 @@
     <string name="devices_settings_desc">Nastavitve, ki vplivajo na vse upravljane naprave.</string>
     <string name="label_app_enabled">Aplikacija omogočena</string>
     <string name="description_app_enabled">Preklopi sposobnost aplikacije za odziv na glasnostne in Bluetooth dogodke.</string>
-    <string name="label_visible_volume_adjustments">Vidne prilagoditve</string>
-    <string name="description_visible_volume_adjustments">Prikaži sistemsko okno glasnosti, ko ta aplikacija izvaja prilagoditve.</string>
     <string name="label_volume_listener">Opazuj spremembe</string>
-    <string name="description_volume_listener">Ostani aktiven, ko je naprava priklopljena, in shrani spremembe glasnosti, ki jih ni povzročila ta aplikacija.</string>
     <string name="label_boot_restore">Obnovi ob zagonu</string>
     <string name="description_boot_restore">Obnovi glasnost po zagonu/ponovnem zagonu, če je priklopljena naprava Bluetooth.</string>
     <!-- Settings/Support-->
@@ -206,24 +194,11 @@
     <string name="settings_support_wiki_description">Naučite se učinkovito uporabljati BVM</string>
     <string name="settings_support_issue_tracker_description">Javni seznam prijav za poročila o hroščih in zahtevah po novih funkcijah.</string>
     <string name="settings_support_issue_tracker_label">Seznam prijav</string>
-    <string name="settings_support_debuglog_label">Razhroščevalni dnevnik</string>
     <string name="settings_support_debuglog_desc">Posnemite delovanje programa v besedilno datoteko, ki jo lahko posredujete.</string>
-    <string name="settings_support_debuglog_recording_desc">Trenutno snemam informacije za odpravljanje napak. Tapnite za ustavitev snemanja.</string>
-    <string name="settings_support_debuglog_path">Pot dnevniške datoteke: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Zelo kratko snemanje</string>
     <string name="settings_support_debuglog_short_recording_msg">To je bilo zelo kratko snemanje. Dnevniki za odpravljanje napak so posnetki, ne posnetki stanja — za koristno dnevniško datoteko reproducirajte težavo med aktivnim snemanjem.</string>
     <string name="settings_support_debuglog_short_recording_continue">Nadaljuj snemanje</string>
     <string name="settings_support_debuglog_short_recording_stop">Ustavi vseeno</string>
-    <string name="settings_support_debuglog_folder_label">Mapa z dnevniki za odpravljanje napak</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d seja z %2$s</item>
-        <item quantity="two">%1$d seji z %2$s</item>
-        <item quantity="few">%1$d seje z %2$s</item>
-        <item quantity="other">%1$d sej z %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Ni shranjenih dnevnikov za odpravljanje napak</string>
-    <string name="settings_support_debuglog_folder_delete_title">Izbriši vse dnevnike za odpravljanje napak?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">To bo trajno izbrisalo vse shranjene seje dnevnikov za odpravljanje napak.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Mesto za druženje in vprašanja.</string>
     <!-- Settings/Acks-->
@@ -232,16 +207,12 @@
     <string name="settings_acks_translation_header">Prevajanje</string>
     <string name="settings_acks_translators_title">Prevajalci</string>
     <string name="settings_acks_translators_people">1. oseba; 2. oseba(izbirno@email.com)</string>
-    <string name="settings_acks_translate_title">Prevedi BVM</string>
-    <string name="settings_acks_translate_desc">Pomagajte prevesti BVM v vaš jezik</string>
     <string name="settings_acks_thanks_header">Zahvale</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Za podporo prevajanju odprtokodnih projektov</string>
     <string name="settings_licenses_label">Dovoljenja</string>
     <string name="settings_translation_label">Prevajanje</string>
     <string name="settings_translation_desc">Pomagajte prevesti aplikacijo v vaš najljubši jezik</string>
-    <string name="settings_sponsor_development_title">Podpri razvoj</string>
-    <string name="settings_sponsor_development_summary">Postanite pokrovitelj in omogočite nadaljnji razvoj.</string>
     <string name="settings_privacy_policy_label">Pravilnik o zasebnosti</string>
     <string name="settings_privacy_policy_desc">Odgovorno ravnanje s podatki.</string>
     <string name="changelog_label">Dnevnik sprememb</string>
@@ -263,10 +234,8 @@
     <string name="backup_restore_success_restore">Obnovitev zaključena — obnovljenih %1$d naprav, %2$d preskočenih.</string>
     <string name="backup_restore_version_warning">Ta varnostna kopija je bila ustvarjena z različico %1$s. Trenutno uporabljate %2$s. Nekatere nastavitve morda ne bodo obnovljene pravilno.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Obvestila o razhroščevanju</string>
     <string name="debug_log_consent_title">Razhroščevalni dnevnik</string>
     <string name="debug_log_consent_explanation">Ta značilnost si v datoteko zabeleži vse, kar počne program.  Ustvarjena datoteka vsebuje občutljive podatke (npr. imena datotek in nameščene programe).  Posredujte jo samo osebam, ki  jim zaupate (npr. razvijalcu, ki poskuša rešiti težavo).</string>
-    <string name="debug_log_recording_progress">Snemanje dnevnika razhroščevanja</string>
     <string name="debug_log_record_action">Snemaj</string>
     <string name="debug_log_stop_action">Ustavi snemanje</string>
     <string name="debug_log_screen_title">Snemalnik dnevnikov za odpravljanje napak</string>
@@ -283,7 +252,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Zavrzi</string>
     <string name="debug_log_screen_keep_action">Ohrani</string>
-    <string name="debug_log_compressing_label">Stiskanje…</string>
     <string name="debug_log_file_label">Posneta datoteka dnevnika</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Je bil dnevnik poslan?</string>
@@ -311,7 +279,6 @@
     <string name="contact_description_question_hint">Podrobno opišite svoje vprašanje.</string>
     <string name="contact_category_section_label">Kategorija</string>
     <string name="contact_debug_log_label">Razhroščevalni dnevnik</string>
-    <string name="contact_debug_log_select_hint">Izberite dnevnik za odpravljanje napak za priložitev</string>
     <string name="contact_debug_log_picker_hint">Priložite dnevnik za odpravljanje napak, da pomagate hitreje diagnosticirati težavo.</string>
     <string name="contact_debug_log_picker_empty">Ni razpoložljivih dnevnikov za odpravljanje napak. Najprej posnemite enega.</string>
     <string name="contact_expected_behavior_label">Pričakovano vedenje</string>
@@ -327,82 +294,32 @@
     <string name="contact_welcome_msg">Vsako sporočilo preberem sam in se potrudim odgovoriti, ampak ker delam na tem sam, lahko traja malo časa. Hvala za vašo potrpežljivost.</string>
     <string name="contact_footer_msg">Vaše sporočilo bo poslano po e-pošti. Informacije o napravi in nastavitvi so priložene samodejno.</string>
     <string name="contact_no_email_app_msg">Na tej napravi ni najdene nobene e-poštne aplikacije.</string>
-    <string name="contact_attachment_missing_msg">Datoteka dnevnika za odpravljanje napak več ne obstaja</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Shranjeni dnevniki za odpravljanje napak</string>
     <string name="settings_support_stored_logs_desc">%1$d sej (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Ni shranjenih dnevnikov za odpravljanje napak</string>
-    <string name="settings_support_stored_logs_delete_title">Izbriši shranjene dnevnike?</string>
-    <string name="settings_support_stored_logs_delete_msg">To bo izbrisalo vseh %1$d shranjenih sej dnevnikov za odpravljanje napak.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Shranjeni dnevniki za odpravljanje napak so izbrisani</string>
-    <string name="label_bug_reports">Poročila o napakah</string>
-    <string name="description_bug_reports">Samodejno poročanje o napakah in zrušitvah.</string>
     <string name="label_add_device">Dodaj napravo</string>
-    <string name="label_just_a_moment_please">Prosim, trenutek.</string>
     <string name="label_notification_channel_status">Stanje</string>
     <string name="label_notification_channel_setup">Potrebna je nastavitev</string>
     <string name="monitor_notification_starting">Zaganjanje…</string>
     <string name="action_set">Nastavi</string>
     <string name="action_cancel">Prekliči</string>
-    <string name="label_invalid_input">Neveljaven vnos.</string>
     <string name="action_reset">Ponastavi</string>
     <string name="label_no_connected_devices">Ni priklopljenih naprav</string>
-    <string name="label_status_idle">V mirovanju</string>
-    <string name="label_status_adjusting_volumes">Prilagajanje glasnosti</string>
-    <string name="label_premium_version">Premium različica</string>
     <string name="general_upgrade_action">Nadgradi</string>
     <string name="common_upgrade_required_label">Zahtevana nadgradnja</string>
-    <string name="label_premium_version_required">Zahtevana je premium različica</string>
-    <string name="description_intro_purpose">Ta aplikacija omogoča vaši napravi Android, da si zapomni glasnost različnih naprav Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Neomejeni profili naprav</string>
-    <string name="upgrade_benefit_connection_actions">Samodejno predvajanje, zagon aplikacij in obvestila o povezavi</string>
-    <string name="upgrade_benefit_theme_customization">Prilagoditev teme, sloga in barv</string>
-    <string name="upgrade_benefit_power_controls">Zaklepanje glasnosti in omejevanje hitrosti</string>
-    <string name="upgrade_benefit_support">Podpri neodvisen razvoj</string>
     <string name="upgrade_benefit_equalizer">• Izenačevalnik za posamezno napravo (za glasbene aplikacije s podporo sistemskega izenačevalnika)</string>
-    <string name="description_intro_tap_the_button">Začnite z dodajanjem prve naprave.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth je onemogočen.</string>
     <string name="title_bluetooth_is_off">Bluetooth je izklopljen</string>
     <string name="action_enable_bluetooth">Omogoči Bluetooth</string>
     <string name="title_bluetooth_permission_required">Zahtevano je dovoljenje za Bluetooth</string>
     <string name="description_bluetooth_permission_required">Ta aplikacija potrebuje dovoljenje za Bluetooth za upravljanje glasnosti vaših naprav.</string>
     <string name="action_grant_permission">Podeli dovoljenje</string>
-    <string name="label_status_listening_for_changes">Počakovanje na spremembe glasnosti</string>
     <string name="action_exit">Izhod</string>
-    <string name="action_start">Zaženi</string>
-    <string name="label_welcome">Dobrodošli!</string>
-    <string name="description_intro_contact">Kontaktirajte me brez oklevanja, če imate vprašanja ali celo idejo za novo funkcijo.</string>
-    <string name="label_translation">Prevajanje</string>
-    <string name="description_help_translate">Pomagajte mi narediti to aplikacijo dostopno v drugih jezikih.</string>
     <string name="label_device_speaker">Sistemski zvoknik</string>
-    <string name="label_keyevent_playpause">Predvajaj-Pavza</string>
-    <string name="label_keyevent_play">Predvajaj</string>
-    <string name="label_keyevent_next">Naprej</string>
-    <string name="label_install_id">ID namestitve</string>
     <string name="message_copied_to_clipboard">Kopirano v odločišče</string>
-    <string name="label_thanks">Zahvale</string>
-    <string name="label_licenses">Dovoljenja</string>
-    <string name="description_ring_volume_additional_permission">Za spremembo glasnosti zvonjenja so potrebna dodatna dovoljenja.</string>
-    <string name="label_missing_permissions">Manjkajoča dovoljenja</string>
-    <string name="action_grant">Podeli</string>
-    <string name="label_advanced">Napredno</string>
-    <string name="label_exclude_health">Izključi zdravstvene profile</string>
-    <string name="description_exclude_health">Nekatere naprave Android se blokirajo pri iskanju profilov Bluetooth za zdravstvene naprave (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Izključi profile strežnika GATT</string>
-    <string name="label_exclude_gatt">Izključi profile GATT</string>
-    <string name="description_exclude_gattserver">Ne poišči profilov Bluetooth vrste \'Generic Attribute\' (GATT) strežnik.</string>
-    <string name="description_exclude_gatt">Ne poišči profilov Bluetooth vrste \'Generic Attribute\' (GATT) odjemalec.</string>
-    <string name="description_waiting_for_devicex">Počakujem, da %s dokonča povezavo</string>
-    <string name="action_undo">Razveljavi</string>
-    <string name="action_show">Prikaži</string>
     <string name="action_dismiss">Opusti</string>
-    <string name="action_fix">Popravi</string>
-    <string name="battery_optimizations_issue_description">Optimizacije baterije so omogočene za to aplikacijo in ji lahko preprečijo prejemanje Bluetooth dogodkov. Razmislite o onemogočanju optimizacij, če imate težave.</string>
     <string name="label_bluetooth_settings">Nastavitve Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 omejuje, kako se aplikacije lahko zaženejo iz ozadja. Za dovoljenje odpiranja aplikacij ob priklopu naprave Bluetooth podeli dovoljenje „Prikazovanje nad drugimi aplikacijami“ (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Izvorna koda</string>
-    <string name="android13_notification_permission_description">Tej aplikaciji podeli dovoljenje za objavo obvestil. To omogoča prikaz obvestila, ko je ta aplikacija aktivna in se izvajajo prilagoditve glasnosti.</string>
-    <string name="privacy_policy_label">Pravilnik o zasebnosti</string>
     <string name="managed_devices_empty_message">Ni konfiguriranih naprav Bluetooth.\nTapnite gumb +, da dodate svojo prvo napravo.</string>
     <string name="label_pro_feature">Premium funkcija</string>
     <plurals name="discover_device_limit_banner">
@@ -435,21 +352,15 @@
     <string name="review_app_review_action">Oceni</string>
     <string name="review_app_dismiss_action">Morda kasneje</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Nakup prekinjen</string>
-    <string name="error_iap_unavailable_message">Nakupi v aplikaciji niso na voljo</string>
-    <string name="error_generic_message">Prišlo je do napake. Prosim, poskusite znova.</string>
-    <string name="error_iap_owned_message">Ta predmet že imate</string>
     <string name="label_no_devices_title">Ni naprav</string>
     <string name="bluemusic_mascot_description">Ikona aplikacije</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Izberi aplikacije</string>
     <string name="devices_app_selection_search_hint">Poišči aplikacije…</string>
-    <string name="devices_app_selection_currently_selected">Trenutno izbrano</string>
     <string name="devices_app_selection_selected_count">Izbranih %d aplikacij</string>
     <string name="general_navigate_back_action">Pojdi nazaj</string>
     <string name="general_reset_action">Ponastavi</string>
     <string name="general_clear_action">Počisti</string>
-    <string name="general_save_action">Shrani</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Zakleni</string>
     <string name="devices_indicator_awake">Budno</string>
@@ -459,7 +370,6 @@
     <string name="devices_indicator_limit">Omejitev</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Ojačanje</string>
-    <string name="devices_indicator_launch">Zaženi</string>
     <string name="devices_indicator_home">Domov</string>
     <string name="devices_indicator_dnd">Ne moti</string>
     <string name="devices_indicator_alert">Opozorilo</string>

--- a/app/src/main/res/values-sq-rAL/strings.xml
+++ b/app/src/main/res/values-sq-rAL/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Disa veçori kanë ndryshuar gjatë përditësimit. Ju lutemi kontrolloni cilësimet e pajisjes tuaj për të siguruar që gjithçka është konfiguruar saktë.</string>
     <string name="onboarding_rewrite_action">Vazhdo</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Nuk u gjetën pajisje të pamenaxhuara</string>
     <string name="discover_all_devices_managed_msg">Të gjitha pajisjet e tua të çiftuara janë të menaxhuara! Ke nevojë për një të re?</string>
     <string name="discover_pair_new_device_action">Çiftua pajisje të re</string>
     <string name="discover_device_speaker_desc">Altoparlanti i vetë i këtij telefoni. Volumet e tij zbatohen kur audio kthehet në telefon, p.sh. pasi pajisja juaj Bluetooth shkëputohet.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Konfigurimi i pajisjes</string>
-    <string name="devices_device_config_section_general_label">Përgjithshta</string>
     <string name="devices_device_config_remove_device_label">Harro pajisje</string>
-    <string name="devices_device_config_remove_device_desc">Harron pajisjen nga ky aplikacion dhe fshi konfigurimin e saj. Kjo nuk e çiftuan pajisjen.</string>
     <string name="devices_device_config_remove_device_action">Harro</string>
     <string name="devices_device_config_remove_device_confirmation">Harro %s nga pajisjet e menaxhuara?</string>
-    <string name="devices_device_config_rename_device_label">Riemëro pajisje</string>
-    <string name="devices_device_config_rename_device_desc">Riemëro këtë pajisje brenda këtij aplikacioni, dhe nëse është e mundur, brenda sistemit.</string>
     <string name="devices_device_config_rename_device_action">Riemëro</string>
     <string name="devices_device_config_enabled_label">Aktivizuar</string>
     <string name="devices_device_config_enabled_desc">Reago ndaj kësaj pajisjeje kur lidhet</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Komandat e luajtjes automatike</string>
     <string name="devices_device_config_autoplay_keycodes_order">Sekuenca e komandave</string>
     <string name="devices_device_config_autoplay_keycodes_label">Komandat</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Konfiguroni cilat komanda të dërgoni dhe në çfarë rendi</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Nuk ka komanda të konfiguruara</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Shto komandë</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimumi %1$d komanda</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Lëviz lart</string>
     <string name="cd_autoplay_keycode_move_down">Lëviz poshtë</string>
     <string name="cd_autoplay_keycode_remove">Hiq</string>
-    <string name="devices_device_config_section_volumes_label">Volumet</string>
     <string name="devices_device_config_section_volume_label">Vëllimi</string>
     <string name="devices_device_config_alarm_volume_label">Vëllimi i alarmit</string>
     <string name="devices_device_config_alarm_volume_desc">Disa aplikacione alarmi përdorin volumin e muzikës në vend.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Zile</string>
     <string name="devices_audio_stream_notification_label">Njoftim</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
-    <string name="devices_neverseen_label">Kurrë i parë</string>
-    <string name="devices_state_connected_label">I lidhur</string>
     <string name="devices_last_connected_label">I lidhur për herë të fundit: %s</string>
     <string name="devices_currently_connected_label">Aktualisht i lidhur</string>
     <string name="devices_device_disabled_label">Pajisja e çaktivizuar</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Cilësimet që ndikojnë në të gjitha pajisjet e menaxhuara.</string>
     <string name="label_app_enabled">Aplikacioni i aktivizuar</string>
     <string name="description_app_enabled">Aktivizohej aftësinë e aplikacionit për t\'iu përgjigjur ngjarjeve të volumit dhe Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Përshtatje të dukshme</string>
-    <string name="description_visible_volume_adjustments">Shfaq dritaren e volumit të sistemit ndërsa ky aplikacion bën përshtatje.</string>
     <string name="label_volume_listener">Mbikëqyr ndryshimet</string>
-    <string name="description_volume_listener">Qëndro aktiv ndërsa pajisja lidhet dhe ruaj ndryshimet e volumit që nuk janë shkaktuar nga ky aplikacion.</string>
     <string name="label_boot_restore">Restauro në nisje</string>
     <string name="description_boot_restore">Restauro volumin pas nisjes/rishisjes nëse pajisja Bluetooth lidhet.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Mëso si të përdorësh BVM në mënyrë efektive</string>
     <string name="settings_support_issue_tracker_description">Një ndjekës publik i problemeve për raporte gabimesh dhe kërkesa përmes veçorish.</string>
     <string name="settings_support_issue_tracker_label">Ndjekës problemesh</string>
-    <string name="settings_support_debuglog_label">Regjistri i gabimit</string>
     <string name="settings_support_debuglog_desc">Regjistro gjithçka që bën aplikacioni në një skedar teksti që mund të ndarë.</string>
-    <string name="settings_support_debuglog_recording_desc">Aktualisht po regjistrohen informacione të debugging. Prekni për të ndaluar regjistrimin.</string>
-    <string name="settings_support_debuglog_path">Rruga regjistri: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Regjistrim shumë i shkurtër</string>
     <string name="settings_support_debuglog_short_recording_msg">Ishte një regjistrim shumë i shkurtër. Regjistrat e debugging janë regjistrime, jo fotografi — riprodhoni problemin ndërkohë që regjistrimi është aktiv që regjistri të jetë i dobishëm.</string>
     <string name="settings_support_debuglog_short_recording_continue">Vazhdo regjistrimin</string>
     <string name="settings_support_debuglog_short_recording_stop">Ndaloje gjithsesi</string>
-    <string name="settings_support_debuglog_folder_label">Dosja e regjistrit të debugging</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d seancë duke përdorur %2$s</item>
-        <item quantity="other">%1$d seanca duke përdorur %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nuk ka regjistër debugging të ruajtur</string>
-    <string name="settings_support_debuglog_folder_delete_title">Fshi të gjithë regjistrat e debugging?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Kjo do të fshijë përgjithmonë të gjitha seancat e ruajtura të regjistrit të debugging.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Një vend për të qëndruar dhe për të bërë pyetje.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Përkthim</string>
     <string name="settings_acks_translators_title">Përkthyesit</string>
     <string name="settings_acks_translators_people">Luan; Scarface (LuanGX@gmail.com)</string>
-    <string name="settings_acks_translate_title">Përkthej BVM</string>
-    <string name="settings_acks_translate_desc">Ndihmo të përkthej BVM në gjuhën tuaj</string>
     <string name="settings_acks_thanks_header">Falenderim</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Për mbështetjen e përkthimit të projekteve me kod të hapur</string>
     <string name="settings_licenses_label">Licencat</string>
     <string name="settings_translation_label">Përkthimi</string>
     <string name="settings_translation_desc">Ndihmoni në përkthimin e aplikacionit në gjuhën tuaj të preferuar</string>
-    <string name="settings_sponsor_development_title">Shpenzo zhvillimin</string>
-    <string name="settings_sponsor_development_summary">Bëhu patron dhe mundëso zhvillimin e vazhdueshëm.</string>
     <string name="settings_privacy_policy_label">Politika e privatësisë</string>
     <string name="settings_privacy_policy_desc">Trajtim përgjegjës i të dhënave.</string>
     <string name="changelog_label">Ndryshimet regjistri</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Rivendosja u përfundua — %1$d pajisje u rivendosën, %2$d u kapërcyen.</string>
     <string name="backup_restore_version_warning">Ky rezervim u krijua me versionin %1$s. Ju po përdorni %2$s. Disa cilësime mund të mos rivendosen saktë.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Njoftimet e debugging</string>
     <string name="debug_log_consent_title">Regjistri i gabimit</string>
     <string name="debug_log_consent_explanation">Ky veçori regjistron gjithçka që bën aplikacioni në një skedar të ndarë. Skedari i gjeneruar përmban informacione të ndjeshme (p.sh. emra skedarësh dhe aplikacione të instaluara). Ndaj vetëm me palë të besuara (p.sh. një zhvilluesi që gjidhjet një problem).</string>
-    <string name="debug_log_recording_progress">Regjistri i regjistrimit të debugging</string>
     <string name="debug_log_record_action">Regjistro</string>
     <string name="debug_log_stop_action">Ndaloni regjistrimin</string>
     <string name="debug_log_screen_title">Rejistues i Regjistrit të Debugging</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Hedh</string>
     <string name="debug_log_screen_keep_action">Mbaj</string>
-    <string name="debug_log_compressing_label">Duke kompresuar…</string>
     <string name="debug_log_file_label">Skedari i regjistrit të regjistruar</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Regjistri u dërgua?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Përshkruaj pyetjen tënde në detaje.</string>
     <string name="contact_category_section_label">Kategoria</string>
     <string name="contact_debug_log_label">Regjistri i debugging</string>
-    <string name="contact_debug_log_select_hint">Zgjidh një regjistër debugging për të bashkangjitur</string>
     <string name="contact_debug_log_picker_hint">Bashkangji një regjistër debugging për të ndihmuar diagnostikimin e problemit më shpejt.</string>
     <string name="contact_debug_log_picker_empty">Nuk ka regjistër debugging të disponueshëm. Regjistro njërin fillimisht.</string>
     <string name="contact_expected_behavior_label">Sjellja e pritshme</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Lexoj çdo mesazh vetë dhe bëj çmos të përgjigjem, por meqë punoj vetëm, mund të duhet pak kohë. Faleminderit për durim.</string>
     <string name="contact_footer_msg">Mesazhi yt do të dërgohet me email. Informacioni i pajisjes dhe i konfigurimit bashkëngjitet automatikisht.</string>
     <string name="contact_no_email_app_msg">Nuk u gjet asnjë aplikacion emaili në këtë pajisje.</string>
-    <string name="contact_attachment_missing_msg">Skedari i regjistrit të debugging nuk ekziston më</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Regjistrat e ruajtur të debugging</string>
     <string name="settings_support_stored_logs_desc">%1$d seanca (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Nuk ka regjistër të ruajtur debugging</string>
-    <string name="settings_support_stored_logs_delete_title">Fshi regjistrat e ruajtur?</string>
-    <string name="settings_support_stored_logs_delete_msg">Kjo do të fshijë të gjitha %1$d seancat e ruajtura të regjistrit të debugging.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Regjistrat e ruajtur të debugging u fshinë</string>
-    <string name="label_bug_reports">Raportet e gabimeve</string>
-    <string name="description_bug_reports">Raportim automatik i gabimeve dhe kërcimit.</string>
     <string name="label_add_device">Shto pajisje</string>
-    <string name="label_just_a_moment_please">Shëndete, një moment.</string>
     <string name="label_notification_channel_status">Statusi</string>
     <string name="label_notification_channel_setup">Kërkohet konfigurim</string>
     <string name="monitor_notification_starting">Po nisen…</string>
     <string name="action_set">Vendos</string>
     <string name="action_cancel">Anulo</string>
-    <string name="label_invalid_input">Hyrje e pavlefshme</string>
     <string name="action_reset">Zgjojë</string>
     <string name="label_no_connected_devices">Nuk ka paisje të lidhur</string>
-    <string name="label_status_idle">Nëpërmjet</string>
-    <string name="label_status_adjusting_volumes">Përshtatje e volumeve</string>
-    <string name="label_premium_version">Versioni premium</string>
     <string name="general_upgrade_action">Ngriti</string>
     <string name="common_upgrade_required_label">Kërkohet përmirësim</string>
-    <string name="label_premium_version_required">Kërkohet versioni premium</string>
-    <string name="description_intro_purpose">Ky aplikacion lejon pajisjen tuaj Android të mbajë mend volumin e pajisjeve të ndryshme Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Profile të pakufizuara pajisje</string>
-    <string name="upgrade_benefit_connection_actions">Luajtje automatike, hapje aplikacioni dhe njoftime lidhjeje</string>
-    <string name="upgrade_benefit_theme_customization">Personalizim i temës, stilit dhe ngjyrës</string>
-    <string name="upgrade_benefit_power_controls">Bllokimi i volumit dhe kufizimi i shpejtësisë</string>
-    <string name="upgrade_benefit_support">Mbështetni zhvillimin e pavarur</string>
     <string name="upgrade_benefit_equalizer">• Ekualizator për çdo pajisje (për aplikacione muzike me mbështetje për ekualizatorin e sistemit)</string>
-    <string name="description_intro_tap_the_button">Filloje duke shtuar pajisjen tuaj të parë.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth është i çaktivizuar.</string>
     <string name="title_bluetooth_is_off">Bluetooth është Mbyllur</string>
     <string name="action_enable_bluetooth">Aktivizo Bluetooth</string>
     <string name="title_bluetooth_permission_required">Leja Bluetooth Kërkohej</string>
     <string name="description_bluetooth_permission_required">Ky aplikacion ka nevojë për lejen e Bluetooth për të menaxhuar volumet e pajisjes tuaj.</string>
     <string name="action_grant_permission">Jep Lejë</string>
-    <string name="label_status_listening_for_changes">Dëgjim ndryshimesh vëllimi</string>
     <string name="action_exit">Dalje</string>
-    <string name="action_start">Fillimi</string>
-    <string name="label_welcome">Mirëse</string>
-    <string name="description_intro_contact">Mos ngurro të më kontaktosh nëse ke pyetje ose edhe një ide për një veçori të re.</string>
-    <string name="label_translation">Përkthim</string>
-    <string name="description_help_translate">Më ndihmo të bëj këtë aplikacion të disponueshëm në gjuhë të tjera.</string>
     <string name="label_device_speaker">Altoparlanti i pajisjes</string>
-    <string name="label_keyevent_playpause">Luaj-Pauzo</string>
-    <string name="label_keyevent_play">Luaj</string>
-    <string name="label_keyevent_next">Tjetri</string>
-    <string name="label_install_id">Instali ID</string>
     <string name="message_copied_to_clipboard">Kopjuar në clipboard</string>
-    <string name="label_thanks">Falenderim</string>
-    <string name="label_licenses">Licencat</string>
-    <string name="description_ring_volume_additional_permission">Lejet shtesë janë të nevojshme për ndryshimin e volumit të ziles.</string>
-    <string name="label_missing_permissions">Lejet që mungojnë</string>
-    <string name="action_grant">Jep</string>
-    <string name="label_advanced">Përparimtari</string>
-    <string name="label_exclude_health">Përjashtimi i profileve të shëndetit</string>
-    <string name="description_exclude_health">Disa pajisje Android varen kur kërkojnë \'Pajisje Shëndetit\' Bluetooth profilit (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Përjashtimi i profileve të serverit GATT</string>
-    <string name="label_exclude_gatt">Përjashtimi i profileve GATT</string>
-    <string name="description_exclude_gattserver">Mos kërkuaj profilet e Bluetooth të llojit \'Atributi Përgjithshëm\' (GATT) server.</string>
-    <string name="description_exclude_gatt">Mos kërkuaj profilet e Bluetooth të llojit \'Atributi Përgjithshëm\' (GATT) klient.</string>
-    <string name="description_waiting_for_devicex">Duke pritur %s për të përfunduar lidhjen</string>
-    <string name="action_undo">Zhbëj</string>
-    <string name="action_show">Shfaq</string>
     <string name="action_dismiss">Përjasho</string>
-    <string name="action_fix">Zgjidh</string>
-    <string name="battery_optimizations_issue_description">Optimizatat e baterisë janë të aktivizuara për këtë aplikacion dhe mund ta parandalojnë atë të marrë ngjarje Bluetooth. Konsideroni çaktivizimin e optimizimeve nëse po përjetoni probleme.</string>
     <string name="label_bluetooth_settings">Cilësimet e Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 kufizon se si aplikacionet mund të lancohen nga foni. Për të lejuar hapjen e aplikacioneve kur lidhet pajisje Bluetooth, jepni lejën \"Shfaq mbi aplikacionet e tjera\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Kodi burim</string>
-    <string name="android13_notification_permission_description">Jepeni këtij aplikacioni lejen për të postuar njoftimet. Kjo lejon shfaqjen e një njoftimi kur ky aplikacion është aktiv dhe bëhen përshtatje të volumit.</string>
-    <string name="privacy_policy_label">Politika e privatësisë</string>
     <string name="managed_devices_empty_message">Nuk ka paisje Bluetooth të konfiguruar.\nPrekni butonin + për të shtuar pajisjen tuaj të parë.</string>
     <string name="label_pro_feature">Veçori premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Rishikimi</string>
     <string name="review_app_dismiss_action">Ndoshta më vonë</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Blerjeja u anulua</string>
-    <string name="error_iap_unavailable_message">Blerjet brenda aplikacionit nuk janë të disponueshme</string>
-    <string name="error_generic_message">Ndodhi një gabim. Ju lutemi provoni përsëri.</string>
-    <string name="error_iap_owned_message">Ju tashmë zotërojnë këtë artikull</string>
     <string name="label_no_devices_title">Nuk ka Paisjesh</string>
     <string name="bluemusic_mascot_description">Ikona e aplikacionit</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Zgjidh Aplikacionet</string>
     <string name="devices_app_selection_search_hint">Kërkoni aplikacionet…</string>
-    <string name="devices_app_selection_currently_selected">Aktualisht i zgjedhur</string>
     <string name="devices_app_selection_selected_count">%d aplikacione të përzgjedhur</string>
     <string name="general_navigate_back_action">Navigo mbrapa</string>
     <string name="general_reset_action">Zgjojë</string>
     <string name="general_clear_action">Pastro</string>
-    <string name="general_save_action">Ruaj</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Bllokimi</string>
     <string name="devices_indicator_awake">Zgjuar</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Kufiri</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Përforcim</string>
-    <string name="devices_indicator_launch">Lance</string>
     <string name="devices_indicator_home">Shtëpi</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Alarm</string>

--- a/app/src/main/res/values-sr/strings.xml
+++ b/app/src/main/res/values-sr/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Неке функције су се промениле током ажурирања. Молим проверите подешавања вашег уређаја да бисте сигурни да је све исправно подешено.</string>
     <string name="onboarding_rewrite_action">Настави</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Ниједан неуправљан уређај није понађен</string>
     <string name="discover_all_devices_managed_msg">Сви ваши спарени уређаји су већ управљани! Требате нови?</string>
     <string name="discover_pair_new_device_action">Упари нови уређај</string>
     <string name="discover_device_speaker_desc">Сопствени звучник телефона. Јачине звука се примењују када се звук врати на телефон, нпр. након што се твој Bluetooth уређај откачи.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Конфигурација уређаја</string>
-    <string name="devices_device_config_section_general_label">Oпште</string>
     <string name="devices_device_config_remove_device_label">Заборави уређај</string>
-    <string name="devices_device_config_remove_device_desc">Заборавља уређај из ове апликације и брише његову конфигурацију. Ово не испарује уређај.</string>
     <string name="devices_device_config_remove_device_action">Заборави</string>
     <string name="devices_device_config_remove_device_confirmation">Заборавити %s са списка управљаних уређаја?</string>
-    <string name="devices_device_config_rename_device_label">Преименуј уређај</string>
-    <string name="devices_device_config_rename_device_desc">Преименује овај уређај у овој апликацији, а ако је могуће и у систему.</string>
     <string name="devices_device_config_rename_device_action">Преименуј</string>
     <string name="devices_device_config_enabled_label">Омогућено</string>
     <string name="devices_device_config_enabled_desc">Реагуј на овај уређај кад је повезан</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Команде аутоматског пуштања</string>
     <string name="devices_device_config_autoplay_keycodes_order">Редослед команди</string>
     <string name="devices_device_config_autoplay_keycodes_label">Команде</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Подеси које команде да се шаљу и којим редоследом</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Нема конфигурисаних команди</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Додај команду</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Максимум %1$d команди</string>
@@ -122,7 +116,6 @@
     <string name="cd_autoplay_keycode_move_up">Помери горе</string>
     <string name="cd_autoplay_keycode_move_down">Помери доле</string>
     <string name="cd_autoplay_keycode_remove">Уклони</string>
-    <string name="devices_device_config_section_volumes_label">Јачине</string>
     <string name="devices_device_config_section_volume_label">Јачина</string>
     <string name="devices_device_config_alarm_volume_label">Јачина аларма</string>
     <string name="devices_device_config_alarm_volume_desc">Неке апликације за аларм уместо тога користе јачину музике.</string>
@@ -156,8 +149,6 @@
     <string name="devices_audio_stream_ring_label">Звон</string>
     <string name="devices_audio_stream_notification_label">Обавештење</string>
     <string name="devices_audio_stream_alarm_label">Аларм</string>
-    <string name="devices_neverseen_label">Никад није виђен</string>
-    <string name="devices_state_connected_label">Повезан</string>
     <string name="devices_last_connected_label">Последња веза: %s</string>
     <string name="devices_currently_connected_label">Тренутно повезан</string>
     <string name="devices_device_disabled_label">Уређај онемогућен</string>
@@ -192,10 +183,7 @@
     <string name="devices_settings_desc">Подешавања која утичу на све управљане уређаје.</string>
     <string name="label_app_enabled">Апликација укључена</string>
     <string name="description_app_enabled">Прекида способност апликације да реагује на догађаје јачине и Bluetooth догађаје.</string>
-    <string name="label_visible_volume_adjustments">Видљива подешавања</string>
-    <string name="description_visible_volume_adjustments">Прикажи системски прозор јачине звука док ова апликација врши подешавања.</string>
     <string name="label_volume_listener">Прати промене</string>
-    <string name="description_volume_listener">Остај активан док је уређај повезан и сачувај промене јачине звука које нису направљене овом апликацијом.</string>
     <string name="label_boot_restore">Врати након покретања</string>
     <string name="description_boot_restore">Врати јачину након покретања/поновног покретања ако је Bluetooth уређај повезан.</string>
     <!-- Settings/Support-->
@@ -205,23 +193,11 @@
     <string name="settings_support_wiki_description">Научи како ефикасно користити BVM</string>
     <string name="settings_support_issue_tracker_description">Јавно праћење проблема за извештаје о грешкама и будућим захтевима.</string>
     <string name="settings_support_issue_tracker_label">Праћење проблема</string>
-    <string name="settings_support_debuglog_label">Извештај о грешкама</string>
     <string name="settings_support_debuglog_desc">Снимите све што апликација ради у текстуалну датотеку коју можете да делите.</string>
-    <string name="settings_support_debuglog_recording_desc">Тренутно снимају се информације отклањања. Додирни за заустављање снимања.</string>
-    <string name="settings_support_debuglog_path">Пут записа: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Врло кратко снимање</string>
     <string name="settings_support_debuglog_short_recording_msg">То је било врло кратко снимање. Дебаг записи су снимци, не снимци тренутног стања — репродукуј проблем док је снимање активно да би запис био користан.</string>
     <string name="settings_support_debuglog_short_recording_continue">Настави снимање</string>
     <string name="settings_support_debuglog_short_recording_stop">Ипак заустави</string>
-    <string name="settings_support_debuglog_folder_label">Фасцикла са дебаг записима</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d сесија користи %2$s</item>
-        <item quantity="few">%1$d сесије користе %2$s</item>
-        <item quantity="other">%1$d сесија користи %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Нема сачуваних дебаг записа</string>
-    <string name="settings_support_debuglog_folder_delete_title">Избрисати све дебаг записе?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Ово ће трајно избрисати све сачуване сесије дебаг записа.</string>
     <string name="settings_support_discord_label">Дискорд</string>
     <string name="settings_support_discord_description">Место за дружење и постављање питања.</string>
     <!-- Settings/Acks-->
@@ -230,16 +206,12 @@
     <string name="settings_acks_translation_header">Превод</string>
     <string name="settings_acks_translators_title">Преводиоци</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Преведи BVM</string>
-    <string name="settings_acks_translate_desc">Помози превођење BVM на свој језик</string>
     <string name="settings_acks_thanks_header">Хвала</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">За подршку превођења пројеката отвореног кода</string>
     <string name="settings_licenses_label">Лиценце</string>
     <string name="settings_translation_label">Превод</string>
     <string name="settings_translation_desc">Помози превођење апликације на свој омиљени језик</string>
-    <string name="settings_sponsor_development_title">Спонзориши развој</string>
-    <string name="settings_sponsor_development_summary">Постаните покровитељ и омогућите даљи развој.</string>
     <string name="settings_privacy_policy_label">Политика приватности</string>
     <string name="settings_privacy_policy_desc">Одговорно поступање са подацима.</string>
     <string name="changelog_label">Дневник измена</string>
@@ -261,10 +233,8 @@
     <string name="backup_restore_success_restore">Враћање завршено — %1$d уређаја враћено, %2$d прескочено.</string>
     <string name="backup_restore_version_warning">Ова резервна копија је направљена са верзијом %1$s. Тренутно користите %2$s. Нека подешавања можда неће бити правилно враћена.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Обавештења о отклањању грешака</string>
     <string name="debug_log_consent_title">Извештај о грешкама</string>
     <string name="debug_log_consent_explanation">Ова функција снима све што апликација ради у датотеку коју можете поделити. Генерисана датотека садржи осетљиве информације (нпр. имена датотека и инсталиране апликације). Делите је само са поузданим странама (нпр. програмером који решава проблем).</string>
-    <string name="debug_log_recording_progress">Снимање дневника за отклањање грешака</string>
     <string name="debug_log_record_action">Сними</string>
     <string name="debug_log_stop_action">Заустави снимање</string>
     <string name="debug_log_screen_title">Снимач дебаг записа</string>
@@ -280,7 +250,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Одбаци</string>
     <string name="debug_log_screen_keep_action">Задржи</string>
-    <string name="debug_log_compressing_label">Компресија…</string>
     <string name="debug_log_file_label">Снимљена датотека евиденције</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Запис послат?</string>
@@ -308,7 +277,6 @@
     <string name="contact_description_question_hint">Опиши своје питање детаљно.</string>
     <string name="contact_category_section_label">Категорија</string>
     <string name="contact_debug_log_label">Извештај о грешкама</string>
-    <string name="contact_debug_log_select_hint">Изабери дебаг запис за прилог</string>
     <string name="contact_debug_log_picker_hint">Приложи дебаг запис да би помогао/ла брже дијагностиковање проблема.</string>
     <string name="contact_debug_log_picker_empty">Нема доступних дебаг записа. Сними пре некога.</string>
     <string name="contact_expected_behavior_label">Очекивано понашање</string>
@@ -323,82 +291,32 @@
     <string name="contact_welcome_msg">Сваку поруку прочитам сам и трудим се да одговорим, али пошто радим на томе сам, може да потраје мало времена. Хвала на стрпљењу.</string>
     <string name="contact_footer_msg">Твоја порука ће бити послата путем имејла. Информације о уређају и подешавању се прилажу аутоматски.</string>
     <string name="contact_no_email_app_msg">Нема апликације за имејл на овом уређају.</string>
-    <string name="contact_attachment_missing_msg">Датотека дебаг записа више не постоји</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Сачувани дебаг записи</string>
     <string name="settings_support_stored_logs_desc">%1$d сесија (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Нема сачуваних дебаг записа</string>
-    <string name="settings_support_stored_logs_delete_title">Избрисати сачуване записе?</string>
-    <string name="settings_support_stored_logs_delete_msg">Ово ће избрисати свих %1$d сачуваних сесија дебаг записа.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Сачувани дебаг записи избрисани</string>
-    <string name="label_bug_reports">Извештаји о грешкама</string>
-    <string name="description_bug_reports">Аутоматско извештавање о грешкама и рушењима.</string>
     <string name="label_add_device">Додај уређај</string>
-    <string name="label_just_a_moment_please">Моментице, молим.</string>
     <string name="label_notification_channel_status">Статус</string>
     <string name="label_notification_channel_setup">Потребна подешавања</string>
     <string name="monitor_notification_starting">Покретање…</string>
     <string name="action_set">Постави</string>
     <string name="action_cancel">Откажи</string>
-    <string name="label_invalid_input">Неисправан унос</string>
     <string name="action_reset">Ресетуј</string>
     <string name="label_no_connected_devices">Ниједан уређај није повезан</string>
-    <string name="label_status_idle">Неактиван</string>
-    <string name="label_status_adjusting_volumes">Подешавање јачина</string>
-    <string name="label_premium_version">Премијум верзија</string>
     <string name="general_upgrade_action">Надогради</string>
     <string name="common_upgrade_required_label">Потребна надоградња</string>
-    <string name="label_premium_version_required">Потребна премијум верзија</string>
-    <string name="description_intro_purpose">Ова апликација омогућава твом Андроид уређају да памти јачину звука различитих Bluetooth уређаја.</string>
-    <string name="upgrade_benefit_unlimited_devices">Неограничени профили уређаја</string>
-    <string name="upgrade_benefit_connection_actions">Аутоматско пуштање, покретање апликације и упозорења о вези</string>
-    <string name="upgrade_benefit_theme_customization">Прилагођавање теме, стила и боје</string>
-    <string name="upgrade_benefit_power_controls">Закључавање јачине звука и ограничавање брзине</string>
-    <string name="upgrade_benefit_support">Подржите независни развој</string>
     <string name="upgrade_benefit_equalizer">• Еквалајзер по уређају (за апликације за музику са подршком за системски еквалајзер)</string>
-    <string name="description_intro_tap_the_button">Почни додавањем свог првог уређаја.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth је онемогућен.</string>
     <string name="title_bluetooth_is_off">Bluetooth је искључен</string>
     <string name="action_enable_bluetooth">Укључи Bluetooth</string>
     <string name="title_bluetooth_permission_required">Потребна Bluetooth дозвола</string>
     <string name="description_bluetooth_permission_required">Ова апликација треба Bluetooth дозволу да би управљала јачинама звука твојих уређаја.</string>
     <string name="action_grant_permission">Додели дозволу</string>
-    <string name="label_status_listening_for_changes">Слуша промене јачине</string>
     <string name="action_exit">Излаз</string>
-    <string name="action_start">Покрени</string>
-    <string name="label_welcome">Добродошли</string>
-    <string name="description_intro_contact">Не оклевај да ме контактираш ако имаш питања или идеју за нову функцију.</string>
-    <string name="label_translation">Превод</string>
-    <string name="description_help_translate">Помози ми да апликација буде доступна на другим језицима.</string>
     <string name="label_device_speaker">Звучник уређаја</string>
-    <string name="label_keyevent_playpause">Пуштаи/Паузирај</string>
-    <string name="label_keyevent_play">Пусти</string>
-    <string name="label_keyevent_next">Следеће</string>
-    <string name="label_install_id">Инсталиран ИД</string>
     <string name="message_copied_to_clipboard">Копирано у међуспремник</string>
-    <string name="label_thanks">Хвала</string>
-    <string name="label_licenses">Лиценце</string>
-    <string name="description_ring_volume_additional_permission">Додатне дозволе су неопходне да би се променила јачина звона.</string>
-    <string name="label_missing_permissions">Недостају дозволе</string>
-    <string name="action_grant">Додели</string>
-    <string name="label_advanced">Напредно</string>
-    <string name="label_exclude_health">Искључи здравствене профиле</string>
-    <string name="description_exclude_health">Неки Андроид уређаји зависе приликом прегледа \'Health Device\' Bluetooth профила (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Искључи GATT сервер профиле</string>
-    <string name="label_exclude_gatt">Искључи GATT профиле</string>
-    <string name="description_exclude_gattserver">Не прегледај Bluetooth профиле типа \'Generic Attribute\' (GATT) сервер.</string>
-    <string name="description_exclude_gatt">Не прегледај Bluetooth профиле типа \'Generic Attribute\' (GATT) клијент.</string>
-    <string name="description_waiting_for_devicex">Чека да %s заврши повезивање</string>
-    <string name="action_undo">Опозови</string>
-    <string name="action_show">Прикажи</string>
     <string name="action_dismiss">Одбаци</string>
-    <string name="action_fix">Поправи</string>
-    <string name="battery_optimizations_issue_description">Оптимизација батерије је омогућена за ову апликацију и може спречити пријем Bluetooth догађаја. Размотри искључивање оптимизације ако имаш проблема.</string>
     <string name="label_bluetooth_settings">Bluetooth подешавања</string>
-    <string name="android10_applaunch_issue_description">Андроид 10 ограничава начин покретања апликација из позадине. Да би омогућио/ла отварање апликација кад се Bluetooth уређај повеже, додели дозволу „Приказ преко других апликација“ (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Изворни код</string>
-    <string name="android13_notification_permission_description">Додели овој апликацији дозволу за постављање обавештења. Омогућава приказивање обавештења кад је апликација активна и врши подешавања јачине звука.</string>
-    <string name="privacy_policy_label">Политика приватности</string>
     <string name="managed_devices_empty_message">Ниједан Bluetooth уређај није подешен.\nДодирни + да додаш свој први уређај.</string>
     <string name="label_pro_feature">Премијум функција</string>
     <plurals name="discover_device_limit_banner">
@@ -430,21 +348,15 @@
     <string name="review_app_review_action">Оцени</string>
     <string name="review_app_dismiss_action">Можда касније</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Куповина отказана</string>
-    <string name="error_iap_unavailable_message">Куповине у апликацији нису доступне</string>
-    <string name="error_generic_message">Дошло је до грешке. Покушај поново.</string>
-    <string name="error_iap_owned_message">Већ поседујеш ову ставку</string>
     <string name="label_no_devices_title">Нема уређаја</string>
     <string name="bluemusic_mascot_description">Икона апликације</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Изабери апликације</string>
     <string name="devices_app_selection_search_hint">Претражи апликације…</string>
-    <string name="devices_app_selection_currently_selected">Тренутно изабрано</string>
     <string name="devices_app_selection_selected_count">%d апликација изабрано</string>
     <string name="general_navigate_back_action">Навигација назад</string>
     <string name="general_reset_action">Ресетуј</string>
     <string name="general_clear_action">Очисти</string>
-    <string name="general_save_action">Сачувај</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Закључај</string>
     <string name="devices_indicator_awake">Будан</string>
@@ -454,7 +366,6 @@
     <string name="devices_indicator_limit">Ограничи</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Подсилење</string>
-    <string name="devices_indicator_launch">Покрени</string>
     <string name="devices_indicator_home">Почетак</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Упозорење</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Vissa enhetsinställningar kan ha återställts under denna uppdatering. Kontrollera dina enhetskonfigurationer.</string>
     <string name="onboarding_rewrite_action">Fortsätt</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Inga ohanterade enheter hittades</string>
     <string name="discover_all_devices_managed_msg">Alla dina parade enheter hanteras redan! Behöver du en ny?</string>
     <string name="discover_pair_new_device_action">Para ny enhet</string>
     <string name="discover_device_speaker_desc">Telefonens egen högtalare. Dess volymer tillämpas när ljud växlar tillbaka till telefonen, t.ex. efter att din Bluetooth-enhet kopplas från.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Enhetskonfiguration</string>
-    <string name="devices_device_config_section_general_label">Allmänt</string>
     <string name="devices_device_config_remove_device_label">Glöm enhet</string>
-    <string name="devices_device_config_remove_device_desc">Glömmer enheten från denna app och tar bort dess konfiguration. Detta tar inte bort parkopplingen.</string>
     <string name="devices_device_config_remove_device_action">Glöm</string>
     <string name="devices_device_config_remove_device_confirmation">Glöm %s från hanterade enheter?</string>
-    <string name="devices_device_config_rename_device_label">Döp om enhet</string>
-    <string name="devices_device_config_rename_device_desc">Döp om denna enhet inom denna app, och om möjligt, inom systemet.</string>
     <string name="devices_device_config_rename_device_action">Döp om</string>
     <string name="devices_device_config_enabled_label">Aktiverad</string>
     <string name="devices_device_config_enabled_desc">Reagera på denna enhet när den ansluts</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Autospelskommandon</string>
     <string name="devices_device_config_autoplay_keycodes_order">Kommandosekvens</string>
     <string name="devices_device_config_autoplay_keycodes_label">Kommandon</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Konfigurera vilka kommandon som ska skickas och i vilken ordning</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Inga kommandon konfigurerade</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Lägg till kommando</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximalt %1$d kommandon</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Flytta upp</string>
     <string name="cd_autoplay_keycode_move_down">Flytta ner</string>
     <string name="cd_autoplay_keycode_remove">Avlägsna</string>
-    <string name="devices_device_config_section_volumes_label">Volymer</string>
     <string name="devices_device_config_section_volume_label">Volym</string>
     <string name="devices_device_config_alarm_volume_label">Larmvolym</string>
     <string name="devices_device_config_alarm_volume_desc">Vissa larmappar använder musikvolymen istället.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Ringsignal</string>
     <string name="devices_audio_stream_notification_label">Avisering</string>
     <string name="devices_audio_stream_alarm_label">Larm</string>
-    <string name="devices_neverseen_label">Aldrig sedd</string>
-    <string name="devices_state_connected_label">Ansluten</string>
     <string name="devices_last_connected_label">Senast ansluten: %s</string>
     <string name="devices_currently_connected_label">För närvarande ansluten</string>
     <string name="devices_device_disabled_label">Enhet inaktiverad</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Inställningar som påverkar alla hanterade enheter.</string>
     <string name="label_app_enabled">Appen aktiverad</string>
     <string name="description_app_enabled">Växlar appens förmåga att reagera på volym och Bluetooth-händelser.</string>
-    <string name="label_visible_volume_adjustments">Synliga justeringar</string>
-    <string name="description_visible_volume_adjustments">Visa systemets volymfönster medan den här appen gör justeringar.</string>
     <string name="label_volume_listener">Observera förändringar</string>
-    <string name="description_volume_listener">Fortsätt vara aktiv medan en enhet är ansluten och spara volymförändringar som inte har orsakats av den här appen.</string>
     <string name="label_boot_restore">Återställ vid omstart av enheten</string>
     <string name="description_boot_restore">Återställ volymen efter uppstart / omstart om en Bluetooth-enhet är ansluten.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Lär dig använda BVM effektivt</string>
     <string name="settings_support_issue_tracker_description">En offentlig ärendeövervakare för buggrapporter och funktionsförfrågningar.</string>
     <string name="settings_support_issue_tracker_label">Ärendeövervakare</string>
-    <string name="settings_support_debuglog_label">Debug-logg</string>
     <string name="settings_support_debuglog_desc">Spela in allt appen gör i en textfil som du kan dela.</string>
-    <string name="settings_support_debuglog_recording_desc">Spelar för närvarande in debug-information. Tryck för att stoppa inspelningen.</string>
-    <string name="settings_support_debuglog_path">Loggsökväg: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Mycket kort inspelning</string>
     <string name="settings_support_debuglog_short_recording_msg">Det var en mycket kort inspelning. Debug-loggar är inspelningar, inte ögonblicksbilder — återskapa problemet medan inspelningen pågår för att loggen ska vara användbar.</string>
     <string name="settings_support_debuglog_short_recording_continue">Fortsätt spela in</string>
     <string name="settings_support_debuglog_short_recording_stop">Stoppa ändå</string>
-    <string name="settings_support_debuglog_folder_label">Debug-logg-mapp</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d session använder %2$s</item>
-        <item quantity="other">%1$d sessioner använder %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Inga debug-loggar lagrade</string>
-    <string name="settings_support_debuglog_folder_delete_title">Ta bort alla debug-loggar?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Detta kommer permanent ta bort alla lagrade debug-loggsessioner.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">En plats att hänga på och ställa frågor.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Översättning</string>
     <string name="settings_acks_translators_title">Översättare</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Översätt BVM</string>
-    <string name="settings_acks_translate_desc">Hjälp till att översätta BVM till ditt språk</string>
     <string name="settings_acks_thanks_header">Tack</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">För stöd av översättning av öppna källkodsprojekt</string>
     <string name="settings_licenses_label">Licenser</string>
     <string name="settings_translation_label">Översättning</string>
     <string name="settings_translation_desc">Hjälp till att översätta appen till ditt favoritspråk</string>
-    <string name="settings_sponsor_development_title">Sponsra utveckling</string>
-    <string name="settings_sponsor_development_summary">Bli en patron och möjliggör fortsatt utveckling.</string>
     <string name="settings_privacy_policy_label">Integritetspolicy</string>
     <string name="settings_privacy_policy_desc">Hantera data ansvarsfullt.</string>
     <string name="changelog_label">Förändringslogg</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Återställning klar — %1$d enheter återställda, %2$d hoppades över.</string>
     <string name="backup_restore_version_warning">Den här säkerhetskopian skapades med version %1$s. Du kör %2$s. Vissa inställningar kanske inte återställs korrekt.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Debug-aviseringar</string>
     <string name="debug_log_consent_title">Debug-logg</string>
     <string name="debug_log_consent_explanation">Denna funktion spelar in allt appen gör i en delbar fil. Den genererade filen innehåller känslig information (t.ex. filnamn och installerade appar). Dela den bara med betrodda parter (t.ex. en utvecklare som felsöker ett problem).</string>
-    <string name="debug_log_recording_progress">Spelar in debug-logg</string>
     <string name="debug_log_record_action">Spela in</string>
     <string name="debug_log_stop_action">Sluta spela in</string>
     <string name="debug_log_screen_title">Debug-logginspelare</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Kasta</string>
     <string name="debug_log_screen_keep_action">Behåll</string>
-    <string name="debug_log_compressing_label">Komprimerar…</string>
     <string name="debug_log_file_label">Inspelade loggfil</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Logg skickad?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Beskriv din fråga i detalj.</string>
     <string name="contact_category_section_label">Kategori</string>
     <string name="contact_debug_log_label">Debug-logg</string>
-    <string name="contact_debug_log_select_hint">Välj en debug-logg att bifoga</string>
     <string name="contact_debug_log_picker_hint">Bifoga en debug-logg för att hjälpa diagnostisera problemet snabbare.</string>
     <string name="contact_debug_log_picker_empty">Inga debug-loggar tillgängliga. Spela in en först.</string>
     <string name="contact_expected_behavior_label">Förväntat beteende</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Jag läser varje meddelande själv och gör mitt bästa för att svara, men eftersom jag arbetar med detta ensam kan det ta lite tid. Tack för ditt tålamod.</string>
     <string name="contact_footer_msg">Ditt meddelande skickas via e-post. Enhets- och konfigurationsinformation bifogas automatiskt.</string>
     <string name="contact_no_email_app_msg">Ingen e-postapp hittades på denna enhet.</string>
-    <string name="contact_attachment_missing_msg">Debug-loggfilen finns inte längre</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Lagrade debug-loggar</string>
     <string name="settings_support_stored_logs_desc">%1$d sessioner (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Inga lagrade debug-loggar</string>
-    <string name="settings_support_stored_logs_delete_title">Ta bort lagrade loggar?</string>
-    <string name="settings_support_stored_logs_delete_msg">Detta kommer ta bort alla %1$d lagrade debug-loggsessioner.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Lagrade debug-loggar borttagna</string>
-    <string name="label_bug_reports">Felrapporter</string>
-    <string name="description_bug_reports">Automatisk fel- och kraschrapportering.</string>
     <string name="label_add_device">Lägg till enhet</string>
-    <string name="label_just_a_moment_please">Ett ögonblick tack.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Konfiguration krävs</string>
     <string name="monitor_notification_starting">Startar upp…</string>
     <string name="action_set">Välj</string>
     <string name="action_cancel">Avbryt</string>
-    <string name="label_invalid_input">Felaktig input</string>
     <string name="action_reset">Återställ</string>
     <string name="label_no_connected_devices">Inga enheter anslutna</string>
-    <string name="label_status_idle">Inaktiv</string>
-    <string name="label_status_adjusting_volumes">Justerar volymer</string>
-    <string name="label_premium_version">Premium-version</string>
     <string name="general_upgrade_action">Uppgradera</string>
     <string name="common_upgrade_required_label">Uppgradering krävs</string>
-    <string name="label_premium_version_required">Premium-versionen krävs</string>
-    <string name="description_intro_purpose">Med den här appen kan din Android-enhet komma ihåg volymen för olika Bluetooth-enheter.</string>
-    <string name="upgrade_benefit_unlimited_devices">Obegränsade enhetsprofiler</string>
-    <string name="upgrade_benefit_connection_actions">Automatisk uppspelning, appstart och anslutningsaviseringar</string>
-    <string name="upgrade_benefit_theme_customization">Anpassning av tema, stil och färg</string>
-    <string name="upgrade_benefit_power_controls">Volymspärr och hastighetsbegränsning</string>
-    <string name="upgrade_benefit_support">Stöd oberoende utveckling</string>
     <string name="upgrade_benefit_equalizer">• Equalizer per enhet (för musikappar med stöd för systemequalizer)</string>
-    <string name="description_intro_tap_the_button">Börja med att lägga till din första enhet.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth är inaktiverat.</string>
     <string name="title_bluetooth_is_off">Bluetooth är av</string>
     <string name="action_enable_bluetooth">Aktivera Bluetooth</string>
     <string name="title_bluetooth_permission_required">Bluetooth-behörighet krävs</string>
     <string name="description_bluetooth_permission_required">Denna app behöver Bluetooth-behörighet för att hantera dina enhetsvolymer.</string>
     <string name="action_grant_permission">Bevilja behörighet</string>
-    <string name="label_status_listening_for_changes">Lyssnar efter volymförändringar</string>
     <string name="action_exit">Stäng</string>
-    <string name="action_start">Starta</string>
-    <string name="label_welcome">Välkommen</string>
-    <string name="description_intro_contact">Tveka inte att kontakta mig om du har frågor eller till och med en idé för en ny funktion.</string>
-    <string name="label_translation">Översättning</string>
-    <string name="description_help_translate">Hjälp mig att göra den här appen tillgänglig på andra språk.</string>
     <string name="label_device_speaker">Enhetshögtalare</string>
-    <string name="label_keyevent_playpause">Spela/Pausa</string>
-    <string name="label_keyevent_play">Spela</string>
-    <string name="label_keyevent_next">Nästa</string>
-    <string name="label_install_id">Installations ID</string>
     <string name="message_copied_to_clipboard">Kopierat till urklipp</string>
-    <string name="label_thanks">Tack</string>
-    <string name="label_licenses">Licenser</string>
-    <string name="description_ring_volume_additional_permission">Ytterligare behörigheter behövs för att ändra volymen på ringsignalen.</string>
-    <string name="label_missing_permissions">Behörighet saknas</string>
-    <string name="action_grant">Bevilja</string>
-    <string name="label_advanced">Avancerat</string>
-    <string name="label_exclude_health">Uteslut hälsoprofiler</string>
-    <string name="description_exclude_health">Vissa Android-enheter hänger sig vid sökning av Bluetoothprofiler av typen \'Hälsoenhet\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Uteslut GATT-serverprofiler</string>
-    <string name="label_exclude_gatt">Uteslut GATT-profiler</string>
-    <string name="description_exclude_gattserver">Ingen sökning på Bluetooth-profiler av typ \'Generiska Attribut\' (GATT) server.</string>
-    <string name="description_exclude_gatt">Ingen sökning på Bluetooth-profiler av typ \'Generiska Attribut\' (GATT) klient.</string>
-    <string name="description_waiting_for_devicex">Väntar på att %s ska slutföra anslutningen</string>
-    <string name="action_undo">Ångra</string>
-    <string name="action_show">Visa</string>
     <string name="action_dismiss">Avfärda</string>
-    <string name="action_fix">Fixa</string>
-    <string name="battery_optimizations_issue_description">Batterioptimering är aktiverad för denna app och kan hindra den från att ta emot Bluetooth-händelser. Överväg att inaktivera optimering om du upplever problem.</string>
     <string name="label_bluetooth_settings">Bluetooth-inställningar</string>
-    <string name="android10_applaunch_issue_description">Android 10 begränsar hur appar kan startas från bakgrunden. För att tillåta öppning av appar när en Bluetooth-enhet ansluts, bevilja behörigheten &quot;Visa över andra appar&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Källkod</string>
-    <string name="android13_notification_permission_description">Ge denna app behörighet att skicka aviseringar. Detta möjliggör visning av en avisering när denna app är aktiv och volymjusteringar görs.</string>
-    <string name="privacy_policy_label">Integritetspolicy</string>
     <string name="managed_devices_empty_message">Inga Bluetooth-enheter konfigurerade.\nTryck på +-knappen för att lägga till din första enhet.</string>
     <string name="label_pro_feature">Premiumfunktion</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Recensera</string>
     <string name="review_app_dismiss_action">Kanske senare</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Köp avbrutet</string>
-    <string name="error_iap_unavailable_message">Köp i appen är inte tillgängliga</string>
-    <string name="error_generic_message">Ett fel inträffade. Försök igen.</string>
-    <string name="error_iap_owned_message">Du äger redan detta objekt</string>
     <string name="label_no_devices_title">Inga enheter</string>
     <string name="bluemusic_mascot_description">Appikon</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Välj appar</string>
     <string name="devices_app_selection_search_hint">Sök appar…</string>
-    <string name="devices_app_selection_currently_selected">Vald för närvarande</string>
     <string name="devices_app_selection_selected_count">%d appar valda</string>
     <string name="general_navigate_back_action">Navigera tillbaka</string>
     <string name="general_reset_action">Återställ</string>
     <string name="general_clear_action">Rensa</string>
-    <string name="general_save_action">Spara</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Lås</string>
     <string name="devices_indicator_awake">Vaken</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Begränsa</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Förstärkning</string>
-    <string name="devices_indicator_launch">Starta</string>
     <string name="devices_indicator_home">Hem</string>
     <string name="devices_indicator_dnd">Stör ej</string>
     <string name="devices_indicator_alert">Varning</string>

--- a/app/src/main/res/values-sw/strings.xml
+++ b/app/src/main/res/values-sw/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Baadhi ya vipengele vimebadilika wakati wa sasisho. Tafadhali angalia mipangilio ya kifaa chako kuhakikisha kila kitu kimesanidiwa vizuri.</string>
     <string name="onboarding_rewrite_action">Endelea</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Hakuna vifaa visivyodhibitiwa vilivyopatikana</string>
     <string name="discover_all_devices_managed_msg">Vifaa vyako vyote vilivyounganishwa vinadhibitiwa! Unahitaji kipya?</string>
     <string name="discover_pair_new_device_action">Unganisha kifaa kipya</string>
     <string name="discover_device_speaker_desc">Spikari ya simu yenyewe. Kiwango cha sauti chake kinatumika wakati sauti inaburudika kwa simu, kwa mfano baada ya kifaa chako cha Bluetooth kutengana.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Usanidi wa kifaa</string>
-    <string name="devices_device_config_section_general_label">Jumla</string>
     <string name="devices_device_config_remove_device_label">Sahau kifaa</string>
-    <string name="devices_device_config_remove_device_desc">Inasahau kifaa kutoka programu hii na kufuta usanidi wake. Hii haifuti muunganiko wa kifaa.</string>
     <string name="devices_device_config_remove_device_action">Sahau</string>
     <string name="devices_device_config_remove_device_confirmation">Sahau %s kutoka kwa vifaa vinavyodhibitiwa?</string>
-    <string name="devices_device_config_rename_device_label">Badilisha jina la kifaa</string>
-    <string name="devices_device_config_rename_device_desc">Badilisha jina la kifaa hiki ndani ya programu hii, na ikiwezekana, ndani ya mfumo.</string>
     <string name="devices_device_config_rename_device_action">Badilisha jina</string>
     <string name="devices_device_config_enabled_label">Imewashwa</string>
     <string name="devices_device_config_enabled_desc">Jibu kwa kifaa hiki kinapounganishwa</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Amri za kucheza kiotomatiki</string>
     <string name="devices_device_config_autoplay_keycodes_order">Mfuatano wa amri</string>
     <string name="devices_device_config_autoplay_keycodes_label">Amri</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Sanidi amri za kutuma na katika mpangilio gani</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Hakuna amri zilizosanidiwa</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Ongeza amri</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Amri %1$d za juu zaidi</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Sogeza juu</string>
     <string name="cd_autoplay_keycode_move_down">Sogeza chini</string>
     <string name="cd_autoplay_keycode_remove">Ondoa</string>
-    <string name="devices_device_config_section_volumes_label">Sauti</string>
     <string name="devices_device_config_section_volume_label">Sauti</string>
     <string name="devices_device_config_alarm_volume_label">Sauti ya kengele</string>
     <string name="devices_device_config_alarm_volume_desc">Baadhi ya programu za kengele hutumia sauti ya muziki badala yake.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Mlio</string>
     <string name="devices_audio_stream_notification_label">Arifa</string>
     <string name="devices_audio_stream_alarm_label">Kengele</string>
-    <string name="devices_neverseen_label">Haijawahi kuonekana</string>
-    <string name="devices_state_connected_label">Imeunganishwa</string>
     <string name="devices_last_connected_label">Iliunganishwa mara ya mwisho: %s</string>
     <string name="devices_currently_connected_label">Imeunganishwa sasa hivi</string>
     <string name="devices_device_disabled_label">Kifaa kimezimwa</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Mipangilio inayoathiri vifaa vyote vinavyodhibitiwa.</string>
     <string name="label_app_enabled">Programu imewezeshwa</string>
     <string name="description_app_enabled">Inabadilisha uwezo wa programu kujibu matukio ya sauti na Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Marekebisho yanayoonekana</string>
-    <string name="description_visible_volume_adjustments">Onyesha dirisha la sauti la mfumo wakati programu hii inafanya marekebisho.</string>
     <string name="label_volume_listener">Angalia mabadiliko</string>
-    <string name="description_volume_listener">Kaa hai wakati kifaa kimeunganishwa na uhifadhi mabadiliko ya sauti ambayo hayakusababishwa na programu hii.</string>
     <string name="label_boot_restore">Rejesha wakati wa kuwasha</string>
     <string name="description_boot_restore">Rejesha sauti baada ya kuwasha/kuanzisha upya kama kifaa cha Bluetooth kimeunganishwa.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Jifunze kutumia BVM kwa ufanisi</string>
     <string name="settings_support_issue_tracker_description">Kifuatiliaji cha umma cha matatizo kwa ripoti za makosa na maombi ya vipengele.</string>
     <string name="settings_support_issue_tracker_label">Kifuatiliaji cha matatizo</string>
-    <string name="settings_support_debuglog_label">Rekodi ya utatuzi</string>
     <string name="settings_support_debuglog_desc">Rekodi kila kitu programu inachofanya katika faili ya maandishi unayoweza kushiriki.</string>
-    <string name="settings_support_debuglog_recording_desc">Inarekodia maelezo ya utatuzi sasa hivi. Gonga ili kusimamisha urekodi.</string>
-    <string name="settings_support_debuglog_path">Njia ya logi: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Urekodi mfupi sana</string>
     <string name="settings_support_debuglog_short_recording_msg">Hiyo ilikuwa urekodi mfupi sana. Logi za utatuzi ni maudhui ya urekodi, si picha — zingatia tatizo wakati urekodi unafanya kazi ili logi iwe na manufaa.</string>
     <string name="settings_support_debuglog_short_recording_continue">Endelea kurekodi</string>
     <string name="settings_support_debuglog_short_recording_stop">Simamisha hata hivyo</string>
-    <string name="settings_support_debuglog_folder_label">Folda ya logi ya utatuzi</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">Kipindi %1$d kinachotumia %2$s</item>
-        <item quantity="other">Vipindi %1$d vinavyotumia %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Hakuna logi za utatuzi zilizohifadhiwa</string>
-    <string name="settings_support_debuglog_folder_delete_title">Futa logi zote za utatuzi?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Hii itafuta kabisa vipindi vyote vya logi za utatuzi vilivyohifadhiwa.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Mahali pa kukutana na kuuliza maswali.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Tafsiri</string>
     <string name="settings_acks_translators_title">Watafsiri</string>
     <string name="settings_acks_translators_people">Mtu1;Mtu2(si@lazima.com)</string>
-    <string name="settings_acks_translate_title">Tafsiri BVM</string>
-    <string name="settings_acks_translate_desc">Saidia kutafsiri BVM katika lugha yako</string>
     <string name="settings_acks_thanks_header">Asante</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Kwa kusaidia tafsiri ya miradi ya chanzo wazi</string>
     <string name="settings_licenses_label">Leseni</string>
     <string name="settings_translation_label">Tafsiri</string>
     <string name="settings_translation_desc">Saidia kutafsiri programu katika lugha unayoipenda</string>
-    <string name="settings_sponsor_development_title">Dhamini maendeleo</string>
-    <string name="settings_sponsor_development_summary">Kuwa mfuasi na uwezeshe maendeleo yanayoendelea.</string>
     <string name="settings_privacy_policy_label">Sera ya faragha</string>
     <string name="settings_privacy_policy_desc">Kushughulikia data kwa uwazi.</string>
     <string name="changelog_label">Historia ya mabadiliko</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Urejesho umekamilika — vifaa %1$d vimerejeshwa, %2$d vimerukwa.</string>
     <string name="backup_restore_version_warning">Hifadhi hii iliundwa na toleo %1$s. Unaendesha %2$s. Baadhi ya mipangilio inaweza isirejeshwe vizuri.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Arifa za marekebisho</string>
     <string name="debug_log_consent_title">Rekodi ya utatuzi</string>
     <string name="debug_log_consent_explanation">Kipengele hiki kinarekodi kila kitu programu inachofanya katika faili linaweza kushirikishwa. Faili lililotengenezwa lina maelezo ya siri (k.m. majina ya mafaili na programu zilizosakiniwa). Shiriki tu na wahusika wanaoweza kuaminika (k.m. msanidi programu anayetatua tatizo).</string>
-    <string name="debug_log_recording_progress">Inaandika rekodi ya marekebisho</string>
     <string name="debug_log_record_action">Rekodi</string>
     <string name="debug_log_stop_action">Acha kuandika</string>
     <string name="debug_log_screen_title">Kirekodi cha Logi ya Utatuzi</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Tupa</string>
     <string name="debug_log_screen_keep_action">Hifadhi</string>
-    <string name="debug_log_compressing_label">Inasogeza…</string>
     <string name="debug_log_file_label">Faili la rekodi lililoandikwa</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Logi imetumwa?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Eleza swali lako kwa undani.</string>
     <string name="contact_category_section_label">Kategoria</string>
     <string name="contact_debug_log_label">Rekodi ya utatuzi</string>
-    <string name="contact_debug_log_select_hint">Chagua logi ya utatuzi ya kuambatisha</string>
     <string name="contact_debug_log_picker_hint">Ambatisha logi ya utatuzi kusaidia kutambua tatizo haraka zaidi.</string>
     <string name="contact_debug_log_picker_empty">Hakuna logi za utatuzi zinazopatikana. Rekodi moja kwanza.</string>
     <string name="contact_expected_behavior_label">Tabia inayotarajiwa</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Ninasoma kila ujumbe mwenyewe na ninajaribu kujibu kwa uwezo wangu wote, lakini kwani ninafanya hii peke yangu, inaweza kuchukua muda kidogo. Asante kwa uvumilivu wako.</string>
     <string name="contact_footer_msg">Ujumbe wako utatumwa kupitia barua pepe. Maelezo ya kifaa na usanidi yanaambatishwa kiotomatiki.</string>
     <string name="contact_no_email_app_msg">Hakuna programu ya barua pepe iliyopatikana kwenye kifaa hiki.</string>
-    <string name="contact_attachment_missing_msg">Faili ya logi ya utatuzi haipo tena</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Logi za utatuzi zilizohifadhiwa</string>
     <string name="settings_support_stored_logs_desc">Vipindi %1$d (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Hakuna logi za utatuzi zilizohifadhiwa</string>
-    <string name="settings_support_stored_logs_delete_title">Futa logi zilizohifadhiwa?</string>
-    <string name="settings_support_stored_logs_delete_msg">Hii itafuta vipindi vyote %1$d vya logi za utatuzi vilivyohifadhiwa.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Logi za utatuzi zilizohifadhiwa zimefutwa</string>
-    <string name="label_bug_reports">Ripoti za hitilafu</string>
-    <string name="description_bug_reports">Ripoti za hitilafu na mgongano kiotomatiki.</string>
     <string name="label_add_device">Ongeza kifaa</string>
-    <string name="label_just_a_moment_please">Subiri kidogo, tafadhali.</string>
     <string name="label_notification_channel_status">Hali</string>
     <string name="label_notification_channel_setup">Usanidi unahitajika</string>
     <string name="monitor_notification_starting">Inaanza…</string>
     <string name="action_set">Weka</string>
     <string name="action_cancel">Ghairi</string>
-    <string name="label_invalid_input">Uingizaji usio halali</string>
     <string name="action_reset">Weka upya</string>
     <string name="label_no_connected_devices">Hakuna vifaa vilivyounganishwa</string>
-    <string name="label_status_idle">Tulivu</string>
-    <string name="label_status_adjusting_volumes">Inabadilisha sauti</string>
-    <string name="label_premium_version">Toleo la premium</string>
     <string name="general_upgrade_action">Boresha</string>
     <string name="common_upgrade_required_label">Uboreshaji unahitajika</string>
-    <string name="label_premium_version_required">Toleo la premium linahitajika</string>
-    <string name="description_intro_purpose">Programu hii inaruhusu kifaa chako cha Android kukumbuka sauti ya vifaa tofauti vya Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Wasifu usio na kikomo wa vifaa</string>
-    <string name="upgrade_benefit_connection_actions">Kucheza kiotomatiki, uzinduzi wa programu na arifa za muunganisho</string>
-    <string name="upgrade_benefit_theme_customization">Ubinafsishaji wa mandhari, mtindo na rangi</string>
-    <string name="upgrade_benefit_power_controls">Kufuli cha sauti na ukomo wa kiwango</string>
-    <string name="upgrade_benefit_support">Saidia maendeleo ya kujitegemea</string>
     <string name="upgrade_benefit_equalizer">• Kisawazishi cha kila kifaa (kwa programu za muziki zinazotumia kisawazishi cha mfumo)</string>
-    <string name="description_intro_tap_the_button">Anza kwa kuongeza kifaa chako cha kwanza.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth imezimwa.</string>
     <string name="title_bluetooth_is_off">Bluetooth Imezimwa</string>
     <string name="action_enable_bluetooth">Washa Bluetooth</string>
     <string name="title_bluetooth_permission_required">Ruhusa ya Bluetooth Inahitajika</string>
     <string name="description_bluetooth_permission_required">Programu hii inahitaji ruhusa ya Bluetooth kudhibiti sauti za kifaa chako.</string>
     <string name="action_grant_permission">Toa Ruhusa</string>
-    <string name="label_status_listening_for_changes">Inusikiliza mabadiliko ya sauti</string>
     <string name="action_exit">Toka</string>
-    <string name="action_start">Anza</string>
-    <string name="label_welcome">Karibu</string>
-    <string name="description_intro_contact">Usisite kuwasiliana nami kama una maswali au hata wazo la kipengele kipya.</string>
-    <string name="label_translation">Tafsiri</string>
-    <string name="description_help_translate">Nisaidie kufanya programu hii iwe inapatikana katika lugha nyingine.</string>
     <string name="label_device_speaker">Spika ya kifaa</string>
-    <string name="label_keyevent_playpause">Cheza-Simamisha</string>
-    <string name="label_keyevent_play">Cheza</string>
-    <string name="label_keyevent_next">Inayofuata</string>
-    <string name="label_install_id">ID ya Usakinishaji</string>
     <string name="message_copied_to_clipboard">Imenakiliwa kwenye ubao wa kunakili</string>
-    <string name="label_thanks">Asante</string>
-    <string name="label_licenses">Leseni</string>
-    <string name="description_ring_volume_additional_permission">Ruhusa za ziada zinahitajika kubadilisha sauti ya mlio.</string>
-    <string name="label_missing_permissions">Ruhusa zinazokosekana</string>
-    <string name="action_grant">Toa</string>
-    <string name="label_advanced">Hali ya juu</string>
-    <string name="label_exclude_health">Tenga profaili za afya</string>
-    <string name="description_exclude_health">Baadhi ya vifaa vya Android huacha kufanya kazi wakati wa kutafuta profaili za Bluetooth za \'Kifaa cha Afya\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Tenga profaili za seva ya GATT</string>
-    <string name="label_exclude_gatt">Tenga profaili za GATT</string>
-    <string name="description_exclude_gattserver">Usitafute profaili za Bluetooth za aina ya seva ya \'Sifa ya Jumla\' (GATT).</string>
-    <string name="description_exclude_gatt">Usitafute profaili za Bluetooth za aina ya mteja wa \'Sifa ya Jumla\' (GATT).</string>
-    <string name="description_waiting_for_devicex">Inasubiri %s kukamilisha muunganisho</string>
-    <string name="action_undo">Rejesha</string>
-    <string name="action_show">Onyesha</string>
     <string name="action_dismiss">Ondoa</string>
-    <string name="action_fix">Rekebisha</string>
-    <string name="battery_optimizations_issue_description">Uboreshaji wa betri umewezeshwa kwa programu hii na unaweza kuzuia kupokea matukio ya Bluetooth. Fikiria kuzima uboreshaji kama unakabiliwa na matatizo.</string>
     <string name="label_bluetooth_settings">Mipangilio ya Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 inazuia jinsi programu zinavyoweza kuzinduliwa kutoka nyuma. Ili kuruhusu kufungua programu wakati kifaa cha Bluetooth kinaunganishwa, toa ruhusa ya \"Onyesha juu ya programu nyingine\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Msimbo wa chanzo</string>
-    <string name="android13_notification_permission_description">Toa ruhusa kwa programu hii kutuma arifa. Hii inawezeshwa kuonyesha arifa wakati programu hii inafanya kazi na marekebisho ya sauti yanafanywa.</string>
-    <string name="privacy_policy_label">Sera ya faragha</string>
     <string name="managed_devices_empty_message">Hakuna vifaa vya Bluetooth vilivyosanidiwa.\nGonga kitufe cha + kuongeza kifaa chako cha kwanza.</string>
     <string name="label_pro_feature">Kipengele cha premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Mapitio</string>
     <string name="review_app_dismiss_action">Labda baadaye</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Ununuzi umefutwa</string>
-    <string name="error_iap_unavailable_message">Manunuzi ndani ya programu hayapatikani</string>
-    <string name="error_generic_message">Hitilafu imetokea. Tafadhali jaribu tena.</string>
-    <string name="error_iap_owned_message">Tayari unamiliki kipengele hiki</string>
     <string name="label_no_devices_title">Hakuna Vifaa</string>
     <string name="bluemusic_mascot_description">Ikoni ya Programu</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Chagua Programu</string>
     <string name="devices_app_selection_search_hint">Tafuta programu…</string>
-    <string name="devices_app_selection_currently_selected">Imechaguliwa sasa hivi</string>
     <string name="devices_app_selection_selected_count">Programu %d zimechaguliwa</string>
     <string name="general_navigate_back_action">Rudi nyuma</string>
     <string name="general_reset_action">Weka upya</string>
     <string name="general_clear_action">Futa</string>
-    <string name="general_save_action">Hifadhi</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Funga</string>
     <string name="devices_indicator_awake">Macho</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Kizuizi</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Ongezeko</string>
-    <string name="devices_indicator_launch">Zindua</string>
     <string name="devices_indicator_home">Nyumbani</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Arifa</string>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">மேம்பாடு மூலம் சில விஷயங்கள் மாறியுள்ளன. அந்த விஷயங்கள் சரியாக அமைக்கப்பட்டுள்ளதாக உறுதிப்படுத்த உங்கள் சாதன அமைப்புகளைச் செக்கவும்.</string>
     <string name="onboarding_rewrite_action">தொடர்</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">நிர்வகிக்கப்படாத சாதனங்கள் ஏதும் காணப்படவில்லை</string>
     <string name="discover_all_devices_managed_msg">உங்கள் எல்லா இணைக்கப்பட்ட சாதனங்களும் நிர்வகிக்கப்படுகின்றன! புதிதாக ஒன்று தேவையா?</string>
     <string name="discover_pair_new_device_action">புதிய சாதனத்தை இணைக்கவும்</string>
     <string name="discover_device_speaker_desc">இந்த ஃபோனின் சொந்த ஸ்பீக்கர். ஆடியோ ஃபோனுக்கு மீண்டும் மாறும் போது அதன் ஒலிகள் பயன்படுத்தப்படுகிறது, எ.கா. உங்கள் ப்ளூடூத் சாதனம் துண்டிக்கப்பட்ட பின்னர்.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">சாதன அமைப்பு</string>
-    <string name="devices_device_config_section_general_label">பொது</string>
     <string name="devices_device_config_remove_device_label">சாதனத்தை மறந்துவிடு</string>
-    <string name="devices_device_config_remove_device_desc">இந்த ஆப்்அலிருந்து சாதனத்தை மறந்து அதன் அமைப்பை நீக்கிவிடுகிறது. இது சாதனத்தை இணைப்பை நீக்காது.</string>
     <string name="devices_device_config_remove_device_action">மறந்துவிடு</string>
     <string name="devices_device_config_remove_device_confirmation">%s-அய் நிர்வகிக்கப்பட்ட சாதனங்களிலிருந்து மறந்துவிடலாமா?</string>
-    <string name="devices_device_config_rename_device_label">சாதனத்தை மறுபெயரிடு</string>
-    <string name="devices_device_config_rename_device_desc">இந்த ஆப்்அல் உள்ளேயும், முடிந்தால், கணினி உள்ளேயும் சாதனத்தை மறுபெயரிடுகிறது.</string>
     <string name="devices_device_config_rename_device_action">மறுபெயரிடு</string>
     <string name="devices_device_config_enabled_label">இயக்கப்பட்ட</string>
     <string name="devices_device_config_enabled_desc">இந்த சாதனம் இணைக்கப்பட்டால் ப்ரதிகிரியுங்கள்</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">தானியங்கி இயக்க கட்டளைகள்</string>
     <string name="devices_device_config_autoplay_keycodes_order">கட்டளை வரிசை</string>
     <string name="devices_device_config_autoplay_keycodes_label">கட்டளைகள்</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">எந்த கட்டளைகளை அனுப்ப வேண்டும், எந்த வரிசையில் என்று அமைக்கவும்</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">கட்டளைகள் எதுவும் அமைக்கப்படவில்லை</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">கட்டளை சேர்க்கவும்</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">அதிகபட்சம் %1$d கட்டளைகள்</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">மேலே நகர்த்து</string>
     <string name="cd_autoplay_keycode_move_down">கீழே நகர்த்து</string>
     <string name="cd_autoplay_keycode_remove">அகற்று</string>
-    <string name="devices_device_config_section_volumes_label">ஒலி அளவுகள்</string>
     <string name="devices_device_config_section_volume_label">ஒலி அளவு</string>
     <string name="devices_device_config_alarm_volume_label">அலாரம் ஒலி அளவு</string>
     <string name="devices_device_config_alarm_volume_desc">சில அலாரம் ஆப்கள் கத்தி ஒலி அளவைப் பயன்படுத்துகின்றன.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">ரிங்</string>
     <string name="devices_audio_stream_notification_label">அறிவிப்பு</string>
     <string name="devices_audio_stream_alarm_label">அலாரம்</string>
-    <string name="devices_neverseen_label">ஒருமுறையும் காணப்படவில்லை</string>
-    <string name="devices_state_connected_label">இணைக்கப்பட்டது</string>
     <string name="devices_last_connected_label">கடைசியாக இணைக்கப்பட்டது: %s</string>
     <string name="devices_currently_connected_label">தற்போது இணைக்கப்பட்டுள்ளது</string>
     <string name="devices_device_disabled_label">சாதனம் முடக்கப்பட்டது</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">அனைத்து நிர்வகிக்கப்பட்ட சாதனங்களை பாதிக்கும் அமைப்புகள்.</string>
     <string name="label_app_enabled">ஆப்் இயங்குகிறது</string>
     <string name="description_app_enabled">ஒலி மற்றும் Bluetooth நிகழ்வுகளுக்கு ப்ரதிகிரிக்கும் ஆப்்அின் திறனை மாற்றுகிறது.</string>
-    <string name="label_visible_volume_adjustments">காணும் சரிசெய்த்தல்கள்</string>
-    <string name="description_visible_volume_adjustments">இந்த ஆப்் சரிசெய்த்தல்கள் செய்யும்போது கணினியின் ஒலி சாளர்த்தைக் காட்டு.</string>
     <string name="label_volume_listener">மாற்றங்களைக் கவனி</string>
-    <string name="description_volume_listener">ஒரு சாதனம் இணைக்கப்பட்டிருக்கும்போது உல்நிலையிருக்கும் மற்றும் இந்த ஆப்்இனால் ஏற்படாத ஒலி மாற்றங்களை சேமிக்கும்.</string>
     <string name="label_boot_restore">தொடக்கம் வெளியில் மீட்டெடு</string>
     <string name="description_boot_restore">Bluetooth சாதனம் இணைக்கப்பட்டிருக்கும்போது தொடக்கம்/மறுதொடக்கத்திற்கு பிறகு ஒலி அளவை மீட்டெடு.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM-அன்னை எற்பட்தாக பயன்படுத்துவது எப்படி என்று அறிக்கவும்</string>
     <string name="settings_support_issue_tracker_description">Bug reports மற்றும் feature requests க்கான ஒரு பொது issue tracker.</string>
     <string name="settings_support_issue_tracker_label">சிக்கல் கண்காணிப்பான்</string>
-    <string name="settings_support_debuglog_label">பிழைத்திருத்த பதிவு</string>
     <string name="settings_support_debuglog_desc">பயன்பாடு செய்யும் எல்லாத்தையும் நீங்கள் பகிருவதற்கு கூடிய ஒரு text file இல் பதிவு செய்வது.</string>
-    <string name="settings_support_debuglog_recording_desc">தற்போது பிழைபோக்கு தகவல் பதிவு செய்து கொண்டிருக்கிறது. பதிவை நிறுத்த தட்டும்.</string>
-    <string name="settings_support_debuglog_path">பதிவு பாதை: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">மிகவும் சிறிய பதிவு</string>
     <string name="settings_support_debuglog_short_recording_msg">இது மிகவும் சிறிய பதிவு ஆகும். பிழைபோக்கு பதிவுகள் பதிவுகளே தவிர உலை படிம்புகள் அல்ல - பதிவு செயலில் இருக்கும்போது பிழையை முண்படுத்தவும் பதிவு பயனுள்ளதாக இருக்கும்.</string>
     <string name="settings_support_debuglog_short_recording_continue">பதிவை தொடர்</string>
     <string name="settings_support_debuglog_short_recording_stop">ஏனும் நிறுத்து</string>
-    <string name="settings_support_debuglog_folder_label">பிழைபோக்கு பதிவு கோப்பை</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d அமர்வு %2$s பயன்படுத்தும்</item>
-        <item quantity="other">%1$d அமர்வுகள் %2$s பயன்படுத்தவும்</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">பிழைபோக்கு பதிவுகள் ஏதும் சேமிக்கப்படவில்லை</string>
-    <string name="settings_support_debuglog_folder_delete_title">அனைத்து பிழைபோக்கு பதிவுகளையும் நீக்கலாமா?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">இது சேமிக்கப்பட்ட அனைத்து பிழைபோக்கு பதிவு அமர்வுகளை நிரந்தரமாக நீக்கிவிடும்.</string>
     <string name="settings_support_discord_label">டிஸ்கார்ட்</string>
     <string name="settings_support_discord_description">ஒன்றாக இருக்கவும் கேள்விகள் கேட்கவும் ஒரு இடம்.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">மொழிபெயர்ப்பு</string>
     <string name="settings_acks_translators_title">மொழிபெயர்ப்பாளர்கள்</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM-அன்னை மொழிபெயர்க்கவும்</string>
-    <string name="settings_acks_translate_desc">BVM-அன்னை உங்கள் மொழியில் மொழிபெயர்க்க உதவுங்கள்</string>
     <string name="settings_acks_thanks_header">நன்றி</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">திறந்த மூல திட்டங்களின் மொழிபெயர்ப்பினை ஆதரித்ததற்காக</string>
     <string name="settings_licenses_label">இஜையங்கள்</string>
     <string name="settings_translation_label">மொழிபெயர்ப்பு</string>
     <string name="settings_translation_desc">ஆப்்அன்னை உங்கள் விரும்பிய மொழியில் மொழிபெயர்க்க உதவுங்கள்</string>
-    <string name="settings_sponsor_development_title">மேம்பாட்டை வழங்கவும்</string>
-    <string name="settings_sponsor_development_summary">ஒரு patron ஆகி தொடர் மேம்பாட்டை சாத்தியமாக்கவும்.</string>
     <string name="settings_privacy_policy_label">தனியுரிமை கொள்கை</string>
     <string name="settings_privacy_policy_desc">தகவலை பொறுப்புடனுடன் கைகாளவது.</string>
     <string name="changelog_label">மாற்றங்கள் பதிவு</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">மீட்டமைவு முடிந்தது — %1$d சாதனங்கள் மீட்டமைக்கப்பட்டன, %2$d தவிர்க்கப்பட்டன.</string>
     <string name="backup_restore_version_warning">இந்த காப்புப்பிரதி %1$s பதிப்பில் உருவாக்கப்பட்டது. நீங்கள் %2$s இயக்குகிறீர்கள். சில அமைப்புகள் சரியாக மீட்டமைக்கப்படாமல் போகலாம்.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">பிழைத்திருத்த அறிவிப்புகள்</string>
     <string name="debug_log_consent_title">பிழைத்திருத்த பதிவு</string>
     <string name="debug_log_consent_explanation">இந்த அம்சம் பயன்பாடு செய்யும் அனைத்தையும் பகிரக்கூடிய கோப்பில் பதிவு செய்கிறது. உருவாக்கப்பட்ட கோப்பில் முக்கியமான தகவல்கள் உள்ளன (எ.கா. கோப்பு பெயர்கள் மற்றும் நிறுவப்பட்ட பயன்பாடுகள்). நம்பகமானவர்களுடன் மட்டுமே பகிரவும் (எ.கா. சிக்கலைத் தீர்க்கும் உருவாக்குநர்).</string>
-    <string name="debug_log_recording_progress">பிழைத்திருத்த பதிவை பதிவு செய்கிறது</string>
     <string name="debug_log_record_action">பதிவு செய்</string>
     <string name="debug_log_stop_action">பதிவு செய்வதை நிறுத்து</string>
     <string name="debug_log_screen_title">பிழைபோக்கு பதிவு பதிவொளி</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">நிராகரி</string>
     <string name="debug_log_screen_keep_action">வைத்திரு</string>
-    <string name="debug_log_compressing_label">சுருக்கிக் கொண்டிருக்கிறது…</string>
     <string name="debug_log_file_label">பதிவு செய்யப்பட்ட பதிவு கோப்பு</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">பதிவு அனுப்பப்பட்டதா?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">உங்கள் கேள்வியை விரிவாக விளக்கும்.</string>
     <string name="contact_category_section_label">வகைப்பரிவு</string>
     <string name="contact_debug_log_label">பிழைத்திருத்த பதிவு</string>
-    <string name="contact_debug_log_select_hint">இணைக்க பிழைபோக்கு பதிவைத் தேர்ந்தெடு</string>
     <string name="contact_debug_log_picker_hint">பிழையை விரைவாக கண்டறிய பிழைபோக்கு பதிவை இணைக்கும்.</string>
     <string name="contact_debug_log_picker_empty">பிழைபோக்கு பதிவுகள் ஏதும் கிடையவில்லை. முதலில் ஒன்றைப் பதிவு செய்யும்.</string>
     <string name="contact_expected_behavior_label">எதிர்பார்க்கப்பட்ட ஆற்றல்</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">ஏனும் பதிலளிக்க முயற்சிக்கிறேன், ஆனால் தனியாக பணியுள்ளதால் சிறிது நேரம் எடுக்கலாம். உங்கள் போறுமைக்கு நன்றி.</string>
     <string name="contact_footer_msg">உங்கள் செய்தி மின்னஞ்சல் ମூலம் அனுப்பப்படும். சாதனம் மற்றும் அமைப்பு தகவல் தானாகவே இணைக்கப்படும்.</string>
     <string name="contact_no_email_app_msg">இந்த சாதனத்தில் மின்னஞ்சல் ஆப்் ஏதும் காணப்படவில்லை.</string>
-    <string name="contact_attachment_missing_msg">பிழைபோக்கு பதிவு கோப்பு இனி இல்லை</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">சேமிக்கப்பட்ட பிழைபோக்கு பதிவுகள்</string>
     <string name="settings_support_stored_logs_desc">%1$d அமர்வுகள் (%2$s)</string>
     <string name="settings_support_stored_logs_empty">சேமிக்கப்பட்ட பிழைதொழில் பதிவுகள் இல்லை</string>
-    <string name="settings_support_stored_logs_delete_title">சேமிக்கப்பட்ட பதிவுகளை நீக்கவுமா?</string>
-    <string name="settings_support_stored_logs_delete_msg">இது அனைத்து %1$d சேமிக்கப்பட்ட பிழைதொழில் பதிவு அழிக்கும்.</string>
-    <string name="settings_support_stored_logs_deleted_msg">சேமிக்கப்பட்ட பிழைதொழில் பதிவுகள் நீக்கப்பட்டன</string>
-    <string name="label_bug_reports">பிழை அறிக்கைகள்</string>
-    <string name="description_bug_reports">தானியல்ப் பிழை மற்றும் இயங்காமல் அறிக்கை.</string>
     <string name="label_add_device">சாதனம் சேர்க்கவும்</string>
-    <string name="label_just_a_moment_please">ஒரு நிமிடம் தாமதிக்கவும்.</string>
     <string name="label_notification_channel_status">நிலை</string>
     <string name="label_notification_channel_setup">அமைவு தேவை</string>
     <string name="monitor_notification_starting">தொடங்குகிறது…</string>
     <string name="action_set">அமை</string>
     <string name="action_cancel">ரத்து செய்</string>
-    <string name="label_invalid_input">தவறான உள்ளீடு</string>
     <string name="action_reset">மீட்டமை</string>
     <string name="label_no_connected_devices">சாதனங்கள் ஏதும் இணைப்பில்லை</string>
-    <string name="label_status_idle">சுலாமல்</string>
-    <string name="label_status_adjusting_volumes">ஒலி அளவுகளை சரிசெய்த்தல் செய்து கொண்டிருக்கிறது</string>
-    <string name="label_premium_version">ப்ரிமியம் பதிப்பு</string>
     <string name="general_upgrade_action">மேம்படுத்து</string>
     <string name="common_upgrade_required_label">மேம்படுத்தல் தேவை</string>
-    <string name="label_premium_version_required">ப்ரிமியம் பதிப்பு தேவைய்</string>
-    <string name="description_intro_purpose">இந்த ஆப்் உங்கள் Android சாதனம் மாற்றமான Bluetooth சாதனங்களின் ஒலி அளவுகளை நினைவில் வைக்க உதவுகிறது.</string>
-    <string name="upgrade_benefit_unlimited_devices">வரம்பற்ற சாதன சுயவிவரங்கள்</string>
-    <string name="upgrade_benefit_connection_actions">தானியங்கி இயக்கம், பயன்பாட்டு தொடக்கம் மற்றும் இணைப்பு எச்சரிக்கைகள்</string>
-    <string name="upgrade_benefit_theme_customization">தீம், பாணி மற்றும் வண்ண தனிப்பயனாக்கம்</string>
-    <string name="upgrade_benefit_power_controls">தொகுதி பூட்டு மற்றும் வீத வரம்பிடல்</string>
-    <string name="upgrade_benefit_support">சுயாதீன வளர்ச்சியை ஆதரிக்கவும்</string>
     <string name="upgrade_benefit_equalizer">• ஒவ்வொரு சாதனத்திற்கும் ஈகுவலைசர் (சிஸ்டம் ஈகுவலைசர் ஆதரவுள்ள இசைப் பயன்பாடுகளுக்கு)</string>
-    <string name="description_intro_tap_the_button">உங்கள் முதல் சாதனத்தை சேர்பதிலிருந்து தொடங்கும்.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth அணைக்கப்பட்டுள்ளது.</string>
     <string name="title_bluetooth_is_off">Bluetooth அணைந்துள்ளது</string>
     <string name="action_enable_bluetooth">Bluetooth இயக்கு</string>
     <string name="title_bluetooth_permission_required">Bluetooth அனுமதி தேவைப்படுகிறது</string>
     <string name="description_bluetooth_permission_required">உங்கள் சாதன ஒலி அளவுகளை நிர்வகிக்க இந்த ஆப்்கு Bluetooth அனுமதி தேவைப்படுகிறது.</string>
     <string name="action_grant_permission">அனுமதி வழங்கு</string>
-    <string name="label_status_listening_for_changes">ஒலி மாற்றங்களைக் கேட்டுக் கொண்டிருக்கிறது</string>
     <string name="action_exit">வெளியேறு</string>
-    <string name="action_start">தொடங்கு</string>
-    <string name="label_welcome">வரவேற்கிறோம்</string>
-    <string name="description_intro_contact">கேள்விகள் அல்லது புதிய சிறப்பியுக்கான கருத்து இருந்தாலும் என்னைத் தொடர்பு கொள்ள தயங்காதீர்கள்.</string>
-    <string name="label_translation">மொழிபெயர்ப்பு</string>
-    <string name="description_help_translate">இந்த ஆப்்அன்னை மற்ற மொழிகளில் கிடைக்கப்பட உதவும்.</string>
     <string name="label_device_speaker">சாதன உருள்</string>
-    <string name="label_keyevent_playpause">இசை-இடைநிறுத்து</string>
-    <string name="label_keyevent_play">இசைப்பிச்சு</string>
-    <string name="label_keyevent_next">அடுத்தது</string>
-    <string name="label_install_id">நிறுவல் ஐடி</string>
     <string name="message_copied_to_clipboard">க்ளிப்போர்டில் நகலெடுக்கப்பட்டது</string>
-    <string name="label_thanks">நன்றி</string>
-    <string name="label_licenses">இஜையங்கள்</string>
-    <string name="description_ring_volume_additional_permission">ரிங் ஒலி அளவை மாற்ற கூடுதலான அனுமதிகள் தேவைப்படுகின்றன.</string>
-    <string name="label_missing_permissions">காணாத அனுமதிகள்</string>
-    <string name="action_grant">வழங்கு</string>
-    <string name="label_advanced">மேம்பட்ட</string>
-    <string name="label_exclude_health">ஆரோக்கிய ப்ரோபைல்களை தவிர்</string>
-    <string name="description_exclude_health">சில Android சாதனங்கள் \'ஆரோக்கிய சாதனம்\' Bluetooth ப்ரோபைல்களை (HDP, 0x1400) தேடும்போது தடுமாறுகின்றன.</string>
-    <string name="label_exclude_gattserver">GATT சேவையர் ப்ரோபைல்களை தவிர்</string>
-    <string name="label_exclude_gatt">GATT ப்ரோபைல்களை தவிர்</string>
-    <string name="description_exclude_gattserver">\'பொதுவான குண்பம்\' (GATT) சேவையர் வகையின் Bluetooth ப்ரோபைல்களை கேளாதீர்.</string>
-    <string name="description_exclude_gatt">\'பொதுவான குண்பம்\' (GATT) களியன்ட் வகையின் Bluetooth ப்ரோபைல்களை கேளாதீர்.</string>
-    <string name="description_waiting_for_devicex">%s இணைப்பை முடிக்க காத்திருக்கிறது</string>
-    <string name="action_undo">செயல்தவிர்</string>
-    <string name="action_show">காட்டு</string>
     <string name="action_dismiss">நிராகரி</string>
-    <string name="action_fix">சரிசெய்</string>
-    <string name="battery_optimizations_issue_description">இந்த ஆப்்கு பட்டரி மேம்பாடுகள் இயக்கப்பட்டுள்ளன மற்றும் Bluetooth நிகழ்வுகளைப் பெற்றுக்கொள்வதைத் தடுக்கலாம். உங்களுக்கு பிரச்சினை இருந்தால் மேம்பாடுகளை குறைக்கலாம்.</string>
     <string name="label_bluetooth_settings">Bluetooth அமைப்புகள்</string>
-    <string name="android10_applaunch_issue_description">Android 10 பின்ணிலையிருந்து ஆப்களை தொடங்குவதைத் தடுக்கிறது. Bluetooth சாதனம் இணைக்கப்படும்போது ஆப்களை திறக்க அனுமதிக்க \"மற்ற ஆப்களின் மேல் காட்டு\" (SYSTEM_ALERT_WINDOW) அனுமதி வழங்கும்.</string>
-    <string name="label_opensource">மூல குறியீடு</string>
-    <string name="android13_notification_permission_description">இந்த ஆப்் இயங்கும்போது மற்றும் ஒலி சரிசெய்த்தல் நடக்கும்போது அறிவிப்பு காட்ட இந்த ஆப்்கு அறிவிப்பு போட்டிட அனுமதி வழங்கும்.</string>
-    <string name="privacy_policy_label">தனியுரிமை கொள்கை</string>
     <string name="managed_devices_empty_message">Bluetooth சாதனங்கள் ஏதும் கட்டமைக்கப்படவில்லை.\nமுதல் சாதனத்தை சேர்க்க + பட்டனை தட்டும்.</string>
     <string name="label_pro_feature">ப்ரிமியம் சிறப்பிய்</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">மார்வு</string>
     <string name="review_app_dismiss_action">பிறகு வேளையில்</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">கொள்முடிவு ரத்துசெய்யப்பட்டது</string>
-    <string name="error_iap_unavailable_message">ஆப்் உள்ளை கொள்முடிவுகள் கிடையவில்லை</string>
-    <string name="error_generic_message">பிழை ஏற்பட்டது. மீண்டும் முயற்சிக்கவும்.</string>
-    <string name="error_iap_owned_message">உங்களிடம் ஈ பொருள் ஏற்கனவே உள்ளது</string>
     <string name="label_no_devices_title">சாதனங்கள் இல்லை</string>
     <string name="bluemusic_mascot_description">ஆப்் சின்னம்</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">ஆப்களைத் தேர்ந்தெடு</string>
     <string name="devices_app_selection_search_hint">ஆப்களை தேடும்…</string>
-    <string name="devices_app_selection_currently_selected">தற்போது தேர்ந்தெடுக்கப்பட்டது</string>
     <string name="devices_app_selection_selected_count">%d ஆப்கள் தேர்ந்தெடுக்கப்பட்டன</string>
     <string name="general_navigate_back_action">பின்னால் செல்</string>
     <string name="general_reset_action">மீட்டமை</string>
     <string name="general_clear_action">அழிக்கு</string>
-    <string name="general_save_action">சேமி</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">பூட்டு</string>
     <string name="devices_indicator_awake">விழிப்பு</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">கட்டுப்படுத்து</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">பூஸ்ட்</string>
-    <string name="devices_indicator_launch">தொடங்கு</string>
     <string name="devices_indicator_home">இல்லம்</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">எச்சரிக்கை</string>

--- a/app/src/main/res/values-te-rIN/strings.xml
+++ b/app/src/main/res/values-te-rIN/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">అప్‌డేట్ సమయంలో కొన్ని లక్షణాలు మారాయి. అన్నీ సరిగ్గా కాన్ఫిగర్ చేయబడ్డాయని నిర్ధారించడానికి దయచేసి మీ పరికర సెట్టింగ్‌లను తనిఖీ చేయండి.</string>
     <string name="onboarding_rewrite_action">కొనసాగించు</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">నిర్వహించబడని పరికరాలు కనుగొనబడలేదు</string>
     <string name="discover_all_devices_managed_msg">మీ అన్ని జోడించిన పరికరాలు నిర్వహించబడుతున్నాయి! కొత్తది కావాలా?</string>
     <string name="discover_pair_new_device_action">కొత్త పరికరాన్ని జత చేయండి</string>
     <string name="discover_device_speaker_desc">ఈ ఫోన్ యొక్క స్వంత స్పీకర్. ఆడియో ఫోన్‌కు తిరిగి మారినప్పుడు దాని వాల్యూమ్‌లు వర్తించబడతాయి, ఉదా. మీ Bluetooth పరికరం డిస్‌కనెక్ట్ చేయబడిన తరువాత.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">పరికర కాన్ఫిగరేషన్</string>
-    <string name="devices_device_config_section_general_label">సాధారణ</string>
     <string name="devices_device_config_remove_device_label">పరికరాన్ని మరచిపో</string>
-    <string name="devices_device_config_remove_device_desc">ఈ యాప్ నుండి పరికరాన్ని మరచిపోయి దాని కాన్ఫిగరేషన్‌ను తొలగిస్తుంది. ఇది పరికరాన్ని అన్‌పేర్ చేయదు.</string>
     <string name="devices_device_config_remove_device_action">మరచిపో</string>
     <string name="devices_device_config_remove_device_confirmation">నిర్వహించిన పరికరాల నుండి %s ని మరచిపోవాలా?</string>
-    <string name="devices_device_config_rename_device_label">పరికరాన్ని పేరు మార్చు</string>
-    <string name="devices_device_config_rename_device_desc">ఈ యాప్‌లో మరియు సాధ్యమైతే సిస్టమ్‌లో కూడా ఈ పరికరాన్ని పేరు మార్చండి.</string>
     <string name="devices_device_config_rename_device_action">పేరు మార్చు</string>
     <string name="devices_device_config_enabled_label">ప్రారంభించబడిన</string>
     <string name="devices_device_config_enabled_desc">కనెక్ట్ అయినప్పుడు ఈ పరికరానికి స్పందించు</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">ఆటోప్లే కమాండ్‌లు</string>
     <string name="devices_device_config_autoplay_keycodes_order">కమాండ్ సీక్వెన్స్</string>
     <string name="devices_device_config_autoplay_keycodes_label">కమాండ్‌లు</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">ఏ కమాండ్‌లను ఏ క్రమంలో పంపించాలో కాన్ఫిగర్ చేయండి</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">ఏ కమాండ్‌లూ కాన్ఫిగర్ చేయలేదు</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">కమాండ్ జోడించు</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">గరిష్ఠంగా %1$d కమాండ్‌లు</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">పైకి జరుపు</string>
     <string name="cd_autoplay_keycode_move_down">కిందకు జరుపు</string>
     <string name="cd_autoplay_keycode_remove">తీసివేయండి</string>
-    <string name="devices_device_config_section_volumes_label">వాల్యూమ్‌లు</string>
     <string name="devices_device_config_section_volume_label">వాల్యూమ్</string>
     <string name="devices_device_config_alarm_volume_label">అలారం వాల్యూమ్</string>
     <string name="devices_device_config_alarm_volume_desc">కొన్ని అలారం యాప్‌లు బదులుగా మ్యూజిక్ వాల్యూమ్ ఉపయోగిస్తాయి.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">రింగ్</string>
     <string name="devices_audio_stream_notification_label">నోటిఫికేషన్</string>
     <string name="devices_audio_stream_alarm_label">అలారం</string>
-    <string name="devices_neverseen_label">ఎప్పుడూ కనుగొనబడలేదు</string>
-    <string name="devices_state_connected_label">కనెక్ట్ అయింది</string>
     <string name="devices_last_connected_label">చివరిగా కనెక్ట్ అయింది: %s</string>
     <string name="devices_currently_connected_label">ప్రస్తుతం కనెక్ట్ అయింది</string>
     <string name="devices_device_disabled_label">పరికరం నిలిపివేయబడింది</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">అన్ని నిర్వహించిన పరికరాలను ప్రభావితం చేసే సెట్టింగ్‌లు.</string>
     <string name="label_app_enabled">యాప్ ఎనేబుల్ చేయబడింది</string>
     <string name="description_app_enabled">వాల్యూమ్ మరియు Bluetooth ఈవెంట్‌లకు స్పందించే యాప్ సామర్ధ్యాన్ని టోగుల్ చేస్తుంది.</string>
-    <string name="label_visible_volume_adjustments">కనిపించే సర్దుబాట్లు</string>
-    <string name="description_visible_volume_adjustments">ఈ యాప్ సర్దుబాట్లు చేస్తున్నప్పుడు సిస్టమ్ వాల్యూమ్ విండో చూపించు.</string>
     <string name="label_volume_listener">మార్పులను గమనించు</string>
-    <string name="description_volume_listener">పరికరం కనెక్ట్ అయి ఉన్నప్పుడు చురుగ్గా ఉండి, ఈ యాప్ వల్ల కాని వాల్యూమ్ మార్పులను సేవ్ చేయండి.</string>
     <string name="label_boot_restore">బూట్ చేసేటప్పుడు పునరుద్ధరించు</string>
     <string name="description_boot_restore">Bluetooth పరికరం కనెక్ట్ అయి ఉంటే బూట్/రీబూట్ తర్వాత వాల్యూమ్ పునరుద్ధరించండి.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM ని సమర్ధంగా ఎలా ఉపయోగించాలో నేర్చుకోండి</string>
     <string name="settings_support_issue_tracker_description">బగ్ రిపోర్ట్స్ మరియు ఫీచర్ రిక్వెస్టుల కోసం పబ్లిక్ ఇమేజ్ ట్రాకర్.</string>
     <string name="settings_support_issue_tracker_label">ఇస్లూ ట్రాకర్</string>
-    <string name="settings_support_debuglog_label">డిబగ్ లాగ్</string>
     <string name="settings_support_debuglog_desc">ఎప్లికేషన్ చేస్తున్న ప్రత్యేక పనిని మీరు శేర్ చేయగల టెక్స్ట్ ఫైల్‌లో రెకార్డ్ చేయండి.</string>
-    <string name="settings_support_debuglog_recording_desc">ప్రస్తుతం డీబగ్ సమాచారం రికార్డ్ చేస్తోంది. రికార్డింగ్ ఆపడానికి నొక్కండి.</string>
-    <string name="settings_support_debuglog_path">లాగ్ పాత్: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">చాలా తక్కువ రికార్డింగ్</string>
     <string name="settings_support_debuglog_short_recording_msg">అది చాలా తక్కువ రికార్డింగ్. డీబగ్ లాగ్‌లు స్నాప్‌షాట్‌లు కాదు, రికార్డింగ్‌లు — లాగ్ ఉపయోగపడాలంటే రికార్డింగ్ యాక్టివ్‌గా ఉన్నప్పుడు సమస్యను పునరుత్పత్తి చేయండి.</string>
     <string name="settings_support_debuglog_short_recording_continue">రికార్డింగ్ కొనసాగించు</string>
     <string name="settings_support_debuglog_short_recording_stop">ఏదైనా ఆపు</string>
-    <string name="settings_support_debuglog_folder_label">డీబగ్ లాగ్ ఫోల్డర్</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d సెషన్ %2$s ఉపయ౏గిస్తోంది</item>
-        <item quantity="other">%1$d సెషన్‌లు %2$s ఉపయ౏గిస్తున్నాయి</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">డీబగ్ లాగ్‌లు సేవ్ చేయబడలేదు</string>
-    <string name="settings_support_debuglog_folder_delete_title">అన్ని డీబగ్ లాగ్‌లు తొలగించాలా?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">ఇది నిల్వ చేసిన అన్ని డీబగ్ లాగ్ సెషన్‌లను శాశ్వతంగా తొలగిస్తుంది.</string>
     <string name="settings_support_discord_label">డిస్కార్డ్</string>
     <string name="settings_support_discord_description">ప్రశ్నలు అడగడానికి మరియు సమయం గడపడానికి స్థలం.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">అనువాదం</string>
     <string name="settings_acks_translators_title">అనువాదకులు</string>
     <string name="settings_acks_translators_people">వ్యక్తి1;వ్యక్తి2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM అనువదించు</string>
-    <string name="settings_acks_translate_desc">BVM ని మీ భాషలోకి అనువదించడానికి సహాయపడండి</string>
     <string name="settings_acks_thanks_header">ధన్యవాదాలు</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">ఓపెన్-సోర్స్ ప్రాజెక్టుల అనువాదానికి మద్దతు ఇవ్వడానికి</string>
     <string name="settings_licenses_label">లైసెన్సులు</string>
     <string name="settings_translation_label">అనువాదం</string>
     <string name="settings_translation_desc">యాప్‌ను మీ ఇష్టమైన భాషలోకి అనువదించడానికి సహాయపడండి</string>
-    <string name="settings_sponsor_development_title">అభివృద్ధికు మద్దతు</string>
-    <string name="settings_sponsor_development_summary">పాట్రన్ అవ్వండి మరియు నిరంతర అభివృద్ధిని సాధ్యం చేయండి.</string>
     <string name="settings_privacy_policy_label">గోప్యతా విధానం</string>
     <string name="settings_privacy_policy_desc">డేటాను బాధ్యతగా నిర్వహించడం.</string>
     <string name="changelog_label">మార్పుల లాగ్</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">పునరుద్ధరణ పూర్తైంది — %1$d పరికరాలు పునరుద్ధరించబడ్డాయి, %2$d దాటవేయబడ్డాయి.</string>
     <string name="backup_restore_version_warning">ఈ బ్యాకప్ వర్షన్ %1$s తో తయారు చేయబడింది. మీరు %2$s నడుపుతున్నారు. కొన్ని సెట్టింగ్‌లు సరిగా పునరుద్ధరించబడకపోవచ్చు.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">డీబగ్ నోటిఫికేషన్లు</string>
     <string name="debug_log_consent_title">డిబగ్ లాగ్</string>
     <string name="debug_log_consent_explanation">ఈ ఫీచర్ యాప్ చేస్తున్న ప్రతిదీ పంచుకోగల ఫైల్‌లో రికార్డ్ చేస్తుంది. సృష్టించబడిన ఫైల్‌లో సున్నితమైన సమాచారం ఉంది (ఉదా. ఫైల్ పేర్లు మరియు ఇన్‌స్టాల్ చేయబడిన యాప్‌లు). దీన్ని విశ్వసనీయ పక్షాలతో మాత్రమే పంచుకోండి (ఉదా. సమస్యను పరిష్కరించే డెవలపర్).</string>
-    <string name="debug_log_recording_progress">డీబగ్ లాగ్ రికార్డ్ చేస్తోంది</string>
     <string name="debug_log_record_action">రికార్డ్ చేయి</string>
     <string name="debug_log_stop_action">రికార్డింగ్ ఆపండి</string>
     <string name="debug_log_screen_title">డీబగ్ లాగ్ రికార్డర్</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">విస్మరించండి</string>
     <string name="debug_log_screen_keep_action">ఉంచు</string>
-    <string name="debug_log_compressing_label">కుదిస్తోంది…</string>
     <string name="debug_log_file_label">రికార్డ్ చేయబడిన లాగ్ ఫైల్</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">లాగ్ పంపారా?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">మీ ప్రశ్నను వివరంగా వివరించండి.</string>
     <string name="contact_category_section_label">వర్గం</string>
     <string name="contact_debug_log_label">డిబగ్ లాగ్</string>
-    <string name="contact_debug_log_select_hint">జతచేయడానికి ఒక డీబగ్ లాగ్ ఎంచుకోండి</string>
     <string name="contact_debug_log_picker_hint">సమస్యను వేగంగా నిర్ధారించడానికి ఒక డీబగ్ లాగ్ జతచేయండి.</string>
     <string name="contact_debug_log_picker_empty">డీబగ్ లాగ్‌లు అందుబాటులో లేవు. ముందు ఒకదాన్ని రికార్డ్ చేయండి.</string>
     <string name="contact_expected_behavior_label">అంచనా ప్రవర్తన</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">నేను ప్రతి సందేశాన్ని స్వయంగా చదువుతాను మరియు సమాధానం ఇవ్వడానికి నా వంతు ప్రయత్నం చేస్తాను, కాని నేను ఒంటరిగా పని చేస్తున్నాను కావున కొంచెం సమయం పట్టవచ్చు. మీ సహనానికి ధన్యవాదాలు.</string>
     <string name="contact_footer_msg">మీ సందేశం ఇమేయిల్ ద్వారా పంపబడుతుంది. పరికర మరియు సెటప్ సమాచారం స్వయంచాలకంగా జతచేయబడుతుంది.</string>
     <string name="contact_no_email_app_msg">ఈ పరికరంలో ఇమేయిల్ యాప్ కనుగొనబడలేదు.</string>
-    <string name="contact_attachment_missing_msg">డీబగ్ లాగ్ ఫైల్ ఇకపుడు లేదు</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">నిల్వ చేసిన డీబగ్ లాగ్‌లు</string>
     <string name="settings_support_stored_logs_desc">%1$d సెషన్‌లు (%2$s)</string>
     <string name="settings_support_stored_logs_empty">నిల్వ చేసిన డీబగ్ లాగ్‌లు లేవు</string>
-    <string name="settings_support_stored_logs_delete_title">నిల్వ చేసిన లాగ్‌లు తొలగించాలా?</string>
-    <string name="settings_support_stored_logs_delete_msg">ఇది అన్ని %1$d నిల్వ చేసిన డీబగ్ లాగ్ సెషన్‌లను తొలగిస్తుంది.</string>
-    <string name="settings_support_stored_logs_deleted_msg">నిల్వ చేసిన డీబగ్ లాగ్‌లు తొలగించబడ్డాయి</string>
-    <string name="label_bug_reports">బగ్ రిపోర్ట్‌లు</string>
-    <string name="description_bug_reports">స్వయంచాలక బగ్ మరియు క్రాష్ రిపోర్టింగ్.</string>
     <string name="label_add_device">పరికరం జోడించు</string>
-    <string name="label_just_a_moment_please">ఒక్క క్షణం, దయచేసి.</string>
     <string name="label_notification_channel_status">స్థితి</string>
     <string name="label_notification_channel_setup">సెటప్ అవసరం</string>
     <string name="monitor_notification_starting">ప్రారంభిస్తోంది…</string>
     <string name="action_set">సెట్ చేయి</string>
     <string name="action_cancel">రద్దు చేయండి</string>
-    <string name="label_invalid_input">చెల్లని ఇన్‌పుట్</string>
     <string name="action_reset">రీసెట్ చేయండి</string>
     <string name="label_no_connected_devices">పరికరాలు కనెక్ట్ అవ్వలేదు</string>
-    <string name="label_status_idle">విరామంలో</string>
-    <string name="label_status_adjusting_volumes">వాల్యూమ్‌లు సర్దుబాటు చేస్తోంది</string>
-    <string name="label_premium_version">ప్రీమియం వెర్షన్</string>
     <string name="general_upgrade_action">అప్‌గ్రేడ్ చేయండి</string>
     <string name="common_upgrade_required_label">అప్‌గ్రేడ్ అవసరం</string>
-    <string name="label_premium_version_required">ప్రీమియం వెర్షన్ అవసరం</string>
-    <string name="description_intro_purpose">ఈ యాప్ మీ Android పరికరం వేర్వేరు Bluetooth పరికరాల వాల్యూమ్‌ను గుర్తుంచుకోవడానికి అనుమతిస్తుంది.</string>
-    <string name="upgrade_benefit_unlimited_devices">అపరిమిత పరికర ప్రొఫైల్‌లు</string>
-    <string name="upgrade_benefit_connection_actions">ఆటోప్లే, యాప్ లాంచ్ మరియు కనెక్షన్ అలర్ట్‌లు</string>
-    <string name="upgrade_benefit_theme_customization">థీమ్, స్టైల్ మరియు రంగు కస్టమైజేషన్</string>
-    <string name="upgrade_benefit_power_controls">వాల్యూమ్ లాక్ మరియు రేట్ లిమిటింగ్</string>
-    <string name="upgrade_benefit_support">స్వతంత్ర అభివృద్ధికి మద్దతు ఇవ్వండి</string>
     <string name="upgrade_benefit_equalizer">• ప్రతి పరికరానికి ఈక్వలైజర్ (సిస్టమ్ ఈక్వలైజర్ సపోర్ట్‌ కలిగిన సంగీత అనువర్తనాల కోసం)</string>
-    <string name="description_intro_tap_the_button">మీ మొదటి పరికరాన్ని జోడించడం ద్వారా ప్రారంభించండి.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth నిలిపివేయబడింది.</string>
     <string name="title_bluetooth_is_off">Bluetooth ఆఫ్‌లో ఉంది</string>
     <string name="action_enable_bluetooth">Bluetooth ఎనేబుల్ చేయి</string>
     <string name="title_bluetooth_permission_required">Bluetooth అనుమతి అవసరం</string>
     <string name="description_bluetooth_permission_required">మీ పరికర వాల్యూమ్‌లను నిర్వహించడానికి ఈ యాప్‌కు Bluetooth అనుమతి అవసరం.</string>
     <string name="action_grant_permission">అనుమతి మంజూరు చేయి</string>
-    <string name="label_status_listening_for_changes">వాల్యూమ్ మార్పుల కోసం వింటోంది</string>
     <string name="action_exit">నిష్క్రమించు</string>
-    <string name="action_start">ప్రారంభించు</string>
-    <string name="label_welcome">స్వాగతం</string>
-    <string name="description_intro_contact">మీకు ప్రశ్నలు ఉంటే లేదా కొత్త ఫీచర్ కోసం ఆలోచన ఉంటే నన్ను సంప్రదించడానికి వెనుకాడకండి.</string>
-    <string name="label_translation">అనువాదం</string>
-    <string name="description_help_translate">ఈ యాప్‌ను ఇతర భాషలలో అందుబాటులో ఉంచడానికి నాకు సహాయపడండి.</string>
     <string name="label_device_speaker">పరికర స్పీకర్</string>
-    <string name="label_keyevent_playpause">ప్లే-పాజ్</string>
-    <string name="label_keyevent_play">ప్లే</string>
-    <string name="label_keyevent_next">తదుపరి</string>
-    <string name="label_install_id">ఇన్స్టాల్ ID</string>
     <string name="message_copied_to_clipboard">క్లిప్‌బోర్డ్‌కు కాపీ చేయబడింది</string>
-    <string name="label_thanks">ధన్యవాదాలు</string>
-    <string name="label_licenses">లైసెన్సులు</string>
-    <string name="description_ring_volume_additional_permission">రింగ్ వాల్యూమ్ మార్చడానికి అదనపు అనుమతులు అవసరం.</string>
-    <string name="label_missing_permissions">అనుమతులు లేవు</string>
-    <string name="action_grant">మంజూరు చేయి</string>
-    <string name="label_advanced">అధునాతన</string>
-    <string name="label_exclude_health">ఆరోగ్య ప్రొఫైల్‌లను మినహాయించు</string>
-    <string name="description_exclude_health">కొన్ని Android పరికరాలు \'Health Device\' Bluetooth ప్రొఫైల్‌లను (HDP, 0x1400) చూస్తున్నప్పుడు హ్యాంగ్ అవుతాయి.</string>
-    <string name="label_exclude_gattserver">GATT సర్వర్ ప్రొఫైల్‌లను మినహాయించు</string>
-    <string name="label_exclude_gatt">GATT ప్రొఫైల్‌లను మినహాయించు</string>
-    <string name="description_exclude_gattserver">\'Generic Attribute\' (GATT) సర్వర్ రకం Bluetooth ప్రొఫైల్‌లను క్వెరీ చేయవద్దు.</string>
-    <string name="description_exclude_gatt">\'Generic Attribute\' (GATT) క్లయింట్ రకం Bluetooth ప్రొఫైల్‌లను క్వెరీ చేయవద్దు.</string>
-    <string name="description_waiting_for_devicex">కనెక్షన్ పూర్తి చేయడానికి %s కోసం వేచి ఉంది</string>
-    <string name="action_undo">రద్దుచేయండి</string>
-    <string name="action_show">చూపించు</string>
     <string name="action_dismiss">తీసివేయండి</string>
-    <string name="action_fix">పరిష్కరించండి</string>
-    <string name="battery_optimizations_issue_description">ఈ యాప్‌కు బ్యాటరీ ఆప్టిమైజేషన్‌లు ప్రారంభించబడ్డాయి మరియు ఇవి Bluetooth ఈవెంట్‌లను స్వీకరించడాన్ని నిరోధించవచ్చు. మీకు సమస్యలు ఎదురవుతున్నట్లయితే ఆప్టిమైజేషన్‌లను నిలిపివేయడాన్ని పరిగణించండి.</string>
     <string name="label_bluetooth_settings">Bluetooth సెట్టింగ్‌లు</string>
-    <string name="android10_applaunch_issue_description">Android 10 యాప్‌లను బ్యాక్‌గ్రౌండ్ నుండి ప్రారంభించే విధానాన్ని పరిమితం చేస్తుంది. Bluetooth పరికరం కనెక్ట్ అయినప్పుడు యాప్‌లు తెరవడానికి అనుమతించడానికి, \"ఇతర యాప్‌లపై ప్రదర్శించు\" (SYSTEM_ALERT_WINDOW) అనుమతిని మంజూరు చేయండి.</string>
-    <string name="label_opensource">సోర్స్ కోడ్</string>
-    <string name="android13_notification_permission_description">నోటిఫికేషన్‌లు పోస్ట్ చేయడానికి ఈ యాప్‌కు అనుమతి ఇవ్వండి. ఈ యాప్ యాక్టివ్‌గా ఉన్నప్పుడు మరియు వాల్యూమ్ సర్దుబాట్లు చేస్తున్నప్పుడు నోటిఫికేషన్ ప్రదర్శించడాన్ని ఇది అనుమతిస్తుంది.</string>
-    <string name="privacy_policy_label">గోప్యతా విధానం</string>
     <string name="managed_devices_empty_message">Bluetooth పరికరాలు కాన్ఫిగర్ చేయబడలేదు.\nమీ మొదటి పరికరాన్ని జోడించడానికి + బటన్‌ను నొక్కండి.</string>
     <string name="label_pro_feature">ప్రీమియం ఫీచర్</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">సమీక్ష</string>
     <string name="review_app_dismiss_action">తరువాత ఆగామి</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">కొనుగోలు రద్దు చేయబడింది</string>
-    <string name="error_iap_unavailable_message">యాప్-లో కొనుగోళ్ళు అందుబాటులో లేవు</string>
-    <string name="error_generic_message">లోపం సంభవించింది. దయచేసి మళ్ళీ ప్రయత్నించండి.</string>
-    <string name="error_iap_owned_message">మీరు ఈ అంశాన్ని ఇప్పటికే కలిగి ఉన్నారు</string>
     <string name="label_no_devices_title">పరికరాలు లేవు</string>
     <string name="bluemusic_mascot_description">యాప్ చిహ్నం</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">యాప్‌లను ఎంచుకొండి</string>
     <string name="devices_app_selection_search_hint">యాప్‌లను శోధించండి…</string>
-    <string name="devices_app_selection_currently_selected">ప్రస్తుతం ఎంచుకున్నది</string>
     <string name="devices_app_selection_selected_count">%d యాప్‌లు ఎంచుకొబడ్డాయి</string>
     <string name="general_navigate_back_action">వెనక్కు నావిగేట్ చేయి</string>
     <string name="general_reset_action">రీసెట్ చేయండి</string>
     <string name="general_clear_action">క్లియర్ చేయి</string>
-    <string name="general_save_action">సేవ్ చేయండి</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">లాక్</string>
     <string name="devices_indicator_awake">మేల్కొని</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">పరిమితి</string>
     <string name="devices_indicator_eq">ఈక్యూ</string>
     <string name="devices_indicator_boost">బూస్ట్</string>
-    <string name="devices_indicator_launch">ప్రారంభించు</string>
     <string name="devices_indicator_home">హోమ్</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">హెచ్చరిక</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">การตั้งค่าอุปกรณ์บางตัวอาจถูกรีเซ็ตระหว่างการอัปเดต โปรดตรวจสอบการกำหนดค่าอุปกรณ์ของคุณ</string>
     <string name="onboarding_rewrite_action">ดำเนินการต่อ</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">ไม่พบอุปกรณ์ที่ยังไม่ได้จัดการ</string>
     <string name="discover_all_devices_managed_msg">อุปกรณ์ที่จับคู่ทั้งหมดถูกจัดการแล้ว! ต้องการอันใหม่มั้ย?</string>
     <string name="discover_pair_new_device_action">จับคู่อุปกรณ์ใหม่</string>
     <string name="discover_device_speaker_desc">ลำโพงของโทรศัพท์เครื่องนี้ ระดับเสียงจะถูกนำไปใช้เมื่อเสียงสลับกลับไปยังโทรศัพท์ เช่น หลังจากอุปกรณ์ Bluetooth ของคุณตัดการเชื่อมต่อ</string>
     <!-- Devices -->
     <string name="devices_device_config_label">การตั้งค่าอุปกรณ์</string>
-    <string name="devices_device_config_section_general_label">ทั่วไป</string>
     <string name="devices_device_config_remove_device_label">ลืมอุปกรณ์</string>
-    <string name="devices_device_config_remove_device_desc">ลืมอุปกรณ์จากแอปนี้และลบการตั้งค่า ไม่ได้ยกเลิกการจับคู่อุปกรณ์</string>
     <string name="devices_device_config_remove_device_action">ลืม</string>
     <string name="devices_device_config_remove_device_confirmation">ลืม %s จากอุปกรณ์ที่จัดการหรือไม่?</string>
-    <string name="devices_device_config_rename_device_label">เปลี่ยนชื่ออุปกรณ์</string>
-    <string name="devices_device_config_rename_device_desc">เปลี่ยนชื่ออุปกรณ์นี้ในแอปนี้ และหากทำได้ก็ในระบบด้วย</string>
     <string name="devices_device_config_rename_device_action">เปลี่ยนชื่อ</string>
     <string name="devices_device_config_enabled_label">เปิดใช้งาน</string>
     <string name="devices_device_config_enabled_desc">ตอบสนองต่ออุปกรณ์นี้เมื่อเชื่อมต่อ</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">คำสั่งเล่นอัตโนมัติ</string>
     <string name="devices_device_config_autoplay_keycodes_order">ลำดับคำสั่ง</string>
     <string name="devices_device_config_autoplay_keycodes_label">คำสั่ง</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">กำหนดคำสั่งที่จะส่งและลำดับการส่ง</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">ยังไม่มีการกำหนดคำสั่ง</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">เพิ่มคำสั่ง</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">สูงสุด %1$d คำสั่ง</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">ย้ายขึ้น</string>
     <string name="cd_autoplay_keycode_move_down">ย้ายลง</string>
     <string name="cd_autoplay_keycode_remove">ลบออก</string>
-    <string name="devices_device_config_section_volumes_label">ระดับเสียง</string>
     <string name="devices_device_config_section_volume_label">ระดับเสียง</string>
     <string name="devices_device_config_alarm_volume_label">ระดับเสียงนาฬิกาปลุก</string>
     <string name="devices_device_config_alarm_volume_desc">แอปนาฬิกาปลุกบางตัวใช้ระดับเสียงเพลงแทน</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">เสียงเรียกเข้า</string>
     <string name="devices_audio_stream_notification_label">การแจ้งเตือน</string>
     <string name="devices_audio_stream_alarm_label">การแจ้งเตือน</string>
-    <string name="devices_neverseen_label">ไม่เคยเห็น</string>
-    <string name="devices_state_connected_label">เชื่อมต่อแล้ว</string>
     <string name="devices_last_connected_label">เชื่อมต่อครั้งล่าสุด: %s</string>
     <string name="devices_currently_connected_label">เชื่อมต่ออยู่ในขณะนี้</string>
     <string name="devices_device_disabled_label">อุปกรณ์ถูกปิดใช้งาน</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">การตั้งค่าที่มีผลต่ออุปกรณ์ที่จัดการทั้งหมด</string>
     <string name="label_app_enabled">แอปที่เปิดใช้งาน</string>
     <string name="description_app_enabled">สลับแอพความสามารถในการตอบสนองต่อเสียงและกิจกรรมบลูทูธ</string>
-    <string name="label_visible_volume_adjustments">ปรับปรุงการมองเห็น</string>
-    <string name="description_visible_volume_adjustments">ปรับการแสดงหน้าต่างข้อมูลของระบบในขณะนี้</string>
     <string name="label_volume_listener">สังเกตการเปลี่ยนแปลง</string>
-    <string name="description_volume_listener">ยังคงใช้งานในขณะที่อุปกรณ์เชื่อมต่อ และบันทึกการเปลี่ยนแปลงระดับเสียงที่ไม่ได้เกิดจากการตรวจสอบนี้</string>
     <string name="label_boot_restore">เรียกคืนเมื่อบูต</string>
     <string name="description_boot_restore">คืนค่าระดับเสียงหลังจากบูต/รีบูตเครื่องถ้าเชื่อมต่ออุปกรณ์บลูทูธแล้ว</string>
     <!-- Settings/Support-->
@@ -203,21 +191,11 @@
     <string name="settings_support_wiki_description">เรียนรู้วิธีใช้ BVM อย่างมีประสิทธิภาพ</string>
     <string name="settings_support_issue_tracker_description">ติดตามปัญหาแบบเปิดสาธารณะสำหรับรายงานปัญหาและคำขอคุณสมบัติใหม่</string>
     <string name="settings_support_issue_tracker_label">ติดตามปัญหา</string>
-    <string name="settings_support_debuglog_label">ล็อกดีบัก</string>
     <string name="settings_support_debuglog_desc">บันทึกทุกอย่างที่แอปทำลงในไฟล์ข้อความที่คุณสามารถแชร์ได้</string>
-    <string name="settings_support_debuglog_recording_desc">กำลังบันทึกข้อมูลดีบักอยู่ แตะเพื่อหยุดบันทึก</string>
-    <string name="settings_support_debuglog_path">ตำแหน่งล็อก: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">การบันทึกสั้นมาก</string>
     <string name="settings_support_debuglog_short_recording_msg">นั่นเป็นการบันทึกที่สั้นมาก ล็อกดีบักเป็นการบันทึก ไม่ใช่ภาพนิ่ง — สร้างปัญหาขึ้นใหม่ขณะที่การบันทึกกำลังทำงานอยู่เพื่อให้ล็อกมีประโยชน์</string>
     <string name="settings_support_debuglog_short_recording_continue">บันทึกต่อ</string>
     <string name="settings_support_debuglog_short_recording_stop">หยุดต่อไป</string>
-    <string name="settings_support_debuglog_folder_label">โฟลเดอร์ล็อกดีบัก</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d เซสชั่นใช้ %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">ไม่มีล็อกดีบักที่เก็บไว้</string>
-    <string name="settings_support_debuglog_folder_delete_title">ลบล็อกดีบักทั้งหมด?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">การดำเนินการนี้จะลบเซสชั่นล็อกดีบักที่เก็บไว้ทั้งหมดอย่างถาวร</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">ที่สำหรับมาฮังเอาและถามคำถาม</string>
     <!-- Settings/Acks-->
@@ -226,16 +204,12 @@
     <string name="settings_acks_translation_header">การแปล</string>
     <string name="settings_acks_translators_title">ผู้แปล</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">แปล BVM</string>
-    <string name="settings_acks_translate_desc">ช่วยแปล BVM เป็นภาษาของคุณ</string>
     <string name="settings_acks_thanks_header">ขอบคุณ</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">สำหรับการสนับสนุนการแปลโครงการ open-source</string>
     <string name="settings_licenses_label">ใบอนุญาต</string>
     <string name="settings_translation_label">การแปล:</string>
     <string name="settings_translation_desc">ช่วยแปลแอปเป็นภาษาที่คุณชื่นชอบ</string>
-    <string name="settings_sponsor_development_title">สนับสนุนการพัฒนา</string>
-    <string name="settings_sponsor_development_summary">เป็นผู้สนับสนุนและทำให้การพัฒนาต่อเนื่องเป็นไปได้</string>
     <string name="settings_privacy_policy_label">นโยบายความเป็นส่วนตัว</string>
     <string name="settings_privacy_policy_desc">การจัดการข้อมูลอย่างมีความรับผิดชอบ</string>
     <string name="changelog_label">บันทึกการเปลี่ยนแปลง</string>
@@ -257,10 +231,8 @@
     <string name="backup_restore_success_restore">กู้คืนเสร็จสิ้น — กู้คืน %1$d อุปกรณ์, ข้าม %2$d อุปกรณ์</string>
     <string name="backup_restore_version_warning">ข้อมูลสำรองนี้สร้างด้วยเวอร์ชัน %1$s คุณกำลังใช้ %2$s การตั้งค่าบางอย่างอาจกู้คืนไม่ถูกต้อง</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">การแจ้งเตือนดีบัก</string>
     <string name="debug_log_consent_title">ล็อกดีบัก</string>
     <string name="debug_log_consent_explanation">คุณสมบัตินี้บันทึกทุกอย่างที่แอปทำลงในไฟล์ที่สามารถแชร์ได้ ไฟล์ที่สร้างขึ้นมีข้อมูลอ่อนไหว (เช่น ชื่อไฟล์และแอปที่ติดตั้ง) แชร์เฉพาะกับบุคคลที่ไว้ใจได้เท่านั้น (เช่น นักพัฒนาที่กำลังแก้ไขปัญหา)</string>
-    <string name="debug_log_recording_progress">กำลังบันทึกล็อกดีบัก</string>
     <string name="debug_log_record_action">บันทึก</string>
     <string name="debug_log_stop_action">หยุดบันทึก</string>
     <string name="debug_log_screen_title">เครื่องบันทึกล็อกดีบัก</string>
@@ -274,7 +246,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">ยกเลิก</string>
     <string name="debug_log_screen_keep_action">เก็บไว้</string>
-    <string name="debug_log_compressing_label">กำลังบีบอัด…</string>
     <string name="debug_log_file_label">ไฟล์ล็อกที่บันทึกไว้</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">ส่งล็อกแล้ว?</string>
@@ -302,7 +273,6 @@
     <string name="contact_description_question_hint">อธิบายคำถามของคุณอย่างละเอียด</string>
     <string name="contact_category_section_label">หมวดหมู่</string>
     <string name="contact_debug_log_label">ล็อกดีบัก</string>
-    <string name="contact_debug_log_select_hint">เลือกล็อกดีบักเพื่อแนบ</string>
     <string name="contact_debug_log_picker_hint">แนบล็อกดีบักเพื่อช่วยวินิจฉัยปัญหาได้เร็วขึ้น</string>
     <string name="contact_debug_log_picker_empty">ไม่มีล็อกดีบักที่ใช้ได้ บันทึกก่อน</string>
     <string name="contact_expected_behavior_label">พฤติกรรมที่คาดหวัง</string>
@@ -315,82 +285,32 @@
     <string name="contact_welcome_msg">ผมอ่านทุกข้อความด้วยตัวเองและพยายามตอบกลับอย่างเต็มที่ แต่เนื่องจากทำงานคนเดียว อาจต้องใช้เวลาสักนิด ขอบคุณสำหรับความอดทน</string>
     <string name="contact_footer_msg">ข้อความของคุณจะถูกส่งทางอีเมล ข้อมูลอุปกรณ์และการตั้งค่าจะถูกแนบโดยอัตโนมัติ</string>
     <string name="contact_no_email_app_msg">ไม่พบแอปอีเมลในอุปกรณ์นี้</string>
-    <string name="contact_attachment_missing_msg">ไฟล์ล็อกดีบักไม่มีอยู่อีกต่อไป</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">ล็อกดีบักที่เก็บไว้</string>
     <string name="settings_support_stored_logs_desc">%1$d เซสชั่น (%2$s)</string>
     <string name="settings_support_stored_logs_empty">ไม่มีล็อกดีบักที่เก็บไว้</string>
-    <string name="settings_support_stored_logs_delete_title">ลบล็อกที่เก็บไว้?</string>
-    <string name="settings_support_stored_logs_delete_msg">การดำเนินการนี้จะลบเซสชั่นล็อกดีบักที่เก็บไว้ทั้งหมด %1$d เซสชั่น</string>
-    <string name="settings_support_stored_logs_deleted_msg">ล็อกดีบักที่เก็บไว้ถูกลบแล้ว</string>
-    <string name="label_bug_reports">แจ้งข้อผิดพลาด</string>
-    <string name="description_bug_reports">ข้อผิดพลาดอัตโนมัติและรายงานความล้มเหลว</string>
     <string name="label_add_device">เพิ่มอุปกรณ์</string>
-    <string name="label_just_a_moment_please">โปรดรอสักครู่</string>
     <string name="label_notification_channel_status">สถานะ</string>
     <string name="label_notification_channel_setup">ต้องตั้งค่า</string>
     <string name="monitor_notification_starting">กำลังเริ่มต้น…</string>
     <string name="action_set">ตั้งค่า</string>
     <string name="action_cancel">ยกเลิก</string>
-    <string name="label_invalid_input">ใส่ไม่ถูกต้อง</string>
     <string name="action_reset">รีเซ็ต</string>
     <string name="label_no_connected_devices">ไม่มีอุปกรณ์ที่เชื่อมต่อ</string>
-    <string name="label_status_idle">ว่าง</string>
-    <string name="label_status_adjusting_volumes">ปรับระดับเสียง</string>
-    <string name="label_premium_version">รุ่นพรีเมี่ยม</string>
     <string name="general_upgrade_action">อัปเกรด</string>
     <string name="common_upgrade_required_label">ต้องอัปเกรด</string>
-    <string name="label_premium_version_required">ต้องการรุ่นพรีเมี่ยม</string>
-    <string name="description_intro_purpose">แอปนี้ช่วยให้อุปกรณ์ Android ของคุณจดจำระดับเสียงของอุปกรณ์บลูทูธแต่ละตัว</string>
-    <string name="upgrade_benefit_unlimited_devices">โปรไฟล์อุปกรณ์ไม่จำกัด</string>
-    <string name="upgrade_benefit_connection_actions">เล่นอัตโนมัติ, เปิดแอป และการแจ้งเตือนการเชื่อมต่อ</string>
-    <string name="upgrade_benefit_theme_customization">ปรับแต่งธีม, สไตล์ และสีสัน</string>
-    <string name="upgrade_benefit_power_controls">การล็อกระดับเสียงและการจำกัดอัตรา</string>
-    <string name="upgrade_benefit_support">สนับสนุนการพัฒนาอิสระ</string>
     <string name="upgrade_benefit_equalizer">• อีควอไลเซอร์แยกตามอุปกรณ์ (สำหรับแอปเพลงที่รองรับอีควอไลเซอร์ระบบ)</string>
-    <string name="description_intro_tap_the_button">เริ่มต้นด้วยการเพิ่มอุปกรณ์ตัวแรกของคุณ</string>
     <string name="description_bluetooth_is_disabled">บลูทูธถูกปิดใช้งาน</string>
     <string name="title_bluetooth_is_off">บลูทูธปิดอยู่</string>
     <string name="action_enable_bluetooth">เปิดบลูทูธ</string>
     <string name="title_bluetooth_permission_required">ต้องการสิทธิ์บลูทูธ</string>
     <string name="description_bluetooth_permission_required">แอปนี้ต้องการสิทธิ์บลูทูธเพื่อจัดการระดับเสียงของอุปกรณ์</string>
     <string name="action_grant_permission">อนุญาตสิทธิ์</string>
-    <string name="label_status_listening_for_changes">ฟังเสียงการเปลี่ยนแปลง</string>
     <string name="action_exit">ปิด</string>
-    <string name="action_start">เริ่ม</string>
-    <string name="label_welcome">ยินดีต้อนรับ</string>
-    <string name="description_intro_contact">อย่าลังเลที่จะติดต่อฉันหากคุณมีคำถามหรือแม้กระทั่งความคิดสำหรับคุณลักษณะใหม่</string>
-    <string name="label_translation">การแปล:</string>
-    <string name="description_help_translate">ช่วยฉันทำแอปนี้ในภาษาอื่น ๆ</string>
     <string name="label_device_speaker">ลำโพงอุปกรณ์</string>
-    <string name="label_keyevent_playpause">เล่น/หยุด</string>
-    <string name="label_keyevent_play">เล่น</string>
-    <string name="label_keyevent_next">ถัดไป</string>
-    <string name="label_install_id">ติดตั้ง ID</string>
     <string name="message_copied_to_clipboard">คัดลอกไปยังคลิปบอร์ด</string>
-    <string name="label_thanks">ขอบคุณ</string>
-    <string name="label_licenses">ใบอนุญาต</string>
-    <string name="description_ring_volume_additional_permission">จำเป็นต้องมีสิทธิ์เพิ่มเติมเพื่อเปลี่ยนระดับเสียงกริ่ง</string>
-    <string name="label_missing_permissions">สิทธิ์ที่ขาดหายไป</string>
-    <string name="action_grant">การอนุญาต</string>
-    <string name="label_advanced">ขั้นสูง</string>
-    <string name="label_exclude_health">ยกเว้นโปรไฟล์สุขภาพ</string>
-    <string name="description_exclude_health">อุปกรณ์แอนดรอยด์บางรุ่นอาจแฮงเมื่อค้นหาโปรไฟล์บลูทูธ \'อุปกรณ์เพื่อสุขภาพ\' (HDP, 0x1400)</string>
-    <string name="label_exclude_gattserver">ยกเว้นโปรไฟล์เซิร์ฟเวอร์ GATT</string>
-    <string name="label_exclude_gatt">ยกเว้นโปรไฟล์ GATT</string>
-    <string name="description_exclude_gattserver">อย่าค้นหาโปรไฟล์บลูทูธของเซิร์ฟเวอร์ \'Gitt\' ชนิด (Generic Attribute \'Type\')</string>
-    <string name="description_exclude_gatt">อย่าค้นหาโปรไฟล์ Bluetooth ของไคลเอนต์ \'แอตทริบิวต์ทั่วไป\' ประเภท (GATT)</string>
-    <string name="description_waiting_for_devicex">รอ %s เพื่อทำการเชื่อมต่อ</string>
-    <string name="action_undo">เลิกทำ</string>
-    <string name="action_show">แสดง</string>
     <string name="action_dismiss">ปิด</string>
-    <string name="action_fix">แก้ไข</string>
-    <string name="battery_optimizations_issue_description">การเพิ่มประสิทธิภาพแบตเตอรี่เปิดใช้งานสำหรับแอปนี้และอาจป้องกันไม่ให้รับกิจกรรม Bluetooth หากพบปัญหาให้พิจารณาปิดการเพิ่มประสิทธิภาพ</string>
     <string name="label_bluetooth_settings">การตั้งค่า Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 จำกัดวิธีเปิดแอปจากพื้นหลัง หากต้องการอนุญาตให้เปิดแอปเมื่อเชื่อมต่ออุปกรณ์ Bluetooth ให้อนุญาตสิทธิ์ &quot;แสดงเหนือแอปอื่น&quot; (SYSTEM_ALERT_WINDOW)</string>
-    <string name="label_opensource">ซอร์สโค้ด</string>
-    <string name="android13_notification_permission_description">อนุญาตให้แอปนี้โพสต์การแจ้งเตือน ซึ่งจะช่วยให้แสดงการแจ้งเตือนเมื่อแอปทำงานอยู่และกำลังปรับระดับเสียง</string>
-    <string name="privacy_policy_label">นโยบายความเป็นส่วนตัว</string>
     <string name="managed_devices_empty_message">ไม่ได้ตั้งค่าอุปกรณ์บลูทูธ\nแตะปุ่ม + เพื่อเพิ่มอุปกรณ์แรกของคุณ</string>
     <string name="label_pro_feature">ฟีเจอร์พรีเมี่ยม</string>
     <plurals name="discover_device_limit_banner">
@@ -420,21 +340,15 @@
     <string name="review_app_review_action">รีวิว</string>
     <string name="review_app_dismiss_action">อาจในคราวหน้า</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">ยกเลิกการซื้อ</string>
-    <string name="error_iap_unavailable_message">ไม่สามารถซื้อในแอปได้</string>
-    <string name="error_generic_message">เกิดข้อผิดพลาด โปรดลองใหม่</string>
-    <string name="error_iap_owned_message">คุณมีสินค้านี้อยู่แล้ว</string>
     <string name="label_no_devices_title">ไม่มีอุปกรณ์</string>
     <string name="bluemusic_mascot_description">ไอคอนแอป</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">เลือกแอป</string>
     <string name="devices_app_selection_search_hint">ค้นหาแอป…</string>
-    <string name="devices_app_selection_currently_selected">เลือกอยู่ในปัจจุบัน</string>
     <string name="devices_app_selection_selected_count">เลือกแอป %d แอป</string>
     <string name="general_navigate_back_action">นำทางย้อนกลับ</string>
     <string name="general_reset_action">รีเซ็ต</string>
     <string name="general_clear_action">ล้าง</string>
-    <string name="general_save_action">บันทึก</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">ล็อก</string>
     <string name="devices_indicator_awake">ตื่น</string>
@@ -444,7 +358,6 @@
     <string name="devices_indicator_limit">จำกัด</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">เพิ่มเสียง</string>
-    <string name="devices_indicator_launch">เปิด</string>
     <string name="devices_indicator_home">หน้าหลัก</string>
     <string name="devices_indicator_dnd">ห้ามรบกวน</string>
     <string name="devices_indicator_alert">แจ้งเตือน</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Bu güncelleme sırasında bazı cihaz ayarları sıfırlanmış olabilir. Lütfen cihaz yapılandırmalarını kontrol et.</string>
     <string name="onboarding_rewrite_action">Devam Et</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Yönetilmeyen cihaz bulunamadı</string>
     <string name="discover_all_devices_managed_msg">Tüm eşleştirilmiş cihazların yönetiliyor! Yeni bir tane mi lazım?</string>
     <string name="discover_pair_new_device_action">Yeni cihaz eşleştir</string>
     <string name="discover_device_speaker_desc">Telefonun kendi hoparlörü. Ses telefona geri döndüğünde (örneğin Bluetooth cihazınızın bağlantısı kesildiğinde) ses seviyeleri uygulanır.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Cihaz yapılandırması</string>
-    <string name="devices_device_config_section_general_label">Genel</string>
     <string name="devices_device_config_remove_device_label">Cihazı unut</string>
-    <string name="devices_device_config_remove_device_desc">Cihazı bu uygulamadan unutur ve yapılandırmasını siler. Bu, cihazın eşleşmesini bozmaz.</string>
     <string name="devices_device_config_remove_device_action">Unut</string>
     <string name="devices_device_config_remove_device_confirmation">%s\'ü yönetilen cihazlardan unutulsun mu?</string>
-    <string name="devices_device_config_rename_device_label">Cihazı yeniden adlandır</string>
-    <string name="devices_device_config_rename_device_desc">Bu cihazı bu uygulama içinde ve mümkünse sistem içinde yeniden adlandır.</string>
     <string name="devices_device_config_rename_device_action">Yeniden Adlandır</string>
     <string name="devices_device_config_enabled_label">Etkin</string>
     <string name="devices_device_config_enabled_desc">Bağlandığında bu cihaza tepki ver</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Otomatik oynatma komutları</string>
     <string name="devices_device_config_autoplay_keycodes_order">Komut sırası</string>
     <string name="devices_device_config_autoplay_keycodes_label">Komutlar</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Hangi komutların gönderileceğini ve hangi sırayla gönderileceğini yapılandırın</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Komut yapılandırılmadı</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Komut ekle</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimum %1$d komut</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Yukarı taşı</string>
     <string name="cd_autoplay_keycode_move_down">Aşağı taşı</string>
     <string name="cd_autoplay_keycode_remove">Kaldır</string>
-    <string name="devices_device_config_section_volumes_label">Ses Düzeyleri</string>
     <string name="devices_device_config_section_volume_label">Ses</string>
     <string name="devices_device_config_alarm_volume_label">Alarm ses yüksekliği</string>
     <string name="devices_device_config_alarm_volume_desc">Bazı alarm uygulamaları bunun yerine müzik sesini kullanır.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Zil</string>
     <string name="devices_audio_stream_notification_label">Bildirim</string>
     <string name="devices_audio_stream_alarm_label">Alarm Sesi</string>
-    <string name="devices_neverseen_label">Hiç görülmedi</string>
-    <string name="devices_state_connected_label">Bağlandı</string>
     <string name="devices_last_connected_label">Son bağlantı: %s</string>
     <string name="devices_currently_connected_label">Şu anda bağlı</string>
     <string name="devices_device_disabled_label">Cihaz devre dışı</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Tüm yönetilen cihazları etkileyen ayarlar.</string>
     <string name="label_app_enabled">Uygulama aktif</string>
     <string name="description_app_enabled">Uygulamanın ses düzeyine ve Bluetooth olaylarına tepki verme yeteneğini değiştirir.</string>
-    <string name="label_visible_volume_adjustments">Görünür ayarlamalar</string>
-    <string name="description_visible_volume_adjustments">Bu uygulama ayarlamalar yaparken sistemin ses düzeyi penceresini göster.</string>
     <string name="label_volume_listener">Değişiklikleri gözlemle</string>
-    <string name="description_volume_listener">Bir cihaz bağlıyken aktif kalın ve bu uygulamanın neden olmadığı ses seviyesi değişikliklerini kaydedin.</string>
     <string name="label_boot_restore">Cihaz açılırken başlat</string>
     <string name="description_boot_restore">Bluetooth cihazı bağlıysa, önyükleme / yeniden başlatma sonrasında sesi geri yükleyin.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM\'i etkili bir şekilde nasıl kullanacağını öğren</string>
     <string name="settings_support_issue_tracker_description">Hata raporları ve özellik istekleri için halka açık sorun takipçisi.</string>
     <string name="settings_support_issue_tracker_label">Sorun takipçisi</string>
-    <string name="settings_support_debuglog_label">Hata ayıklama kayıtı</string>
     <string name="settings_support_debuglog_desc">Uygulamanın yaptığı her şeyi paylaşabileceğin bir metin dosyasına kaydet.</string>
-    <string name="settings_support_debuglog_recording_desc">Şu anda hata ayıklama bilgileri kaydediliyor. Kaydı durdurmak için dokun.</string>
-    <string name="settings_support_debuglog_path">Kayıt yolu: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Çok kısa kayıt</string>
     <string name="settings_support_debuglog_short_recording_msg">Bu çok kısa bir kayıttı. Hata ayıklama günlükleri anlık görüntü değil, kayıttır — günlüğün kullanışlı olması için kayıt etkinken sorunu yeniden üret.</string>
     <string name="settings_support_debuglog_short_recording_continue">Kaydetmeye devam et</string>
     <string name="settings_support_debuglog_short_recording_stop">Yine de durdur</string>
-    <string name="settings_support_debuglog_folder_label">Hata ayıklama günlüğü klasörü</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%2$s kullanan %1$d oturum</item>
-        <item quantity="other">%2$s kullanan %1$d oturum</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Hata ayıklama günlüğü saklanmıyor</string>
-    <string name="settings_support_debuglog_folder_delete_title">Tüm hata ayıklama günlükleri silinsin mi?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Bu işlem tüm saklanan hata ayıklama günlüğü oturumlarını kalıcı olarak siler.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Takılıp soru sorabileceğin bir yer.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Çeviri</string>
     <string name="settings_acks_translators_title">Çevirmenler</string>
     <string name="settings_acks_translators_people">Kişi1;Kişi2(isteğe.bağlı@email.com)</string>
-    <string name="settings_acks_translate_title">BVM\'i Çevir</string>
-    <string name="settings_acks_translate_desc">BVM\'i diline çevirmene yardım et</string>
     <string name="settings_acks_thanks_header">Teşekkürler</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Açık kaynaklı projelerin çevirisini desteklediği için</string>
     <string name="settings_licenses_label">Lisanslar</string>
     <string name="settings_translation_label">Çeviri</string>
     <string name="settings_translation_desc">Uygulamayı en sevdiğiniz dile çevirmeye yardımcı olun</string>
-    <string name="settings_sponsor_development_title">Geliştirmeyi destekle</string>
-    <string name="settings_sponsor_development_summary">Patron ol ve geliştirmenin devam etmesini sağla.</string>
     <string name="settings_privacy_policy_label">Gizlilik politikası</string>
     <string name="settings_privacy_policy_desc">Verileri sorumlu bir şekilde işleme.</string>
     <string name="changelog_label">Değişiklik günlüğü</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Geri yükleme tamamlandı — %1$d cihaz geri yüklendi, %2$d atlandı.</string>
     <string name="backup_restore_version_warning">Bu yedek %1$s sürümüyle oluşturuldu. Siz %2$s çalıştırıyorsunuz. Bazı ayarlar doğru geri yüklenmeyebilir.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Hata ayıklama bildirimleri</string>
     <string name="debug_log_consent_title">Hata ayıklama kayıtı</string>
     <string name="debug_log_consent_explanation">Bu özellik uygulamanın yaptığı her şeyi paylaşılabilir bir dosyaya kaydeder. Oluşturulan dosya hassas bilgiler içerir (dosya adları ve yüklü uygulamalar gibi). Sadece güvenilir kişilerle paylaş (sorun gidermesi yapan geliştirici gibi).</string>
-    <string name="debug_log_recording_progress">Hata ayıklama kayıtı alınıyor</string>
     <string name="debug_log_record_action">Kaydet</string>
     <string name="debug_log_stop_action">Kaydı durdur</string>
     <string name="debug_log_screen_title">Hata Ayıklama Kayıtçısı</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Vazgeç</string>
     <string name="debug_log_screen_keep_action">Sakla</string>
-    <string name="debug_log_compressing_label">Sıkıştırılıyor…</string>
     <string name="debug_log_file_label">Kaydedilen kayıt dosyası</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Günlük gönderildi mi?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Sorunuzu ayrıntılı olarak açıkla.</string>
     <string name="contact_category_section_label">Kategori</string>
     <string name="contact_debug_log_label">Hata ayıklama günlüğü</string>
-    <string name="contact_debug_log_select_hint">Eklemek için bir hata ayıklama günlüğü seç</string>
     <string name="contact_debug_log_picker_hint">Sorunu daha hızlı teşhis etmeye yardımcı olmak için hata ayıklama günlüğü ekle.</string>
     <string name="contact_debug_log_picker_empty">Kullanılabilir hata ayıklama günlüğü yok. Önce bir tane kaydet.</string>
     <string name="contact_expected_behavior_label">Beklenen davranış</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Her mesajı kendim okuyorum ve elimden geldiğince cevaplamaya çalışıyorum, ancak bunu tek başıma yaptığım için biraz zaman alabilir. Sabrın için teşekkürler.</string>
     <string name="contact_footer_msg">Mesajın e-posta ile gönderilecek. Cihaz ve kurulum bilgileri otomatik olarak eklenir.</string>
     <string name="contact_no_email_app_msg">Bu cihazda e-posta uygulaması bulunamadı.</string>
-    <string name="contact_attachment_missing_msg">Hata ayıklama günlüğü dosyası artık mevcut değil</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Saklanan hata ayıklama günlükleri</string>
     <string name="settings_support_stored_logs_desc">%1$d oturum (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Saklanan hata ayıklama günlüğü yok</string>
-    <string name="settings_support_stored_logs_delete_title">Saklanan günlükler silinsin mi?</string>
-    <string name="settings_support_stored_logs_delete_msg">Bu işlem saklanan tüm %1$d hata ayıklama günlüğü oturumunu siler.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Saklanan hata ayıklama günlükleri silindi</string>
-    <string name="label_bug_reports">Hata raporları</string>
-    <string name="description_bug_reports">Otomatik hata ve çökme bildirimi.</string>
     <string name="label_add_device">Cihaz ekle</string>
-    <string name="label_just_a_moment_please">Bir dakika, lütfen.</string>
     <string name="label_notification_channel_status">Durum</string>
     <string name="label_notification_channel_setup">Kurulum gerekli</string>
     <string name="monitor_notification_starting">Başlatılıyor…</string>
     <string name="action_set">Ayarla</string>
     <string name="action_cancel">İptal</string>
-    <string name="label_invalid_input">Geçersiz giriş</string>
     <string name="action_reset">Sıfırla</string>
     <string name="label_no_connected_devices">Bağlı cihaz bulunamadı</string>
-    <string name="label_status_idle">Boşta</string>
-    <string name="label_status_adjusting_volumes">Ses düzeyini ayarla</string>
-    <string name="label_premium_version">Ücretli Sürüm</string>
     <string name="general_upgrade_action">Yükselt</string>
     <string name="common_upgrade_required_label">Yükseltme gerekli</string>
-    <string name="label_premium_version_required">Ücretli sürüm gerekli</string>
-    <string name="description_intro_purpose">Bu uygulama, Android cihazınızın farklı Bluetooth cihazlarının ses seviyesini hatırlamasını sağlar.</string>
-    <string name="upgrade_benefit_unlimited_devices">Sınırsız cihaz profili</string>
-    <string name="upgrade_benefit_connection_actions">Otomatik oynatma, uygulama başlatma ve bağlantı uyarıları</string>
-    <string name="upgrade_benefit_theme_customization">Tema, stil ve renk özelleştirmesi</string>
-    <string name="upgrade_benefit_power_controls">Ses kilidi ve hız sınırlama</string>
-    <string name="upgrade_benefit_support">Bağımsız geliştirmeyi destekle</string>
     <string name="upgrade_benefit_equalizer">• Cihaz başına ekolayzer (sistem ekolayzer desteği olan müzik uygulamaları için)</string>
-    <string name="description_intro_tap_the_button">İlk aygıtınızı ekleyerek başlayın.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth devre dışı.</string>
     <string name="title_bluetooth_is_off">Bluetooth Kapalı</string>
     <string name="action_enable_bluetooth">Bluetooth\'u Etkinleştir</string>
     <string name="title_bluetooth_permission_required">Bluetooth İzni Gerekli</string>
     <string name="description_bluetooth_permission_required">Bu uygulamanın cihaz seslerini yönetmek için Bluetooth iznine ihtiyacı var.</string>
     <string name="action_grant_permission">İzin Ver</string>
-    <string name="label_status_listening_for_changes">Ses değişimi için dinleniyor</string>
     <string name="action_exit">Çıkış</string>
-    <string name="action_start">Başlat</string>
-    <string name="label_welcome">Hoşgeldiniz</string>
-    <string name="description_intro_contact">Yeni bir özellik için sorularınız veya bir fikriniz varsa benimle iletişime geçmekten çekinmeyin.</string>
-    <string name="label_translation">Çeviri</string>
-    <string name="description_help_translate">Bu uygulamayı diğer diller için kullanılabilir yapmama yardım edin.</string>
     <string name="label_device_speaker">Cihaz hoparlörü</string>
-    <string name="label_keyevent_playpause">Oynat/Duraklat</string>
-    <string name="label_keyevent_play">Oynat</string>
-    <string name="label_keyevent_next">Sonraki</string>
-    <string name="label_install_id">Kurulum ID</string>
     <string name="message_copied_to_clipboard">Panoya kopyalandı</string>
-    <string name="label_thanks">Teşekkürler</string>
-    <string name="label_licenses">Lisanslar</string>
-    <string name="description_ring_volume_additional_permission">Zil sesini değiştirmek için ek izinler gereklidir.</string>
-    <string name="label_missing_permissions">Eksik izinler</string>
-    <string name="action_grant">Yetkilendir</string>
-    <string name="label_advanced">Gelişmiş</string>
-    <string name="label_exclude_health">Sağlık profillerini dışla</string>
-    <string name="description_exclude_health">Bazı Android cihazlar \'Sağlık Cihazı\' Bluetooth profillerine bakarken takılıyor (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">GATT sunucu profillerini dışla</string>
-    <string name="label_exclude_gatt">GATT profillerini dışla</string>
-    <string name="description_exclude_gattserver">\'Generic Attribute\' (GATT) sunucusunun Bluetooth profillerini sorgulama.</string>
-    <string name="description_exclude_gatt">\'Generic Attribute\' (GATT) istemcisinin Bluetooth profillerini sorgulamayın.</string>
-    <string name="description_waiting_for_devicex">Bağlantının tamamlanması için %s bekleniyor</string>
-    <string name="action_undo">Geri al</string>
-    <string name="action_show">Göster</string>
     <string name="action_dismiss">Reddet</string>
-    <string name="action_fix">Düzelt</string>
-    <string name="battery_optimizations_issue_description">Batarya iyileştirmeleri bu uygulama için etkindir ve bu, Bluetooth olaylarını almasını engelleyebilir. Sorun yaşıyorsanız optimizasyonları devre dışı bırakmayı deneyin.</string>
     <string name="label_bluetooth_settings">Bluetooth ayarları</string>
-    <string name="android10_applaunch_issue_description">Android 10, uygulamaların arka planda nasıl başlatılabileceğini kısıtlar. Bir Bluetooth cihazı bağlandığında uygulamaların açılmasına izin vermek için \&quot;Diğer uygulamalar üzerinde görüntüleme\&quot; iznini verin (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Kaynak kodu</string>
-    <string name="android13_notification_permission_description">Bu uygulamaya bildirim gönderme izni ver. Bu, uygulama aktifken ve ses ayarlamaları yapılırken bildirim gösterilmesini sağlar.</string>
-    <string name="privacy_policy_label">Gizlilik politikası</string>
     <string name="managed_devices_empty_message">Hiçbir Bluetooth cihazı yapılandırılmamış.\nİlk cihazını eklemek için + düğmesine dokun.</string>
     <string name="label_pro_feature">Premium özellik</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Değerlendir</string>
     <string name="review_app_dismiss_action">Belki daha sonra</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Satın alma iptal edildi</string>
-    <string name="error_iap_unavailable_message">Uygulama içi satın almalar mevcut değil</string>
-    <string name="error_generic_message">Bir hata oluştu. Lütfen tekrar dene.</string>
-    <string name="error_iap_owned_message">Bu öğeye zaten sahipsin</string>
     <string name="label_no_devices_title">Cihaz Yok</string>
     <string name="bluemusic_mascot_description">Uygulama Simgesi</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Uygulamaları Seç</string>
     <string name="devices_app_selection_search_hint">Uygulamaları ara…</string>
-    <string name="devices_app_selection_currently_selected">Şu anda seçili</string>
     <string name="devices_app_selection_selected_count">%d uygulama seçildi</string>
     <string name="general_navigate_back_action">Geri git</string>
     <string name="general_reset_action">Sıfırla</string>
     <string name="general_clear_action">Temizle</string>
-    <string name="general_save_action">Kaydet</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Kilit</string>
     <string name="devices_indicator_awake">Uyanık</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Sınır</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Yükseltme</string>
-    <string name="devices_indicator_launch">Başlat</string>
     <string name="devices_indicator_home">Ana sayfa</string>
     <string name="devices_indicator_dnd">RE</string>
     <string name="devices_indicator_alert">Uyarı</string>

--- a/app/src/main/res/values-uk/strings.xml
+++ b/app/src/main/res/values-uk/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Деякі налаштування пристроїв могли бути скинуті під час цього оновлення. Будь ласка, перевір конфігурації своїх пристроїв.</string>
     <string name="onboarding_rewrite_action">Продовжити</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Не знайдено некерованих пристроїв</string>
     <string name="discover_all_devices_managed_msg">Усі твої спарені пристрої вже керуються! Потрібен новий?</string>
     <string name="discover_pair_new_device_action">Спарити новий пристрій</string>
     <string name="discover_device_speaker_desc">Вбудований динамік телефону. Його гучність застосовується, коли звук переключається назад на телефон, наприклад, після відключення пристрою Bluetooth.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Конфігурація пристрою</string>
-    <string name="devices_device_config_section_general_label">Загальні</string>
     <string name="devices_device_config_remove_device_label">Забути пристрій</string>
-    <string name="devices_device_config_remove_device_desc">Забуває пристрій з цього додатку і видаляє його конфігурацію. Це не скасовує спарювання пристрою.</string>
     <string name="devices_device_config_remove_device_action">Забути</string>
     <string name="devices_device_config_remove_device_confirmation">Забути %s з керованих пристроїв?</string>
-    <string name="devices_device_config_rename_device_label">Перейменувати пристрій</string>
-    <string name="devices_device_config_rename_device_desc">Перейменувати цей пристрій в додатку і, якщо можливо, в системі.</string>
     <string name="devices_device_config_rename_device_action">Перейменувати</string>
     <string name="devices_device_config_enabled_label">Увімкнено</string>
     <string name="devices_device_config_enabled_desc">Реагувати на цей пристрій при підключенні</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Команди автовідтворення</string>
     <string name="devices_device_config_autoplay_keycodes_order">Послідовність команд</string>
     <string name="devices_device_config_autoplay_keycodes_label">Команди</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Налаштуйте, які команди надсилати та в якому порядку</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Команди не налаштовано</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Додати команду</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Максимум %1$d команд</string>
@@ -123,7 +117,6 @@
     <string name="cd_autoplay_keycode_move_up">Перемістити вгору</string>
     <string name="cd_autoplay_keycode_move_down">Перемістити вниз</string>
     <string name="cd_autoplay_keycode_remove">Видалити</string>
-    <string name="devices_device_config_section_volumes_label">Гучності</string>
     <string name="devices_device_config_section_volume_label">Гучність</string>
     <string name="devices_device_config_alarm_volume_label">Гучність будильника</string>
     <string name="devices_device_config_alarm_volume_desc">Деякі додатки будильника використовують гучність музики замість цього.</string>
@@ -157,8 +150,6 @@
     <string name="devices_audio_stream_ring_label">Дзвінок</string>
     <string name="devices_audio_stream_notification_label">Сповіщення</string>
     <string name="devices_audio_stream_alarm_label">Будильник</string>
-    <string name="devices_neverseen_label">Незнайомий пристрій</string>
-    <string name="devices_state_connected_label">Під\'єднано</string>
     <string name="devices_last_connected_label">Останнє під\'єднання: %s</string>
     <string name="devices_currently_connected_label">Зараз під\'єднано</string>
     <string name="devices_device_disabled_label">Пристрій вимкнено</string>
@@ -193,10 +184,7 @@
     <string name="devices_settings_desc">Налаштування, які впливають на всі керовані пристрої.</string>
     <string name="label_app_enabled">Додаток увімкнено</string>
     <string name="description_app_enabled">Вмикає здатнісь додатку реагувати на події, пов\'язані з гучністю та bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Візуалізація налаштувань</string>
-    <string name="description_visible_volume_adjustments">Виводити вікно системної гучності при налаштуваннях цим додатком.</string>
     <string name="label_volume_listener">Відстеження змін</string>
-    <string name="description_volume_listener">Залишатись активним доки пристрій приєднаний та зберігати зміни гучності, внесені іншими додатками.</string>
     <string name="label_boot_restore">Відновити при завантаженні</string>
     <string name="description_boot_restore">Відновлення гучності після завантаження/перезавантаження, якщо пристрій Bluetooth під\'єднано.</string>
     <!-- Settings/Support-->
@@ -206,24 +194,11 @@
     <string name="settings_support_wiki_description">Дізнайся, як ефективно використовувати BVM</string>
     <string name="settings_support_issue_tracker_description">Публічний трекер проблем для звітів про помилки і запитів на нові функції.</string>
     <string name="settings_support_issue_tracker_label">Трекер проблем</string>
-    <string name="settings_support_debuglog_label">Лог налагодження</string>
     <string name="settings_support_debuglog_desc">Записує все, що робить додаток, у текстовий файл, яким можна поділитися.</string>
-    <string name="settings_support_debuglog_recording_desc">Зараз записується інформація для налагодження. Натисні, щоб припинити запис.</string>
-    <string name="settings_support_debuglog_path">Шлях до логу: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Дуже короткий запис</string>
     <string name="settings_support_debuglog_short_recording_msg">Це був дуже короткий запис. Логи налагодження — це записи, а не знімки — відтвори проблему під час активного запису, щоб лог був корисним.</string>
     <string name="settings_support_debuglog_short_recording_continue">Продовжити запис</string>
     <string name="settings_support_debuglog_short_recording_stop">Зупинити все одно</string>
-    <string name="settings_support_debuglog_folder_label">Папка логів налагодження</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d сесія використовує %2$s</item>
-        <item quantity="few">%1$d сесії використовують %2$s</item>
-        <item quantity="many">%1$d сесій використовують %2$s</item>
-        <item quantity="other">%1$d сесії використовують %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Немає збережених логів налагодження</string>
-    <string name="settings_support_debuglog_folder_delete_title">Видалити всі логи налагодження?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Це назавжди видалить усі збережені сесії логів налагодження.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Місце, де можна поспілкуватися і поставити питання.</string>
     <!-- Settings/Acks-->
@@ -232,16 +207,12 @@
     <string name="settings_acks_translation_header">Переклад</string>
     <string name="settings_acks_translators_title">Перекладачі</string>
     <string name="settings_acks_translators_people">Особа1;Особа2(опція@email.com)</string>
-    <string name="settings_acks_translate_title">Переклад BVM</string>
-    <string name="settings_acks_translate_desc">Допоможи перекласти BVM на свою мову</string>
     <string name="settings_acks_thanks_header">Подяка</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">За підтримку перекладу проєктів з відкритим кодом</string>
     <string name="settings_licenses_label">Ліцензії</string>
     <string name="settings_translation_label">Переклад</string>
     <string name="settings_translation_desc">Допоможіть перекласти застосунок вашою улюбленою мовою</string>
-    <string name="settings_sponsor_development_title">Спонсор розробки</string>
-    <string name="settings_sponsor_development_summary">Стань патроном і зроби подальшу розробку можливою.</string>
     <string name="settings_privacy_policy_label">Політика конфіденційності</string>
     <string name="settings_privacy_policy_desc">Відповідальне поводження з даними.</string>
     <string name="changelog_label">Список змін</string>
@@ -263,10 +234,8 @@
     <string name="backup_restore_success_restore">Відновлення завершено — відновлено %1$d пристроїв, %2$d пропущено.</string>
     <string name="backup_restore_version_warning">Цю резервну копію створено у версії %1$s. Ви використовуєте %2$s. Деякі налаштування можуть не відновитися коректно.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Сповіщення налагодження</string>
     <string name="debug_log_consent_title">Лог налагодження</string>
     <string name="debug_log_consent_explanation">Ця функція записує все, що робить додаток, у файл, яким можна поділитися. Створений файл містить чутливу інформацію (наприклад, назви файлів і встановлені додатки). Ділися ним лише з надійними особами (наприклад, з розробником, який вирішує проблему).</string>
-    <string name="debug_log_recording_progress">Запис лога налагодження</string>
     <string name="debug_log_record_action">Записати</string>
     <string name="debug_log_stop_action">Припинити запис</string>
     <string name="debug_log_screen_title">Рекордер логів налагодження</string>
@@ -283,7 +252,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Відмінити</string>
     <string name="debug_log_screen_keep_action">Зберегти</string>
-    <string name="debug_log_compressing_label">Стискання…</string>
     <string name="debug_log_file_label">Записаний лог-файл</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Лог відправлено?</string>
@@ -311,7 +279,6 @@
     <string name="contact_description_question_hint">Опиши своє питання детально.</string>
     <string name="contact_category_section_label">Категорія</string>
     <string name="contact_debug_log_label">Лог налагодження</string>
-    <string name="contact_debug_log_select_hint">Вибери лог налагодження для прикріплення</string>
     <string name="contact_debug_log_picker_hint">Прикріпи лог налагодження, щоб допомогти діагностувати проблему швидше.</string>
     <string name="contact_debug_log_picker_empty">Немає доступних логів налагодження. Спочатку запиши один.</string>
     <string name="contact_expected_behavior_label">Очікувана поведінка</string>
@@ -327,82 +294,32 @@
     <string name="contact_welcome_msg">Я читаю кожне повідомлення особисто і намагаюся відповісти, але оскільки я працюю над цим один, це може зайняти трохи часу. Дякую за терпіння.</string>
     <string name="contact_footer_msg">Твоє повідомлення буде відправлено електронною поштою. Інформація про пристрій та налаштування прикріплюється автоматично.</string>
     <string name="contact_no_email_app_msg">На цьому пристрої не знайдено поштового додатку.</string>
-    <string name="contact_attachment_missing_msg">Файл логу налагодження більше не існує</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Збережені логи налагодження</string>
     <string name="settings_support_stored_logs_desc">%1$d сесій (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Немає збережених логів налагодження</string>
-    <string name="settings_support_stored_logs_delete_title">Видалити збережені логи?</string>
-    <string name="settings_support_stored_logs_delete_msg">Це видалить усі %1$d збережених сесій логів налагодження.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Збережені логи налагодження видалено</string>
-    <string name="label_bug_reports">Звіти про збої</string>
-    <string name="description_bug_reports">Авто-надсилання звітів про збої та аварії.</string>
     <string name="label_add_device">Додати пристрій</string>
-    <string name="label_just_a_moment_please">Хвилинку...</string>
     <string name="label_notification_channel_status">Стан</string>
     <string name="label_notification_channel_setup">Потрібно налаштування</string>
     <string name="monitor_notification_starting">Запуск…</string>
     <string name="action_set">Налаштувати</string>
     <string name="action_cancel">Скасувати</string>
-    <string name="label_invalid_input">Невірний ввід</string>
     <string name="action_reset">Скинути</string>
     <string name="label_no_connected_devices">Пристроїв не під\'єднано</string>
-    <string name="label_status_idle">Бездіяльність</string>
-    <string name="label_status_adjusting_volumes">Налаштування гучності</string>
-    <string name="label_premium_version">Преміум-версія</string>
     <string name="general_upgrade_action">Підвищити статус</string>
     <string name="common_upgrade_required_label">Потрібне оновлення</string>
-    <string name="label_premium_version_required">Потрібна преміум-версія</string>
-    <string name="description_intro_purpose">Додаток дозволяє вашому Android запам\'ятовувати гучність різних пристроїв Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Необмежена кількість профілів пристроїв</string>
-    <string name="upgrade_benefit_connection_actions">Автовідтворення, запуск програм та сповіщення про підключення</string>
-    <string name="upgrade_benefit_theme_customization">Налаштування теми, стилю та кольорів</string>
-    <string name="upgrade_benefit_power_controls">Блокування гучності та обмеження частоти</string>
-    <string name="upgrade_benefit_support">Підтримати незалежну розробку</string>
     <string name="upgrade_benefit_equalizer">• Еквалайзер для кожного пристрою (для музичних програм з підтримкою системного еквалайзера)</string>
-    <string name="description_intro_tap_the_button">Розпочнімо з додавання Вашого першого пристрою.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth вимкнений.</string>
     <string name="title_bluetooth_is_off">Bluetooth вимкнено</string>
     <string name="action_enable_bluetooth">Увімкнути Bluetooth</string>
     <string name="title_bluetooth_permission_required">Потрібен дозвіл Bluetooth</string>
     <string name="description_bluetooth_permission_required">Цей додаток потребує дозволу Bluetooth для керування гучністю твоїх пристроїв.</string>
     <string name="action_grant_permission">Надати дозвіл</string>
-    <string name="label_status_listening_for_changes">Прослуховування змін гучності</string>
     <string name="action_exit">Вихід</string>
-    <string name="action_start">Почати</string>
-    <string name="label_welcome">Вітаємо</string>
-    <string name="description_intro_contact">Не соромтеся зв\'затись зі мною, якщо маєте питання чи навіть пропозиції нових функцій.</string>
-    <string name="label_translation">Переклад</string>
-    <string name="description_help_translate">Допоможіть зробити цей додаток доступним на інших мовах.</string>
     <string name="label_device_speaker">Динамік пристрою</string>
-    <string name="label_keyevent_playpause">Грати-Пауза</string>
-    <string name="label_keyevent_play">Грати</string>
-    <string name="label_keyevent_next">Наступне</string>
-    <string name="label_install_id">ID Установки</string>
     <string name="message_copied_to_clipboard">Збережено у буфері</string>
-    <string name="label_thanks">Спасибі</string>
-    <string name="label_licenses">Ліцензії</string>
-    <string name="description_ring_volume_additional_permission">Для зміни гучності дзвінка потрібні додаткові дозволи.</string>
-    <string name="label_missing_permissions">Немає дозволів</string>
-    <string name="action_grant">Надати</string>
-    <string name="label_advanced">Розширені</string>
-    <string name="label_exclude_health">Виключити профілі здоров’я</string>
-    <string name="description_exclude_health">Деякі Android-пристрої зависають при пошуку профілів Bluetooth \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Виключити профілі GATT server</string>
-    <string name="label_exclude_gatt">Виключити GATT профілі</string>
-    <string name="description_exclude_gattserver">Не пропувати профілі Bluetooth типу \'Generic Attribute\' (GATT) server.</string>
-    <string name="description_exclude_gatt">Не пропувати профілі Bluetooth типу \'Generic Attribute\' (GATT) client.</string>
-    <string name="description_waiting_for_devicex">Очікування завершення підключення %s</string>
-    <string name="action_undo">Скасувати</string>
-    <string name="action_show">Показати</string>
     <string name="action_dismiss">Приховати</string>
-    <string name="action_fix">Виправити</string>
-    <string name="battery_optimizations_issue_description">Оптимізації батареї увімкнені для цього додатку і можуть завадити отриманню подій Bluetooth. Розглянь можливість вимкнення оптимізацій, якщо виникають проблеми.</string>
     <string name="label_bluetooth_settings">Налаштування Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 обмежує, як додатки можуть запускатися з фону. Каб дозволити відкривання додатків при підключенні Bluetooth-пристрою, надай дозвіл &quot;Показ поверх інших додатків&quot; (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Код джерела</string>
-    <string name="android13_notification_permission_description">Надай цьому додатку дозвіл на публікацію сповіщень. Це дозволяє показувати сповіщення, коли додаток активний і відбувається регулювання гучності.</string>
-    <string name="privacy_policy_label">Політика приватності</string>
     <string name="managed_devices_empty_message">Немає налаштованих Bluetooth-пристроїв.\nНатисні кнопку +, щоб додати перший пристрій.</string>
     <string name="label_pro_feature">Преміум функція</string>
     <plurals name="discover_device_limit_banner">
@@ -435,21 +352,15 @@
     <string name="review_app_review_action">Огляд</string>
     <string name="review_app_dismiss_action">Можливо пізніше</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Покупку скасовано</string>
-    <string name="error_iap_unavailable_message">Покупки в додатку недоступні</string>
-    <string name="error_generic_message">Сталася помилка. Будь ласка, спробуй ще раз.</string>
-    <string name="error_iap_owned_message">Цей товар уже в тебе є</string>
     <string name="label_no_devices_title">Немає пристроїв</string>
     <string name="bluemusic_mascot_description">Іконка додатку</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Вибрати додатки</string>
     <string name="devices_app_selection_search_hint">Пошук додатків…</string>
-    <string name="devices_app_selection_currently_selected">Наразі вибрано</string>
     <string name="devices_app_selection_selected_count">Вибрано %d додатків</string>
     <string name="general_navigate_back_action">Повернутися назад</string>
     <string name="general_reset_action">Скинути</string>
     <string name="general_clear_action">Очистити</string>
-    <string name="general_save_action">Зберегти</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Блокування</string>
     <string name="devices_indicator_awake">Активний</string>
@@ -459,7 +370,6 @@
     <string name="devices_indicator_limit">Обмеження</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Підсилення</string>
-    <string name="devices_indicator_launch">Запуск</string>
     <string name="devices_indicator_home">Головна</string>
     <string name="devices_indicator_dnd">НТ</string>
     <string name="devices_indicator_alert">Сповіщення</string>

--- a/app/src/main/res/values-ur-rIN/strings.xml
+++ b/app/src/main/res/values-ur-rIN/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">اپڈیٹ کے دوران کچھ خصوصیات تبدیل ہو گئی ہیں۔ براہ کرم اپنی ڈیوائس کی ترتیبات چیک کریں تاکہ یقین ہو کہ سب کچھ درست طریقے سے ترتیب دیا گیا ہے۔</string>
     <string name="onboarding_rewrite_action">جاری رکھیں</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">کوئی غیر منظم ڈیوائس نہیں ملی</string>
     <string name="discover_all_devices_managed_msg">آپ کی تمام جوڑی گئی ڈیوائسیں منظم ہیں! کوئی نئی ڈیوائس چاہیے؟</string>
     <string name="discover_pair_new_device_action">نئی ڈیوائس جوڑیں</string>
     <string name="discover_device_speaker_desc">یہ فون کا اپنا اسپیکر۔ جب آڈیو فون پر واپس آتا ہے تو اس کے حجم کو لاگو کیا جاتا ہے، مثال کے طور پر آپ کے Bluetooth ڈیوائس کے منقطع ہونے کے بعد۔</string>
     <!-- Devices -->
     <string name="devices_device_config_label">ڈیوائس کی ترتیب</string>
-    <string name="devices_device_config_section_general_label">عمومی</string>
     <string name="devices_device_config_remove_device_label">ڈیوائس بھول جائیں</string>
-    <string name="devices_device_config_remove_device_desc">اس ایپ سے ڈیوائس کو بھول جاتا ہے اور اس کی ترتیب حذف کر دیتا ہے۔ یہ ڈیوائس کو غیر جوڑا نہیں کرتا۔</string>
     <string name="devices_device_config_remove_device_action">بھول جائیں</string>
     <string name="devices_device_config_remove_device_confirmation">%s کو منظم ڈیوائسز سے بھول جائیں؟</string>
-    <string name="devices_device_config_rename_device_label">ڈیوائس کا نام بدلیں</string>
-    <string name="devices_device_config_rename_device_desc">اس ایپ میں اور اگر ممکن ہو تو سسٹم میں بھی اس ڈیوائس کا نام بدلیں۔</string>
     <string name="devices_device_config_rename_device_action">نام بدلیں</string>
     <string name="devices_device_config_enabled_label">فعال</string>
     <string name="devices_device_config_enabled_desc">اس ڈیوائس کے منسلک ہونے پر ردعمل ظاہر کریں</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">آٹو پلے کمانڈز</string>
     <string name="devices_device_config_autoplay_keycodes_order">کمانڈ ترتیب</string>
     <string name="devices_device_config_autoplay_keycodes_label">کمانڈز</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">ترتیب دیں کہ کون سی کمانڈز بھیجنی ہیں اور کس ترتیب میں</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">کوئی کمانڈ ترتیب نہیں دی گئی</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">کمانڈ شامل کریں</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">زیادہ سے زیادہ %1$d کمانڈز</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">اوپر منتقل کریں</string>
     <string name="cd_autoplay_keycode_move_down">نیچے منتقل کریں</string>
     <string name="cd_autoplay_keycode_remove">ہٹائیں</string>
-    <string name="devices_device_config_section_volumes_label">والیومز</string>
     <string name="devices_device_config_section_volume_label">والیوم</string>
     <string name="devices_device_config_alarm_volume_label">الارم والیوم</string>
     <string name="devices_device_config_alarm_volume_desc">کچھ الارم ایپس میوزک والیوم بجائے استعمال کرتی ہیں۔</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">رنگٹون</string>
     <string name="devices_audio_stream_notification_label">نوٹیفیکیشن</string>
     <string name="devices_audio_stream_alarm_label">الارم</string>
-    <string name="devices_neverseen_label">کبھی نہیں دیکھی</string>
-    <string name="devices_state_connected_label">منسلک</string>
     <string name="devices_last_connected_label">آخری کنیکشن: %s</string>
     <string name="devices_currently_connected_label">ابھی منسلک ہے</string>
     <string name="devices_device_disabled_label">ڈیوائس معطل</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">تمام منظم ڈیوائسز کو متاثر کرنے والی ترتیبات۔</string>
     <string name="label_app_enabled">ایپ فعال</string>
     <string name="description_app_enabled">والیوم اور بلوٹوتھ واقعات پر ایپ کی ردعمل کی صلاحیت کو ٹوگل کرتا ہے۔</string>
-    <string name="label_visible_volume_adjustments">نظر آنے والی ایڈجسٹمنٹس</string>
-    <string name="description_visible_volume_adjustments">جب یہ ایپ ایڈجسٹمنٹ کرے تو سسٹم والیوم ونڈو دکھائیں۔</string>
     <string name="label_volume_listener">تبدیلیاں مشاہدہ کریں</string>
-    <string name="description_volume_listener">جب کوئی ڈیوائس منسلک ہو فعال رہیں اور والیوم تبدیلیاں محفوظ کریں جو اس ایپ سے نہیں ہوئیۚ۔</string>
     <string name="label_boot_restore">بوٹ پر بحال کریں</string>
     <string name="description_boot_restore">اگر بلوٹوتھ ڈیوائس منسلک ہو تو بوٹینگ/ریبوٹینگ کے بعد والیوم بحال کریں۔</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">BVM کو مؤثر طریقے سے استعمال کرنا سیکھیں</string>
     <string name="settings_support_issue_tracker_description">بگ رپورٹس اور فیچر کی درخواستوں کے لیے عوامی ایشو ٹریکر۔</string>
     <string name="settings_support_issue_tracker_label">ایشو ٹریکر</string>
-    <string name="settings_support_debuglog_label">ڈیبگ لاگ</string>
     <string name="settings_support_debuglog_desc">ایپ جو کچھ بھی کر رہی ہے اس کا تمام ریکارڈ ایک ٹیکسٹ فائل میں محفوظ کریں جسے آپ شیئر کر سکتے ہیں۔</string>
-    <string name="settings_support_debuglog_recording_desc">ابھی ڈیبگ معلومات ریکارڈ ہو رہی ہے۔ ریکارڈنگ روکنے کے لیے ٹیپ کریں۔</string>
-    <string name="settings_support_debuglog_path">لاگ المقام: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">بہت مختصر ریکارڈنگ</string>
     <string name="settings_support_debuglog_short_recording_msg">یہ بہت مختصر ریکارڈنگ تھی۔ ڈیبگ لاگ ریکارڈنگز ہیں، اسنیپشٹس نہیں — لاگ کو مفید بنانے کے لیے ریکارڈنگ فعال ہونے دوران مسئلہ دوبارہ پیدا کریں۔</string>
     <string name="settings_support_debuglog_short_recording_continue">ریکارڈنگ جاری رکھیں</string>
     <string name="settings_support_debuglog_short_recording_stop">بہرحال روکیں</string>
-    <string name="settings_support_debuglog_folder_label">ڈیبگ لاگ فولڈر</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d سیشن %2$s استعمال کر رہا ہے</item>
-        <item quantity="other">%1$d سیشنز %2$s استعمال کر رہے ہیں</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">کوئی ڈیبگ لاگز محفوظ نہیں</string>
-    <string name="settings_support_debuglog_folder_delete_title">تمام ڈیبگ لاگز حذف کریں؟</string>
-    <string name="settings_support_debuglog_folder_delete_msg">یہ تمام محفوظ ڈیبگ لاگ سیشنز مستقل طور پر حذف کر دے گا۔</string>
     <string name="settings_support_discord_label">ڈسکارڈ</string>
     <string name="settings_support_discord_description">گفتگو کرنے اور سوالات پوچھنے کی جگہ۔</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">ترجمہ</string>
     <string name="settings_acks_translators_title">مترجمین</string>
     <string name="settings_acks_translators_people">شخص1;شخص2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">BVM ترجمہ کریں</string>
-    <string name="settings_acks_translate_desc">BVM کو اپنی زبان میں ترجمہ کرنے میں مدد کریں</string>
     <string name="settings_acks_thanks_header">شکریہ</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">اوپن سورس منصوبوں کے ترجمہ کی حمایت کرنے کے لیے</string>
     <string name="settings_licenses_label">لائسنسز</string>
     <string name="settings_translation_label">ترجمہ</string>
     <string name="settings_translation_desc">ایپ کو اپنی پسندیدہ زبان میں ترجمہ کرنے میں مدد کریں</string>
-    <string name="settings_sponsor_development_title">ڈیولپمنٹ کو سپانسر کریں</string>
-    <string name="settings_sponsor_development_summary">سرپرست بنیں اور مسلسل ترقی کو ممکن بنائیں۔</string>
     <string name="settings_privacy_policy_label">پرائیویسی پالیسی</string>
     <string name="settings_privacy_policy_desc">ڈیٹا کو ذمہ داری سے سنبھالنا۔</string>
     <string name="changelog_label">تبدیلیوں کی فہرست</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">بحالی مکمل — %1$d ڈیوائسز بحال کیے گیے، %2$d چھوڑ دیے گیے۔</string>
     <string name="backup_restore_version_warning">یہ بیک اپ ورژن %1$s سے بنایا گیا تھا۔ آپ %2$s چلا رہے ہیں۔ کچھ سیٹنگز صحیح طریقے سے بحال نہیں ہو سکتیں۔</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">ڈیبگ نوٹیفکیشنز</string>
     <string name="debug_log_consent_title">ڈیبگ لاگ</string>
     <string name="debug_log_consent_explanation">یہ فیچر ایپ کی تمام کارروائیوں کو ایک شیئر کرنے والی فائل میں ریکارڈ کرتا ہے۔ بنایا گیا فائل حساس معلومات پر مشتمل ہے (جیسے فائل نام اور انسٹال شدہ ایپس)۔ صرف قابل اعتماد افراد کے ساتھ شیئر کریں (جیسے کسی مسئلے کو حل کرنے والا ڈیولپر)۔</string>
-    <string name="debug_log_recording_progress">ڈیبگ لاگ ریکارڈ کر رہا ہے</string>
     <string name="debug_log_record_action">ریکارڈ</string>
     <string name="debug_log_stop_action">ریکارڈنگ بند کریں</string>
     <string name="debug_log_screen_title">ڈیبگ لاگ ریکارڈر</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">رد کریں</string>
     <string name="debug_log_screen_keep_action">رکھیں</string>
-    <string name="debug_log_compressing_label">کمپریس ہو رہا ہے…</string>
     <string name="debug_log_file_label">ریکارڈ شدہ لاگ فائل</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">لاگ بھیجی؟</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">اپنے سوال کو تفصیل سے بیان کریں۔</string>
     <string name="contact_category_section_label">زمرہ</string>
     <string name="contact_debug_log_label">ڈیبگ لاگ</string>
-    <string name="contact_debug_log_select_hint">منسلک کرنے کے لیے ڈیبگ لاگ منتخب کریں</string>
     <string name="contact_debug_log_picker_hint">مسئلہ تیزی سے تشخیص کرنے کے لیے ڈیبگ لاگ منسلک کریں۔</string>
     <string name="contact_debug_log_picker_empty">کوئی ڈیبگ لاگ دستیاب نہیں۔ پہلے ایک ریکارڈ کریں۔</string>
     <string name="contact_expected_behavior_label">متوقع طرز عمل</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">میں ہر پیغام خود پڑھتا ہےں اور جواب دینے کی بہترین کوشش کرتا ہے، لیکن کیونکہ میں اکیلا کام کرتا ہےں، تھوڑا وقت لگ سکتا ہے۔ آپ کی صبر کا شکریہ۔</string>
     <string name="contact_footer_msg">آپ کا پیغام ایمیل کے ذریعے بھیجا جائے گا۔ ڈیوائس اور سیٹاپ کی معلومات خودکار منسلک ہو جاتی ہے۔</string>
     <string name="contact_no_email_app_msg">اس ڈیوائس پر کوئی ایمیل ایپ نہیں ملی۔</string>
-    <string name="contact_attachment_missing_msg">ڈیبگ لاگ فائل موجود نہیں ہے</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">محفوظ ڈیبگ لاگز</string>
     <string name="settings_support_stored_logs_desc">%1$d سیشنز (%2$s)</string>
     <string name="settings_support_stored_logs_empty">کوئی محفوظ ڈیبگ لاگز نہیں</string>
-    <string name="settings_support_stored_logs_delete_title">محفوظ لاگز حذف کریں؟</string>
-    <string name="settings_support_stored_logs_delete_msg">یہ تمام %1$d محفوظ ڈیبگ لاگ سیشنز حذف کر دے گا۔</string>
-    <string name="settings_support_stored_logs_deleted_msg">محفوظ ڈیبگ لاگز حذف ہو گئیں</string>
-    <string name="label_bug_reports">بگ رپورٹس</string>
-    <string name="description_bug_reports">خودکار بگ اور کریش رپورٹنگ۔</string>
     <string name="label_add_device">ڈیوائس شامل کریں</string>
-    <string name="label_just_a_moment_please">بس ایک لمحہ۔</string>
     <string name="label_notification_channel_status">حیثیت</string>
     <string name="label_notification_channel_setup">سیٹ اپ ضروری ہے</string>
     <string name="monitor_notification_starting">شروع ہو رہا ہے…</string>
     <string name="action_set">سیٹ کریں</string>
     <string name="action_cancel">منسوخ کریں</string>
-    <string name="label_invalid_input">غلط ان پٹ</string>
     <string name="action_reset">ری سیٹ کریں</string>
     <string name="label_no_connected_devices">کوئی ڈیوائس منسلک نہیں</string>
-    <string name="label_status_idle">خالی</string>
-    <string name="label_status_adjusting_volumes">والیومز ایڈجسٹ ہو رہی ہیں</string>
-    <string name="label_premium_version">پریمیم ورژن</string>
     <string name="general_upgrade_action">اپ گریڈ کریں</string>
     <string name="common_upgrade_required_label">اپگریڈ ضروری ہے</string>
-    <string name="label_premium_version_required">پریمیم ورژن ضروری ہے</string>
-    <string name="description_intro_purpose">یہ ایپ آپ کے اینڈرائیڈ ڈیوائس کو مختلف بلوٹوتھ ڈیوائسز کا والیوم یاد رکھنے دیتی ہے۔</string>
-    <string name="upgrade_benefit_unlimited_devices">لامحدود ڈیوائس پروفائلز</string>
-    <string name="upgrade_benefit_connection_actions">آٹوپلے، ایپ لانچ اور کنکشن الرٹس</string>
-    <string name="upgrade_benefit_theme_customization">تھیم، اسٹائل اور رنگ کی حسب ضرورت تبدیلی</string>
-    <string name="upgrade_benefit_power_controls">والیوم لاک اور ریٹ لمیٹنگ</string>
-    <string name="upgrade_benefit_support">آزاد ترقی کو سپورٹ کریں</string>
     <string name="upgrade_benefit_equalizer">• فی ڈیوائس ایکولائزر (نظام ایکولائزر والی موسیقی ایپس کے لیے)</string>
-    <string name="description_intro_tap_the_button">اپنی پہلی ڈیوائس شامل کرکے شروع کریں۔</string>
     <string name="description_bluetooth_is_disabled">بلوٹوتھ غیر فعال ہے.</string>
     <string name="title_bluetooth_is_off">بلوٹوتھ بند ہے</string>
     <string name="action_enable_bluetooth">بلوٹوتھ فعال کریں</string>
     <string name="title_bluetooth_permission_required">بلوٹوتھ کی اجازت ضروری ہے</string>
     <string name="description_bluetooth_permission_required">اس ایپ کو آپ کی ڈیوائس والیوم منظم کرنے کے لیے بلوٹوتھ کی اجازت کی ضرورت ہے۔</string>
     <string name="action_grant_permission">اجازت دیں</string>
-    <string name="label_status_listening_for_changes">والیوم تبدیلیاں سننا</string>
     <string name="action_exit">باہر نکلیں</string>
-    <string name="action_start">شروع</string>
-    <string name="label_welcome">خوش آمدید</string>
-    <string name="description_intro_contact">اگر آپ کو کوئی سوال ہے یا نئے فیچر کا خیال ہے تو بےجھجھک مجھ سے رابطہ کریں۔</string>
-    <string name="label_translation">ترجمہ</string>
-    <string name="description_help_translate">اس ایپ کو دوسری زبانوں میں دستیاب بنانے میں میری مدد کریں۔</string>
     <string name="label_device_speaker">ڈیوائس اسپیکر</string>
-    <string name="label_keyevent_playpause">پلے-ٹھہراؤ</string>
-    <string name="label_keyevent_play">چلائیں</string>
-    <string name="label_keyevent_next">آگے</string>
-    <string name="label_install_id">انسٹال ID</string>
     <string name="message_copied_to_clipboard">کلپ بورڈ پر کاپی ہو گئی</string>
-    <string name="label_thanks">شکریہ</string>
-    <string name="label_licenses">لائسنسز</string>
-    <string name="description_ring_volume_additional_permission">رنگٹون والیوم تبدیل کرنے کے لیے اضافی اجازتیں ضروری ہیں۔</string>
-    <string name="label_missing_permissions">اجازتیں غائب</string>
-    <string name="action_grant">دیں</string>
-    <string name="label_advanced">جدید تر</string>
-    <string name="label_exclude_health">ہیلتھ پروفائلز خارج کریں</string>
-    <string name="description_exclude_health">کچھ اینڈرائیڈ ڈیوائسیز \'ہیلتھ ڈیوائس\' بلوٹوتھ پروفائلز (HDP, 0x1400) دیکھنے پر ہینگ ہو جاتی ہیں۔</string>
-    <string name="label_exclude_gattserver">GATT سرور پروفائلز خارج کریں</string>
-    <string name="label_exclude_gatt">GATT پروفائلز خارج کریں</string>
-    <string name="description_exclude_gattserver">\'جنیریک ایٹریبیوٹ\' (GATT) سرور قسم کے بلوٹوتھ پروفائلز کو قوئی نہیں کریں۔</string>
-    <string name="description_exclude_gatt">\'جنیریک ایٹریبیوٹ\' (GATT) کلائنٹ قسم کے بلوٹوتھ پروفائلز کو قوئی نہیں کریں۔</string>
-    <string name="description_waiting_for_devicex">%s کے منسلکی مکمل ہونے کا انتظار</string>
-    <string name="action_undo">واپس کریں</string>
-    <string name="action_show">دکھائیں</string>
     <string name="action_dismiss">بار کریں</string>
-    <string name="action_fix">حل کریں</string>
-    <string name="battery_optimizations_issue_description">اس ایپ کے لیے بیٹری آپٹیمائزیشنز فعال ہیں اور بلوٹوتھ واقعات ملنے سے روک سکتی ہیں۔ اگر مسائل ہیں تو آپٹیمائزیشنز بند کرنے کی کوشش کریں۔</string>
     <string name="label_bluetooth_settings">بلوٹوتھ ترتیبات</string>
-    <string name="android10_applaunch_issue_description">اینڈرائیڈ 10 بیک گراؤنڈ سے ایپس کیسے شروع ہوں پر پابندی لگاتا ہے۔ بلوٹوتھ ڈیوائس منسلک ہونے پر ایپس کھولنے کی اجازت دینے کے لیے \'دوسری ایپس کے اوپر دکھائیں\' (SYSTEM_ALERT_WINDOW) اجازت دیں۔</string>
-    <string name="label_opensource">سورس کوڈ</string>
-    <string name="android13_notification_permission_description">اس ایپ کو نوٹیفیکیشنز پوسٹ کرنے کی اجازت دیں۔ یہ ایپ کے فعال ہونے اور والیوم ایڈجسٹمنٹ کے دوران نوٹیفیکیشن دکھانے کو ممکن بناتا ہے۔</string>
-    <string name="privacy_policy_label">پرائیویسی پالیسی</string>
     <string name="managed_devices_empty_message">کوئی بلوٹوتھ ڈیوائس ترتیب نہیں۔\nاپنی پہلی ڈیوائس شامل کرنے کے لیے + بٹن ٹیپ کریں۔</string>
     <string name="label_pro_feature">پریمیم فیچر</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">ریویو</string>
     <string name="review_app_dismiss_action">شاید بعد میں</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">خریداری منسوخ</string>
-    <string name="error_iap_unavailable_message">این ایپ خریداری دستیاب نہیں</string>
-    <string name="error_generic_message">ایک غلطی ہوئی۔ براہ کرم دوبارہ کوشش کریں۔</string>
-    <string name="error_iap_owned_message">یہ آئٹم پہلے سے آپ کے پاس ہے</string>
     <string name="label_no_devices_title">کوئی ڈیوائس نہیں</string>
     <string name="bluemusic_mascot_description">ایپ آئیکن</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">ایپس منتخب کریں</string>
     <string name="devices_app_selection_search_hint">ایپس تلاش کریں…</string>
-    <string name="devices_app_selection_currently_selected">ابھی منتخب</string>
     <string name="devices_app_selection_selected_count">%d ایپس منتخب</string>
     <string name="general_navigate_back_action">واپس نیویگیٹ کریں</string>
     <string name="general_reset_action">ری سیٹ کریں</string>
     <string name="general_clear_action">صاف کریں</string>
-    <string name="general_save_action">محفوظ کریں</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">لاک</string>
     <string name="devices_indicator_awake">جگا</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">حد</string>
     <string name="devices_indicator_eq">ای کیو</string>
     <string name="devices_indicator_boost">بوسٹ</string>
-    <string name="devices_indicator_launch">شروع کریں</string>
     <string name="devices_indicator_home">ہوم</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">الرٹ</string>

--- a/app/src/main/res/values-uz/strings.xml
+++ b/app/src/main/res/values-uz/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Yangilanish jarayonida ba\'zi funksiyalar o\'zgardi. Hamma narsa to\'g\'ri sozlanganligini tekshirish uchun qurilma sozlamalarini ko\'rib chiqing.</string>
     <string name="onboarding_rewrite_action">Davom etish</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Boshqarilmagan qurilmalar topilmadi</string>
     <string name="discover_all_devices_managed_msg">Barcha juftlashtirilgan qurilmalaringiz boshqarilmoqda! Yangi qurilma kerakmi?</string>
     <string name="discover_pair_new_device_action">Yangi qurilma juftlashtirish</string>
     <string name="discover_device_speaker_desc">Telefonning o\'z karnaysi. Uning ovoz darajalari audio telefonga qaytganda qo\'llaniladi, masalan, Bluetooth qurilmangiz uzilgandan keyin.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Qurilma sozlamalari</string>
-    <string name="devices_device_config_section_general_label">Umumiy</string>
     <string name="devices_device_config_remove_device_label">Qurilmani unutish</string>
-    <string name="devices_device_config_remove_device_desc">Qurilmani ushbu ilovadan o\'chirib, uning sozlamalarini o\'chiradi. Bu qurilmani juftlashtirishdan chiqarmaydi.</string>
     <string name="devices_device_config_remove_device_action">Unutish</string>
     <string name="devices_device_config_remove_device_confirmation">%s ni boshqariladigan qurilmalardan unutasizmi?</string>
-    <string name="devices_device_config_rename_device_label">Qurilmani qayta nomlash</string>
-    <string name="devices_device_config_rename_device_desc">Bu qurilmani ushbu ilovada va iloji bo\'lsa tizimda ham qayta nomlaydi.</string>
     <string name="devices_device_config_rename_device_action">Qayta nomlash</string>
     <string name="devices_device_config_enabled_label">Yoqilgan</string>
     <string name="devices_device_config_enabled_desc">Bu qurilma ulanganda munosabat bildirish</string>
@@ -93,7 +88,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Avtomatik ijro buyruqlari</string>
     <string name="devices_device_config_autoplay_keycodes_order">Buyruqlar ketma-ketligi</string>
     <string name="devices_device_config_autoplay_keycodes_label">Buyruqlar</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Qaysi buyruqlarni va qanday tartibda yuborishni sozlang</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Hech qanday buyruq sozlanmagan</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Buyruq qo\'shish</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maksimal %1$d ta buyruq</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">Yuqoriga ko\'chirish</string>
     <string name="cd_autoplay_keycode_move_down">Pastga ko\'chirish</string>
     <string name="cd_autoplay_keycode_remove">Olib tashlash</string>
-    <string name="devices_device_config_section_volumes_label">Ovozlar</string>
     <string name="devices_device_config_section_volume_label">Ovoz</string>
     <string name="devices_device_config_alarm_volume_label">Signal ovozi</string>
     <string name="devices_device_config_alarm_volume_desc">Ba\'zi signal ilovalari musiqa ovozidan foydalanadi.</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">Jiringlash</string>
     <string name="devices_audio_stream_notification_label">Bildirishnoma</string>
     <string name="devices_audio_stream_alarm_label">Signal</string>
-    <string name="devices_neverseen_label">Hech qachon ko\'rilmagan</string>
-    <string name="devices_state_connected_label">Ulangan</string>
     <string name="devices_last_connected_label">Oxirgi ulanish: %s</string>
     <string name="devices_currently_connected_label">Hozirda ulangan</string>
     <string name="devices_device_disabled_label">Qurilma o\'chirilgan</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">Barcha boshqariladigan qurilmalarga ta\'sir qiluvchi sozlamalar.</string>
     <string name="label_app_enabled">Ilova yoqilgan</string>
     <string name="description_app_enabled">Ilovaning ovoz va Bluetooth voqealariga munosabat bildirish qobiliyatini yoqadi/o\'chiradi.</string>
-    <string name="label_visible_volume_adjustments">Ko\'rinadigan sozlamalar</string>
-    <string name="description_visible_volume_adjustments">Bu ilova sozlamalar amalga oshirayotganda tizimning ovoz oynasini ko\'rsatish.</string>
     <string name="label_volume_listener">O\'zgarishlarni kuzatish</string>
-    <string name="description_volume_listener">Qurilma ulanganda faol bo\'lib turib, ushbu ilova tomonidan amalga oshirilmagan ovoz o\'zgarishlarini saqlash.</string>
     <string name="label_boot_restore">Yuklanganda tiklash</string>
     <string name="description_boot_restore">Bluetooth qurilma ulangan bo\'lsa, yuklash/qayta yuklashdan keyin ovozni tiklash.</string>
     <!-- Settings/Support-->
@@ -203,22 +191,11 @@
     <string name="settings_support_wiki_description">BVM dan samarali foydalanishni o\'rganing</string>
     <string name="settings_support_issue_tracker_description">Xato hisobotlari va yangi xususiyat so\'rovlari uchun ommaviy muammo kuzatuvchisi.</string>
     <string name="settings_support_issue_tracker_label">Muammo kuzatuvchisi</string>
-    <string name="settings_support_debuglog_label">Debug jurnal</string>
     <string name="settings_support_debuglog_desc">Ilovaning barcha harakatlarini ulashishingiz mumkin bo\'lgan matn fayliga yozish.</string>
-    <string name="settings_support_debuglog_recording_desc">Hozir nosozlik ma\'lumotlarini yozib olmoqda. To\'xtatish uchun bosing.</string>
-    <string name="settings_support_debuglog_path">Jurnal yo\'li: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Juda qisqa yozuv</string>
     <string name="settings_support_debuglog_short_recording_msg">Bu juda qisqa yozuv edi. Nosozlik jurnallari tasvirlar emas, yozuvlardir — jurnal foydali bo\'lishi uchun yozuv faol bo\'lgan vaqtda muammoni qayta yarating.</string>
     <string name="settings_support_debuglog_short_recording_continue">Yozishni davom ettirish</string>
     <string name="settings_support_debuglog_short_recording_stop">Baribir to\'xtatish</string>
-    <string name="settings_support_debuglog_folder_label">Nosozlik jurnali papkasi</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d ta sessiya %2$s ishlatmoqda</item>
-        <item quantity="other">%1$d ta sessiya %2$s ishlatmoqda</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Nosozlik jurnallari yo\'q</string>
-    <string name="settings_support_debuglog_folder_delete_title">Barcha nosozlik jurnallarini o\'chirasizmi?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Bu barcha saqlangan nosozlik jurnal sessiyalarini doimiy ravishda o\'chiradi.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Muloqot qilish va savollar berish uchun joy.</string>
     <!-- Settings/Acks-->
@@ -227,16 +204,12 @@
     <string name="settings_acks_translation_header">Tarjima</string>
     <string name="settings_acks_translators_title">Tarjimonlar</string>
     <string name="settings_acks_translators_people">Shaxs1;Shaxs2(ixtiyoriy@email.com)</string>
-    <string name="settings_acks_translate_title">BVM ni tarjima qilish</string>
-    <string name="settings_acks_translate_desc">BVM ni o\'z tilingizga tarjima qilishda yordam bering</string>
     <string name="settings_acks_thanks_header">Rahmat</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Ochiq kodli loyihalar tarjimasini qo\'llab-quvvatgani uchun</string>
     <string name="settings_licenses_label">Litsenziyalar</string>
     <string name="settings_translation_label">Tarjima</string>
     <string name="settings_translation_desc">Ilovani sevimli tilingizga tarjima qilishda yordam bering</string>
-    <string name="settings_sponsor_development_title">Rivojlanishni homiylik qilish</string>
-    <string name="settings_sponsor_development_summary">Homiy bo\'ling va davomiy rivojlanishni davom ettirishga yordam bering.</string>
     <string name="settings_privacy_policy_label">Maxfiylik siyosati</string>
     <string name="settings_privacy_policy_desc">Ma\'lumotlar bilan mas\'uliyat bilan ishlash.</string>
     <string name="changelog_label">O\'zgarishlar jurnali</string>
@@ -258,10 +231,8 @@
     <string name="backup_restore_success_restore">Tiklash tugadi — %1$d ta qurilma tiklandi, %2$d tasi o\'tkazib yuborildi.</string>
     <string name="backup_restore_version_warning">Bu zaxira %1$s versiyasida yaratilgan. Siz %2$s versiyasini ishlatyapsiz. Ba\'zi sozlamalar to\'g\'ri tiklanmasligi mumkin.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Nosozliklarni tuzatish bildirishlari</string>
     <string name="debug_log_consent_title">Debug jurnal</string>
     <string name="debug_log_consent_explanation">Bu xususiyat ilovaning barcha faoliyatini baham ko\'rish mumkin bo\'lgan faylga yozadi. Yaratilgan fayl maxfiy ma\'lumotlarni o\'z ichiga oladi (masalan, fayl nomlari va o\'rnatilgan ilovalar). Uni faqat ishonchli tomonlar bilan baham ko\'ring (masalan, muammoni hal qilayotgan ishlab chiqaruvchi).</string>
-    <string name="debug_log_recording_progress">Nosozliklarni tuzatish jurnali yozilmoqda</string>
     <string name="debug_log_record_action">Yozish</string>
     <string name="debug_log_stop_action">Yozishni to\'xtatish</string>
     <string name="debug_log_screen_title">Nosozlik jurnali yozib oluvchi</string>
@@ -276,7 +247,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Rad etish</string>
     <string name="debug_log_screen_keep_action">Saqlash</string>
-    <string name="debug_log_compressing_label">Siqilmoqda…</string>
     <string name="debug_log_file_label">Yozib olingan jurnal fayli</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Jurnal yuborildi?</string>
@@ -304,7 +274,6 @@
     <string name="contact_description_question_hint">Savolingizni batafsil tasvirlab bering.</string>
     <string name="contact_category_section_label">Kategoriya</string>
     <string name="contact_debug_log_label">Debug jurnal</string>
-    <string name="contact_debug_log_select_hint">Biriktirish uchun nosozlik jurnalini tanlash</string>
     <string name="contact_debug_log_picker_hint">Muammoni tezroq tashxislash uchun nosozlik jurnalini biriktiring.</string>
     <string name="contact_debug_log_picker_empty">Nosozlik jurnallari mavjud emas. Avval birini yozib oling.</string>
     <string name="contact_expected_behavior_label">Kutilgan xatti-harakat</string>
@@ -318,82 +287,32 @@
     <string name="contact_welcome_msg">Har bir xabarni o\'zim o\'qiyman va javob berishga harakat qilaman, lekin bu ishni yolg\'iz qilayotganimda, biroz vaqt ketishi mumkin. Sabringiz uchun rahmat.</string>
     <string name="contact_footer_msg">Xabaringiz elektron pochta orqali yuboriladi. Qurilma va sozlash ma\'lumotlari avtomatik biriktiriladi.</string>
     <string name="contact_no_email_app_msg">Bu qurilmada elektron pochta ilovasi topilmadi.</string>
-    <string name="contact_attachment_missing_msg">Nosozlik jurnal fayli endi mavjud emas</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Saqlangan nosozlik jurnallari</string>
     <string name="settings_support_stored_logs_desc">%1$d ta sessiya (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Saqlangan nosozlik jurnallari yo\'q</string>
-    <string name="settings_support_stored_logs_delete_title">Saqlangan jurnallarni o\'chirasizmi?</string>
-    <string name="settings_support_stored_logs_delete_msg">Bu barcha %1$d ta saqlangan nosozlik jurnal sessiyasini o\'chiradi.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Saqlangan nosozlik jurnallari o\'chirildi</string>
-    <string name="label_bug_reports">Xato hisobotlari</string>
-    <string name="description_bug_reports">Avtomatik xato va nosozlik hisoboti.</string>
     <string name="label_add_device">Qurilma qo\'shish</string>
-    <string name="label_just_a_moment_please">Bir lahza, iltimos.</string>
     <string name="label_notification_channel_status">Holat</string>
     <string name="label_notification_channel_setup">Sozlash talab qilinadi</string>
     <string name="monitor_notification_starting">Ishga tushmoqda…</string>
     <string name="action_set">O\'rnatish</string>
     <string name="action_cancel">Bekor qilish</string>
-    <string name="label_invalid_input">Noto\'g\'ri ma\'lumot</string>
     <string name="action_reset">Qayta o\'rnatish</string>
     <string name="label_no_connected_devices">Ulangan qurilmalar yo\'q</string>
-    <string name="label_status_idle">Faoliyatsiz</string>
-    <string name="label_status_adjusting_volumes">Ovozlarni sozlash</string>
-    <string name="label_premium_version">Premium versiya</string>
     <string name="general_upgrade_action">Yangilash</string>
     <string name="common_upgrade_required_label">Yangilash talab qilinadi</string>
-    <string name="label_premium_version_required">Premium versiya talab qilinadi</string>
-    <string name="description_intro_purpose">Bu ilova Android qurilmangizga turli Bluetooth qurilmalar uchun ovoz darajasini eslab qolish imkonini beradi.</string>
-    <string name="upgrade_benefit_unlimited_devices">Cheklanmagan qurilma profillari</string>
-    <string name="upgrade_benefit_connection_actions">Avtomatik ijro, ilova ishga tushirish va ulanish ogohlantirishlari</string>
-    <string name="upgrade_benefit_theme_customization">Mavzu, uslub va rang sozlamalari</string>
-    <string name="upgrade_benefit_power_controls">Ovoz qulfi va tezlik cheklash</string>
-    <string name="upgrade_benefit_support">Mustaqil rivojlanishni qo\'llab-quvvatlash</string>
     <string name="upgrade_benefit_equalizer">• Har bir qurilma uchun ekvalayzer (tizim ekvalayzerini qo\'llab-quvvatlaydigan musiqa ilovalari uchun)</string>
-    <string name="description_intro_tap_the_button">Birinchi qurilmangizni qo\'shib boshlang.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth o\'chirilgan.</string>
     <string name="title_bluetooth_is_off">Bluetooth o\'chiq</string>
     <string name="action_enable_bluetooth">Bluetoothni yoqish</string>
     <string name="title_bluetooth_permission_required">Bluetooth ruxsati talab qilinadi</string>
     <string name="description_bluetooth_permission_required">Bu ilova qurilma ovozlarini boshqarish uchun Bluetooth ruxsatiga muhtoj.</string>
     <string name="action_grant_permission">Ruxsat berish</string>
-    <string name="label_status_listening_for_changes">Ovoz o\'zgarishlarini tinglash</string>
     <string name="action_exit">Chiqish</string>
-    <string name="action_start">Boshlash</string>
-    <string name="label_welcome">Xush kelibsiz</string>
-    <string name="description_intro_contact">Savollaringiz yoki yangi funksiya uchun g\'oyangiz bo\'lsa, mendan so\'rashdan tortinmang.</string>
-    <string name="label_translation">Tarjima</string>
-    <string name="description_help_translate">Ilovani boshqa tillarda mavjud qilishimga yordam bering.</string>
     <string name="label_device_speaker">Qurilma dinamigi</string>
-    <string name="label_keyevent_playpause">O\'ynash-To\'xtatish</string>
-    <string name="label_keyevent_play">O\'ynash</string>
-    <string name="label_keyevent_next">Keyingisi</string>
-    <string name="label_install_id">O\'rnatish identifikatori</string>
     <string name="message_copied_to_clipboard">Vaqtinchalik xotiraga nusxalandi</string>
-    <string name="label_thanks">Rahmat</string>
-    <string name="label_licenses">Litsenziyalar</string>
-    <string name="description_ring_volume_additional_permission">Jiringlash ovozini o\'zgartirish uchun qo\'shimcha ruxsatlar talab qilinadi.</string>
-    <string name="label_missing_permissions">Ruxsatlar yetishmaydi</string>
-    <string name="action_grant">Berish</string>
-    <string name="label_advanced">Kengaytirilgan</string>
-    <string name="label_exclude_health">Sog\'liq profillarini istisno qilish</string>
-    <string name="description_exclude_health">Ba\'zi Android qurilmalari \"Sog\'liq qurilmasi\" Bluetooth profillarini (HDP, 0x1400) qidirishda qotib qoladi.</string>
-    <string name="label_exclude_gattserver">GATT server profillarini istisno qilish</string>
-    <string name="label_exclude_gatt">GATT profillarini istisno qilish</string>
-    <string name="description_exclude_gattserver">\'Umumiy atribut\' (GATT) serveri turidagi Bluetooth profillarini so\'ramaslik.</string>
-    <string name="description_exclude_gatt">\'Umumiy atribut\' (GATT) mijozi turidagi Bluetooth profillarini so\'ramaslik.</string>
-    <string name="description_waiting_for_devicex">%s ulanishni yakunlashini kutish</string>
-    <string name="action_undo">Bekor qilish</string>
-    <string name="action_show">Ko\'rsatish</string>
     <string name="action_dismiss">Yopish</string>
-    <string name="action_fix">Tuzatish</string>
-    <string name="battery_optimizations_issue_description">Bu ilova uchun batareya optimallashtirishlari yoqilgan va bu ilovaning Bluetooth voqealarini olishiga to\'sqinlik qilishi mumkin. Agar muammolar yuzaga kelsa, optimallashtirishlarni o\'chirishni ko\'ring.</string>
     <string name="label_bluetooth_settings">Bluetooth sozlamalari</string>
-    <string name="android10_applaunch_issue_description">Android 10 ilovalarni fonda ishga tushirishni cheklaydi. Bluetooth qurilmasi ulanganda ilovalarni ochishga ruxsat berish uchun \"Boshqa ilovalar ustida ko\'rsatish\" (SYSTEM_ALERT_WINDOW) ruxsatini bering.</string>
-    <string name="label_opensource">Manba kodi</string>
-    <string name="android13_notification_permission_description">Bu ilova bildirishnomalar yuborish ruxsatini bering. Bu ilova faol bo\'lganda va ovoz sozlamalari amalga oshirilayotganda bildirishnoma ko\'rsatishni ta\'minlaydi.</string>
-    <string name="privacy_policy_label">Maxfiylik siyosati</string>
     <string name="managed_devices_empty_message">Bluetooth qurilmalar sozlanmagan.\nBirinchi qurilmangizni qo\'shish uchun + tugmasini bosing.</string>
     <string name="label_pro_feature">Premium funksiya</string>
     <plurals name="discover_device_limit_banner">
@@ -424,21 +343,15 @@
     <string name="review_app_review_action">Ko\'rib chiqish</string>
     <string name="review_app_dismiss_action">Balki keyinroq</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Xarid bekor qilindi</string>
-    <string name="error_iap_unavailable_message">Ilovadagi xaridlar mavjud emas</string>
-    <string name="error_generic_message">Xato yuz berdi. Iltimos, qayta urinib ko\'ring.</string>
-    <string name="error_iap_owned_message">Siz allaqachon bu narsaga egasiz</string>
     <string name="label_no_devices_title">Qurilmalar yo\'q</string>
     <string name="bluemusic_mascot_description">Ilova belgisi</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Ilovalarni tanlash</string>
     <string name="devices_app_selection_search_hint">Ilovalarni qidirish…</string>
-    <string name="devices_app_selection_currently_selected">Hozir tanlangan</string>
     <string name="devices_app_selection_selected_count">%d ta ilova tanlangan</string>
     <string name="general_navigate_back_action">Orqaga o\'tish</string>
     <string name="general_reset_action">Qayta o\'rnatish</string>
     <string name="general_clear_action">Tozalash</string>
-    <string name="general_save_action">Saqlash</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Qulflash</string>
     <string name="devices_indicator_awake">Uyg\'oq</string>
@@ -448,7 +361,6 @@
     <string name="devices_indicator_limit">Cheklash</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Kuchaytirish</string>
-    <string name="devices_indicator_launch">Ishga tushirish</string>
     <string name="devices_indicator_home">Uy</string>
     <string name="devices_indicator_dnd">BQQ</string>
     <string name="devices_indicator_alert">Ogohlantirish</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Một số cài đặt thiết bị có thể đã được đặt lại trong quá trình cập nhật này. Vui lòng kiểm tra cấu hình thiết bị của bạn.</string>
     <string name="onboarding_rewrite_action">Tiếp tục</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Không tìm thấy thiết bị chưa được quản lý</string>
     <string name="discover_all_devices_managed_msg">Tất cả thiết bị đã ghép nối đều được quản lý! Cần thiết bị mới?</string>
     <string name="discover_pair_new_device_action">Ghép nối thiết bị mới</string>
     <string name="discover_device_speaker_desc">Loa của chính chiếc điện thoại này. Âm lượng của nó được áp dụng khi âm thanh chuyển trở lại điện thoại, ví dụ như sau khi thiết bị Bluetooth của bạn ngắt kết nối.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Cấu hình thiết bị</string>
-    <string name="devices_device_config_section_general_label">Tổng quan</string>
     <string name="devices_device_config_remove_device_label">Quên thiết bị</string>
-    <string name="devices_device_config_remove_device_desc">Quên thiết bị khỏi ứng dụng này và xóa cấu hình của nó. Điều này không hủy ghép nối thiết bị.</string>
     <string name="devices_device_config_remove_device_action">Quên</string>
     <string name="devices_device_config_remove_device_confirmation">Quên %s khỏi danh sách thiết bị được quản lý?</string>
-    <string name="devices_device_config_rename_device_label">Đổi tên thiết bị</string>
-    <string name="devices_device_config_rename_device_desc">Đổi tên thiết bị này trong ứng dụng, và nếu có thể, trong hệ thống.</string>
     <string name="devices_device_config_rename_device_action">Đổi tên</string>
     <string name="devices_device_config_enabled_label">Được kích hoạt</string>
     <string name="devices_device_config_enabled_desc">Phản ứng với thiết bị này khi được kết nối</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Lệnh tự động phát</string>
     <string name="devices_device_config_autoplay_keycodes_order">Trình tự lệnh</string>
     <string name="devices_device_config_autoplay_keycodes_label">Lệnh</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Cấu hình lệnh nào sẽ gửi và theo thứ tự nào</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Chưa có lệnh nào được cấu hình</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Thêm lệnh</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Tối đa %1$d lệnh</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">Di chuyển lên</string>
     <string name="cd_autoplay_keycode_move_down">Di chuyển xuống</string>
     <string name="cd_autoplay_keycode_remove">Loại bỏ</string>
-    <string name="devices_device_config_section_volumes_label">Âm lượng</string>
     <string name="devices_device_config_section_volume_label">Âm lượng</string>
     <string name="devices_device_config_alarm_volume_label">Âm lượng báo thức</string>
     <string name="devices_device_config_alarm_volume_desc">Một số ứng dụng báo thức sử dụng âm lượng nhạc để thay thế.</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">Chuông</string>
     <string name="devices_audio_stream_notification_label">Thông báo</string>
     <string name="devices_audio_stream_alarm_label">Báo thức</string>
-    <string name="devices_neverseen_label">Không nhìn thấy</string>
-    <string name="devices_state_connected_label">Đã kết nối</string>
     <string name="devices_last_connected_label">Lần kết nối cuối: %s</string>
     <string name="devices_currently_connected_label">Đang kết nối</string>
     <string name="devices_device_disabled_label">Thiết bị bị vô hiệu hóa</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">Các cài đặt ảnh hưởng đến tất cả thiết bị được quản lý.</string>
     <string name="label_app_enabled">Ứng dụng được kích hoạt</string>
     <string name="description_app_enabled">Chuyển đổi khả năng hiển thị ứng dụng để phản ứng với sự kiện âm lượng và bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Các điều chỉnh hiển thị</string>
-    <string name="description_visible_volume_adjustments">Hiển thị cửa sổ âm lượng của hệ thống trong khi ứng dụng này thực hiện các điều chỉnh.</string>
     <string name="label_volume_listener">Theo dõi các thay đổi</string>
-    <string name="description_volume_listener">Luôn hoạt động trong khi thiết bị được kết nối và lưu các thay đổi âm lượng không do ứng dụng này.</string>
     <string name="label_boot_restore">Khôi phục khi khởi động</string>
     <string name="description_boot_restore">Khôi phục âm lượng sau khi khởi động/khởi động lại nếu một thiết bị Bluetooth được kết nối.</string>
     <!-- Settings/Support-->
@@ -203,21 +191,11 @@
     <string name="settings_support_wiki_description">Tìm hiểu cách sử dụng BVM hiệu quả</string>
     <string name="settings_support_issue_tracker_description">Bộ theo dõi sự cố công khai cho báo cáo lỗi và yêu cầu tính năng.</string>
     <string name="settings_support_issue_tracker_label">Theo dõi sự cố</string>
-    <string name="settings_support_debuglog_label">Nhật ký gỡ lỗi</string>
     <string name="settings_support_debuglog_desc">Ghi lại mọi thứ ứng dụng đang làm vào một tập tin văn bản mà bạn có thể chia sẻ.</string>
-    <string name="settings_support_debuglog_recording_desc">Đang ghi lại thông tin gỡ lỗi. Nhấn để dừng ghi.</string>
-    <string name="settings_support_debuglog_path">Đường dẫn nhật ký: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Ghi rất ngắn</string>
     <string name="settings_support_debuglog_short_recording_msg">Đó là một bản ghi rất ngắn. Nhật ký gỡ lỗi là bản ghi, không phải ảnh chụp — hãy tái tạo sự cố trong khi đang ghi để nhật ký có ích.</string>
     <string name="settings_support_debuglog_short_recording_continue">Tiếp tục ghi</string>
     <string name="settings_support_debuglog_short_recording_stop">Dừng dù sao</string>
-    <string name="settings_support_debuglog_folder_label">Thư mục nhật ký gỡ lỗi</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d phiên sử dụng %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Không có nhật ký gỡ lỗi được lưu trữ</string>
-    <string name="settings_support_debuglog_folder_delete_title">Xóa tất cả nhật ký gỡ lỗi?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Thao tác này sẽ xóa vĩnh viễn tất cả các phiên nhật ký gỡ lỗi đã lưu trữ.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">Nơi để trò chuyện và đặt câu hỏi.</string>
     <!-- Settings/Acks-->
@@ -228,16 +206,12 @@
     <string name="settings_acks_translators_people">Đỗ Văn Chức(dovanchuc7521);ThePrimalPea(PeaID);Vo Thanh Tung(wst1001_qqfc); PhongInk(PhongInk);Nguyễn Trung Hậu(Nguyen_Trung_Hau);
 Hai511;
 TheNothingGuy</string>
-    <string name="settings_acks_translate_title">Dịch BVM</string>
-    <string name="settings_acks_translate_desc">Giúp dịch BVM sang ngôn ngữ của bạn</string>
     <string name="settings_acks_thanks_header">Cảm ơn</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Vì hỗ trợ dịch thuật các dự án mở nguồn</string>
     <string name="settings_licenses_label">Giấy phép</string>
     <string name="settings_translation_label">Dịch thuật</string>
     <string name="settings_translation_desc">Hãy giúp dịch ứng dụng sang ngôn ngữ bạn yêu thích</string>
-    <string name="settings_sponsor_development_title">Tài trợ phát triển</string>
-    <string name="settings_sponsor_development_summary">Trở thành nhà bảo trợ và giúp việc phát triển tiếp tục có thể.</string>
     <string name="settings_privacy_policy_label">Chính sách bảo mật</string>
     <string name="settings_privacy_policy_desc">Xử lý dữ liệu có trách nhiệm.</string>
     <string name="changelog_label">Nhật ký thay đổi</string>
@@ -259,10 +233,8 @@ TheNothingGuy</string>
     <string name="backup_restore_success_restore">Khôi phục hoàn tất — đã khôi phục %1$d thiết bị, bỏ qua %2$d.</string>
     <string name="backup_restore_version_warning">Bản sao lưu này được tạo với phiên bản %1$s. Bạn đang dùng phiên bản %2$s. Một số cài đặt có thể không được khôi phục đúng.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Thông báo gỡ lỗi</string>
     <string name="debug_log_consent_title">Nhật ký gỡ lỗi</string>
     <string name="debug_log_consent_explanation">Tính năng này ghi lại mọi thứ ứng dụng đang làm vào một tập tin có thể chia sẻ. Tập tin được tạo chứa thông tin nhạy cảm (ví dụ tên tập tin và ứng dụng đã cài). Chỉ chia sẻ với các bên đáng tin cậy (ví dụ nhà phát triển khắc phục sự cố).</string>
-    <string name="debug_log_recording_progress">Đang ghi nhật ký gỡ lỗi</string>
     <string name="debug_log_record_action">Ghi lại</string>
     <string name="debug_log_stop_action">Dừng ghi</string>
     <string name="debug_log_screen_title">Bộ ghi nhật ký gỡ lỗi</string>
@@ -276,7 +248,6 @@ TheNothingGuy</string>
     </plurals>
     <string name="debug_log_screen_discard_action">Loại bỏ</string>
     <string name="debug_log_screen_keep_action">Giữ lại</string>
-    <string name="debug_log_compressing_label">Đang nén…</string>
     <string name="debug_log_file_label">Tập tin nhật ký đã ghi</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">Đã gửi nhật ký?</string>
@@ -304,7 +275,6 @@ TheNothingGuy</string>
     <string name="contact_description_question_hint">Mô tả câu hỏi của bạn một cách chi tiết.</string>
     <string name="contact_category_section_label">Danh mục</string>
     <string name="contact_debug_log_label">Nhật ký gỡ lỗi</string>
-    <string name="contact_debug_log_select_hint">Chọn nhật ký gỡ lỗi để đính kèm</string>
     <string name="contact_debug_log_picker_hint">Đính kèm nhật ký gỡ lỗi để giúp chẩn đoán sự cố nhanh hơn.</string>
     <string name="contact_debug_log_picker_empty">Không có nhật ký gỡ lỗi nào. Hãy ghi một cái trước.</string>
     <string name="contact_expected_behavior_label">Hành vi mong đợi</string>
@@ -317,83 +287,32 @@ TheNothingGuy</string>
     <string name="contact_welcome_msg">Tôi tự đọc từng tin nhắn và cố gắng hết sức để trả lời, nhưng vì tôi làm việc một mình nên có thể mất một chút thời gian. Cảm ơn sự kiên nhẫn của bạn.</string>
     <string name="contact_footer_msg">Tin nhắn của bạn sẽ được gửi qua email. Thông tin thiết bị và cài đặt được đính kèm tự động.</string>
     <string name="contact_no_email_app_msg">Không tìm thấy ứng dụng email trên thiết bị này.</string>
-    <string name="contact_attachment_missing_msg">Tệp nhật ký gỡ lỗi không còn tồn tại</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Nhật ký gỡ lỗi đã lưu trữ</string>
     <string name="settings_support_stored_logs_desc">%1$d phiên (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Không có nhật ký gỡ lỗi đã lưu trữ</string>
-    <string name="settings_support_stored_logs_delete_title">Xóa nhật ký đã lưu trữ?</string>
-    <string name="settings_support_stored_logs_delete_msg">Thao tác này sẽ xóa tất cả %1$d phiên nhật ký gỡ lỗi đã lưu trữ.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Nhật ký gỡ lỗi đã lưu trữ đã bị xóa</string>
-    <string name="label_bug_reports">Báo lỗi</string>
-    <string name="description_bug_reports">Tự động báo lỗi và crash.</string>
     <string name="label_add_device">Thêm thiết bị</string>
-    <string name="label_just_a_moment_please">Xin chờ một chút.</string>
     <string name="label_notification_channel_status">Trạng thái</string>
     <string name="label_notification_channel_setup">Cần thiết lập</string>
     <string name="monitor_notification_starting">Khởi động…</string>
     <string name="action_set">Đặt</string>
     <string name="action_cancel">Hủy bỏ</string>
-    <string name="label_invalid_input">Dữ liệu nhập không hợp lệ</string>
     <string name="action_reset">Thiết lập lại</string>
     <string name="label_no_connected_devices">Không có thiết bị nào được kết nối</string>
-    <string name="label_status_idle">Không hoạt động</string>
-    <string name="label_status_adjusting_volumes">Điều chỉnh âm lượng</string>
-    <string name="label_premium_version">Bản trả phí</string>
     <string name="general_upgrade_action">Nâng cấp</string>
     <string name="common_upgrade_required_label">Yêu cầu nâng cấp</string>
-    <string name="label_premium_version_required">Yêu cầu phiên bản trả phí</string>
-    <string name="description_intro_purpose">Ứng dụng này cho phép Android ghi nhớ mức âm lượng của thiết bị Bluetooth khác nhau.</string>
-    <string name="upgrade_benefit_unlimited_devices">Không giới hạn hồ sơ thiết bị</string>
-    <string name="upgrade_benefit_connection_actions">Tự phát, mở ứng dụng và cảnh báo kết nối</string>
-    <string name="upgrade_benefit_theme_customization">Tùy chỉnh giao diện, kiểu dáng và màu sắc</string>
-    <string name="upgrade_benefit_power_controls">Khóa âm lượng và giới hạn tốc độ</string>
-    <string name="upgrade_benefit_support">Hỗ trợ phát triển độc lập</string>
     <string name="upgrade_benefit_equalizer">• Bộ cân bằng theo thiết bị (cho ứng dụng nhạc hỗ trợ bộ cân bằng hệ thống)</string>
-    <string name="description_intro_tap_the_button">Bắt đầu bằng cách thêm thiết bị đầu tiên của bạn.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth bị tắt.</string>
     <string name="title_bluetooth_is_off">Bluetooth đã tắt</string>
     <string name="action_enable_bluetooth">Bật Bluetooth</string>
     <string name="title_bluetooth_permission_required">Cần quyền Bluetooth</string>
     <string name="description_bluetooth_permission_required">Ứng dụng này cần quyền Bluetooth để quản lý âm lượng thiết bị của bạn.</string>
     <string name="action_grant_permission">Cấp quyền</string>
-    <string name="label_status_listening_for_changes">Lắng nghe thay đổi âm lượng</string>
     <string name="action_exit">Thoát</string>
-    <string name="action_start">Bắt đầu</string>
-    <string name="label_welcome">Chào mừng</string>
-    <string name="description_intro_contact">Đừng ngần ngại liên hệ với tôi nếu bạn có thắc mắc hoặc thậm chí là một ý tưởng cho một tính năng mới.</string>
-    <string name="label_translation">Dịch thuật</string>
-    <string name="description_help_translate">Giúp tôi để ứng dụng này có các ngôn ngữ khác.</string>
     <string name="label_device_speaker">Thiết bị loa</string>
-    <string name="label_keyevent_playpause">Phát- Tạm dừng</string>
-    <string name="label_keyevent_play">Phát</string>
-    <string name="label_keyevent_next">Tiếp</string>
-    <string name="label_install_id">Cài đặt ID</string>
     <string name="message_copied_to_clipboard">Chép vào bộ nhớ tạm</string>
-    <string name="label_thanks">Cảm ơn</string>
-    <string name="label_licenses">Giấy phép</string>
-    <string name="description_ring_volume_additional_permission">Các quyền bổ sung là cần thiết để thay đổi âm lượng chuông.</string>
-    <string name="label_missing_permissions">Thiếu quyền</string>
-    <string name="action_grant">Chấp thuận</string>
-    <string name="label_advanced">Nâng cao</string>
-    <string name="label_exclude_health">Loại trừ cấu hình sức khoẻ</string>
-    <string name="description_exclude_health">Một số thiết bị Android bị treo khi tìm kiếm cấu hình Bluetooth \'Thiết bị Y tế\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Loại trừ các cấu hình server GATT</string>
-    <string name="label_exclude_gatt">Loại trừ các cấu hình GATT</string>
-    <string name="description_exclude_gattserver">Không truy vấn cấu hình Bluetooth của máy chủ \'Thuộc tính Chung\' (GATT).</string>
-    <string name="description_exclude_gatt">Không truy vấn cấu hình Bluetooth của ứng dụng thuộc tính \'Thuộc tính Chung\' (GATT).</string>
-    <string name="description_waiting_for_devicex">Chờ %s để hoàn thành kết nối</string>
-    <string name="action_undo">Hoàn tác</string>
-    <string name="action_show">Hiển thị</string>
     <string name="action_dismiss">Bỏ qua</string>
-    <string name="action_fix">Sửa</string>
-    <string name="battery_optimizations_issue_description">Tối ưu hóa pin được bật cho ứng dụng này và có thể ngăn ứng dụng nhận các sự kiện Bluetooth. Vô hiệu hóa nếu bạn đang gặp vấn đề.</string>
     <string name="label_bluetooth_settings">Cài đặt Bluetooth</string>
-    <string name="android10_applaunch_issue_description">Android 10 hạn chế cách các ứng dụng có thể chạy nền. Để cho phép mở ứng dụng khi thiết bị Bluetooth kết nối, hãy cấp quyền \&quot;Hiển thị trên các ứng dụng khác\&quot; 
-(SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Mã nguồn</string>
-    <string name="android13_notification_permission_description">Cấp quyền cho ứng dụng này để gửi thông báo. Điều này cho phép hiển thị thông báo khi ứng dụng hoạt động và đang điều chỉnh âm lượng.</string>
-    <string name="privacy_policy_label">Chính sách bảo mật</string>
     <string name="managed_devices_empty_message">Chưa có thiết bị Bluetooth nào được cấu hình.\nNhấn nút + để thêm thiết bị đầu tiên.</string>
     <string name="label_pro_feature">Tính năng trả phí</string>
     <plurals name="discover_device_limit_banner">
@@ -423,21 +342,15 @@ TheNothingGuy</string>
     <string name="review_app_review_action">Đánh giá</string>
     <string name="review_app_dismiss_action">Để sau</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Mua hàng bị hủy</string>
-    <string name="error_iap_unavailable_message">Mua hàng trong ứng dụng không khả dụng</string>
-    <string name="error_generic_message">Có lỗi xảy ra. Vui lòng thử lại.</string>
-    <string name="error_iap_owned_message">Bạn đã sở hữu mục này</string>
     <string name="label_no_devices_title">Không có thiết bị</string>
     <string name="bluemusic_mascot_description">Biểu tượng ứng dụng</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Chọn ứng dụng</string>
     <string name="devices_app_selection_search_hint">Tìm kiếm ứng dụng…</string>
-    <string name="devices_app_selection_currently_selected">Hiện đang chọn</string>
     <string name="devices_app_selection_selected_count">Đã chọn %d ứng dụng</string>
     <string name="general_navigate_back_action">Điều hướng quay lại</string>
     <string name="general_reset_action">Đặt lại</string>
     <string name="general_clear_action">Xóa</string>
-    <string name="general_save_action">Lưu</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Khóa</string>
     <string name="devices_indicator_awake">Thức</string>
@@ -447,7 +360,6 @@ TheNothingGuy</string>
     <string name="devices_indicator_limit">Giới hạn</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Tăng âm</string>
-    <string name="devices_indicator_launch">Mở</string>
     <string name="devices_indicator_home">Màn hình chính</string>
     <string name="devices_indicator_dnd">KTR</string>
     <string name="devices_indicator_alert">Cảnh báo</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">在此更新过程中，某些设备设置可能已被重置。请检查您的设备配置。</string>
     <string name="onboarding_rewrite_action">继续</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">没有找到未管理的设备</string>
     <string name="discover_all_devices_managed_msg">你所有配对的设备都已管理！需要新的吗？</string>
     <string name="discover_pair_new_device_action">配对新设备</string>
     <string name="discover_device_speaker_desc">此手机自己的扬声器。当音频切换回手机时（例如蓝牙设备断开连接后），将应用其音量。</string>
     <!-- Devices -->
     <string name="devices_device_config_label">设备配置</string>
-    <string name="devices_device_config_section_general_label">常规</string>
     <string name="devices_device_config_remove_device_label">忘记设备</string>
-    <string name="devices_device_config_remove_device_desc">从此应用中忘记设备并删除其配置。这不会取消配对设备。</string>
     <string name="devices_device_config_remove_device_action">忘记</string>
     <string name="devices_device_config_remove_device_confirmation">从管理设备中忘记 %s？</string>
-    <string name="devices_device_config_rename_device_label">重命名设备</string>
-    <string name="devices_device_config_rename_device_desc">在此应用内重命名此设备，如果可能的话，也在系统内重命名。</string>
     <string name="devices_device_config_rename_device_action">重命名</string>
     <string name="devices_device_config_enabled_label">已启用</string>
     <string name="devices_device_config_enabled_desc">连接此设备时作出反应</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">自动播放命令</string>
     <string name="devices_device_config_autoplay_keycodes_order">命令序列</string>
     <string name="devices_device_config_autoplay_keycodes_label">命令</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">配置要发送的命令及其顺序</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">未配置命令</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">添加命令</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">最多 %1$d 条命令</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">上移</string>
     <string name="cd_autoplay_keycode_move_down">下移</string>
     <string name="cd_autoplay_keycode_remove">删除</string>
-    <string name="devices_device_config_section_volumes_label">音量</string>
     <string name="devices_device_config_section_volume_label">音量</string>
     <string name="devices_device_config_alarm_volume_label">闹钟音量</string>
     <string name="devices_device_config_alarm_volume_desc">一些闹钟应用使用媒体音量。</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">铃声</string>
     <string name="devices_audio_stream_notification_label">通知</string>
     <string name="devices_audio_stream_alarm_label">闹钟</string>
-    <string name="devices_neverseen_label">设备未曾连接</string>
-    <string name="devices_state_connected_label">设备已连接</string>
     <string name="devices_last_connected_label">最后连接：%s</string>
     <string name="devices_currently_connected_label">当前已连接</string>
     <string name="devices_device_disabled_label">设备已禁用</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">影响所有管理设备的设置。</string>
     <string name="label_app_enabled">应用已启用</string>
     <string name="description_app_enabled">切换应用对音量和蓝牙事件的反应能力。</string>
-    <string name="label_visible_volume_adjustments">可见调整</string>
-    <string name="description_visible_volume_adjustments">此应用进行调整时显示系统音量窗口。</string>
     <string name="label_volume_listener">监听变化</string>
-    <string name="description_volume_listener">设备连接时保持活动状态，并保存非此应用引起的音量变化。</string>
     <string name="label_boot_restore">开机恢复</string>
     <string name="description_boot_restore">开机/重启后如果蓝牙设备已连接，则恢复音量。</string>
     <!-- Settings/Support-->
@@ -203,21 +191,11 @@
     <string name="settings_support_wiki_description">学习如何有效使用 BVM</string>
     <string name="settings_support_issue_tracker_description">用于错误报告和功能请求的公开问题跟踪器。</string>
     <string name="settings_support_issue_tracker_label">问题跟踪器</string>
-    <string name="settings_support_debuglog_label">调试日志</string>
     <string name="settings_support_debuglog_desc">将应用的所有操作记录到可分享的文本文件中。</string>
-    <string name="settings_support_debuglog_recording_desc">正在记录调试信息。点击停止记录。</string>
-    <string name="settings_support_debuglog_path">日志路径：%1$s</string>
     <string name="settings_support_debuglog_short_recording_title">录制时间很短</string>
     <string name="settings_support_debuglog_short_recording_msg">这次录制非常短。调试日志是录制，而不是快照 — 在录制活跃时重现问题，日志才能有用。</string>
     <string name="settings_support_debuglog_short_recording_continue">继续录制</string>
     <string name="settings_support_debuglog_short_recording_stop">仍然停止</string>
-    <string name="settings_support_debuglog_folder_label">调试日志文件夹</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d 个会话使用 %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">没有存储的调试日志</string>
-    <string name="settings_support_debuglog_folder_delete_title">删除所有调试日志？</string>
-    <string name="settings_support_debuglog_folder_delete_msg">这将永久删除所有已存储的调试日志会话。</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">一个闲逛和提问的地方。</string>
     <!-- Settings/Acks-->
@@ -226,16 +204,12 @@
     <string name="settings_acks_translation_header">翻译</string>
     <string name="settings_acks_translators_title">翻译者</string>
     <string name="settings_acks_translators_people">用户一;用户二(optional@email.com)</string>
-    <string name="settings_acks_translate_title">翻译 BVM</string>
-    <string name="settings_acks_translate_desc">帮助将 BVM 翻译成您的语言</string>
     <string name="settings_acks_thanks_header">感谢</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">支持开源项目的翻译</string>
     <string name="settings_licenses_label">许可证</string>
     <string name="settings_translation_label">翻译</string>
     <string name="settings_translation_desc">帮助将应用翻译成你喜欢的语言</string>
-    <string name="settings_sponsor_development_title">赞助开发</string>
-    <string name="settings_sponsor_development_summary">成为赞助者，使持续开发成为可能。</string>
     <string name="settings_privacy_policy_label">隐私政策</string>
     <string name="settings_privacy_policy_desc">负责任地处理数据。</string>
     <string name="changelog_label">更新日志</string>
@@ -257,10 +231,8 @@
     <string name="backup_restore_success_restore">恢复完成 — 已恢复 %1$d 台设备，跳过 %2$d 台。</string>
     <string name="backup_restore_version_warning">此备份是使用版本 %1$s 创建的。您当前运行的是 %2$s。部分设置可能无法正确恢复。</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">调试通知</string>
     <string name="debug_log_consent_title">调试日志</string>
     <string name="debug_log_consent_explanation">此功能将应用的所有操作记录到可分享的文件中。生成的文件包含敏感信息（例如文件名和安装的应用）。仅与信任的方分享（例如正在解决问题的开发人员）。</string>
-    <string name="debug_log_recording_progress">正在记录调试日志</string>
     <string name="debug_log_record_action">记录</string>
     <string name="debug_log_stop_action">停止记录</string>
     <string name="debug_log_screen_title">调试日志记录器</string>
@@ -274,7 +246,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">丢弃</string>
     <string name="debug_log_screen_keep_action">保留</string>
-    <string name="debug_log_compressing_label">压缩中…</string>
     <string name="debug_log_file_label">已记录的日志文件</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">日志已发送？</string>
@@ -302,7 +273,6 @@
     <string name="contact_description_question_hint">详细描述您的问题。</string>
     <string name="contact_category_section_label">类别</string>
     <string name="contact_debug_log_label">调试日志</string>
-    <string name="contact_debug_log_select_hint">选择要附加的调试日志</string>
     <string name="contact_debug_log_picker_hint">附加调试日志以帮助更快地诊断问题。</string>
     <string name="contact_debug_log_picker_empty">没有可用的调试日志。请先录制一个。</string>
     <string name="contact_expected_behavior_label">预期行为</string>
@@ -315,82 +285,32 @@
     <string name="contact_welcome_msg">我亲自阅读每条消息并尽力回复，但由于我是一个人在做这件事，可能需要一点时间。感谢您的耐心。</string>
     <string name="contact_footer_msg">您的消息将通过电子邮件发送。设备和设置信息会自动附加。</string>
     <string name="contact_no_email_app_msg">此设备上未找到电子邮件应用。</string>
-    <string name="contact_attachment_missing_msg">调试日志文件不再存在</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">已存储的调试日志</string>
     <string name="settings_support_stored_logs_desc">%1$d 个会话 (%2$s)</string>
     <string name="settings_support_stored_logs_empty">没有已存储的调试日志</string>
-    <string name="settings_support_stored_logs_delete_title">删除存储的日志？</string>
-    <string name="settings_support_stored_logs_delete_msg">这将删除全部 %1$d 个已存储的调试日志会话。</string>
-    <string name="settings_support_stored_logs_deleted_msg">已存储的调试日志已删除</string>
-    <string name="label_bug_reports">错误报告</string>
-    <string name="description_bug_reports">自动发送缺陷和崩溃报告。</string>
     <string name="label_add_device">添加设备</string>
-    <string name="label_just_a_moment_please">请稍等一下。</string>
     <string name="label_notification_channel_status">状态</string>
     <string name="label_notification_channel_setup">需要设置</string>
     <string name="monitor_notification_starting">正在启动…</string>
     <string name="action_set">应用</string>
     <string name="action_cancel">取消</string>
-    <string name="label_invalid_input">输入的内容无效</string>
     <string name="action_reset">重置</string>
     <string name="label_no_connected_devices">没有设备连接</string>
-    <string name="label_status_idle">空闲</string>
-    <string name="label_status_adjusting_volumes">调整音量</string>
-    <string name="label_premium_version">高级版本</string>
     <string name="general_upgrade_action">升级</string>
     <string name="common_upgrade_required_label">需要升级</string>
-    <string name="label_premium_version_required">需要高级版本</string>
-    <string name="description_intro_purpose">此应用可让您的Android设备，记住来自不同蓝牙设备的音量。</string>
-    <string name="upgrade_benefit_unlimited_devices">无限设备配置</string>
-    <string name="upgrade_benefit_connection_actions">自动播放、启动应用及连接提醒</string>
-    <string name="upgrade_benefit_theme_customization">主题、样式和颜色自定义</string>
-    <string name="upgrade_benefit_power_controls">音量锁定和速率限制</string>
-    <string name="upgrade_benefit_support">支持独立开发</string>
     <string name="upgrade_benefit_equalizer">• 独立设备均衡器（适用于支持系统均衡器的音乐应用）</string>
-    <string name="description_intro_tap_the_button">首先添加您的第一个设备。</string>
     <string name="description_bluetooth_is_disabled">蓝牙已禁用。</string>
     <string name="title_bluetooth_is_off">蓝牙已关闭</string>
     <string name="action_enable_bluetooth">启用蓝牙</string>
     <string name="title_bluetooth_permission_required">需要蓝牙权限</string>
     <string name="description_bluetooth_permission_required">此应用需要蓝牙权限来管理您的设备音量。</string>
     <string name="action_grant_permission">授予权限</string>
-    <string name="label_status_listening_for_changes">侦听音量变化</string>
     <string name="action_exit">退出</string>
-    <string name="action_start">启动</string>
-    <string name="label_welcome">欢迎</string>
-    <string name="description_intro_contact">如果您对新功能有任何疑问或想法，请随时与我联系。</string>
-    <string name="label_translation">翻译</string>
-    <string name="description_help_translate">帮助我翻译此应用为其他语言。</string>
     <string name="label_device_speaker">设备扬声器</string>
-    <string name="label_keyevent_playpause">播放-暂停</string>
-    <string name="label_keyevent_play">播放</string>
-    <string name="label_keyevent_next">下一个</string>
-    <string name="label_install_id">安装 ID</string>
     <string name="message_copied_to_clipboard">已复制到剪切板</string>
-    <string name="label_thanks">致谢</string>
-    <string name="label_licenses">许可证</string>
-    <string name="description_ring_volume_additional_permission">需要额外的权限才能更改铃声音量。</string>
-    <string name="label_missing_permissions">缺少权限</string>
-    <string name="action_grant">授予</string>
-    <string name="label_advanced">高级</string>
-    <string name="label_exclude_health">排除安全的配置文件</string>
-    <string name="description_exclude_health">一些 Android 设备在查找“Health Device”蓝牙配置文件时挂起 （HDP，0×1400）。</string>
-    <string name="label_exclude_gattserver">排除 GATT 服务器配置文件</string>
-    <string name="label_exclude_gatt">排除 GATT 配置文件</string>
-    <string name="description_exclude_gattserver">不要查询“通用属性”（GATT）服务器类型的蓝牙配置文件。</string>
-    <string name="description_exclude_gatt">不要查询“通用属性”（GATT）客户端类型的蓝牙配置文件。</string>
-    <string name="description_waiting_for_devicex">等待 %s 完成连接</string>
-    <string name="action_undo">撤销</string>
-    <string name="action_show">显示</string>
     <string name="action_dismiss">忽略</string>
-    <string name="action_fix">修复</string>
-    <string name="battery_optimizations_issue_description">为此应用启用了电池优化，可能会阻止其接收蓝牙事件。 如果遇到问题，请考虑禁用对此程序的电池优化。</string>
     <string name="label_bluetooth_settings">蓝牙设置</string>
-    <string name="android10_applaunch_issue_description">Android 10 限制如何从后台启动应用。要允许在蓝牙设备连接时打开应用，请授予\&quot;在其他应用上显示\&quot;的权限（SYSTEM_ALERT_WINDOW）。</string>
-    <string name="label_opensource">源代码</string>
-    <string name="android13_notification_permission_description">授予此应用发送通知的权限。这使得在此应用活动和调整音量时能够显示通知。</string>
-    <string name="privacy_policy_label">隐私政策</string>
     <string name="managed_devices_empty_message">没有配置蓝牙设备。\n点击 + 按钮添加您的第一个设备。</string>
     <string name="label_pro_feature">高级功能</string>
     <plurals name="discover_device_limit_banner">
@@ -420,21 +340,15 @@
     <string name="review_app_review_action">评论</string>
     <string name="review_app_dismiss_action">稍后再说</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">购买已取消</string>
-    <string name="error_iap_unavailable_message">应用内购买不可用</string>
-    <string name="error_generic_message">发生错误。请重试。</string>
-    <string name="error_iap_owned_message">您已拥有此项目</string>
     <string name="label_no_devices_title">没有设备</string>
     <string name="bluemusic_mascot_description">应用图标</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">选择应用</string>
     <string name="devices_app_selection_search_hint">搜索应用…</string>
-    <string name="devices_app_selection_currently_selected">当前已选择</string>
     <string name="devices_app_selection_selected_count">已选择 %d 个应用</string>
     <string name="general_navigate_back_action">返回</string>
     <string name="general_reset_action">重置</string>
     <string name="general_clear_action">清除</string>
-    <string name="general_save_action">保存</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">锁定</string>
     <string name="devices_indicator_awake">唤醒</string>
@@ -444,7 +358,6 @@
     <string name="devices_indicator_limit">限制</string>
     <string name="devices_indicator_eq">均衡器</string>
     <string name="devices_indicator_boost">增强</string>
-    <string name="devices_indicator_launch">启动</string>
     <string name="devices_indicator_home">主页</string>
     <string name="devices_indicator_dnd">勿扰</string>
     <string name="devices_indicator_alert">提醒</string>

--- a/app/src/main/res/values-zh-rHK/strings.xml
+++ b/app/src/main/res/values-zh-rHK/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">更新期間部分功能已變更。請檢查你的裝置設定，確保一切都配置正確。</string>
     <string name="onboarding_rewrite_action">繼續</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">找不到未管理的裝置</string>
     <string name="discover_all_devices_managed_msg">你所有配對的裝置都已管理！需要新的？</string>
     <string name="discover_pair_new_device_action">配對新裝置</string>
     <string name="discover_device_speaker_desc">此手機本身的揚聲器。當音訊切換回手機時，其音量會被套用，例如在藍牙裝置斷開連線後。</string>
     <!-- Devices -->
     <string name="devices_device_config_label">裝置設定</string>
-    <string name="devices_device_config_section_general_label">一般</string>
     <string name="devices_device_config_remove_device_label">忽略裝置</string>
-    <string name="devices_device_config_remove_device_desc">從此應用將該裝置忽略並刪除其設定。這不會取消配對裝置。</string>
     <string name="devices_device_config_remove_device_action">忽略</string>
     <string name="devices_device_config_remove_device_confirmation">從已管理裝置中忽略 %s？</string>
-    <string name="devices_device_config_rename_device_label">重命名裝置</string>
-    <string name="devices_device_config_rename_device_desc">在此應用內重命名裝置，如可行，也在系統中重命名。</string>
     <string name="devices_device_config_rename_device_action">重命名</string>
     <string name="devices_device_config_enabled_label">已啟用</string>
     <string name="devices_device_config_enabled_desc">連接時回應此裝置</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">自動播放指令</string>
     <string name="devices_device_config_autoplay_keycodes_order">指令序列</string>
     <string name="devices_device_config_autoplay_keycodes_label">指令</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">設定要發送的指令及其順序</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">未設定任何指令</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">新增指令</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">最多 %1$d 個指令</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">向上移動</string>
     <string name="cd_autoplay_keycode_move_down">向下移動</string>
     <string name="cd_autoplay_keycode_remove">移除</string>
-    <string name="devices_device_config_section_volumes_label">音量</string>
     <string name="devices_device_config_section_volume_label">音量</string>
     <string name="devices_device_config_alarm_volume_label">鬧鐘音量</string>
     <string name="devices_device_config_alarm_volume_desc">部分鬧鐘應用使用音樂音量。</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">鈴聲</string>
     <string name="devices_audio_stream_notification_label">通知</string>
     <string name="devices_audio_stream_alarm_label">鬧鐘</string>
-    <string name="devices_neverseen_label">從未見過</string>
-    <string name="devices_state_connected_label">已連接</string>
     <string name="devices_last_connected_label">上次連接：%s</string>
     <string name="devices_currently_connected_label">目前已連接</string>
     <string name="devices_device_disabled_label">裝置已停用</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">影響所有受管裝置的設定。</string>
     <string name="label_app_enabled">應用已啟用</string>
     <string name="description_app_enabled">切換應用對音量和藍牙事件的回應能力。</string>
-    <string name="label_visible_volume_adjustments">顯示調整</string>
-    <string name="description_visible_volume_adjustments">此應用進行調整時，顯示系統的音量窗口。</string>
     <string name="label_volume_listener">監測變化</string>
-    <string name="description_volume_listener">裝置連接期間保持活動，並儲存非此應用引起的音量變化。</string>
     <string name="label_boot_restore">開機恢復</string>
     <string name="description_boot_restore">如果藍牙裝置已連接，從開機/重新開機後恢復音量。</string>
     <!-- Settings/Support-->
@@ -203,21 +191,11 @@
     <string name="settings_support_wiki_description">學習如何有效使用 BVM</string>
     <string name="settings_support_issue_tracker_description">一個公用問題追蹤器，用於錯誤報告和功能要求。</string>
     <string name="settings_support_issue_tracker_label">問題追蹤器</string>
-    <string name="settings_support_debuglog_label">偵錯記錄</string>
     <string name="settings_support_debuglog_desc">將應用程式正在做的所有事情記錄到一個文字檔案中，您可以分享它。</string>
-    <string name="settings_support_debuglog_recording_desc">目前正在録製除錯資訊。點擊停止録製。</string>
-    <string name="settings_support_debuglog_path">日誌路徑：%1$s</string>
     <string name="settings_support_debuglog_short_recording_title">錄製時間非常短</string>
     <string name="settings_support_debuglog_short_recording_msg">錄製時間非常短。除錯日誌是錄製，而非快照——請在錄製活動期間復現問題，日誌才會有用。</string>
     <string name="settings_support_debuglog_short_recording_continue">繼續錄製</string>
     <string name="settings_support_debuglog_short_recording_stop">仍然停止</string>
-    <string name="settings_support_debuglog_folder_label">除錯日誌資料夾</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d 個工作階段，使用 %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">未儲存除錯日誌</string>
-    <string name="settings_support_debuglog_folder_delete_title">刪除所有除錯日誌？</string>
-    <string name="settings_support_debuglog_folder_delete_msg">這會永久刪除所有已儲存的除錯日誌工作階段。</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">一個可以在其中閒逛並提出問題的地方。</string>
     <!-- Settings/Acks-->
@@ -226,16 +204,12 @@
     <string name="settings_acks_translation_header">翻譯</string>
     <string name="settings_acks_translators_title">翻譯人員</string>
     <string name="settings_acks_translators_people">Adeptus2</string>
-    <string name="settings_acks_translate_title">翻譯 BVM</string>
-    <string name="settings_acks_translate_desc">協助將 BVM 翻譯成你的語言</string>
     <string name="settings_acks_thanks_header">感謝</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">支持開源項目的翻譯</string>
     <string name="settings_licenses_label">授權</string>
     <string name="settings_translation_label">翻譯</string>
     <string name="settings_translation_desc">協助將應用翻譯成你最喜歡的語言</string>
-    <string name="settings_sponsor_development_title">贊助開發</string>
-    <string name="settings_sponsor_development_summary">成為贊助者，使持續開發成為可能。</string>
     <string name="settings_privacy_policy_label">私隱政策</string>
     <string name="settings_privacy_policy_desc">以負責的態度處理資料。</string>
     <string name="changelog_label">變更記錄</string>
@@ -257,10 +231,8 @@
     <string name="backup_restore_success_restore">還原完成 — 已還原 %1$d 個裝置，已跳過 %2$d 個。</string>
     <string name="backup_restore_version_warning">此備份是以版本 %1$s 建立的。您目前執行的是 %2$s。部分設定可能無法正確還原。</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">偵錯通知</string>
     <string name="debug_log_consent_title">偵錯記錄</string>
     <string name="debug_log_consent_explanation">此功能將應用程式執行的所有操作記錄到可分享的檔案中。產生的檔案包含敏感資訊（例如檔案名稱和已安裝的應用程式）。僅與可信任的對象分享（例如正在排除問題的開發者）。</string>
-    <string name="debug_log_recording_progress">正在記錄偵錯記錄</string>
     <string name="debug_log_record_action">錄製</string>
     <string name="debug_log_stop_action">停止記錄</string>
     <string name="debug_log_screen_title">除錯日誌錄製器</string>
@@ -274,7 +246,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">捨棄</string>
     <string name="debug_log_screen_keep_action">保留</string>
-    <string name="debug_log_compressing_label">壓縮中…</string>
     <string name="debug_log_file_label">已記錄的記錄檔案</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">日誌已傳送？</string>
@@ -302,7 +273,6 @@
     <string name="contact_description_question_hint">詳細描述你的問題。</string>
     <string name="contact_category_section_label">類別</string>
     <string name="contact_debug_log_label">偵錯記錄</string>
-    <string name="contact_debug_log_select_hint">選擇要附加的除錯日誌</string>
     <string name="contact_debug_log_picker_hint">附加除錯日誌以幫助更快診斷問題。</string>
     <string name="contact_debug_log_picker_empty">沒有可用的除錯日誌。請先錄製一個。</string>
     <string name="contact_expected_behavior_label">預期行為</string>
@@ -315,82 +285,32 @@
     <string name="contact_welcome_msg">我亲自閱讀每一條訊息並盡力回覆，但因為我是独自開發的，可能需要一點時間。感謝你的耐心。</string>
     <string name="contact_footer_msg">你的訊息將通過電郵發送。裝置和設定資訊會自動附加。</string>
     <string name="contact_no_email_app_msg">此裝置上找不到電郵應用。</string>
-    <string name="contact_attachment_missing_msg">除錯日誌檔案已不存在</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">已儲存的除錯日誌</string>
     <string name="settings_support_stored_logs_desc">%1$d 個工作階段 (%2$s)</string>
     <string name="settings_support_stored_logs_empty">沒有儲存的除錯日誌</string>
-    <string name="settings_support_stored_logs_delete_title">刪除已儲存的日誌？</string>
-    <string name="settings_support_stored_logs_delete_msg">這會刪除所有 %1$d 個已儲存的除錯日誌工作階段。</string>
-    <string name="settings_support_stored_logs_deleted_msg">已儲存的除錯日誌已刪除</string>
-    <string name="label_bug_reports">錯誤報告</string>
-    <string name="description_bug_reports">自動錯誤與崩潰報告。</string>
     <string name="label_add_device">新增裝置</string>
-    <string name="label_just_a_moment_please">請稍候。</string>
     <string name="label_notification_channel_status">狀態</string>
     <string name="label_notification_channel_setup">需要設定</string>
     <string name="monitor_notification_starting">正在啟動…</string>
     <string name="action_set">設定</string>
     <string name="action_cancel">取消</string>
-    <string name="label_invalid_input">無效輸入</string>
     <string name="action_reset">重設</string>
     <string name="label_no_connected_devices">沒有裝置連接</string>
-    <string name="label_status_idle">空閑</string>
-    <string name="label_status_adjusting_volumes">正在調整音量</string>
-    <string name="label_premium_version">高級版本</string>
     <string name="general_upgrade_action">升級</string>
     <string name="common_upgrade_required_label">需要升級</string>
-    <string name="label_premium_version_required">需要高級版本</string>
-    <string name="description_intro_purpose">此應用讓你的 Android 裝置記住不同藍牙裝置的音量。</string>
-    <string name="upgrade_benefit_unlimited_devices">無限裝置設定檔</string>
-    <string name="upgrade_benefit_connection_actions">自動播放、啟動應用程式及連線提醒</string>
-    <string name="upgrade_benefit_theme_customization">主題、樣式及顏色自訂</string>
-    <string name="upgrade_benefit_power_controls">音量鎖定及速率限制</string>
-    <string name="upgrade_benefit_support">支持獨立開發</string>
     <string name="upgrade_benefit_equalizer">• 每部裝置的均衡器（適用於支援系統均衡器的音樂應用程式）</string>
-    <string name="description_intro_tap_the_button">從新增你的第一個裝置開始。</string>
     <string name="description_bluetooth_is_disabled">藍牙已停用.</string>
     <string name="title_bluetooth_is_off">藍牙已關閉</string>
     <string name="action_enable_bluetooth">啟用藍牙</string>
     <string name="title_bluetooth_permission_required">需要藍牙權限</string>
     <string name="description_bluetooth_permission_required">此應用需要藍牙權限來管理你的裝置音量。</string>
     <string name="action_grant_permission">授予權限</string>
-    <string name="label_status_listening_for_changes">監聽音量變化</string>
     <string name="action_exit">退出</string>
-    <string name="action_start">開始</string>
-    <string name="label_welcome">歡迎</string>
-    <string name="description_intro_contact">如果你有任何問題或新功能的想法，隨時聯絡我。</string>
-    <string name="label_translation">翻譯</string>
-    <string name="description_help_translate">幫助我讓此應用支援更多語言。</string>
     <string name="label_device_speaker">裝置揚聲器</string>
-    <string name="label_keyevent_playpause">播放/暫停</string>
-    <string name="label_keyevent_play">播放</string>
-    <string name="label_keyevent_next">下一首</string>
-    <string name="label_install_id">安裝 ID</string>
     <string name="message_copied_to_clipboard">已複製到剪貼簿</string>
-    <string name="label_thanks">感謝</string>
-    <string name="label_licenses">授權</string>
-    <string name="description_ring_volume_additional_permission">更改鈴聲音量需要額外權限。</string>
-    <string name="label_missing_permissions">缺少權限</string>
-    <string name="action_grant">授予</string>
-    <string name="label_advanced">進階</string>
-    <string name="label_exclude_health">排除健康配檔</string>
-    <string name="description_exclude_health">部分 Android 裝置在查詢「健康裝置」藍牙配檔 (HDP、0x1400) 時會卡機。</string>
-    <string name="label_exclude_gattserver">排除 GATT 伺服器配檔</string>
-    <string name="label_exclude_gatt">排除 GATT 配檔</string>
-    <string name="description_exclude_gattserver">不查詢「通用屬性」(GATT) 伺服器類型的藍牙配檔。</string>
-    <string name="description_exclude_gatt">不查詢「通用屬性」(GATT) 用戶端類型的藍牙配檔。</string>
-    <string name="description_waiting_for_devicex">等待 %s 完成連接</string>
-    <string name="action_undo">復原</string>
-    <string name="action_show">顯示</string>
     <string name="action_dismiss">關閉</string>
-    <string name="action_fix">修正</string>
-    <string name="battery_optimizations_issue_description">此應用已啟用電池游淡優化，可能會阻止接收藍牙事件。如果你遇到問題，請考慮關閉游淡模式。</string>
     <string name="label_bluetooth_settings">藍牙設定</string>
-    <string name="android10_applaunch_issue_description">Android 10 限制应用從後台啟動的方式。要允許藍牙裝置連接時開啟應用，請授予「在其他應用上方顯示」(SYSTEM_ALERT_WINDOW) 權限。</string>
-    <string name="label_opensource">原始碼</string>
-    <string name="android13_notification_permission_description">授予此應用發送通知的權限。此權限可展示此應用活動且正在調整音量時的通知。</string>
-    <string name="privacy_policy_label">私隱政策</string>
     <string name="managed_devices_empty_message">未配置任何藍牙裝置。\n點擊 + 按鈕新增你的第一個裝置。</string>
     <string name="label_pro_feature">高級功能</string>
     <plurals name="discover_device_limit_banner">
@@ -420,21 +340,15 @@
     <string name="review_app_review_action">評論</string>
     <string name="review_app_dismiss_action">稍後再說</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">購買已取消</string>
-    <string name="error_iap_unavailable_message">應用內購買不可用</string>
-    <string name="error_generic_message">發生錯誤。請重試。</string>
-    <string name="error_iap_owned_message">你已擁有此項目</string>
     <string name="label_no_devices_title">沒有裝置</string>
     <string name="bluemusic_mascot_description">應用圖標</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">選擇應用</string>
     <string name="devices_app_selection_search_hint">搜尋應用…</string>
-    <string name="devices_app_selection_currently_selected">目前已選擇</string>
     <string name="devices_app_selection_selected_count">已選擇 %d 個應用</string>
     <string name="general_navigate_back_action">返回</string>
     <string name="general_reset_action">重設</string>
     <string name="general_clear_action">清除</string>
-    <string name="general_save_action">儲存</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">鎖定</string>
     <string name="devices_indicator_awake">喚醒</string>
@@ -444,7 +358,6 @@
     <string name="devices_indicator_limit">限制</string>
     <string name="devices_indicator_eq">均衡器</string>
     <string name="devices_indicator_boost">增強</string>
-    <string name="devices_indicator_launch">啟動</string>
     <string name="devices_indicator_home">主畫面</string>
     <string name="devices_indicator_dnd">勿打擾</string>
     <string name="devices_indicator_alert">提示</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">在此次更新過程中，某些裝置設定可能已被重設。請檢查您的裝置設定。</string>
     <string name="onboarding_rewrite_action">繼續</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">找不到未管理的裝置</string>
     <string name="discover_all_devices_managed_msg">您的所有配對裝置都已管理！需要配對新裝置嗎？</string>
     <string name="discover_pair_new_device_action">配對新裝置</string>
     <string name="discover_device_speaker_desc">此手機的揚聲器。當音訊切換回手機時（例如藍牙設備斷開連接後），會應用其音量。</string>
     <!-- Devices -->
     <string name="devices_device_config_label">裝置設定</string>
-    <string name="devices_device_config_section_general_label">一般</string>
     <string name="devices_device_config_remove_device_label">忘記裝置</string>
-    <string name="devices_device_config_remove_device_desc">從這個應用程式中忘記裝置並刪除其設定。這不會取消裝置的配對。</string>
     <string name="devices_device_config_remove_device_action">忘記</string>
     <string name="devices_device_config_remove_device_confirmation">要從管理裝置中忘記 %s 嗎？</string>
-    <string name="devices_device_config_rename_device_label">重新命名裝置</string>
-    <string name="devices_device_config_rename_device_desc">在這個應用程式中重新命名此裝置，如果可能的話，也在系統中重新命名。</string>
     <string name="devices_device_config_rename_device_action">重新命名</string>
     <string name="devices_device_config_enabled_label">已啟用</string>
     <string name="devices_device_config_enabled_desc">連線時對此裝置作出反應</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">自動播放指令</string>
     <string name="devices_device_config_autoplay_keycodes_order">指令序列</string>
     <string name="devices_device_config_autoplay_keycodes_label">指令</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">設定要發送哪些指令及其順序</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">未設定指令</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">新增指令</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">最多 %1$d 個指令</string>
@@ -120,7 +114,6 @@
     <string name="cd_autoplay_keycode_move_up">向上移動</string>
     <string name="cd_autoplay_keycode_move_down">向下移動</string>
     <string name="cd_autoplay_keycode_remove">移除</string>
-    <string name="devices_device_config_section_volumes_label">音量</string>
     <string name="devices_device_config_section_volume_label">音量</string>
     <string name="devices_device_config_alarm_volume_label">鬧鐘音量</string>
     <string name="devices_device_config_alarm_volume_desc">一些鬧鐘應用程式使用音樂音量來代替。</string>
@@ -154,8 +147,6 @@
     <string name="devices_audio_stream_ring_label">鈴聲</string>
     <string name="devices_audio_stream_notification_label">通知</string>
     <string name="devices_audio_stream_alarm_label">鬧鐘</string>
-    <string name="devices_neverseen_label">從未見過</string>
-    <string name="devices_state_connected_label">已連線</string>
     <string name="devices_last_connected_label">最後連接時間：%s</string>
     <string name="devices_currently_connected_label">目前已連接</string>
     <string name="devices_device_disabled_label">裝置已停用</string>
@@ -190,10 +181,7 @@
     <string name="devices_settings_desc">影響所有管理裝置的設定。</string>
     <string name="label_app_enabled">應用程式已啟用</string>
     <string name="description_app_enabled">切換應用對音量和藍牙事件作出反應的能力。</string>
-    <string name="label_visible_volume_adjustments">可見調整</string>
-    <string name="description_visible_volume_adjustments">在此應用調整時顯示系統音量視窗。</string>
     <string name="label_volume_listener">Observe changes</string>
-    <string name="description_volume_listener">當此應用程式正在為此裝置進行調整時，顯示系統音量視窗</string>
     <string name="label_boot_restore">開機後復原</string>
     <string name="description_boot_restore">在開機/重新開機後，如果連上藍牙裝置就復原音量。</string>
     <!-- Settings/Support-->
@@ -203,21 +191,11 @@
     <string name="settings_support_wiki_description">學習如何有效地使用 BVM</string>
     <string name="settings_support_issue_tracker_description">用於錯誤回報和功能請求的公開問題追蹤系統。</string>
     <string name="settings_support_issue_tracker_label">問題追蹤</string>
-    <string name="settings_support_debuglog_label">除錯日誌</string>
     <string name="settings_support_debuglog_desc">將應用程式所做的一切記錄到一個您可以分享的文字檔案中。</string>
-    <string name="settings_support_debuglog_recording_desc">目前正在記錄除錯資訊。點擊停止記錄。</string>
-    <string name="settings_support_debuglog_path">日誌路徑：%1$s</string>
     <string name="settings_support_debuglog_short_recording_title">錄製時間很短</string>
     <string name="settings_support_debuglog_short_recording_msg">這次錄製非常短。除錯日誌是錄製，而不是快照 — 在錄製進行中重現問題，日誌才能有用。</string>
     <string name="settings_support_debuglog_short_recording_continue">繼續錄製</string>
     <string name="settings_support_debuglog_short_recording_stop">仍然停止</string>
-    <string name="settings_support_debuglog_folder_label">除錯日誌資料夾</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="other">%1$d 個工作階段使用 %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">沒有存儲的除錯日誌</string>
-    <string name="settings_support_debuglog_folder_delete_title">刪除所有除錯日誌？</string>
-    <string name="settings_support_debuglog_folder_delete_msg">這將永久刪除所有已存儲的除錯日誌工作階段。</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">一個可以關逛和提問的地方。</string>
     <!-- Settings/Acks-->
@@ -226,16 +204,12 @@
     <string name="settings_acks_translation_header">翻譯</string>
     <string name="settings_acks_translators_title">翻譯者</string>
     <string name="settings_acks_translators_people">Adeptus2</string>
-    <string name="settings_acks_translate_title">翻譯 BVM</string>
-    <string name="settings_acks_translate_desc">協助將 BVM 翻譯成您的語言</string>
     <string name="settings_acks_thanks_header">鳴謝</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">支持開源專案的翻譯</string>
     <string name="settings_licenses_label">授權條款</string>
     <string name="settings_translation_label">翻譯</string>
     <string name="settings_translation_desc">幫助將應用程式翻譯為你喜愛的語言</string>
-    <string name="settings_sponsor_development_title">贊助開發</string>
-    <string name="settings_sponsor_development_summary">成為贊助者，讓持續開發成為可能。</string>
     <string name="settings_privacy_policy_label">隱私權政策</string>
     <string name="settings_privacy_policy_desc">負責任地處理資料。</string>
     <string name="changelog_label">更新日誌</string>
@@ -257,10 +231,8 @@
     <string name="backup_restore_success_restore">還原完成 — 已還原 %1$d 台裝置，略過 %2$d 台。</string>
     <string name="backup_restore_version_warning">此備份由版本 %1$s 建立。你目前使用的是 %2$s。部分設定可能無法正確還原。</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">除錯通知</string>
     <string name="debug_log_consent_title">除錯日誌</string>
     <string name="debug_log_consent_explanation">此功能會將應用程式所做的一切記錄到可分享的檔案中。產生的檔案包含敏感資訊（例如檔案名稱和已安裝的應用程式）。請只與可信任的對象分享（例如正在解決問題的開發者）。</string>
-    <string name="debug_log_recording_progress">正在記錄除錯日誌</string>
     <string name="debug_log_record_action">記錄</string>
     <string name="debug_log_stop_action">停止記錄</string>
     <string name="debug_log_screen_title">除錯日誌記錄器</string>
@@ -274,7 +246,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">破棄</string>
     <string name="debug_log_screen_keep_action">保留</string>
-    <string name="debug_log_compressing_label">壓縮中…</string>
     <string name="debug_log_file_label">已記錄的日誌檔案</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">日誌已發送？</string>
@@ -302,7 +273,6 @@
     <string name="contact_description_question_hint">詳細描述您的問題。</string>
     <string name="contact_category_section_label">類別</string>
     <string name="contact_debug_log_label">除錯日誌</string>
-    <string name="contact_debug_log_select_hint">選擇要附加的除錯日誌</string>
     <string name="contact_debug_log_picker_hint">附加除錯日誌以幫助更快地診斷問題。</string>
     <string name="contact_debug_log_picker_empty">沒有可用的除錯日誌。請先錄製一個。</string>
     <string name="contact_expected_behavior_label">預期行為</string>
@@ -315,82 +285,32 @@
     <string name="contact_welcome_msg">我親自閱讀每條訊息並盡力回覆，但由於我獨自一人在做這件事，可能需要一點時間。感謝您的耐心。</string>
     <string name="contact_footer_msg">您的訊息將透過電子郵件發送。裝置和設定資訊會自動附加。</string>
     <string name="contact_no_email_app_msg">此裝置上未找到電子郵件應用程式。</string>
-    <string name="contact_attachment_missing_msg">除錯日誌檔案不再存在</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">已存儲的除錯日誌</string>
     <string name="settings_support_stored_logs_desc">%1$d 個工作階段 (%2$s)</string>
     <string name="settings_support_stored_logs_empty">沒有已存儲的除錯日誌</string>
-    <string name="settings_support_stored_logs_delete_title">刪除存儲的日誌？</string>
-    <string name="settings_support_stored_logs_delete_msg">這將刪除全部 %1$d 個已存儲的除錯日誌工作階段。</string>
-    <string name="settings_support_stored_logs_deleted_msg">已存儲的除錯日誌已刪除</string>
-    <string name="label_bug_reports">錯誤回報</string>
-    <string name="description_bug_reports">自動回報錯誤和當機報告。</string>
     <string name="label_add_device">新增裝置</string>
-    <string name="label_just_a_moment_please">請稍等一下。</string>
     <string name="label_notification_channel_status">狀態</string>
     <string name="label_notification_channel_setup">需要設定</string>
     <string name="monitor_notification_starting">正在啟動…</string>
     <string name="action_set">設定</string>
     <string name="action_cancel">取消</string>
-    <string name="label_invalid_input">無效的輸入</string>
     <string name="action_reset">重設</string>
     <string name="label_no_connected_devices">沒有裝置連線</string>
-    <string name="label_status_idle">閒置</string>
-    <string name="label_status_adjusting_volumes">調整音量</string>
-    <string name="label_premium_version">付費版本</string>
     <string name="general_upgrade_action">升級</string>
     <string name="common_upgrade_required_label">需要升級</string>
-    <string name="label_premium_version_required">需要付費版本</string>
-    <string name="description_intro_purpose">這個應用程式允許 Android 記住不同的藍牙裝置的音量。</string>
-    <string name="upgrade_benefit_unlimited_devices">無限裝置設定檔</string>
-    <string name="upgrade_benefit_connection_actions">自動播放、啟動應用程式與連線提醒</string>
-    <string name="upgrade_benefit_theme_customization">主題、風格與顏色自訂</string>
-    <string name="upgrade_benefit_power_controls">音量鎖定與限速</string>
-    <string name="upgrade_benefit_support">支持獨立開發</string>
     <string name="upgrade_benefit_equalizer">• 個別裝置等化器（適用於支援系統等化器的音樂應用程式）</string>
-    <string name="description_intro_tap_the_button">從新增你的第一個裝置開始。</string>
     <string name="description_bluetooth_is_disabled">藍牙已停用。</string>
     <string name="title_bluetooth_is_off">藍牙已關閉</string>
     <string name="action_enable_bluetooth">啟用藍牙</string>
     <string name="title_bluetooth_permission_required">需要藍牙權限</string>
     <string name="description_bluetooth_permission_required">此應用程式需要藍牙權限來管理您的裝置音量。</string>
     <string name="action_grant_permission">授予權限</string>
-    <string name="label_status_listening_for_changes">聆聽音量變更</string>
     <string name="action_exit">離開</string>
-    <string name="action_start">執行</string>
-    <string name="label_welcome">歡迎</string>
-    <string name="description_intro_contact">若有疑問或新功能的好點子，不要猶豫，直接和我聯絡。</string>
-    <string name="label_translation">翻譯</string>
-    <string name="description_help_translate">協助我將這個應用程式翻譯成其他語言。</string>
     <string name="label_device_speaker">裝置揚聲器</string>
-    <string name="label_keyevent_playpause">播放 - 暫停</string>
-    <string name="label_keyevent_play">播放</string>
-    <string name="label_keyevent_next">下一首</string>
-    <string name="label_install_id">安裝 ID</string>
     <string name="message_copied_to_clipboard">已複製到剪貼簿</string>
-    <string name="label_thanks">感謝</string>
-    <string name="label_licenses">授權條款</string>
-    <string name="description_ring_volume_additional_permission">變更鈴聲音量需要額外權限。</string>
-    <string name="label_missing_permissions">缺少權限</string>
-    <string name="action_grant">授權</string>
-    <string name="label_advanced">進階</string>
-    <string name="label_exclude_health">排除健康設定檔</string>
-    <string name="description_exclude_health">一些 Android 裝置在查找「健康裝置」藍牙設定檔 (HDP, 0x1400) 時掛起。</string>
-    <string name="label_exclude_gattserver">排除 GATT 伺服器設定檔</string>
-    <string name="label_exclude_gatt">排除 GATT 設定檔</string>
-    <string name="description_exclude_gattserver">不要查詢「通用屬性」(GATT) 伺服器類型的藍牙設定檔。</string>
-    <string name="description_exclude_gatt">不要查詢「通用屬性」(GATT) 用戶端類型的藍牙設定檔。</string>
-    <string name="description_waiting_for_devicex">等待 %s 完成連線</string>
-    <string name="action_undo">復原</string>
-    <string name="action_show">顯示</string>
     <string name="action_dismiss">忽略</string>
-    <string name="action_fix">修復</string>
-    <string name="battery_optimizations_issue_description">該應用程式啟用了電池效能最佳化功能，會阻止它接收藍牙事件。如果你遇到問題，請考慮停用電池效能最佳化功能。</string>
     <string name="label_bluetooth_settings">藍牙設定</string>
-    <string name="android10_applaunch_issue_description">Android 10 限制了應用程式從背景啟動的方式。要允許在藍牙裝置連線時開啟應用程式，請授予「顯示在其他應用程式上層」權限 (SYSTEM_ALERT_WINDOW)。</string>
-    <string name="label_opensource">原始碼</string>
-    <string name="android13_notification_permission_description">授予此應用程式發送通知的權限。這讓應用程式活躍時及調整音量時能顯示通知。</string>
-    <string name="privacy_policy_label">隱私權政策</string>
     <string name="managed_devices_empty_message">沒有設定藍牙裝置。\n點擊 + 按鈕來新增您的第一個裝置。</string>
     <string name="label_pro_feature">付費功能</string>
     <plurals name="discover_device_limit_banner">
@@ -420,21 +340,15 @@
     <string name="review_app_review_action">評論</string>
     <string name="review_app_dismiss_action">稍後再說</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">購買已取消</string>
-    <string name="error_iap_unavailable_message">無法使用應用程式內購買</string>
-    <string name="error_generic_message">發生錯誤。請再試一次。</string>
-    <string name="error_iap_owned_message">您已經擁有此項目</string>
     <string name="label_no_devices_title">沒有裝置</string>
     <string name="bluemusic_mascot_description">應用程式圖示</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">選擇應用程式</string>
     <string name="devices_app_selection_search_hint">搜尋應用程式…</string>
-    <string name="devices_app_selection_currently_selected">目前已選取</string>
     <string name="devices_app_selection_selected_count">已選取 %d 個應用程式</string>
     <string name="general_navigate_back_action">返回</string>
     <string name="general_reset_action">重設</string>
     <string name="general_clear_action">清除</string>
-    <string name="general_save_action">儲存</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">鎖定</string>
     <string name="devices_indicator_awake">喚醒</string>
@@ -444,7 +358,6 @@
     <string name="devices_indicator_limit">限制</string>
     <string name="devices_indicator_eq">等化器</string>
     <string name="devices_indicator_boost">增益</string>
-    <string name="devices_indicator_launch">啟動</string>
     <string name="devices_indicator_home">主頁</string>
     <string name="devices_indicator_dnd">勿擾</string>
     <string name="devices_indicator_alert">Alert</string>

--- a/app/src/main/res/values-zu/strings.xml
+++ b/app/src/main/res/values-zu/strings.xml
@@ -26,19 +26,14 @@
     <string name="onboarding_rewrite_features">Ezinye izici ziguqukile ngesikhathi sokubuyekeza. Sicela uhlole izilungiselelo zedivayisi yakho ukuqinisekisa ukuthi konke kulungiselwe ngendlela efanele.</string>
     <string name="onboarding_rewrite_action">Qhubeka</string>
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">Azikho izidivayisi ezingaphathwa ezitholakele</string>
     <string name="discover_all_devices_managed_msg">Wonke amadivayisi akho asebenzisana nawo aphathwa! Udinga elisha?</string>
     <string name="discover_pair_new_device_action">Hlanganisa idivayisi entsha</string>
     <string name="discover_device_speaker_desc">Isahluko sefowuni sayo. Umthwali waso usetshenziswa lapho umsindo ubuya efowunini, isibonelo, emva kokuthi isixwayiso sakho se-Bluetooth siqedele ukunxibelelana.</string>
     <!-- Devices -->
     <string name="devices_device_config_label">Ukucwaninga kwedivayisi</string>
-    <string name="devices_device_config_section_general_label">Okujwayelekile</string>
     <string name="devices_device_config_remove_device_label">Libale idivayisi</string>
-    <string name="devices_device_config_remove_device_desc">Ilibala idivayisi kulolu hlelo futhi lisuse ukucwaninga kwalo. Lokhu akuhlukani idivayisi nesevisi ye-Bluetooth.</string>
     <string name="devices_device_config_remove_device_action">Libala</string>
     <string name="devices_device_config_remove_device_confirmation">Libala %s ezidivaysini eziphathwayo?</string>
-    <string name="devices_device_config_rename_device_label">Phinda uqambe igama idivayisi</string>
-    <string name="devices_device_config_rename_device_desc">Phinda uqambe igama lale divayisi kulolu hlelo, futhi uma kunokwenzeka, ngaphakathi kohlelo.</string>
     <string name="devices_device_config_rename_device_action">Phinda uqambe igama</string>
     <string name="devices_device_config_enabled_label">Kunikwe amandla</string>
     <string name="devices_device_config_enabled_desc">Phendula kule divayisi uma ixhunyiwe</string>
@@ -94,7 +89,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Imiyalo yokudlala ngokuzenzakalela</string>
     <string name="devices_device_config_autoplay_keycodes_order">Ukulandelana kwemiyalo</string>
     <string name="devices_device_config_autoplay_keycodes_label">Imiyalo</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Lungisa ukuthi imuphi imiyalo ozothumela nangayiphi indlela</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">Ayikho imiyalo ebekiwe</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Engeza umyalo</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Imiyalo ephakeme %1$d</string>
@@ -121,7 +115,6 @@
     <string name="cd_autoplay_keycode_move_up">Nyukela phezulu</string>
     <string name="cd_autoplay_keycode_move_down">Ehla phansi</string>
     <string name="cd_autoplay_keycode_remove">Susa</string>
-    <string name="devices_device_config_section_volumes_label">Amavolumu</string>
     <string name="devices_device_config_section_volume_label">Ivolumu</string>
     <string name="devices_device_config_alarm_volume_label">Ivolumu ye-alamu</string>
     <string name="devices_device_config_alarm_volume_desc">Ezinye izinhlelo ze-alamu zisebenzisa ivolumu yomuziki esikhundleni sayo.</string>
@@ -155,8 +148,6 @@
     <string name="devices_audio_stream_ring_label">Ukhalo</string>
     <string name="devices_audio_stream_notification_label">Isaziso</string>
     <string name="devices_audio_stream_alarm_label">I-alamu</string>
-    <string name="devices_neverseen_label">Akuzange ibonakale</string>
-    <string name="devices_state_connected_label">Ixhunyiwe</string>
     <string name="devices_last_connected_label">Ixhunyiwe okwedlule: %s</string>
     <string name="devices_currently_connected_label">Ixhunyiwe manje</string>
     <string name="devices_device_disabled_label">Idivayisi ivaliwe</string>
@@ -191,10 +182,7 @@
     <string name="devices_settings_desc">Izilungiselelo ezithinta wonke amadivayisi aphathwayo.</string>
     <string name="label_app_enabled">Uhlelo lukhona</string>
     <string name="description_app_enabled">Guqula ukwazi kohlelo ukuphendula ezigamekweni zamavolumu ne-Bluetooth.</string>
-    <string name="label_visible_volume_adjustments">Ukuhlela okubonakalayo</string>
-    <string name="description_visible_volume_adjustments">Bonisa ifasitela lamavolumu lesistem ngenkathi lolu hlelo lenza ukuhlela.</string>
     <string name="label_volume_listener">Buka izinguquko</string>
-    <string name="description_volume_listener">Hlala usebenza ngenkathi idivayisi ixhunyiwe futhi ulondoloze izinguquko zamavolumu ezingenziwanga ngalolu hlelo.</string>
     <string name="label_boot_restore">Buyisela ekuqaleni uma kuvulwa</string>
     <string name="description_boot_restore">Buyisela ivolumu ngemuva kokuqala/ukuqala kabusha uma idivayisi ye-Bluetooth ixhunyiwe.</string>
     <!-- Settings/Support-->
@@ -204,22 +192,11 @@
     <string name="settings_support_wiki_description">Funda ukusebenzisa i-BVM ngempumelelo</string>
     <string name="settings_support_issue_tracker_description">Isixhumanisi esivulekile sezinkinga sokubika amaphutha nezicelo zeziqu.</string>
     <string name="settings_support_issue_tracker_label">Isixhumanisi sezinkinga</string>
-    <string name="settings_support_debuglog_label">Ilogi lokuphephisa iziphazamiso</string>
     <string name="settings_support_debuglog_desc">Rekhoda konke uhlelo olukwenzayo kufayela lombhalo ongawabelana ngalo.</string>
-    <string name="settings_support_debuglog_recording_desc">Manje iqopha ulwazi lwe-debug. Thepha ukuqeda ukuqopha.</string>
-    <string name="settings_support_debuglog_path">Indlela ye-log: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Ukuqopha okufushane kakhulu</string>
     <string name="settings_support_debuglog_short_recording_msg">Kwakuwukuqopha okufushane kakhulu. Ama-debug log ayizinto ezirekhodiwe, hhayi izithombe — phinda inkinga ngenkathi ukuqopha kusebenza ukuze i-log ibe yusizo.</string>
     <string name="settings_support_debuglog_short_recording_continue">Qhubeka ukuqopha</string>
     <string name="settings_support_debuglog_short_recording_stop">Misa noma kunjalo</string>
-    <string name="settings_support_debuglog_folder_label">Ifulda ye-debug log</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">Uhlelo %1$d olwethula %2$s</item>
-        <item quantity="other">Izingxenye %1$d ezisebenzisa %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">Awekho ama-debug log agcinwe</string>
-    <string name="settings_support_debuglog_folder_delete_title">Susa wonke ama-debug log?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">Lokhu kuzosusa ngokuphelele zonke izingxenye ze-debug log ezigcinwe.</string>
     <string name="settings_support_discord_label">I-Discord</string>
     <string name="settings_support_discord_description">Indawo yokuzijabulisa futhi ubuze imibuzo.</string>
     <!-- Settings/Acks-->
@@ -228,16 +205,12 @@
     <string name="settings_acks_translation_header">Ukuhumusha</string>
     <string name="settings_acks_translators_title">Abahumushi</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Humusha i-BVM</string>
-    <string name="settings_acks_translate_desc">Siza ukuhumushela i-BVM olimini lwakho</string>
     <string name="settings_acks_thanks_header">Ngiyabonga</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
     <string name="settings_acks_crowdin_desc">Ngokusekela ukuhumushwa kwamaphrojekthi avu-source</string>
     <string name="settings_licenses_label">Amalayisensi</string>
     <string name="settings_translation_label">Ukuhumusha</string>
     <string name="settings_translation_desc">Siza ukuhumushela uhlelo olimini ozithandela kulo</string>
-    <string name="settings_sponsor_development_title">Xhasa ukuthuthukiswa</string>
-    <string name="settings_sponsor_development_summary">Yiba umxhasi wenze ukuqhubeka nokuthuthukiswa kube nokwenzeka.</string>
     <string name="settings_privacy_policy_label">Inqubomgomo yobumfihlo</string>
     <string name="settings_privacy_policy_desc">Ukuphatha idatha ngokufanele.</string>
     <string name="changelog_label">Uhlu lwezinguquko</string>
@@ -259,10 +232,8 @@
     <string name="backup_restore_success_restore">Ukubuyisela kuqediwe — amadivayisi angu-%1$d abuyiselwe, angu-%2$d agcagcwe.</string>
     <string name="backup_restore_version_warning">Lesi sipele sidalwe ngoguqulo lwa-%1$s. Usebenzisa inguqulo %2$s. Ezinye izilungiselelo zingeke zibuyiselwe kahle.</string>
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Izaziso zokulungisa amaphutha</string>
     <string name="debug_log_consent_title">Ilogi lokuphephisa iziphazamiso</string>
     <string name="debug_log_consent_explanation">Lesi sici sirekhoda konke okwenziwa yi-app kufayela elingabelwana. Ifayela elenziwe liqukethe ulwazi olubucayi (isib. amagama amafayela nezinhlelo zokusebenza ezifakiwe). Yabelane nalo kuphela nezinhlangothi ezithembekile (isib. umthuthukisi oxazulula inkinga).</string>
-    <string name="debug_log_recording_progress">Kurekhoda umvala wokulungisa amaphutha</string>
     <string name="debug_log_record_action">Qopha</string>
     <string name="debug_log_stop_action">Misa ukurekhoda</string>
     <string name="debug_log_screen_title">Umqophi we-Debug Log</string>
@@ -277,7 +248,6 @@
     </plurals>
     <string name="debug_log_screen_discard_action">Lahla</string>
     <string name="debug_log_screen_keep_action">Gcina</string>
-    <string name="debug_log_compressing_label">Kuyacindezela...</string>
     <string name="debug_log_file_label">Ifayela lomvala olurekhodewe</string>
     <!-- Debug Log Sessions -->
     <string name="support_debuglog_sent_title">I-log ithunyelwe?</string>
@@ -305,7 +275,6 @@
     <string name="contact_description_question_hint">Chaza umbuzo wakho ngokuningiliziwe.</string>
     <string name="contact_category_section_label">Isigaba</string>
     <string name="contact_debug_log_label">Ilogi lokuphephisa iziphazamiso</string>
-    <string name="contact_debug_log_select_hint">Khetha i-debug log ukuyinamathisela</string>
     <string name="contact_debug_log_picker_hint">Namathisela i-debug log ukusiza ukuxilonga inkinga ngokushesha.</string>
     <string name="contact_debug_log_picker_empty">Awekho ama-debug log atholakalayo. Qopha olunye kuqala.</string>
     <string name="contact_expected_behavior_label">Ukuziphatha okwakulindelekile</string>
@@ -319,82 +288,32 @@
     <string name="contact_welcome_msg">Ngifunda wonke umyalezo mina ngokwami futhi ngizama kakhulu ukuphendula, kodwa ngoba ngisebenza ngokuwodwa, kungathatha isikhathi esincane. Ngiyabonga ngesineke sakho.</string>
     <string name="contact_footer_msg">Umyalezo wakho uzothumelwa nge-imeyili. Ulwazi lwedivayisi nokusethwa kunamathiselwa ngokuzenzakalelayo.</string>
     <string name="contact_no_email_app_msg">Akukho uhlelo lwe-imeyili oLutholakele kule divayisi.</string>
-    <string name="contact_attachment_missing_msg">Ifayela le-debug log alikho okunye</string>
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Ama-debug log agcinwe</string>
     <string name="settings_support_stored_logs_desc">Izingxenye %1$d (%2$s)</string>
     <string name="settings_support_stored_logs_empty">Awekho ama-debug log agcinwe</string>
-    <string name="settings_support_stored_logs_delete_title">Susa ama-log agcinwe?</string>
-    <string name="settings_support_stored_logs_delete_msg">Lokhu kuzosusa zonke izingxenye %1$d ze-debug log ezigcinwe.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Ama-debug log agcinwe asusiwe</string>
-    <string name="label_bug_reports">Imibiko yebhagi</string>
-    <string name="description_bug_reports">Ukubika kwezibhagi nokulimala ngokuzenzakalelayo.</string>
     <string name="label_add_device">Engeza idivayisi</string>
-    <string name="label_just_a_moment_please">Isikhashana nje, sicela.</string>
     <string name="label_notification_channel_status">Isimo</string>
     <string name="label_notification_channel_setup">Ukulungiselela kuyadingeka</string>
     <string name="monitor_notification_starting">Iqalaqala...</string>
     <string name="action_set">Setha</string>
     <string name="action_cancel">Yekisa</string>
-    <string name="label_invalid_input">Okokufaka okungalungile</string>
     <string name="action_reset">Setha kabusha</string>
     <string name="label_no_connected_devices">Azikho izidivayisi ezixhunyiwe</string>
-    <string name="label_status_idle">Ilele</string>
-    <string name="label_status_adjusting_volumes">Ihlela amavolumu</string>
-    <string name="label_premium_version">Inguqulo ye-premium</string>
     <string name="general_upgrade_action">Thuthukisa</string>
     <string name="common_upgrade_required_label">Ukuphakamisa kuyadingeka</string>
-    <string name="label_premium_version_required">Kudingeka inguqulo ye-premium</string>
-    <string name="description_intro_purpose">Lolu hlelo luvumela idivayisi yakho ye-Android ukukhumbula ivolumu yezidivayisi ezihlukene ze-Bluetooth.</string>
-    <string name="upgrade_benefit_unlimited_devices">Amaphrofayela amadivayisi angenamkhawulo</string>
-    <string name="upgrade_benefit_connection_actions">Ukudlala ngokuzenzakalela, ukuqalisa uhlelo lokusebenza nezaziso zokulumeka</string>
-    <string name="upgrade_benefit_theme_customization">Ukuguqulwa kwetheme, isitayela nembala</string>
-    <string name="upgrade_benefit_power_controls">Ukukhiya amazwi nokunciphisa inani</string>
-    <string name="upgrade_benefit_support">Seka ukuthuthukiswa okuzimele</string>
     <string name="upgrade_benefit_equalizer">• I-equalizer ngosistimu (zezinhlelo zokuhlabelela ezisekela i-equalizer yesistimu)</string>
-    <string name="description_intro_tap_the_button">Qala ngokwengeza idivayisi yakho yokuqala.</string>
     <string name="description_bluetooth_is_disabled">I-Bluetooth ikhubaziwe.</string>
     <string name="title_bluetooth_is_off">I-Bluetooth ivaliwe</string>
     <string name="action_enable_bluetooth">Vula i-Bluetooth</string>
     <string name="title_bluetooth_permission_required">Kudingeka Imvume ye-Bluetooth</string>
     <string name="description_bluetooth_permission_required">Lolu hlelo ludinga imvume ye-Bluetooth ukuphatha amavolumu edivayisi yakho.</string>
     <string name="action_grant_permission">Nikeza Imvume</string>
-    <string name="label_status_listening_for_changes">Ilalela izinguquko zamavolumu</string>
     <string name="action_exit">Phuma</string>
-    <string name="action_start">Qala</string>
-    <string name="label_welcome">Sawubona</string>
-    <string name="description_intro_contact">Ungasongi ukuxhumana nami uma unemibuzo noma nombono wezici entsha.</string>
-    <string name="label_translation">Ukuhumusha</string>
-    <string name="description_help_translate">Ngisiza ukwenza lolu hlelo lutholakale ngezinye izilimi.</string>
     <string name="label_device_speaker">Isipika sedivayisi</string>
-    <string name="label_keyevent_playpause">Dlala-Misa</string>
-    <string name="label_keyevent_play">Dlala</string>
-    <string name="label_keyevent_next">Okulandelayo</string>
-    <string name="label_install_id">I-ID yokufaka</string>
     <string name="message_copied_to_clipboard">Ikhophelwe ku-clipboard</string>
-    <string name="label_thanks">Ngiyabonga</string>
-    <string name="label_licenses">Amalayisensi</string>
-    <string name="description_ring_volume_additional_permission">Izimvume ezengeziwe zidingeka ukushintsha ivolumu yokhalo.</string>
-    <string name="label_missing_permissions">Izimvume ezilahlekile</string>
-    <string name="action_grant">Nika</string>
-    <string name="label_advanced">Okuthuthukisiwe</string>
-    <string name="label_exclude_health">Khipha amaphrofayili ezempilo</string>
-    <string name="description_exclude_health">Ezinye izidivayisi ze-Android zime uma zifuna amaphrofayili we-Bluetooth \'Health Device\' (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Khipha amaphrofayili eseva ye-GATT</string>
-    <string name="label_exclude_gatt">Khipha amaphrofayili e-GATT</string>
-    <string name="description_exclude_gattserver">Ungabuzi amaphrofayili we-Bluetooth ohlobo lwe-\'Generic Attribute\' (GATT) iseva.</string>
-    <string name="description_exclude_gatt">Ungabuzi amaphrofayili we-Bluetooth ohlobo lwe-\'Generic Attribute\' (GATT) ikhuleki.</string>
-    <string name="description_waiting_for_devicex">Ilinde %s ukuqedela uxhumano</string>
-    <string name="action_undo">Hlehlisa</string>
-    <string name="action_show">Bonisa</string>
     <string name="action_dismiss">Lahla</string>
-    <string name="action_fix">Lungisa</string>
-    <string name="battery_optimizations_issue_description">Ukuqinisekisa ibhethri kukhona kulolu hlelo futhi kungavimbela ukwamukela izigameko ze-Bluetooth. Cabanga ukucisha ukuqinisekisa uma uhlanganisa izinkinga.</string>
     <string name="label_bluetooth_settings">Izilungiselelo ze-Bluetooth</string>
-    <string name="android10_applaunch_issue_description">I-Android 10 ikhawuleza ukuthi izinhlelo zingaqalwa kanjani emuva. Ukuvumela ukuvula izinhlelo uma idivayisi ye-Bluetooth ixhuma, nikeza imvume \"Bonisa phezu kwezinhlelo ezinye\" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Ikhodi yomthombo</string>
-    <string name="android13_notification_permission_description">Nikeza lolu hlelo imvume yokuthuma izaziso. Lokhu kuvula ukuboniswa kwesaziso uma lolu hlelo lusebenza futhi ukuhlela kwamavolumu kwenziwa.</string>
-    <string name="privacy_policy_label">Inqubomgomo yobumfihlo</string>
     <string name="managed_devices_empty_message">Azikho izidivayisi ze-Bluetooth ezilungiselwe.\nThepha inkinobho + ukwengeza idivayisi yakho yokuqala.</string>
     <string name="label_pro_feature">Isici se-premium</string>
     <plurals name="discover_device_limit_banner">
@@ -425,21 +344,15 @@
     <string name="review_app_review_action">Buyekeza</string>
     <string name="review_app_dismiss_action">Mhlawumbe kamuva</string>
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Ukuthenga kukhanseliwe</string>
-    <string name="error_iap_unavailable_message">Ukuthenga phakathi kohlelo akutholakali</string>
-    <string name="error_generic_message">Kwenzeke iphutha. Sicela uzame futhi.</string>
-    <string name="error_iap_owned_message">Seninobunikazi balo item</string>
     <string name="label_no_devices_title">Azikho Izidivayisi</string>
     <string name="bluemusic_mascot_description">Isithonjana Sohlelo</string>
     <!-- App Selection -->
     <string name="devices_app_selection_title">Khetha Izinhlelo</string>
     <string name="devices_app_selection_search_hint">Sesha izinhlelo...</string>
-    <string name="devices_app_selection_currently_selected">Okhethiwe manje</string>
     <string name="devices_app_selection_selected_count">Izinhlelo ezikhethi %d</string>
     <string name="general_navigate_back_action">Buyela emuva</string>
     <string name="general_reset_action">Setha kabusha</string>
     <string name="general_clear_action">Sula</string>
-    <string name="general_save_action">Londoloza</string>
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Vala</string>
     <string name="devices_indicator_awake">Phapheme</string>
@@ -449,7 +362,6 @@
     <string name="devices_indicator_limit">Maweza</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Ukukhulisa</string>
-    <string name="devices_indicator_launch">Qalisa</string>
     <string name="devices_indicator_home">Ikhaya</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Isaziso</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,20 +29,15 @@
     <string name="onboarding_rewrite_action">Continue</string>
 
     <!-- Discover -->
-    <string name="discover_no_unmnaged_devices_msg">No unmanaged devices found</string>
     <string name="discover_all_devices_managed_msg">All your paired devices are managed! Need a new one?</string>
     <string name="discover_pair_new_device_action">Pair new device</string>
     <string name="discover_device_speaker_desc">This phone\'s own speaker. Its volumes are applied when audio switches back to the phone, e.g. after your Bluetooth device disconnects.</string>
 
     <!-- Devices -->
     <string name="devices_device_config_label">Device configuration</string>
-    <string name="devices_device_config_section_general_label">General</string>
     <string name="devices_device_config_remove_device_label">Forget device</string>
-    <string name="devices_device_config_remove_device_desc">Forgets the device from this app and deletes its configuration. This does not unpair the device.</string>
     <string name="devices_device_config_remove_device_action">Forget</string>
     <string name="devices_device_config_remove_device_confirmation">Forget %s from managed devices?</string>
-    <string name="devices_device_config_rename_device_label">Rename device</string>
-    <string name="devices_device_config_rename_device_desc">Rename this device within this app, and if possible, within the system.</string>
     <string name="devices_device_config_rename_device_action">Rename</string>
     <string name="devices_device_config_enabled_label">Enabled</string>
     <string name="devices_device_config_enabled_desc">React to this device when connected</string>
@@ -101,7 +96,6 @@
     <string name="devices_device_config_autoplay_keycodes_title">Autoplay commands</string>
     <string name="devices_device_config_autoplay_keycodes_order">Command sequence</string>
     <string name="devices_device_config_autoplay_keycodes_label">Commands</string>
-    <string name="devices_device_config_autoplay_keycodes_desc">Configure which commands to send and in what order</string>
     <string name="devices_device_config_autoplay_keycodes_none_set">No commands configured</string>
     <string name="devices_device_config_autoplay_keycodes_add_action">Add command</string>
     <string name="devices_device_config_autoplay_keycodes_max_reached">Maximum %1$d commands</string>
@@ -129,7 +123,6 @@
     <string name="cd_autoplay_keycode_move_down">Move down</string>
     <string name="cd_autoplay_keycode_remove">Remove</string>
 
-    <string name="devices_device_config_section_volumes_label">Volumes</string>
     <string name="devices_device_config_section_volume_label">Volume</string>
     <string name="devices_device_config_alarm_volume_label">Alarm volume</string>
     <string name="devices_device_config_alarm_volume_desc">Some alarm apps use the music volume instead.</string>
@@ -166,8 +159,6 @@
     <string name="devices_audio_stream_notification_label">Notification</string>
     <string name="devices_audio_stream_alarm_label">Alarm</string>
 
-    <string name="devices_neverseen_label">Never seen</string>
-    <string name="devices_state_connected_label">Connected</string>
     <string name="devices_last_connected_label">Last connected: %s</string>
     <string name="devices_currently_connected_label">Currently connected</string>
     <string name="devices_device_disabled_label">Device disabled</string>
@@ -208,10 +199,7 @@
 
     <string name="label_app_enabled">App enabled</string>
     <string name="description_app_enabled">Toggles the app’s ability to react to volume and Bluetooth events.</string>
-    <string name="label_visible_volume_adjustments">Visible adjustments</string>
-    <string name="description_visible_volume_adjustments">Show the system\'s volume window while this app makes adjustments.</string>
     <string name="label_volume_listener">Observe changes</string>
-    <string name="description_volume_listener">Stay active while a device is connected and save volume changes that have not been caused by this app.</string>
     <string name="label_boot_restore">Restore on boot</string>
     <string name="description_boot_restore">Restore volume after booting/rebooting if a Bluetooth device is connected.</string>
 
@@ -222,22 +210,11 @@
     <string name="settings_support_wiki_description">Learn how to use BVM effectively</string>
     <string name="settings_support_issue_tracker_description">A public issue tracker for bug reports and feature requests.</string>
     <string name="settings_support_issue_tracker_label">Issue tracker</string>
-    <string name="settings_support_debuglog_label">Debug log</string>
     <string name="settings_support_debuglog_desc">Record everything the app is doing into a text file that you can share.</string>
-    <string name="settings_support_debuglog_recording_desc">Currently recording debug information. Tap to stop recording.</string>
-    <string name="settings_support_debuglog_path">Log path: %1$s</string>
     <string name="settings_support_debuglog_short_recording_title">Very short recording</string>
     <string name="settings_support_debuglog_short_recording_msg">That was a very short recording. Debug logs are recordings, not snapshots — reproduce the issue while recording is active for the log to be useful.</string>
     <string name="settings_support_debuglog_short_recording_continue">Continue recording</string>
     <string name="settings_support_debuglog_short_recording_stop">Stop anyway</string>
-    <string name="settings_support_debuglog_folder_label">Debug log folder</string>
-    <plurals name="settings_support_debuglog_folder_desc">
-        <item quantity="one">%1$d session using %2$s</item>
-        <item quantity="other">%1$d sessions using %2$s</item>
-    </plurals>
-    <string name="settings_support_debuglog_folder_empty_desc">No debug logs stored</string>
-    <string name="settings_support_debuglog_folder_delete_title">Delete all debug logs?</string>
-    <string name="settings_support_debuglog_folder_delete_msg">This will permanently delete all stored debug log sessions.</string>
     <string name="settings_support_discord_label">Discord</string>
     <string name="settings_support_discord_description">A place to hang out in and ask questions.</string>
 
@@ -247,8 +224,6 @@
     <string name="settings_acks_translation_header">Translation</string>
     <string name="settings_acks_translators_title">Translators</string>
     <string name="settings_acks_translators_people">Person1;Person2(optional@email.com)</string>
-    <string name="settings_acks_translate_title">Translate BVM</string>
-    <string name="settings_acks_translate_desc">Help translate BVM into your language</string>
 
     <string name="settings_acks_thanks_header">Thanks</string>
     <string name="settings_acks_crowdin_title">crowdin.com</string>
@@ -257,9 +232,6 @@
 
     <string name="settings_translation_label">Translation</string>
     <string name="settings_translation_desc">Help translate the app into your favorite language</string>
-
-    <string name="settings_sponsor_development_title">Sponsor development</string>
-    <string name="settings_sponsor_development_summary">Become a patron and make continued development possible.</string>
 
     <string name="settings_privacy_policy_label">Privacy policy</string>
     <string name="settings_privacy_policy_desc">Handling data responsibly.</string>
@@ -285,10 +257,8 @@
     <string name="backup_restore_version_warning">This backup was created with version %1$s. You\'re running %2$s. Some settings may not restore correctly.</string>
 
     <!-- Debug Log -->
-    <string name="debug_notification_channel_label">Debug notifications</string>
     <string name="debug_log_consent_title">Debug log</string>
     <string name="debug_log_consent_explanation">This feature records everything the app is doing into a shareable file. The generated file contains sensitive information (e.g. file names and installed apps). Only share it with trusted parties (e.g. a developer troubleshooting an issue).</string>
-    <string name="debug_log_recording_progress">Recording debug log</string>
     <string name="debug_log_record_action">Record</string>
     <string name="debug_log_stop_action">Stop recording</string>
     <string name="debug_log_screen_title">Debug Log Recorder</string>
@@ -304,7 +274,6 @@
 
     <string name="debug_log_screen_discard_action">Discard</string>
     <string name="debug_log_screen_keep_action">Keep</string>
-    <string name="debug_log_compressing_label">Compressing…</string>
     <string name="debug_log_file_label">Recorded log file</string>
 
     <!-- Debug Log Sessions -->
@@ -334,7 +303,6 @@
     <string name="contact_description_question_hint">Describe your question in detail.</string>
     <string name="contact_category_section_label">Category</string>
     <string name="contact_debug_log_label">Debug log</string>
-    <string name="contact_debug_log_select_hint">Select a debug log to attach</string>
     <string name="contact_debug_log_picker_hint">Attach a debug log to help diagnose the issue faster.</string>
     <string name="contact_debug_log_picker_empty">No debug logs available. Record one first.</string>
     <string name="contact_expected_behavior_label">Expected behavior</string>
@@ -348,92 +316,37 @@
     <string name="contact_welcome_msg">I read every message myself and do my best to reply, but since I work on this alone, it can take a little time. Thanks for your patience.</string>
     <string name="contact_footer_msg">Your message will be sent via email. Device and setup information is attached automatically.</string>
     <string name="contact_no_email_app_msg">No email app found on this device.</string>
-    <string name="contact_attachment_missing_msg">Debug log file no longer exists</string>
 
     <!-- Support/Stored Logs -->
     <string name="settings_support_stored_logs_label">Stored debug logs</string>
     <string name="settings_support_stored_logs_desc">%1$d sessions (%2$s)</string>
     <string name="settings_support_stored_logs_empty">No stored debug logs</string>
-    <string name="settings_support_stored_logs_delete_title">Delete stored logs?</string>
-    <string name="settings_support_stored_logs_delete_msg">This will delete all %1$d stored debug log sessions.</string>
-    <string name="settings_support_stored_logs_deleted_msg">Stored debug logs deleted</string>
-
-
-    <string name="label_bug_reports">Bug reports</string>
-    <string name="description_bug_reports">Automatic bug and crash reporting.</string>
-
 
     <string name="label_add_device">Add device</string>
-    <string name="label_just_a_moment_please">Just a moment, please.</string>
     <string name="label_notification_channel_status">Status</string>
     <string name="label_notification_channel_setup">Setup required</string>
     <string name="monitor_notification_starting">Starting up…</string>
     <string name="action_set">Set</string>
     <string name="action_cancel">Cancel</string>
-    <string name="label_invalid_input">Invalid input</string>
     <string name="action_reset">Reset</string>
     <string name="label_no_connected_devices">No devices connected</string>
-    <string name="label_status_idle">Idle</string>
-    <string name="label_status_adjusting_volumes">Adjusting volumes</string>
-    <string name="label_premium_version">Premium version</string>
     <string name="general_upgrade_action">Upgrade</string>
     <string name="common_upgrade_required_label">Upgrade required</string>
-    <string name="label_premium_version_required">Premium version required</string>
-    <string name="description_intro_purpose">This app allows your Android device to remember the volume of different Bluetooth devices.</string>
-    <string name="upgrade_benefit_unlimited_devices">Unlimited device profiles</string>
-    <string name="upgrade_benefit_connection_actions">Autoplay, app launch and connection alerts</string>
-    <string name="upgrade_benefit_theme_customization">Theme, style and color customization</string>
-    <string name="upgrade_benefit_power_controls">Volume lock and rate limiting</string>
-    <string name="upgrade_benefit_support">Support independent development</string>
     <string name="upgrade_benefit_equalizer">• Per-device equalizer (for music apps with system equalizer support)</string>
-    <string name="description_intro_tap_the_button">Start by adding your first device.</string>
     <string name="description_bluetooth_is_disabled">Bluetooth is disabled.</string>
     <string name="title_bluetooth_is_off">Bluetooth is Off</string>
     <string name="action_enable_bluetooth">Enable Bluetooth</string>
     <string name="title_bluetooth_permission_required">Bluetooth Permission Required</string>
     <string name="description_bluetooth_permission_required">This app needs Bluetooth permission to manage your device volumes.</string>
     <string name="action_grant_permission">Grant Permission</string>
-    <string name="label_status_listening_for_changes">Listening for volume changes</string>
     <string name="action_exit">Exit</string>
 
-
-    <string name="action_start">Start</string>
-    <string name="label_welcome">Welcome</string>
-    <string name="description_intro_contact">Don\'t hesitate to contact me if you have questions or even an idea for a new feature.</string>
-    <string name="label_translation">Translation</string>
-    <string name="description_help_translate">Help me make this app available in other languages.</string>
     <string name="label_device_speaker">Device speaker</string>
 
-    <string name="label_keyevent_playpause">Play-Pause</string>
-    <string name="label_keyevent_play">Play</string>
-    <string name="label_keyevent_next">Next</string>
-    <string name="label_install_id">Install ID</string>
     <string name="message_copied_to_clipboard">Copied to clipboard</string>
-    <string name="label_thanks">Thanks</string>
-    <string name="label_licenses">Licenses</string>
 
-    <string name="description_ring_volume_additional_permission">Additional permissions are necessary to change the ring volume.</string>
-    <string name="label_missing_permissions">Missing permissions</string>
-    <string name="action_grant">Grant</string>
-    <string name="label_advanced">Advanced</string>
-    <string name="label_exclude_health">Exclude health profiles</string>
-    <string name="description_exclude_health">Some Android devices hang when looking up \'Health Device\' Bluetooth profiles (HDP, 0x1400).</string>
-    <string name="label_exclude_gattserver">Exclude GATT server profiles</string>
-    <string name="label_exclude_gatt">Exclude GATT profiles</string>
-    <string name="description_exclude_gattserver">Don\'t query Bluetooth profiles of type \'Generic Attribute\' (GATT) server.</string>
-    <string name="description_exclude_gatt">Don\'t query Bluetooth profiles of type \'Generic Attribute\' (GATT) client.</string>
-
-    <string name="description_waiting_for_devicex">Waiting for %s to complete connection</string>
-    <string name="action_undo">Undo</string>
-    <string name="action_show">Show</string>
     <string name="action_dismiss">Dismiss</string>
-    <string name="action_fix">Fix</string>
-    <string name="battery_optimizations_issue_description">Battery optimizations are enabled for this app and can prevent it from receiving Bluetooth events. Consider disabling optimizations if you are experiencing issues.</string>
     <string name="label_bluetooth_settings">Bluetooth settings</string>
-    <string name="android10_applaunch_issue_description">Android 10 restricts how apps can be launched from the background. To allow opening apps when a Bluetooth device connects, grant the permission "Display over other apps" (SYSTEM_ALERT_WINDOW).</string>
-    <string name="label_opensource">Source code</string>
-    <string name="android13_notification_permission_description">Grant this app permission to post notifications. This enables displaying a notification when this app is active and volume adjustments are being made.</string>
-    <string name="privacy_policy_label">Privacy policy</string>
     <string name="managed_devices_empty_message">No Bluetooth devices configured.\nTap the + button to add your first device.</string>
     <string name="label_pro_feature">Premium feature</string>
     <plurals name="discover_device_limit_banner">
@@ -466,10 +379,6 @@
     <string name="review_app_dismiss_action">Maybe later</string>
 
     <!-- IAP Error Messages -->
-    <string name="error_iap_cancelled_message">Purchase cancelled</string>
-    <string name="error_iap_unavailable_message">In-app purchases are not available</string>
-    <string name="error_generic_message">An error occurred. Please try again.</string>
-    <string name="error_iap_owned_message">You already own this item</string>
 
     <string name="label_no_devices_title">No Devices</string>
 
@@ -478,12 +387,10 @@
     <!-- App Selection -->
     <string name="devices_app_selection_title">Select Apps</string>
     <string name="devices_app_selection_search_hint">Search apps…</string>
-    <string name="devices_app_selection_currently_selected">Currently selected</string>
     <string name="devices_app_selection_selected_count">%d apps selected</string>
     <string name="general_navigate_back_action">Navigate back</string>
     <string name="general_reset_action">Reset</string>
     <string name="general_clear_action">Clear</string>
-    <string name="general_save_action">Save</string>
 
     <!-- Device option indicators -->
     <string name="devices_indicator_lock">Lock</string>
@@ -494,7 +401,6 @@
     <string name="devices_indicator_limit">Limit</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Boost</string>
-    <string name="devices_indicator_launch">Launch</string>
     <string name="devices_indicator_home">Home</string>
     <string name="devices_indicator_dnd">DND</string>
     <string name="devices_indicator_alert">Alert</string>


### PR DESCRIPTION
## What changed

No user-facing behavior change. Deletes 88 string resources that nothing in the app referenced any more, along with their translations in all 77 locale files.

## Technical Context

- Detection was reference-based, not lint-based: every identifier in the base and flavor `strings.xml` files was checked against `R.string.`/`R.plurals.` in Kotlin/Java, `@string/`/`@plurals/` in every XML (layouts, manifest, widget and preference resources), and any bare occurrence anywhere in `app/src`. The app never calls `getIdentifier`, so there is no dynamic-lookup path that reference checking would miss.
- Git pickaxe over everything except `strings.xml` explains each one: 33 lost their last user in the v3.0 Compose rewrite (ea49a9b6), 21 were added and never wired up, and 31 were orphaned by later reworks (debug log unification, FOSS upgrade screen rebuild, error report removal, GATT query change, and others). The commit message lists the commit per group.
- Translations were deleted alongside the base entries. Leaving them would turn each into an `ExtraTranslation` lint error.
- The strings still exist on Crowdin until the next source push removes them there; their translator context was written earlier today and disappears with them.
- Compilation cannot catch a missing string, so both flavors were installed on clean API 34 emulators and driven through onboarding, the dashboard, device discovery, the device configuration screen, every settings sub-screen, support and debug log, acknowledgements and the upgrade screen. No `Resources$NotFoundException`, no crash. The Google Play purchase-result dialogs were not reachable (no Play account on the emulator, so billing never connects); those paths use the current `upgrades_gplay_*` strings, not the four deleted `error_iap_*` ones.