### PR TITLE
Document that translator context lives on Crowdin

### DIFF
--- a/.claude/rules/localization.md
+++ b/.claude/rules/localization.md
@@ -21,3 +21,7 @@ from you. Write the English string in the base `values/strings.xml` and stop the
 - Do not hand-write or fan out sub-agents to produce per-locale translations.
 - To pull and validate incoming translations, use the `android-translation:crowdin-pull`
   skill; to fill gaps on Crowdin itself, use `android-translation:crowdin-translate`.
+- String context, character limits and file context are managed on Crowdin through the
+  android-translation plugin's `crowdin-annotate` skill. XML comments in
+  `values/strings.xml` no longer reach translators once a string's context has been written
+  on Crowdin; change it there.


### PR DESCRIPTION
## What changed

No user-facing behavior change. Adds one bullet to `.claude/rules/localization.md`.

## Technical Context

- Every string in `strings-app.xml`, `strings-app-gplay.xml` and `strings-app-foss.xml` now has a context written directly on Crowdin. Crowdin only re-derives a string's context from its XML comment while the stored context is still in canonical form (the identifier, or identifier plus comment); any other stored value is sticky, and the comment is ignored on every later source push.
- The practical consequence is invisible from the repository: editing a comment in `values/strings.xml` no longer changes anything a translator sees. This bullet records that, and points at where to change it instead.
- Reversible per string if ever needed (reset the context to the identifier, then push once with a temporary comment and once without), but that is per string, not a switch.