### PR TITLE
Migrate Claude plugins to Clanker Cafe

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,12 +4,18 @@
     "deny": []
   },
   "enabledPlugins": {
-    "android-translation@claude-code-cafe": true,
-    "debugbadger@claude-code-cafe": true,
-    "jvm-tools@claude-code-cafe": true,
+    "android-translation@claude-code-cafe": false,
+    "debugbadger@claude-code-cafe": false,
+    "jvm-tools@claude-code-cafe": false,
     "frontend-design@claude-plugins-official": true,
-    "support@claude-code-cafe": true,
-    "google-play@claude-code-cafe": true,
-    "devtools@claude-code-cafe": true
+    "support@claude-code-cafe": false,
+    "google-play@claude-code-cafe": false,
+    "devtools@claude-code-cafe": false,
+    "android-translation@clanker-cafe": true,
+    "debugbadger@clanker-cafe": true,
+    "jvm-tools@clanker-cafe": true,
+    "support@clanker-cafe": true,
+    "google-play@clanker-cafe": true,
+    "devtools@clanker-cafe": true
   }
 }


### PR DESCRIPTION
## What changed

No user-facing behavior change. Move the six project Claude plugins to Clanker Cafe.

## Technical Context

- Old plugin IDs remain explicitly disabled, with their registrations, cached versions and workflow records retained for rollback and case continuity.
- A fresh Claude session verified replacement plugins, commands, skills, agents, hooks and MCP schemas without device or service actions.
