### PR TITLE
Show active volume limits on the dashboard and while adjusting them

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDevice.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/ManagedDevice.kt
@@ -136,8 +136,8 @@ data class ManagedDevice(
         if (!volumeLimit) return null
         val target = getVolume(type) ?: return null
         if (target !in 0f..1f) return null
-        val min = getVolumeMin(type)
-        val max = getVolumeMax(type)
+        val min = normalizeVolumeLimitMin(getVolumeMin(type))
+        val max = normalizeVolumeLimitMax(getVolumeMax(type))
         if (min == null && max == null) return null
         return VolumeBand(min = min, max = max)
     }

--- a/app/src/main/java/eu/darken/bluemusic/devices/core/VolumeLimitToggle.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/core/VolumeLimitToggle.kt
@@ -4,6 +4,7 @@ import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.common.upgrade.isProForUi
 import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
+import kotlin.math.roundToInt
 
 // The pro check uses the UI gate: a paying user must not be told "not pro" just because billing
 // hasn't settled yet. It only guards enabling — turning the limit off is always allowed, so a free
@@ -39,6 +40,24 @@ fun requireValidVolumeLimit(min: Float?, max: Float?) {
     require(min == null || max == null || min <= max) { "Volume limit minimum $min is above maximum $max" }
 }
 
