### PR TITLE
Show when monitoring is off and re-enable it from the dashboard

### DIFF
--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardAction.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardAction.kt
@@ -12,6 +12,8 @@ sealed interface DashboardAction {
         val volumeMode: VolumeMode
     ) : DashboardAction
 
+    data object EnableMonitoring : DashboardAction
+
     data object RequestBluetoothPermission : DashboardAction
 
     data object RequestNotificationPermission : DashboardAction

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Block
 import androidx.compose.material.icons.filled.BluetoothDisabled
 import androidx.compose.material.icons.twotone.Add
 import androidx.compose.material.icons.twotone.Bluetooth
@@ -65,6 +66,7 @@ import eu.darken.bluemusic.common.compose.navigationBarBottomPadding
 import eu.darken.bluemusic.common.debug.logging.Logging.Priority.INFO
 import eu.darken.bluemusic.common.debug.logging.log
 import eu.darken.bluemusic.common.debug.logging.logTag
+import eu.darken.bluemusic.common.error.ErrorEventHandler
 import eu.darken.bluemusic.common.navigation.Nav
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import eu.darken.bluemusic.devices.core.DeviceAddr
@@ -82,6 +84,8 @@ import eu.darken.bluemusic.upgrade.ui.brandTitleTwoTone
 fun DevicesScreenHost(vm: DashboardViewModel = hiltViewModel()) {
 
     val state by vm.state.collectAsStateWithLifecycle()
+
+    ErrorEventHandler(vm)
 
     val activity = LocalContext.current as? android.app.Activity
 
@@ -182,6 +186,14 @@ fun DevicesScreen(
                 .horizontalCutoutPadding(),
             contentPadding = PaddingValues(top = 8.dp, bottom = 8.dp + navBarPadding)
         ) {
+            if (!state.isMonitoringEnabled) {
+                item {
+                    MonitoringDisabledCard(
+                        onEnable = { onDeviceAction(DashboardAction.EnableMonitoring) }
+                    )
+                }
+            }
+
             // Critical permission/state cards - these block normal functionality
             if (!state.hasBluetoothPermission) {
                 item {
@@ -355,6 +367,56 @@ private fun ManagedDevicesTopBar(
             }
         }
     )
+}
+
+@Composable
+private fun MonitoringDisabledCard(
+    onEnable: () -> Unit
+) {
+    Card(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp, vertical = 8.dp),
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.errorContainer
+        )
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Block,
+                contentDescription = null,
+                modifier = Modifier.size(48.dp),
+                tint = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Text(
+                text = stringResource(R.string.title_monitoring_is_off),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(R.string.description_monitoring_is_disabled),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onErrorContainer,
+                textAlign = TextAlign.Center
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Button(
+                onClick = onEnable,
+                colors = androidx.compose.material3.ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error
+                )
+            ) {
+                Text(stringResource(R.string.action_enable_monitoring))
+            }
+        }
+    }
 }
 
 @Composable

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModel.kt
@@ -221,7 +221,8 @@ class DashboardViewModel @Inject constructor(
         // Seeded, so the debounce and the equalizer engine probe behind it can never hold up the
         // dashboard itself.
         eqStatusFlow.onStart { emit(null) },
-    ) { upgradeInfo, bluetoothState, devicesWithApps, batteryHint, overlayHint, notificationHint, dndHint, lockedDevices, speakerHintDismissed, review, eqStatus ->
+        devicesSettings.isEnabled.flow,
+    ) { upgradeInfo, bluetoothState, devicesWithApps, batteryHint, overlayHint, notificationHint, dndHint, lockedDevices, speakerHintDismissed, review, eqStatus, isMonitoringEnabled ->
         val showSpeakerHint = !speakerHintDismissed &&
             devicesWithApps.any { it.device.type != SourceDevice.Type.PHONE_SPEAKER } &&
             devicesWithApps.none { it.device.type == SourceDevice.Type.PHONE_SPEAKER }
@@ -242,6 +243,7 @@ class DashboardViewModel @Inject constructor(
             // Lowest priority card: only asked for on an otherwise quiet dashboard, i.e. no hint or
             // permission card is competing for attention and the user actually has devices set up.
             showReviewCard = review.shouldAskForReview &&
+                isMonitoringEnabled &&
                 bluetoothState.hasPermission &&
                 bluetoothState.isEnabled &&
                 !batteryHint.shouldShow &&
@@ -251,6 +253,7 @@ class DashboardViewModel @Inject constructor(
                 !showSpeakerHint &&
                 devicesWithApps.isNotEmpty(),
             eqStatus = eqStatus,
+            isMonitoringEnabled = isMonitoringEnabled,
         )
     }.asStateFlow()
 
@@ -284,6 +287,7 @@ class DashboardViewModel @Inject constructor(
         val showSpeakerHint: Boolean = false,
         val showReviewCard: Boolean = false,
         val eqStatus: EqStatusFor? = null,
+        val isMonitoringEnabled: Boolean = true,
     ) {
         // Convenience property for backwards compatibility
         val devices: List<ManagedDevice> get() = devicesWithApps.map { it.device }
@@ -312,6 +316,10 @@ class DashboardViewModel @Inject constructor(
     fun action(action: DashboardAction) = launch {
         log(tag) { "action: $action" }
         when (action) {
+            is DashboardAction.EnableMonitoring -> {
+                devicesSettings.setEnabled(true)
+            }
+
             is DashboardAction.RequestBluetoothPermission -> {
                 launch {
                     val permission = permissionHelper.getBluetoothPermission()

--- a/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
+++ b/app/src/main/java/eu/darken/bluemusic/devices/ui/settings/DevicesSettingsViewModel.kt
@@ -10,7 +10,6 @@ import eu.darken.bluemusic.common.navigation.NavigationController
 import eu.darken.bluemusic.common.ui.ViewModel4
 import eu.darken.bluemusic.common.upgrade.UpgradeRepo
 import eu.darken.bluemusic.devices.core.DevicesSettings
-import eu.darken.bluemusic.monitor.core.service.MonitorControl
 import kotlinx.coroutines.flow.combine
 import javax.inject.Inject
 
@@ -21,7 +20,6 @@ constructor(
     dispatcherProvider: DispatcherProvider,
     navCtrl: NavigationController,
     private val devicesSettings: DevicesSettings,
-    private val monitorControl: MonitorControl,
     upgradeRepo: UpgradeRepo,
 ) : ViewModel4(dispatcherProvider, logTag("Settings", "Devices", "ViewModel"), navCtrl) {
 
@@ -42,16 +40,10 @@ constructor(
         navTo(Nav.Main.Upgrade())
     }
 
+    // MonitorControl observes enabledState and both starts and stops the service.
     fun onToggleEnabled(enabled: Boolean) = launch {
         log(tag) { "onToggleEnabled($enabled)" }
         devicesSettings.setEnabled(enabled)
-        // Disabling is handled centrally: MonitorControl observes enabledState and stops the
-        // service; the orchestrator's own watcher tears down the session as a safety net.
-        // forceStart: a quick disable->enable can race the old session's teardown — a plain
-        // start would be swallowed by onStartCommand and killed by the old job's stopSelf.
-        if (enabled) {
-            monitorControl.startMonitor(forceStart = true)
-        }
     }
 
     fun onToggleRestoreOnBoot(enabled: Boolean) = launch {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -336,6 +336,9 @@
     <string name="description_bluetooth_is_disabled">Bluetooth is disabled.</string>
     <string name="title_bluetooth_is_off">Bluetooth is Off</string>
     <string name="action_enable_bluetooth">Enable Bluetooth</string>
+    <string name="title_monitoring_is_off">Monitoring is Off</string>
+    <string name="description_monitoring_is_disabled">BlueMusic is not reacting to Bluetooth connections or volume changes. Saved volumes, limits and locks are not applied automatically.</string>
+    <string name="action_enable_monitoring">Enable monitoring</string>
     <string name="title_bluetooth_permission_required">Bluetooth Permission Required</string>
     <string name="description_bluetooth_permission_required">This app needs Bluetooth permission to manage your device volumes.</string>
     <string name="action_grant_permission">Grant Permission</string>

--- a/app/src/screenshotTest/kotlin/eu/darken/bluemusic/screenshots/PlayStoreLocales.kt
+++ b/app/src/screenshotTest/kotlin/eu/darken/bluemusic/screenshots/PlayStoreLocales.kt
@@ -9,10 +9,10 @@ import androidx.compose.ui.tooling.preview.Preview
  * Multi-preview annotation for all Play Store locales (light mode).
  * [name] = fastlane directory name, [locale] = Android resource qualifier.
  *
- * The set is fastlane/metadata/android/* intersected with the languages Play accepts for a store
- * listing. fastlane/remove_unsupported_languages.sh drops the rest just before upload, so the two
- * lists have to agree: a locale rendered here but deleted there is wasted work, and one kept there
- * without a render ships a listing with no screenshots.
+ * The set is the fastlane/metadata/android/<locale> directories intersected with the languages
+ * Play accepts for a store listing. fastlane/remove_unsupported_languages.sh drops the rest just
+ * before upload, so the two lists have to agree: a locale rendered here but deleted there is
+ * wasted work, and one kept there without a render ships a listing with no screenshots.
  */
 @Retention(AnnotationRetention.BINARY)
 @Target(AnnotationTarget.ANNOTATION_CLASS, AnnotationTarget.FUNCTION)

--- a/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreenMonitoringTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardScreenMonitoringTest.kt
@@ -1,0 +1,95 @@
+package eu.darken.bluemusic.devices.ui.dashboard
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.test.core.app.ApplicationProvider
+import eu.darken.bluemusic.R
+import eu.darken.bluemusic.bluetooth.core.MockDevice
+import eu.darken.bluemusic.common.compose.PreviewWrapper
+import io.kotest.matchers.shouldBe
+import org.junit.Test
+import testhelpers.compose.BaseComposeRobolectricTest
+
+class DashboardScreenMonitoringTest : BaseComposeRobolectricTest() {
+
+    private val context: Context
+        get() = ApplicationProvider.getApplicationContext()
+
+    private val cardTitle: String
+        get() = context.getString(R.string.title_monitoring_is_off)
+    private val enableAction: String
+        get() = context.getString(R.string.action_enable_monitoring)
+
+    private fun dashboardState(isMonitoringEnabled: Boolean) = DashboardViewModel.State(
+        devicesWithApps = listOf(
+            DashboardViewModel.DeviceWithApps(MockDevice().toManagedDevice(isConnected = true), emptyList())
+        ),
+        isBluetoothEnabled = true,
+        hasBluetoothPermission = true,
+        isMonitoringEnabled = isMonitoringEnabled,
+    )
+
+    @Test
+    fun `the card shows while monitoring is off`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                DashboardScreenUnderTest(
+                    isMonitoringEnabled = false,
+                    onDeviceAction = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(cardTitle).assertIsDisplayed()
+    }
+
+    @Test
+    fun `the card stays hidden while monitoring is on`() {
+        composeRule.setContent {
+            PreviewWrapper {
+                DashboardScreenUnderTest(
+                    isMonitoringEnabled = true,
+                    onDeviceAction = {},
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(cardTitle).assertDoesNotExist()
+    }
+
+    @Test
+    fun `the enable action reports the EnableMonitoring action`() {
+        val actions = mutableListOf<DashboardAction>()
+        composeRule.setContent {
+            PreviewWrapper {
+                DashboardScreenUnderTest(
+                    isMonitoringEnabled = false,
+                    onDeviceAction = { actions.add(it) },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(enableAction).performClick()
+
+        actions shouldBe listOf(DashboardAction.EnableMonitoring)
+    }
+
+    @Composable
+    private fun DashboardScreenUnderTest(
+        isMonitoringEnabled: Boolean,
+        onDeviceAction: (DashboardAction) -> Unit,
+    ) {
+        DevicesScreen(
+            state = dashboardState(isMonitoringEnabled),
+            onAddDevice = {},
+            onDeviceConfig = {},
+            onDeviceAction = onDeviceAction,
+            onNavigateToSettings = {},
+            onNavigateToUpgrade = {},
+            onRequestBluetoothPermission = {},
+        )
+    }
+}

--- a/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModelTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/devices/ui/dashboard/DashboardViewModelTest.kt
@@ -95,6 +95,7 @@ class DashboardViewModelTest : BaseTest() {
     private lateinit var dndHintDismissed: DataStoreValue<Boolean>
     private lateinit var speakerHintDismissed: DataStoreValue<Boolean>
     private lateinit var lockedDevices: DataStoreValue<Set<DeviceAddr>>
+    private lateinit var monitoringEnabled: DataStoreValue<Boolean>
 
     @BeforeEach
     fun setup() {
@@ -153,6 +154,7 @@ class DashboardViewModelTest : BaseTest() {
         dndHintDismissed = stubBoolValue(true)
         speakerHintDismissed = stubBoolValue(false)
         lockedDevices = stubSetValue(emptySet())
+        monitoringEnabled = stubBoolValue(true)
 
         every { generalSettings.isBatteryOptimizationHintDismissed } returns batteryHintDismissed
         every { generalSettings.isAndroid10AppLaunchHintDismissed } returns android10HintDismissed
@@ -160,6 +162,7 @@ class DashboardViewModelTest : BaseTest() {
         every { generalSettings.isDndAccessHintDismissed } returns dndHintDismissed
         every { generalSettings.isSpeakerHintDismissed } returns speakerHintDismissed
         every { devicesSettings.lockedDevices } returns lockedDevices
+        every { devicesSettings.isEnabled } returns monitoringEnabled
 
         // Default: hint helpers report shouldShow=false unless test sets up otherwise.
         every { permissionHelper.getBatteryOptimizationHint(any()) } returns
@@ -413,6 +416,31 @@ class DashboardViewModelTest : BaseTest() {
         updateSlot.captured(false) shouldBe true
     }
 
+    @Test
+    fun `state reports monitoring disabled when the master switch is off`() = runTest(UnconfinedTestDispatcher()) {
+        val enabled = MutableStateFlow(false)
+        every { monitoringEnabled.flow } returns enabled
+
+        val vm = viewModel()
+        backgroundScope.launch { vm.state.collect { } }
+        runCurrent()
+
+        vm.state.value!!.isMonitoringEnabled shouldBe false
+
+        enabled.value = true
+        runCurrent()
+
+        vm.state.value!!.isMonitoringEnabled shouldBe true
+    }
+
+    @Test
+    fun `enable monitoring action writes the setting`() = runTest(UnconfinedTestDispatcher()) {
+        viewModel().action(DashboardAction.EnableMonitoring)
+        advanceUntilIdle()
+
+        coVerify { devicesSettings.setEnabled(true) }
+    }
+
     /**
      * Every gate the review card sits behind, satisfied at once. The negative tests below each flip
      * exactly one of them, so a gate that silently stops mattering surfaces as a failure.
@@ -457,6 +485,14 @@ class DashboardViewModelTest : BaseTest() {
         every { bluetoothRepo.state } returns MutableStateFlow(
             BluetoothRepo.State(isEnabled = false, hasPermission = true, devices = emptySet())
         )
+
+        viewModel().state.filterNotNull().first().showReviewCard shouldBe false
+    }
+
+    @Test
+    fun `the review card stays hidden while monitoring is off`() = runTest(UnconfinedTestDispatcher()) {
+        quietDashboard()
+        every { monitoringEnabled.flow } returns MutableStateFlow(false)
 
         viewModel().state.filterNotNull().first().showReviewCard shouldBe false
     }

--- a/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorControlTest.kt
+++ b/app/src/test/java/eu/darken/bluemusic/monitor/core/service/MonitorControlTest.kt
@@ -162,6 +162,19 @@ class MonitorControlTest : BaseTest() {
     }
 
     @Test
+    fun `re-enabling with a persistent device starts the service exactly once`() = runTestWithControl {
+        enabledFlow.value = DevicesSettings.EnabledState(isEnabled = false, toggleEpoch = 1L)
+        devicesFlow.value = listOf(device(active = true, requiresPersistentSession = true))
+        verify(exactly = 0) { context.startServiceCompat(any()) }
+
+        enabledFlow.value = DevicesSettings.EnabledState(isEnabled = true, toggleEpoch = 2L)
+
+        // Exactly one: the enabled-state transition alone drives the start, so callers that only
+        // write the setting do not need a start call of their own.
+        verify(exactly = 1) { context.startServiceCompat(fakeIntent) }
+    }
+
+    @Test
     fun `active device with the equalizer enabled triggers service start`() = runTestWithControl {
         eqOperationalFlow.value = true
         devicesFlow.value = listOf(device(active = true, requiresPersistentSession = false, eqEnabled = true))


### PR DESCRIPTION
## What changed

BlueMusic has a master switch that controls whether it reacts to Bluetooth connections and volume changes at all. While that switch is off, saved volumes, volume limits and adjustment locks all stop being applied automatically. Until now the dashboard gave no sign of this, and the switch itself sits two taps deep under Settings > Devices, so the app could look like it was simply not working with nothing on screen explaining why.

The dashboard now shows a card at the top whenever monitoring is switched off. It says what has stopped, and its button turns monitoring back on without leaving the screen. The card then disappears on its own.

It renders above every other dashboard card, because the master switch gates everything else including the Bluetooth reaction: granting a permission or turning Bluetooth on while it is off changes nothing. The "rate the app" prompt no longer appears next to it.

Also included, unrelated to the above: a fix for a broken comment in the screenshot test sources that had stopped that source set compiling since late August.

## Technical Context

- The flag gates three separate entry points (the service is stopped, the Bluetooth broadcast receiver returns early, and the monitor aborts before registering the volume observer), but the dashboard state carried no representation of it, so the UI could show an active volume-limit indicator while nothing was enforcing it.
- Enabling is now setting-only, and this is the part worth the closest review. Writing the setting advances a toggle epoch that `MonitorControl`'s observer already reacts to, so the imperative start the settings toggle used to issue was a second forced start of the same service, each one cancelling and replacing the monitoring job. The observer is now the single authority, and `DevicesSettingsViewModel` no longer depends on `MonitorControl`. This deliberately changes the behavior of the existing settings toggle.
- The card's wording is load-bearing. Manual volume adjustment from the dashboard is not gated on the flag, so sliders keep working and keep respecting volume limits while monitoring is off. Only automatic reaction stops, and the copy says exactly that.
- The dashboard host had no error handler while the settings screen did, so a failed setting write from the new button would have been silent. Adding one also surfaces previously swallowed errors from the other dashboard actions.
- The screenshot test fix: Kotlin block comments nest, unlike Java's, so a `/*` sequence inside a KDoc (from the path `fastlane/metadata/android/*`) opened a comment that was never closed.
