### PR TITLE
Remove retired Claude Cafe plugin settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,13 +4,7 @@
     "deny": []
   },
   "enabledPlugins": {
-    "android-translation@claude-code-cafe": false,
-    "debugbadger@claude-code-cafe": false,
-    "jvm-tools@claude-code-cafe": false,
     "frontend-design@claude-plugins-official": true,
-    "support@claude-code-cafe": false,
-    "google-play@claude-code-cafe": false,
-    "devtools@claude-code-cafe": false,
     "android-translation@clanker-cafe": true,
     "debugbadger@clanker-cafe": true,
     "jvm-tools@clanker-cafe": true,


### PR DESCRIPTION
## What changed

No user-facing behavior change. Remove retired Claude Code Cafe plugin settings from the project configuration.

## Technical Context

- The plugins have already migrated to Clanker Cafe; the disabled entries belong to the retired marketplace.