+/** How every surface spells a bound out. */
+fun Float.toVolumePercent(): Int = (this * 100).roundToInt()
+
+/**
+ * A bound at the stream's own extreme constrains nothing: 0% is the stream's minimum and 100% its
+ * maximum. Null instead keeps [ManagedDevice.hasEffectiveVolumeLimit] false, so a fully open band
+ * doesn't hold the foreground service and its notification alive.
+ *
+ * The test is the displayed percentage, not the raw float: 0.004f prints as "At least 0%" while
+ * behaving as a floor.
+ *
+ * 0f -> null, 0.004f -> null, 0.2f -> 0.2f
+ */
+fun normalizeVolumeLimitMin(min: Float?): Float? = min?.takeIf { it.toVolumePercent() > 0 }
+
+/** The ceiling half of [normalizeVolumeLimitMin]: 1f -> null, 0.996f -> null, 0.7f -> 0.7f. */
+fun normalizeVolumeLimitMax(max: Float?): Float? = max?.takeIf { it.toVolumePercent() < 100 }
+
 suspend fun DeviceRepo.setVolumeLimit(address: DeviceAddr, type: AudioStream.Type, min: Float?, max: Float?) {
     requireValidVolumeLimit(min, max)
 
@@ -56,11 +75,28 @@ suspend fun DeviceRepo.setVolumeLimit(address: DeviceAddr, type: AudioStream.Typ
 fun DeviceConfigEntity.withVolumeLimit(type: AudioStream.Type, min: Float?, max: Float?): DeviceConfigEntity {
     requireValidVolumeLimit(min, max)
 
+    val normalizedMin = normalizeVolumeLimitMin(min)
+    val normalizedMax = normalizeVolumeLimitMax(max)
+
     return when (type) {
-        AudioStream.Type.MUSIC -> copy(musicVolumeMin = min, musicVolumeMax = max)
-        AudioStream.Type.CALL -> copy(callVolumeMin = min, callVolumeMax = max)
-        AudioStream.Type.RINGTONE -> copy(ringVolumeMin = min, ringVolumeMax = max)
-        AudioStream.Type.NOTIFICATION -> copy(notificationVolumeMin = min, notificationVolumeMax = max)
-        AudioStream.Type.ALARM -> copy(alarmVolumeMin = min, alarmVolumeMax = max)
+        AudioStream.Type.MUSIC -> copy(musicVolumeMin = normalizedMin, musicVolumeMax = normalizedMax)
+        AudioStream.Type.CALL -> copy(callVolumeMin = normalizedMin, callVolumeMax = normalizedMax)
+        AudioStream.Type.RINGTONE -> copy(ringVolumeMin = normalizedMin, ringVolumeMax = normalizedMax)
+        AudioStream.Type.NOTIFICATION -> copy(notificationVolumeMin = normalizedMin, notificationVolumeMax = normalizedMax)
+        AudioStream.Type.ALARM -> copy(alarmVolumeMin = normalizedMin, alarmVolumeMax = normalizedMax)
     }
 }
+
+/** [normalizeVolumeLimitMin] / [normalizeVolumeLimitMax] applied to all five streams. */
+fun DeviceConfigEntity.normalizedVolumeLimits(): DeviceConfigEntity = copy(
+    musicVolumeMin = normalizeVolumeLimitMin(musicVolumeMin),
+    musicVolumeMax = normalizeVolumeLimitMax(musicVolumeMax),
+    callVolumeMin = normalizeVolumeLimitMin(callVolumeMin),
+    callVolumeMax = normalizeVolumeLimitMax(callVolumeMax),
+    ringVolumeMin = normalizeVolumeLimitMin(ringVolumeMin),
+    ringVolumeMax = normalizeVolumeLimitMax(ringVolumeMax),
+    notificationVolumeMin = normalizeVolumeLimitMin(notificationVolumeMin),
+    notificationVolumeMax = normalizeVolumeLimitMax(notificationVolumeMax),
+    alarmVolumeMin = normalizeVolumeLimitMin(alarmVolumeMin),
+    alarmVolumeMax = normalizeVolumeLimitMax(alarmVolumeMax),
+)

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/config/components/VolumeLimitCard.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/config/components/VolumeLimitCard.kt
@@ -31,6 +31,8 @@ import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
 import eu.darken.bluemusic.common.compose.UpgradeBadge
 import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.core.normalizeVolumeLimitMax
+import eu.darken.bluemusic.devices.core.normalizeVolumeLimitMin
 import eu.darken.bluemusic.devices.ui.icon
 import eu.darken.bluemusic.devices.ui.volumelimit.getVolumeLimitDescription
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
@@ -46,8 +48,8 @@ data class VolumeLimitSummary(
 fun ManagedDevice.volumeLimitSummaries(): List<VolumeLimitSummary> = AudioStream.Type.entries
     .filter { getVolume(it) != null }
     .mapNotNull { type ->
-        val min = getVolumeMin(type)
-        val max = getVolumeMax(type)
+        val min = normalizeVolumeLimitMin(getVolumeMin(type))
+        val max = normalizeVolumeLimitMax(getVolumeMax(type))
         if (min == null && max == null) null else VolumeLimitSummary(type, min, max)
     }
 

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/device/OptionIndicators.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/rows/device/OptionIndicators.kt
@@ -24,6 +24,7 @@ import androidx.compose.material.icons.twotone.Lock
 import androidx.compose.material.icons.twotone.NotificationsActive
 import androidx.compose.material.icons.twotone.PowerOff
 import androidx.compose.material.icons.twotone.Speed
+import androidx.compose.material.icons.twotone.UnfoldLess
 import androidx.compose.material.icons.twotone.Visibility
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -59,6 +60,7 @@ fun OptionIndicators(
         if (device.volumeObservingEffective) add(Icons.TwoTone.Visibility to stringResource(R.string.devices_indicator_observe))
         if (device.volumeSaveOnDisconnect) add(Icons.TwoTone.PowerOff to stringResource(R.string.devices_indicator_disconnect))
         if (device.volumeRateLimiterEffective) add(Icons.TwoTone.Speed to stringResource(R.string.devices_indicator_limit))
+        if (device.hasEffectiveVolumeLimit) add(Icons.TwoTone.UnfoldLess to stringResource(R.string.devices_indicator_volume_range))
         if (device.eqEnabled) add(Icons.TwoTone.Equalizer to stringResource(R.string.devices_indicator_eq))
         if (device.eqEnabled && (device.eqBoostGain ?: 0) > 0) {
             add(Icons.AutoMirrored.TwoTone.VolumeUp to stringResource(R.string.devices_indicator_boost))
@@ -152,7 +154,7 @@ private fun OptionIndicatorsPreview() {
     PreviewWrapper {
         // The mock device already has these settings enabled by default
         val base = MockDevice().toManagedDevice()
-        val mockDevice = base.copy(config = base.config.copy(eqEnabled = true, eqBoostGain = 600))
+        val mockDevice = base.copy(config = base.config.copy(eqEnabled = true, eqBoostGain = 600, volumeLimit = true, musicVolumeMin = 0.2f, musicVolumeMax = 0.7f))
 
         val mockApps = listOf(
             AppInfo(

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/volumelimit/VolumeLimitPreference.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/volumelimit/VolumeLimitPreference.kt
@@ -25,8 +25,10 @@ import androidx.compose.ui.unit.dp
 import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.Preview2
 import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.devices.core.normalizeVolumeLimitMax
+import eu.darken.bluemusic.devices.core.normalizeVolumeLimitMin
+import eu.darken.bluemusic.devices.core.toVolumePercent
 import eu.darken.bluemusic.monitor.core.audio.AudioStream
-import kotlin.math.roundToInt
 
 /**
  * Picks the lowest and highest volume a stream may reach.
@@ -37,7 +39,6 @@ import kotlin.math.roundToInt
 @Composable
 fun VolumeLimitPreference(
     title: String,
-    description: String,
     icon: ImageVector,
     min: Float?,
     max: Float?,
@@ -75,8 +76,9 @@ fun VolumeLimitPreference(
                     style = MaterialTheme.typography.bodyLarge,
                     color = MaterialTheme.colorScheme.onSurface
                 )
+                val (boundMin, boundMax) = range.toBounds()
                 Text(
-                    text = description,
+                    text = getVolumeLimitDescription(boundMin, boundMax),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant
                 )
@@ -91,19 +93,17 @@ fun VolumeLimitPreference(
             // Writing on every frame of a drag would hit the database dozens of times per gesture.
             onValueChangeFinished = {
                 dragging = false
-                // A thumb at its extreme is no bound at all: 0% and 100% resolve to the stream's own
-                // bounds. Storing them as values would keep the foreground service alive for a band
-                // that constrains nothing.
-                onLimitChange(
-                    range.start.takeIf { it > 0f },
-                    range.endInclusive.takeIf { it < 1f },
-                )
+                val (newMin, newMax) = range.toBounds()
+                onLimitChange(newMin, newMax)
             },
             valueRange = 0f..1f,
             steps = stepCount?.let { it - 1 } ?: 0,
         )
     }
 }
+
+private fun ClosedFloatingPointRange<Float>.toBounds(): Pair<Float?, Float?> =
+    normalizeVolumeLimitMin(start) to normalizeVolumeLimitMax(endInclusive)
 
 @Composable
 internal fun getStreamLabel(type: AudioStream.Type): String = when (type) {
@@ -118,16 +118,14 @@ internal fun getStreamLabel(type: AudioStream.Type): String = when (type) {
 internal fun getVolumeLimitDescription(min: Float?, max: Float?): String = when {
     min != null && max != null -> stringResource(
         R.string.devices_device_config_volume_limit_range_desc,
-        min.toPercent(),
-        max.toPercent(),
+        min.toVolumePercent(),
+        max.toVolumePercent(),
     )
 
-    min != null -> stringResource(R.string.devices_device_config_volume_limit_min_desc, min.toPercent())
-    max != null -> stringResource(R.string.devices_device_config_volume_limit_max_desc, max.toPercent())
+    min != null -> stringResource(R.string.devices_device_config_volume_limit_min_desc, min.toVolumePercent())
+    max != null -> stringResource(R.string.devices_device_config_volume_limit_max_desc, max.toVolumePercent())
     else -> stringResource(R.string.devices_device_config_volume_limit_unset_desc)
 }
-
-private fun Float.toPercent(): Int = (this * 100).roundToInt()
 
 @Preview2
 @Composable
@@ -136,7 +134,6 @@ private fun VolumeLimitPreferencePreview() {
         Column {
             VolumeLimitPreference(
                 title = "Limit for Music",
-                description = "Between 20% and 70%",
                 icon = Icons.TwoTone.MusicNote,
                 min = 0.2f,
                 max = 0.7f,
@@ -145,7 +142,6 @@ private fun VolumeLimitPreferencePreview() {
             )
             VolumeLimitPreference(
                 title = "Limit for Call",
-                description = "No limit set",
                 icon = Icons.TwoTone.Phone,
                 min = null,
                 max = null,

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/volumelimit/VolumeLimitScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/volumelimit/VolumeLimitScreen.kt
@@ -159,10 +159,6 @@ fun VolumeLimitScreen(
                                     R.string.devices_device_config_volume_limit_stream_label,
                                     getStreamLabel(streamType),
                                 ),
-                                description = getVolumeLimitDescription(
-                                    device.getVolumeMin(streamType),
-                                    device.getVolumeMax(streamType),
-                                ),
                                 icon = streamType.icon,
                                 min = device.getVolumeMin(streamType),
                                 max = device.getVolumeMax(streamType),

--- a/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupMappers.kt
+++ b/app/src/main/java/eu/darken/bluemusic/main/backup/core/BackupMappers.kt
@@ -1,6 +1,7 @@
 package eu.darken.bluemusic.main.backup.core
 
 import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import eu.darken.bluemusic.devices.core.normalizedVolumeLimits
 import eu.darken.bluemusic.devices.core.requireValidVolumeLimit
 import eu.darken.bluemusic.monitor.core.alert.AlertType
 import eu.darken.bluemusic.monitor.core.audio.DndMode
@@ -93,7 +94,7 @@ fun DeviceConfigBackup.toEntity(): DeviceConfigEntity = DeviceConfigEntity(
     eqEnabled = eqEnabled,
     eqBandLevels = eqBandLevels,
     eqBoostGain = eqBoostGain,
-)
+).normalizedVolumeLimits()
 
 /**
  * Checks for enum values in the backup that are not recognized by the current app version.

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -399,6 +399,7 @@
     <string name="devices_indicator_observe">Observe</string>
     <string name="devices_indicator_disconnect">Disconnect</string>
     <string name="devices_indicator_limit">Limit</string>
+    <string name="devices_indicator_volume_range">Range</string>
     <string name="devices_indicator_eq">EQ</string>
     <string name="devices_indicator_boost">Boost</string>
     <string name="devices_indicator_home">Home</string>

--- a/app/src/test/java/eu/darken/bluemusic/devices/core/ManagedDeviceTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/core/ManagedDeviceTest.kt
@@ -424,6 +424,57 @@ class ManagedDeviceTest : BaseTest() {
         ).hasEffectiveVolumeLimit shouldBe false
     }
 
+    // 0% is the stream's own minimum and 100% its maximum, so such a band constrains nothing.
+    @Test
+    fun `getVolumeBand - null for bounds at the stream extremes`() {
+        listOf(
+            0f to null,
+            null to 1f,
+            0f to 1f,
+        ).forEach { (min, max) ->
+            val device = create(
+                config = DeviceConfigEntity(
+                    address = "AA:BB:CC:DD:EE:FF",
+                    volumeLimit = true,
+                    musicVolume = 0.5f,
+                    musicVolumeMin = min,
+                    musicVolumeMax = max,
+                )
+            )
+            device.getVolumeBand(AudioStream.Type.MUSIC) shouldBe null
+            device.hasEffectiveVolumeLimit shouldBe false
+        }
+    }
+
+    @Test
+    fun `getVolumeBand - drops only the extreme half of a band`() {
+        create(
+            config = DeviceConfigEntity(
+                address = "AA:BB:CC:DD:EE:FF",
+                volumeLimit = true,
+                musicVolume = 0.5f,
+                musicVolumeMin = 0f,
+                musicVolumeMax = 0.6f,
+            )
+        ).getVolumeBand(AudioStream.Type.MUSIC) shouldBe VolumeBand(min = null, max = 0.6f)
+    }
+
+    @Test
+    fun `getVolumeBand - an ordinary band is untouched`() {
+        val device = create(
+            config = DeviceConfigEntity(
+                address = "AA:BB:CC:DD:EE:FF",
+                volumeLimit = true,
+                musicVolume = 0.5f,
+                musicVolumeMin = 0.2f,
+                musicVolumeMax = 0.6f,
+            )
+        )
+
+        device.getVolumeBand(AudioStream.Type.MUSIC) shouldBe VolumeBand(min = 0.2f, max = 0.6f)
+        device.hasEffectiveVolumeLimit shouldBe true
+    }
+
     // endregion
 
     @Test

--- a/app/src/test/java/eu/darken/bluemusic/devices/core/VolumeLimitToggleTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/core/VolumeLimitToggleTest.kt
@@ -147,4 +147,66 @@ class VolumeLimitToggleTest : BaseTest() {
         }
         coVerify(exactly = 0) { repo.updateDevice(any(), any()) }
     }
+
+    @Test
+    fun `setVolumeLimit stores a floor at the stream minimum as no floor`() = runTest {
+        val repo = deviceRepo()
+        val update = slot<(DeviceConfigEntity) -> DeviceConfigEntity>()
+        coEvery { repo.updateDevice(address, capture(update)) } returns Unit
+
+        repo.setVolumeLimit(address, AudioStream.Type.MUSIC, min = 0f, max = 0.6f)
+
+        val updated = update.captured(DeviceConfigEntity(address = address))
+        updated.musicVolumeMin shouldBe null
+        updated.musicVolumeMax shouldBe 0.6f
+    }
+
+    @Test
+    fun `setVolumeLimit stores a ceiling at the stream maximum as no ceiling`() = runTest {
+        val repo = deviceRepo()
+        val update = slot<(DeviceConfigEntity) -> DeviceConfigEntity>()
+        coEvery { repo.updateDevice(address, capture(update)) } returns Unit
+
+        repo.setVolumeLimit(address, AudioStream.Type.MUSIC, min = 0.2f, max = 1f)
+
+        val updated = update.captured(DeviceConfigEntity(address = address))
+        updated.musicVolumeMin shouldBe 0.2f
+        updated.musicVolumeMax shouldBe null
+    }
+
+    // A continuous slider can land here; it prints as "At least 0%", so it is not a floor.
+    @Test
+    fun `setVolumeLimit stores a sub-percent floor as no floor`() = runTest {
+        val repo = deviceRepo()
+        val update = slot<(DeviceConfigEntity) -> DeviceConfigEntity>()
+        coEvery { repo.updateDevice(address, capture(update)) } returns Unit
+
+        repo.setVolumeLimit(address, AudioStream.Type.MUSIC, min = 0.004f, max = null)
+
+        update.captured(DeviceConfigEntity(address = address)).musicVolumeMin shouldBe null
+    }
+
+    @Test
+    fun `setVolumeLimit stores bounds inside the range unchanged`() = runTest {
+        val repo = deviceRepo()
+        val update = slot<(DeviceConfigEntity) -> DeviceConfigEntity>()
+        coEvery { repo.updateDevice(address, capture(update)) } returns Unit
+
+        repo.setVolumeLimit(address, AudioStream.Type.MUSIC, min = 0.2f, max = 0.6f)
+
+        val updated = update.captured(DeviceConfigEntity(address = address))
+        updated.musicVolumeMin shouldBe 0.2f
+        updated.musicVolumeMax shouldBe 0.6f
+    }
+
+    // Normalizing first would turn this into the valid pair 0.5f / null and swallow the rejection.
+    @Test
+    fun `setVolumeLimit validates before normalizing`() = runTest {
+        val repo = deviceRepo()
+
+        shouldThrow<IllegalArgumentException> {
+            repo.setVolumeLimit(address, AudioStream.Type.MUSIC, min = 0.5f, max = 0f)
+        }
+        coVerify(exactly = 0) { repo.updateDevice(any(), any()) }
+    }
 }

--- a/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/rows/device/OptionIndicatorsTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/rows/device/OptionIndicatorsTest.kt
@@ -1,0 +1,69 @@
+package eu.darken.bluemusic.devices.ui.dashboard.rows.device
+
+import android.content.Context
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.bluetooth.core.MockDevice
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+import eu.darken.bluemusic.devices.core.ManagedDevice
+import eu.darken.bluemusic.devices.core.database.DeviceConfigEntity
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class OptionIndicatorsTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val rangeLabel: String
+        get() = context.getString(R.string.devices_indicator_volume_range)
+
+    private fun render(configure: DeviceConfigEntity.() -> DeviceConfigEntity) {
+        val base: ManagedDevice = MockDevice().toManagedDevice()
+        val device = base.copy(config = base.config.configure())
+        composeRule.setContent {
+            PreviewWrapper {
+                OptionIndicators(device = device)
+            }
+        }
+    }
+
+    @Test
+    fun `a bounded stream shows the range chip`() {
+        render { copy(volumeLimit = true, musicVolumeMin = 0.2f) }
+
+        composeRule.onNodeWithText(rangeLabel).assertIsDisplayed()
+    }
+
+    // The toggle alone is a normal state: the bounds are only offered once it is on, so a device
+    // that has it on and nothing bounded is not limited by anything.
+    @Test
+    fun `the toggle without a bound shows no range chip`() {
+        render {
+            copy(
+                volumeLimit = true,
+                musicVolumeMin = null,
+                musicVolumeMax = null,
+                callVolumeMin = null,
+                callVolumeMax = null,
+                ringVolumeMin = null,
+                ringVolumeMax = null,
+                notificationVolumeMin = null,
+                notificationVolumeMax = null,
+                alarmVolumeMin = null,
+                alarmVolumeMax = null,
+            )
+        }
+
+        composeRule.onNodeWithText(rangeLabel).assertDoesNotExist()
+    }
+
+    @Test
+    fun `a stored bound with the toggle off shows no range chip`() {
+        render { copy(volumeLimit = false, musicVolumeMin = 0.2f) }
+
+        composeRule.onNodeWithText(rangeLabel).assertDoesNotExist()
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/devices/ui/volumelimit/VolumeLimitPreferenceTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/ui/volumelimit/VolumeLimitPreferenceTest.kt
@@ -1,5 +1,6 @@
 package eu.darken.bluemusic.devices.ui.volumelimit
 
+import android.content.Context
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.twotone.MusicNote
 import androidx.compose.runtime.MutableState
@@ -9,17 +10,28 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performSemanticsAction
 import androidx.compose.ui.test.performTouchInput
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.R
 import eu.darken.bluemusic.common.compose.PreviewWrapper
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import org.junit.Test
 import testhelpers.compose.BaseComposeRobolectricTest
+import kotlin.math.roundToInt
 
 class VolumeLimitPreferenceTest : BaseComposeRobolectricTest() {
 
     private var lastLimit: Pair<Float?, Float?>? = null
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private fun rangeDesc(min: Int, max: Int): String =
+        context.getString(R.string.devices_device_config_volume_limit_range_desc, min, max)
 
     private fun render(min: Float?, max: Float?, stepCount: Int? = null) =
         render(mutableStateOf(min to max), stepCount)
@@ -30,7 +42,6 @@ class VolumeLimitPreferenceTest : BaseComposeRobolectricTest() {
             PreviewWrapper {
                 VolumeLimitPreference(
                     title = "Limit for Music",
-                    description = "No limit set",
                     icon = Icons.TwoTone.MusicNote,
                     min = bounds.value.first,
                     max = bounds.value.second,
@@ -136,6 +147,59 @@ class VolumeLimitPreferenceTest : BaseComposeRobolectricTest() {
         thumb(1).performTouchInput { up() }
 
         lastLimit!!.second shouldBe dragged[1].takeIf { it < 1f }
+    }
+
+    @Test
+    fun `stored bounds render as the description`() {
+        render(min = 0.2f, max = 0.6f)
+
+        composeRule.onNodeWithText(rangeDesc(20, 60)).assertIsDisplayed()
+    }
+
+    // The stored bounds only catch up after the release commits, so a description derived from them
+    // would sit at the old band for the whole gesture.
+    @Test
+    fun `the description follows the thumb mid drag`() {
+        render(min = 0.2f, max = 0.6f)
+
+        thumb(1).performTouchInput {
+            down(center)
+            // The first move is spent on the touch slop, only the second one reaches the thumb.
+            moveTo(center + Offset(SLIDER_DRAG_PX, 0f))
+            moveTo(center + Offset(2 * SLIDER_DRAG_PX, 0f))
+        }
+
+        val dragged = rangeDesc(20, (thumbValues()[1] * 100).roundToInt())
+        dragged shouldNotBe rangeDesc(20, 60)
+        composeRule.onNodeWithText(dragged).assertIsDisplayed()
+        lastLimit shouldBe null
+
+        thumb(1).performTouchInput { up() }
+    }
+
+    @Test
+    fun `a thumb at its extreme reads as unbounded`() {
+        render(min = 0.2f, max = 0.6f)
+
+        thumb(1).performSemanticsAction(SemanticsActions.SetProgress) { it(1f) }
+
+        composeRule
+            .onNodeWithText(context.getString(R.string.devices_device_config_volume_limit_min_desc, 20))
+            .assertIsDisplayed()
+    }
+
+    // Without a step count the slider is continuous, so it can land just above the bottom. That
+    // prints as 0%, and what the text says has to match what gets stored.
+    @Test
+    fun `a sub-percent thumb reads as unbounded`() {
+        render(min = 0.2f, max = 0.6f, stepCount = null)
+
+        thumb(0).performSemanticsAction(SemanticsActions.SetProgress) { it(0.004f) }
+
+        composeRule
+            .onNodeWithText(context.getString(R.string.devices_device_config_volume_limit_max_desc, 60))
+            .assertIsDisplayed()
+        lastLimit shouldBe (null to 0.6f)
     }
 
     // A 16 level stream has 15 steps; the slider counts the 14 values sitting between its two ends.

--- a/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupMappersTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/main/backup/core/BackupMappersTest.kt
@@ -169,6 +169,39 @@ class BackupMappersTest : BaseTest() {
         backup.detectUnknownEnums().shouldBeEmpty()
     }
 
+    // A backup written before bounds were normalized can carry a band that constrains nothing.
+    @Test
+    fun `backup to entity drops bounds at the stream extremes`() {
+        val backup = DeviceConfigBackup(
+            address = "test",
+            volumeLimit = true,
+            musicVolume = 0.5f,
+            musicVolumeMin = 0f,
+            musicVolumeMax = 1f,
+        )
+
+        val entity = backup.toEntity()
+
+        entity.musicVolumeMin shouldBe null
+        entity.musicVolumeMax shouldBe null
+    }
+
+    @Test
+    fun `backup to entity keeps ordinary bounds`() {
+        val backup = DeviceConfigBackup(
+            address = "test",
+            volumeLimit = true,
+            musicVolume = 0.5f,
+            musicVolumeMin = 0.2f,
+            musicVolumeMax = 0.6f,
+        )
+
+        val entity = backup.toEntity()
+
+        entity.musicVolumeMin shouldBe 0.2f
+        entity.musicVolumeMax shouldBe 0.6f
+    }
+
     @Test
     fun `minimal entity round-trips correctly`() {
         val entity = DeviceConfigEntity(address = "FF:EE:DD:CC:BB:AA")


### PR DESCRIPTION
## What changed

Devices that have a minimum or maximum volume set now show a "Range" badge on the dashboard, alongside the existing badges for lock, EQ and the rest, so you can see at a glance which devices are limited without opening them.

On the volume limit screen, the text under each slider updates while you drag a thumb instead of waiting for you to let go, so you can read the exact percentage you are setting as you set it.

A limit pinned to 0% or 100% is no longer treated as a limit anywhere in the app. Those are the stream's own minimum and maximum, so such a band never constrained anything, but it still counted as an active limit: it would show the new badge, read as "Between 0% and 100%" on the device config card, and keep the background service running for a device nothing was being applied to.

## Technical Context

- The badge is gated on `hasEffectiveVolumeLimit` (switch on **and** at least one managed stream actually bounded), matching how the observe and rate-limiter badges are gated. Turning the switch on without setting a bound shows nothing.
- `VolumeLimitPreference` no longer takes a description from its parent; it derives the text from its own in-progress range. The write still happens only on release, so a drag does not hit the database per frame.
- The "0% and 100% are not bounds" rule now lives in one place (`normalizeVolumeLimitMin/Max`) and is applied on write, on read via `getVolumeBand`, in the config card summary, and in backup restore. The read-side application is what makes already-stored data behave correctly without a database migration.
- `withVolumeLimit` validates the raw pair before normalizing. Normalizing first would turn the invalid pair `0.5f / 0f` into a valid `0.5f / null` and swallow the rejection.
- Worth a close look: `ManagedDevice.getVolumeBand` is the single read path every enforcement module and the foreground-service predicate go through, so the normalization there has the widest blast radius in the diff.
